### PR TITLE
test: add missing tests and edge cases for refactor safety

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -338,6 +338,67 @@ describe("ConversationSession", () => {
     expect(() => session.stop()).not.toThrow();
   });
 
+  it("emits error messages from stderr", () => {
+    const session = createSession();
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    mockProc._stderr.push("something went wrong");
+
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(1);
+    if (errors[0].type === "error") {
+      expect(errors[0].message).toContain("stderr:");
+      expect(errors[0].message).toContain("something went wrong");
+    }
+  });
+
+  it("defaults command to claude", () => {
+    const session = createSession();
+    session.sendMessage("Hi");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it("uses custom command when provided", () => {
+    const session = createSession({ command: "bash" });
+    session.sendMessage("Hi");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "bash",
+      expect.any(Array),
+      expect.any(Object),
+    );
+  });
+
+  it("exposes metadata with correct workspaceId", () => {
+    const session = createSession();
+    expect(session.metadata.workspaceId).toBe("ws-test");
+    expect(session.metadata.messageCount).toBe(0);
+    expect(session.metadata.sessionId).toBe(session.sessionId);
+  });
+
+  it("persists cancelled message with cancelled flag", async () => {
+    const session = createSession({ sessionId: "cancel-persist" });
+
+    session.sendMessage("Hi");
+    mockProc._stdout.push(assistantLine("Partial response"));
+    mockProc._emitClose(1); // non-zero = cancelled
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const messagesPath = join(tempDir, "sessions", "cancel-persist", "messages.jsonl");
+    const raw = await readFile(messagesPath, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+
+    expect(lines.length).toBe(2);
+    const assistantMsg = JSON.parse(lines[1]);
+    expect(assistantMsg.cancelled).toBe(true);
+  });
+
   it("persists user message on send", async () => {
     const session = createSession({ sessionId: "persist-test" });
 

--- a/backend/src/api/projects.test.ts
+++ b/backend/src/api/projects.test.ts
@@ -103,6 +103,11 @@ describe("DELETE /api/projects/:id", () => {
     const getRes = await app.inject({ method: "GET", url: `/api/projects/${id}` });
     expect(getRes.statusCode).toBe(404);
   });
+
+  it("returns 404 for non-existent project", async () => {
+    const res = await app.inject({ method: "DELETE", url: "/api/projects/nonexistent" });
+    expect(res.statusCode).toBe(404);
+  });
 });
 
 describe("POST /api/projects/:id/fetch", () => {

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -6,6 +6,7 @@ import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { projectRoutes } from "./projects.js";
 import { workspaceRoutes } from "./workspaces.js";
 import { git } from "../utils/git.js";
+import { loadProject, saveProject } from "../state/state.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -105,7 +106,19 @@ describe("DELETE /api/workspaces/:wsId", () => {
   });
 });
 
