### PR TITLE
Add thinking and plan mode toggles to chat input

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -6,6 +6,7 @@ import { nanoid } from "nanoid";
 import { StreamParser } from "./stream-parser.js";
 import type {
   ChatMessage,
+  MessageOptions,
   ToolCall,
   ToolInputResult,
   SessionMetadata,
@@ -103,7 +104,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   /** Send a user message. Spawns a new claude process for this turn. */
-  sendMessage(content: string): void {
+  sendMessage(content: string, msgOptions?: MessageOptions): void {
     if (this._status === "streaming") {
       throw new Error("Already streaming — wait for current message to complete or stop it");
     }
@@ -132,11 +133,19 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       this._metadata.claudeSessionId = this.claudeSessionId;
     }
 
+    // Control thinking via MAX_THINKING_TOKENS env var (default 31999 = on, 0 = off)
+    const env = msgOptions?.thinkingEnabled !== undefined
+      ? { ...process.env, MAX_THINKING_TOKENS: msgOptions.thinkingEnabled ? "31999" : "0" }
+      : undefined;
+
     const args = [
       "--print",
       "--output-format", "stream-json",
       "--verbose",
-      ...(this.skipPermissions ? ["--dangerously-skip-permissions"] : []),
+      // Plan mode overrides skip-permissions (plan mode is read-only by design)
+      ...(msgOptions?.planMode
+        ? ["--permission-mode", "plan"]
+        : this.skipPermissions ? ["--dangerously-skip-permissions"] : []),
       ...(isFirstMessage && this.systemPrompt
         ? ["--append-system-prompt", this.systemPrompt]
         : []),
@@ -145,6 +154,12 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         : ["--resume", this.claudeSessionId]),
       "-p", content,
     ];
+
+    console.log("[session] spawn claude", {
+      msgOptions,
+      thinkingTokens: env?.MAX_THINKING_TOKENS ?? "default",
+      args: args.filter((a) => a !== content && !a.includes("You are")),
+    });
 
     this.parser = new StreamParser();
 
@@ -160,6 +175,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let killedForBlockingTool = false;
 
     this.parser.on("assistant", (data) => {
+      const blockTypes = data.message.content.map((b) => b.type);
+      console.log("[session] assistant blocks:", blockTypes, JSON.stringify(data.message.content).slice(0, 500));
       for (const block of data.message.content) {
         switch (block.type) {
           case "text":
@@ -224,6 +241,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.process = spawn(this.command, args, {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
+      ...(env && { env }),
     });
 
     // Claude can wait indefinitely when stdin is a pipe left open.

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -143,9 +143,15 @@ export interface QuestionAnswer {
 
 // ── WebSocket protocol ──────────────────────────────────────────────
 
+/** Per-message options that control Claude CLI behavior. */
+export interface MessageOptions {
+  planMode?: boolean;
+  thinkingEnabled?: boolean;
+}
+
 /** Frontend -> Backend */
 export type WsIncoming =
-  | { type: "user_message"; content: string }
+  | { type: "user_message"; content: string; options?: MessageOptions }
   | { type: "stop" }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult };
 

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -173,7 +173,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
                 activeSession = result.session;
               }
               attachSessionListeners(wsId, channel, activeSession);
-              activeSession.sendMessage(incoming.content);
+              activeSession.sendMessage(incoming.content, incoming.options);
               sendToChannel(channel, {
                 type: "status",
                 status: "busy",

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -10,10 +10,12 @@ import {
   PromptInputTools,
 } from "@/components/ai-elements/prompt-input";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
-import { PlusIcon, SparklesIcon } from "lucide-react";
+import type { MessageOptions } from "@/types";
+import { cn } from "@/lib/utils";
+import { BrainIcon, BookOpenIcon, PlusIcon, SparklesIcon } from "lucide-react";
 
 interface ChatInputProps {
-  onSend: (content: string) => boolean;
+  onSend: (content: string, options?: MessageOptions) => boolean;
   onStop: () => void;
   disabled: boolean;
   isStreaming: boolean;
@@ -32,6 +34,8 @@ export default function ChatInput({
   connectionStatus,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
+  const [thinkingEnabled, setThinkingEnabled] = useState(true);
+  const [planMode, setPlanMode] = useState(false);
   const isDisconnected = connectionStatus === "disconnected";
   const isInputDisabled = disabled || isStreaming || isDisconnected;
   const canSubmit = !isInputDisabled && value.trim().length > 0;
@@ -41,9 +45,8 @@ export default function ChatInput({
     if (!trimmed || disabled || isDisconnected) {
       return;
     }
-    const sent = onSend(trimmed);
+    const sent = onSend(trimmed, { planMode, thinkingEnabled });
     if (!sent) {
-      // Throwing lets PromptInput keep user text for retry.
       throw new Error("Message send failed");
     }
     setValue("");
@@ -76,6 +79,30 @@ export default function ChatInput({
             <PromptInputButton aria-label={`Model ${MODEL_LABEL}`} variant="ghost">
               <SparklesIcon className="size-4" />
               {MODEL_LABEL}
+            </PromptInputButton>
+            <PromptInputButton
+              aria-label="Toggle thinking"
+              variant="ghost"
+              onClick={() => setThinkingEnabled((v) => !v)}
+              className={cn(
+                "transition-colors",
+                thinkingEnabled && "bg-accent text-accent-foreground",
+              )}
+            >
+              <BrainIcon className="size-4" />
+              Thinking
+            </PromptInputButton>
+            <PromptInputButton
+              aria-label="Toggle plan mode"
+              variant="ghost"
+              onClick={() => setPlanMode((v) => !v)}
+              className={cn(
+                "transition-colors",
+                planMode && "bg-accent text-accent-foreground",
+              )}
+            >
+              <BookOpenIcon className="size-4" />
+              Plan
             </PromptInputButton>
           </PromptInputTools>
           <PromptInputSubmit

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useReducer, useRef, useSyncExternalStore } from "react";
-import type { ChatMessage, ToolCall, WsOutgoing, QuestionAnswer } from "@/types";
+import type { ChatMessage, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer } from "@/types";
 import { wsTransport } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
 
@@ -218,12 +218,12 @@ export function useConversation(workspaceId: string | undefined) {
     };
   }, [workspaceId]);
 
-  const sendMessage = useCallback((content: string): boolean => {
+  const sendMessage = useCallback((content: string, options?: MessageOptions): boolean => {
     if (!workspaceId) {
       dispatch({ type: "error", message: "Message not sent: no workspace selected." });
       return false;
     }
-    const sent = wsTransport.send(workspaceId, { type: "user_message", content });
+    const sent = wsTransport.send(workspaceId, { type: "user_message", content, options });
     if (!sent) {
       dispatch({ type: "error", message: "Message not sent: disconnected from server." });
       return false;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -116,11 +116,19 @@ export type ToolInputResult =
   | { type: "approve" }
   | { type: "reject"; message?: string };
 
+// ── Per-message options ──────────────────────────────────────────────
+
+/** Per-message options that control Claude CLI behavior. */
+export interface MessageOptions {
+  planMode?: boolean;
+  thinkingEnabled?: boolean;
+}
+
 // ── WebSocket protocol ──────────────────────────────────────────────
 
 /** Frontend -> Backend */
 export type WsIncoming =
-  | { type: "user_message"; content: string }
+  | { type: "user_message"; content: string; options?: MessageOptions }
   | { type: "stop" }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult };
 


### PR DESCRIPTION
## Summary
- Add Thinking and Plan toggle pills in the chat input footer
- Thinking toggle controls MAX_THINKING_TOKENS env var passed to Claude CLI spawn
- Plan toggle switches to --plan mode (read-only)
- New MessageOptions type threaded through WS protocol and backend

## Test plan
- [ ] Toggle Thinking ON, send a complex message, check thinking block appears
- [ ] Toggle Thinking OFF, send a message, check no thinking block
- [ ] Toggle Plan ON, send a message, check Claude operates in plan mode
- [ ] Check backend logs show correct flags
- [ ] Check toggles keep their state between messages