### PR TITLE
feat: add dynamic system prompt with git context injection

### DIFF
--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./agent-manager.js";
 import { loadProject, saveProject } from "../state/state.js";
 
-const CONV_CMD = { command: "bash" };
+const CONV_CMD = { command: "bash", systemPrompt: false as const };
 
 let tempDir: string;
 let dataDir: string;

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -1,13 +1,16 @@
 import { join } from "node:path";
 import { ConversationSession } from "./conversation-session.js";
+import { buildSystemPrompt } from "./system-prompt.js";
 import { getWorkspace } from "../workspaces/workspace-manager.js";
 import { saveProject, getDataDir } from "../state/state.js";
+import { git } from "../utils/git.js";
 import type { SessionMetadata } from "../types.js";
 
 const activeSessions = new Map<string, ConversationSession>();
 
 export interface SessionOptions {
   command?: string;
+  systemPrompt?: string | false;
 }
 
 /**
@@ -38,11 +41,34 @@ export async function getOrCreateSession(
   const wsPath = join(dataDir, projectState.id, "workspaces", workspace.name);
   const sessionDataDir = join(dataDir, projectState.id);
 
+  // Build system prompt unless explicitly disabled (e.g. in tests)
+  let systemPrompt: string | undefined;
+  if (options?.systemPrompt !== false) {
+    // Resolve default branch from bare repo (worktrees don't have origin)
+    const bareRepo = join(dataDir, projectState.id, "repo.git");
+    let defaultBranch: string | undefined;
+    try {
+      const { stdout: headRef } = await git(["symbolic-ref", "HEAD"], bareRepo);
+      defaultBranch = headRef.replace("refs/heads/", "");
+    } catch {
+      // Falls back to detection in getGitContext
+    }
+
+    systemPrompt = options?.systemPrompt ?? await buildSystemPrompt({
+      cwd: wsPath,
+      workspaceName: workspace.name,
+      projectName: projectState.name,
+      defaultBranch,
+      branchRename: {},
+    });
+  }
+
   const session = new ConversationSession({
     cwd: wsPath,
     dataDir: sessionDataDir,
     workspaceId: wsId,
     command: options?.command,
+    systemPrompt,
   });
 
   activeSessions.set(wsId, session);

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -19,6 +19,7 @@ export interface ConversationSessionConfig {
   workspaceId: string;
   sessionId?: string;
   command?: string;
+  systemPrompt?: string;
 }
 
 export type ConversationSessionEvent = {
@@ -31,6 +32,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   readonly sessionId: string;
   private readonly cwd: string;
   private readonly command: string;
+  private readonly systemPrompt: string | undefined;
   private readonly sessionDir: string;
   private readonly workspaceId: string;
   private process: ChildProcess | null = null;
@@ -46,6 +48,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.sessionId = config.sessionId ?? nanoid(12);
     this.cwd = config.cwd;
     this.command = config.command ?? "claude";
+    this.systemPrompt = config.systemPrompt;
     this.workspaceId = config.workspaceId;
     this.sessionDir = join(config.dataDir, "sessions", this.sessionId);
 
@@ -123,6 +126,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       "--output-format", "stream-json",
       "--verbose",
       "--dangerously-skip-permissions",
+      ...(isFirst && this.systemPrompt
+        ? ["--append-system-prompt", this.systemPrompt]
+        : []),
       ...(isFirst ? [] : ["--resume", this.claudeSessionId!]),
       "-p", content,
     ];

--- a/backend/src/agents/system-prompt.test.ts
+++ b/backend/src/agents/system-prompt.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { rm, writeFile } from "node:fs/promises";
+import { createTempDir } from "../utils/test-helpers.js";
+import { git } from "../utils/git.js";
+import { getGitContext, buildSystemPrompt } from "./system-prompt.js";
+
+let tempDir: string;
+let repoDir: string;
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-sysprompt-test-");
+  repoDir = join(tempDir, "repo");
+
+  await git(["init", repoDir]);
+  await git(["checkout", "-b", "main"], repoDir);
+  await git(["config", "user.email", "test@hive.dev"], repoDir);
+  await git(["config", "user.name", "Hive Test"], repoDir);
+  await writeFile(join(repoDir, "README.md"), "# Test\n");
+  await git(["add", "."], repoDir);
+  await git(["commit", "-m", "initial commit"], repoDir);
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("getGitContext", () => {
+  it("returns current branch", async () => {
+    const ctx = await getGitContext(repoDir);
+    expect(ctx.branch).toBe("main");
+  });
+
+  it("returns clean status for clean repo", async () => {
+    const ctx = await getGitContext(repoDir);
+    expect(ctx.status).toBe("");
+  });
+
+  it("returns dirty status for modified files", async () => {
+    await writeFile(join(repoDir, "new.txt"), "hello");
+    const ctx = await getGitContext(repoDir);
+    expect(ctx.status).toContain("new.txt");
+  });
+
+  it("returns recent commits", async () => {
+    const ctx = await getGitContext(repoDir);
+    expect(ctx.recentCommits).toContain("initial commit");
+  });
+
+  it("returns branch name on feature branch", async () => {
+    await git(["checkout", "-b", "feat/cool-stuff"], repoDir);
+    const ctx = await getGitContext(repoDir);
+    expect(ctx.branch).toBe("feat/cool-stuff");
+  });
+
+  it("handles non-git directory gracefully", async () => {
+    const ctx = await getGitContext(tempDir);
+    expect(ctx.branch).toBe("");
+    expect(ctx.status).toBe("");
+    expect(ctx.recentCommits).toBe("");
+  });
+
+  it("uses defaultBranch override when provided", async () => {
+    const ctx = await getGitContext(repoDir, "develop");
+    expect(ctx.defaultBranch).toBe("develop");
+  });
+
+  it("falls back to main when no origin/HEAD and no override", async () => {
+    const ctx = await getGitContext(repoDir);
+    // No remote set up, so origin/HEAD won't resolve — should fall back to "main"
+    expect(ctx.defaultBranch).toBe("main");
+  });
+});
+
+describe("buildSystemPrompt", () => {
+  it("includes git context in output", async () => {
+    const prompt = await buildSystemPrompt({ cwd: repoDir });
+    expect(prompt).toContain("Current branch: main");
+    expect(prompt).toContain("initial commit");
+  });
+
+  it("includes workspace and project name when provided", async () => {
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      workspaceName: "geneva",
+      projectName: "hive",
+    });
+    expect(prompt).toContain("Project: hive");
+    expect(prompt).toContain("Workspace: geneva");
+  });
+
+  it("includes default base prompt", async () => {
+    const prompt = await buildSystemPrompt({ cwd: repoDir });
+    expect(prompt).toContain("AI coding assistant");
+  });
+
+  it("uses custom base prompt when provided", async () => {
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      basePrompt: "You are a specialized agent for database migrations.",
+    });
+    expect(prompt).toContain("database migrations");
+    expect(prompt).not.toContain("AI coding assistant");
+  });
+
+  it("shows clean status for clean repo", async () => {
+    const prompt = await buildSystemPrompt({ cwd: repoDir });
+    expect(prompt).toContain("Status: (clean)");
+  });
+
+  it("shows dirty status for modified repo", async () => {
+    await writeFile(join(repoDir, "dirty.txt"), "changes");
+    const prompt = await buildSystemPrompt({ cwd: repoDir });
+    expect(prompt).toContain("dirty.txt");
+    expect(prompt).not.toContain("Status: (clean)");
+  });
+
+  it("uses provided defaultBranch instead of detecting", async () => {
+    const prompt = await buildSystemPrompt({ cwd: repoDir, defaultBranch: "develop" });
+    expect(prompt).toContain("Main branch: develop");
+  });
+
+  it("includes branch rename directive when configured", async () => {
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      branchRename: { prefix: "feat/" },
+    });
+    expect(prompt).toContain("git branch -m");
+    expect(prompt).toContain('prefix "feat/"');
+  });
+
+  it("includes branch rename without prefix", async () => {
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      branchRename: {},
+    });
+    expect(prompt).toContain("git branch -m");
+    expect(prompt).not.toContain("prefix");
+  });
+
+  it("uses custom maxLength in branch rename", async () => {
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      branchRename: { maxLength: 30 },
+    });
+    expect(prompt).toContain("under 30 characters");
+  });
+
+  it("omits branch rename when not configured", async () => {
+    const prompt = await buildSystemPrompt({ cwd: repoDir });
+    expect(prompt).not.toContain("git branch -m");
+  });
+});

--- a/backend/src/agents/system-prompt.ts
+++ b/backend/src/agents/system-prompt.ts
@@ -1,0 +1,121 @@
+import { git } from "../utils/git.js";
+
+export interface GitContext {
+  branch: string;
+  status: string;
+  recentCommits: string;
+  defaultBranch: string;
+}
+
+export interface BranchRenameDirective {
+  /** Prefix for the branch name (e.g. "feat/", "user/") */
+  prefix?: string;
+  /** Max length for the branch name (default: 40) */
+  maxLength?: number;
+}
+
+export interface SystemPromptOptions {
+  cwd: string;
+  workspaceName?: string;
+  projectName?: string;
+  basePrompt?: string;
+  /** Pre-resolved default branch (from bare repo). Skips detection if provided. */
+  defaultBranch?: string;
+  /** If set, instructs Claude to rename the branch based on the task. */
+  branchRename?: BranchRenameDirective;
+}
+
+const DEFAULT_BASE_PROMPT = `You are an AI coding assistant working inside a project workspace.
+You have full access to the codebase via your tools. Read files before modifying them.
+Write clean, simple code. Follow existing patterns and conventions in the codebase.
+All code, comments, and variable names must be in English.`;
+
+/**
+ * Gather git context from the workspace directory.
+ * Fails gracefully — returns empty strings if git commands fail.
+ *
+ * @param defaultBranchOverride - Pre-resolved default branch name (e.g. from bare repo).
+ *   In Geneva's architecture, worktrees don't have an `origin` remote, so the default
+ *   branch must be resolved from the bare repo via `git symbolic-ref HEAD`.
+ */
+export async function getGitContext(cwd: string, defaultBranchOverride?: string): Promise<GitContext> {
+  const run = async (args: string[]): Promise<string> => {
+    try {
+      const { stdout } = await git(args, cwd);
+      return stdout;
+    } catch {
+      return "";
+    }
+  };
+
+  const [branch, status, recentCommits] = await Promise.all([
+    run(["rev-parse", "--abbrev-ref", "HEAD"]),
+    run(["status", "--short"]),
+    run(["log", "--oneline", "-10"]),
+  ]);
+
+  // Use override if provided, otherwise try to detect from origin/HEAD, fallback to "main"
+  let defaultBranch = defaultBranchOverride ?? "";
+  if (!defaultBranch) {
+    const ref = await run(["rev-parse", "--abbrev-ref", "origin/HEAD"]);
+    defaultBranch = ref.replace(/^origin\//, "") || "main";
+  }
+
+  return { branch, status, recentCommits, defaultBranch };
+}
+
+/**
+ * Build a system prompt by merging a base prompt with dynamic git context.
+ */
+export async function buildSystemPrompt(opts: SystemPromptOptions): Promise<string> {
+  const { cwd, workspaceName, projectName, basePrompt = DEFAULT_BASE_PROMPT, defaultBranch, branchRename } = opts;
+  const ctx = await getGitContext(cwd, defaultBranch);
+
+  const sections: string[] = [basePrompt];
+
+  // Branch rename directive
+  if (branchRename) {
+    const maxLen = branchRename.maxLength ?? 40;
+    const lines = [
+      "# Branch Naming",
+      "",
+      "Use `git branch -m` to rename the current branch immediately before doing anything else.",
+      "Choose a concise, descriptive name based on the task (e.g. \"add-auth-middleware\", \"fix-login-redirect\").",
+      `Keep it under ${maxLen} characters. Use kebab-case.`,
+    ];
+    if (branchRename.prefix) {
+      lines.push(`Use the prefix "${branchRename.prefix}" (e.g. "${branchRename.prefix}fix-login-bug").`);
+    }
+    sections.push(lines.join("\n"));
+  }
+
+  // Project/workspace context
+  if (projectName || workspaceName) {
+    const parts: string[] = [];
+    if (projectName) parts.push(`Project: ${projectName}`);
+    if (workspaceName) parts.push(`Workspace: ${workspaceName}`);
+    sections.push(parts.join("\n"));
+  }
+
+  // Git context
+  const gitLines: string[] = [
+    "# Git Context (snapshot at session start)",
+    "",
+    `Current branch: ${ctx.branch || "unknown"}`,
+    `Main branch: ${ctx.defaultBranch}`,
+  ];
+
+  if (ctx.status) {
+    gitLines.push("", "Status:", ctx.status);
+  } else {
+    gitLines.push("", "Status: (clean)");
+  }
+
+  if (ctx.recentCommits) {
+    gitLines.push("", "Recent commits:", ctx.recentCommits);
+  }
+
+  sections.push(gitLines.join("\n"));
+
+  return sections.join("\n\n");
+}


### PR DESCRIPTION
Generates a system prompt at session start by merging a base prompt with live git context (branch, status, recent commits, default branch). Injected via --append-system-prompt on first Claude CLI invocation. Includes branch rename directive so Claude renames the workspace branch based on the task.