+describe("DELETE /api/workspaces/:wsId", () => {
+  it("returns 404 for non-existent workspace", async () => {
+    const res = await app.inject({ method: "DELETE", url: "/api/workspaces/nonexistent" });
+    expect(res.statusCode).toBe(404);
+  });
+});
+
 describe("GET /api/workspaces/:wsId/diff", () => {
+  it("returns 404 for non-existent workspace", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/workspaces/nonexistent/diff" });
+    expect(res.statusCode).toBe(404);
+  });
+
   it("returns diff", async () => {
     const createRes = await app.inject({
       method: "POST",
@@ -150,5 +163,24 @@ describe("POST /api/workspaces/:wsId/merge", () => {
   it("returns 404 for non-existent workspace", async () => {
     const res = await app.inject({ method: "POST", url: "/api/workspaces/nonexistent/merge" });
     expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 when workspace is busy", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const ws = createRes.json();
+
+    // Set workspace to busy
+    const state = await loadProject(projectId, dataDir);
+    const workspace = state!.workspaces.find((w) => w.id === ws.id)!;
+    workspace.status = "busy";
+    workspace.activeSessionId = "some-session";
+    await saveProject(state!, dataDir);
+
+    const res = await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/merge` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("Cannot merge");
   });
 });

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, vi, beforeAll } from "vitest";
+
+// Prevent the top-level main() from actually listening on a port
+vi.mock("fastify", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fastify")>();
+  const originalDefault = actual.default;
+  return {
+    ...actual,
+    default: (...args: Parameters<typeof originalDefault>) => {
+      const instance = originalDefault(...args);
+      const originalListen = instance.listen.bind(instance);
+      instance.listen = (async (...listenArgs: unknown[]) => {
+        // Only block the main() auto-listen (which uses port 3000)
+        const opts = listenArgs[0] as { port?: number } | undefined;
+        if (opts?.port === 3000) {
+          return "mocked";
+        }
+        return originalListen(...listenArgs);
+      }) as typeof instance.listen;
+      return instance;
+    },
+  };
+});
+
+import { buildApp } from "./index.js";
+
+let app: Awaited<ReturnType<typeof buildApp>>;
+
+afterEach(async () => {
+  await app?.close();
+});
+
+describe("buildApp", () => {
+  it("returns a Fastify instance", async () => {
+    app = await buildApp();
+    expect(app).toBeDefined();
+    expect(typeof app.listen).toBe("function");
+  });
+
+  it("registers /health endpoint", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/health" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ status: "ok" });
+  });
+
+  it("registers project routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/projects" });
+    expect(res.statusCode).not.toBe(404);
+  });
+
+  it("registers workspace routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/workspaces/test-ws" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("not found");
+  });
+
+  it("registers session routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/workspaces/test-ws/session" });
+    expect(res.statusCode).toBe(404);
+    expect(res.json().error).toContain("No active session");
+  });
+});

--- a/backend/src/utils/git.test.ts
+++ b/backend/src/utils/git.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { join } from "node:path";
+import { mkdtemp, rm, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { git } from "./git.js";
+
+let tempDir: string;
+
+import { beforeEach, afterEach } from "vitest";
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "hive-git-test-"));
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("git()", () => {
+  it("runs a git command and returns stdout/stderr", async () => {
+    await git(["init", tempDir]);
+    const result = await git(["status"], tempDir);
+    expect(result.stdout).toContain("On branch");
+  });
+
+  it("trims stdout and stderr whitespace", async () => {
+    await git(["init", tempDir]);
+    const { stdout } = await git(["rev-parse", "--git-dir"], tempDir);
+    expect(stdout).toBe(".git");
+    expect(stdout).not.toMatch(/^\s/);
+    expect(stdout).not.toMatch(/\s$/);
+  });
+
+  it("passes cwd correctly", async () => {
+    const subDir = join(tempDir, "sub");
+    await mkdir(subDir, { recursive: true });
+    await git(["init", subDir]);
+    const { stdout } = await git(["rev-parse", "--show-toplevel"], subDir);
+    expect(stdout).toContain("sub");
+  });
+
+  it("throws on invalid git command", async () => {
+    await expect(git(["not-a-real-command"])).rejects.toThrow();
+  });
+
+  it("throws on non-existent repo path", async () => {
+    await expect(
+      git(["status"], join(tempDir, "nonexistent")),
+    ).rejects.toThrow();
+  });
+
+  it("returns stderr alongside stdout", async () => {
+    await git(["init", tempDir]);
+    // git status on a fresh repo still has a valid stdout
+    const result = await git(["status"], tempDir);
+    expect(result).toHaveProperty("stdout");
+    expect(result).toHaveProperty("stderr");
+  });
+});

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -13,6 +13,7 @@ import {
   mergeWorkspace,
 } from "./workspace-manager.js";
 import { git } from "../utils/git.js";
+import { loadProject, saveProject } from "../state/state.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -74,6 +75,10 @@ describe("listWorkspaces", () => {
     const list = await listWorkspaces(projectId, dataDir);
     expect(list).toEqual([]);
   });
+
+  it("throws for non-existent project", async () => {
+    await expect(listWorkspaces("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
 });
 
 describe("getWorkspace", () => {
@@ -116,6 +121,10 @@ describe("getWorkspaceDiff", () => {
     expect(diff).toBe("");
   });
 
+  it("throws for non-existent workspace", async () => {
+    await expect(getWorkspaceDiff("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+
   it("returns diff after making changes", async () => {
     const ws = await createWorkspace(projectId, dataDir);
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);
@@ -134,6 +143,19 @@ describe("getWorkspaceDiff", () => {
 });
 
 describe("mergeWorkspace", () => {
+  it("throws when workspace is busy", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const state = await loadProject(projectId, dataDir);
+    const workspace = state!.workspaces.find((w) => w.id === ws.id)!;
+    workspace.status = "busy";
+    workspace.activeSessionId = "some-session";
+    await saveProject(state!, dataDir);
+
+    await expect(mergeWorkspace(ws.id, dataDir)).rejects.toThrow(
+      "Cannot merge while a session is active",
+    );
+  });
+
   it("merges changes into the default branch", async () => {
     const ws = await createWorkspace(projectId, dataDir);
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);


### PR DESCRIPTION
New test files for git wrapper (6 tests) and buildApp/health endpoint (5 tests). Added edge cases across existing suites: merge busy workspace, nonexistent resource errors, stderr output, cancelled persistence, and command defaults. 123 → 146 tests.