### PR TITLE
Refine workspace headers and empty state

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,8 +4,8 @@ import AppLayout from "@/components/AppLayout";
 import ProjectView from "@/pages/ProjectView";
 import WorkspaceView from "@/pages/WorkspaceView";
 import AddProjectDialog from "@/components/AddProjectDialog";
+import EmptyStateLogo from "@/components/EmptyStateLogo";
 import { useProjects } from "@/hooks/useProjects";
-import hiveLogo from "@/assets/hive-logo.png";
 
 export default function App() {
   const { projects, loading, createProject, deleteProject } = useProjects();
@@ -32,15 +32,7 @@ export default function App() {
           <Route index element={<Navigate to="/projects" replace />} />
           <Route
             path="projects"
-            element={
-              <div className="flex h-full items-center justify-center">
-                <img
-                  src={hiveLogo}
-                  alt="Hive logo"
-                  className="h-44 w-44 object-contain md:h-56 md:w-56"
-                />
-              </div>
-            }
+            element={<EmptyStateLogo />}
           />
           <Route path="projects/:id" element={<ProjectView />} />
           <Route path="workspaces/:wsId" element={<WorkspaceView />} />

--- a/frontend/src/components/EmptyStateLogo.tsx
+++ b/frontend/src/components/EmptyStateLogo.tsx
@@ -1,0 +1,18 @@
+import hiveLogo from "@/assets/hive-logo.png";
+import { cn } from "@/lib/utils";
+
+interface EmptyStateLogoProps {
+  className?: string;
+}
+
+export default function EmptyStateLogo({ className }: EmptyStateLogoProps) {
+  return (
+    <div className={cn("flex h-full items-center justify-center", className)}>
+      <img
+        src={hiveLogo}
+        alt="Hive logo"
+        className="h-44 w-44 object-contain md:h-56 md:w-56"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -33,75 +33,74 @@ export default function Sidebar({
 
   return (
     <div className="flex h-full w-60 flex-col border-r bg-sidebar text-sidebar-foreground">
-      <div className="flex items-center justify-between border-b px-4 py-3">
+      <div className="flex h-14 items-center justify-between border-b px-4">
         <Link to="/" className="font-title text-lg tracking-wide">
           Hive
         </Link>
       </div>
 
-      <ScrollArea className="flex-1 px-2 py-2">
-        <div className="mb-2 px-2 text-xs font-semibold uppercase text-muted-foreground">
-          Projects
-        </div>
-        {loading ? (
-          <div className="space-y-2 px-2">
-            <Skeleton className="h-6 w-full" />
-            <Skeleton className="h-6 w-3/4" />
-            <Skeleton className="h-6 w-full" />
-          </div>
-        ) : (
-          projects.map((project) => (
-            <div key={project.id} className="mb-1">
-              <div className="group flex items-center">
-                <Link
-                  to={`/projects/${project.id}`}
-                  className={`flex-1 rounded-md px-2 py-1.5 text-sm font-medium hover:bg-sidebar-accent ${
-                    activeProjectId === project.id ? "bg-sidebar-accent" : ""
-                  }`}
-                >
-                  {project.name}
-                </Link>
-                <button
-                  className="mr-1 hidden rounded p-0.5 text-muted-foreground hover:text-destructive group-hover:block"
-                  onClick={() => setDeleteTarget(project)}
-                  title="Delete project"
-                >
-                  <svg
-                    className="h-3.5 w-3.5"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
-                    />
-                  </svg>
-                </button>
-              </div>
-              {(project.workspaces ?? []).map((ws) => (
-                <Link
-                  key={ws.id}
-                  to={`/workspaces/${ws.id}`}
-                  className={`flex items-center gap-1.5 rounded-md px-4 py-1 text-sm hover:bg-sidebar-accent ${
-                    activeWsId === ws.id ? "bg-sidebar-accent" : ""
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-2 w-2 rounded-full ${
-                      ws.status === "busy"
-                        ? "bg-blue-500"
-                        : "bg-muted-foreground/40"
-                    }`}
-                  />
-                  {ws.name}
-                </Link>
-              ))}
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {loading ? (
+            <div className="space-y-2 px-2">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-3/4" />
+              <Skeleton className="h-6 w-full" />
             </div>
-          ))
-        )}
+          ) : (
+            projects.map((project) => (
+              <div key={project.id} className="mb-1">
+                <div className="group flex items-center">
+                  <Link
+                    to={`/projects/${project.id}`}
+                    className={`flex-1 rounded-md px-2 py-1.5 text-sm font-medium hover:bg-sidebar-accent ${
+                      activeProjectId === project.id ? "bg-sidebar-accent" : ""
+                    }`}
+                  >
+                    {project.name}
+                  </Link>
+                  <button
+                    className="mr-1 hidden rounded p-0.5 text-muted-foreground hover:text-destructive group-hover:block"
+                    onClick={() => setDeleteTarget(project)}
+                    title="Delete project"
+                  >
+                    <svg
+                      className="h-3.5 w-3.5"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
+                {(project.workspaces ?? []).map((ws) => (
+                  <Link
+                    key={ws.id}
+                    to={`/workspaces/${ws.id}`}
+                    className={`flex items-center gap-1.5 rounded-md px-4 py-1 text-sm hover:bg-sidebar-accent ${
+                      activeWsId === ws.id ? "bg-sidebar-accent" : ""
+                    }`}
+                  >
+                    <span
+                      className={`inline-block h-2 w-2 rounded-full ${
+                        ws.status === "busy"
+                          ? "bg-blue-500"
+                          : "bg-muted-foreground/40"
+                      }`}
+                    />
+                    {ws.name}
+                  </Link>
+                ))}
+              </div>
+            ))
+          )}
+        </div>
       </ScrollArea>
 
       <div className="border-t p-2">

--- a/frontend/src/pages/ProjectView.tsx
+++ b/frontend/src/pages/ProjectView.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useParams } from "react-router-dom";
 import { useWorkspaces } from "@/hooks/useWorkspaces";
 import WorkspaceCard from "@/components/WorkspaceCard";
+import EmptyStateLogo from "@/components/EmptyStateLogo";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -46,9 +47,7 @@ export default function ProjectView() {
           ))}
         </div>
       ) : workspaces.length === 0 ? (
-        <p className="text-muted-foreground">
-          No workspaces yet. Create one to start working.
-        </p>
+        <EmptyStateLogo className="min-h-[360px]" />
       ) : (
         <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {workspaces.map((ws) => (

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useParams } from "react-router-dom";
+import { RotateCcwIcon } from "lucide-react";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import {
@@ -156,12 +157,12 @@ export default function WorkspaceView() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Header */}
-      <div className="flex items-center justify-between border-b px-6 py-4">
-        <div>
-          <h1 className="font-title text-2xl tracking-wide">{workspace.name}</h1>
-          <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
-            <span>{workspace.branch}</span>
+      {/* Chat area + right panel */}
+      <div className="flex min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          <div className="flex h-14 items-center gap-2 border-b px-4">
+            <span className="truncate text-sm font-semibold text-foreground">{workspace.name}</span>
+            <span className="truncate text-sm text-muted-foreground">{workspace.branch}</span>
             <Badge variant={hasActiveSession ? "default" : "secondary"}>
               <span
                 className={`mr-1.5 inline-block h-2 w-2 rounded-full ${
@@ -173,20 +174,17 @@ export default function WorkspaceView() {
             <Badge variant={isStreaming ? "default" : "outline"}>
               {isStreaming ? "streaming" : "ready"}
             </Badge>
-          </div>
-        </div>
-        <div className="flex gap-2">
-          {hasActiveSession && (
-            <Button variant="destructive" size="sm" onClick={handleCleanSession}>
-              Clean Session
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="ml-auto text-muted-foreground hover:text-foreground"
+              onClick={handleCleanSession}
+              aria-label="Restart session"
+              title="Restart session"
+            >
+              <RotateCcwIcon />
             </Button>
-          )}
-        </div>
-      </div>
-
-      {/* Chat area + right panel */}
-      <div className="flex min-h-0 flex-1 overflow-hidden">
-        <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+          </div>
           {error && (
             <div className="border-b bg-destructive/10 px-4 py-2 text-sm text-destructive">
               {error}
@@ -211,7 +209,7 @@ export default function WorkspaceView() {
         </div>
 
         <aside className="hidden w-80 shrink-0 border-l bg-background lg:flex lg:flex-col">
-          <div className="border-b px-4 py-3 text-xs uppercase tracking-wide text-muted-foreground">
+          <div className="flex h-14 items-center border-b px-4 text-xs uppercase tracking-wide text-muted-foreground">
             Files
           </div>
           <div className="min-h-0 flex-1 overflow-auto p-3">


### PR DESCRIPTION
## Summary
- remove the extra "Projects" header in the sidebar
- align workspace view headers to a consistent 56px height
- replace duplicated logo empty states with a shared EmptyStateLogo component
- show the logo empty state when a project has zero workspaces

## Validation
- npm run lint --workspace @hive/frontend
- npm run typecheck --workspace @hive/frontend
