### PR TITLE
test: lock terminal persistence behavior with regression specs

### DIFF
--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,5 +1,8 @@
 import { Outlet } from "react-router-dom";
 import Sidebar from "./Sidebar";
+import Terminal from "./Terminal";
+import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
+import { cn } from "@/lib/utils";
 import type { Project } from "@/types";
 
 interface AppLayoutProps {
@@ -9,6 +12,26 @@ interface AppLayoutProps {
   onAddWorkspace: (projectId: string) => Promise<unknown>;
 }
 
+function TerminalLayer() {
+  const { activeTerminals, visibleTerminalWsId } = useTerminalContext();
+
+  return (
+    <>
+      {[...activeTerminals].map((wsId) => (
+        <div
+          key={wsId}
+          className={cn(
+            "absolute inset-x-0 bottom-0 top-12 z-10",
+            wsId === visibleTerminalWsId ? "" : "invisible pointer-events-none",
+          )}
+        >
+          <Terminal workspaceId={wsId} visible={wsId === visibleTerminalWsId} />
+        </div>
+      ))}
+    </>
+  );
+}
+
 export default function AppLayout({
   projects,
   loading,
@@ -16,16 +39,19 @@ export default function AppLayout({
   onAddWorkspace,
 }: AppLayoutProps) {
   return (
-    <div className="flex h-screen">
-      <Sidebar
-        projects={projects}
-        loading={loading}
-        onAddProject={onAddProject}
-        onAddWorkspace={onAddWorkspace}
-      />
-      <main className="flex-1 overflow-hidden">
-        <Outlet />
-      </main>
-    </div>
+    <TerminalProvider>
+      <div className="flex h-screen">
+        <Sidebar
+          projects={projects}
+          loading={loading}
+          onAddProject={onAddProject}
+          onAddWorkspace={onAddWorkspace}
+        />
+        <main className="relative flex-1 overflow-hidden">
+          <Outlet />
+          <TerminalLayer />
+        </main>
+      </div>
+    </TerminalProvider>
   );
 }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -13,7 +13,7 @@ interface AppLayoutProps {
 }
 
 function TerminalLayer() {
-  const { activeTerminals, visibleTerminalWsId } = useTerminalContext();
+  const { activeTerminals, visibleTerminalWsId, closeTerminal } = useTerminalContext();
 
   return (
     <>
@@ -25,7 +25,11 @@ function TerminalLayer() {
             wsId === visibleTerminalWsId ? "" : "invisible pointer-events-none",
           )}
         >
-          <Terminal workspaceId={wsId} visible={wsId === visibleTerminalWsId} />
+          <Terminal
+            workspaceId={wsId}
+            visible={wsId === visibleTerminalWsId}
+            onExit={() => closeTerminal(wsId)}
+          />
         </div>
       ))}
     </>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { FolderPlus, GitBranch, Settings } from "lucide-react";
+import { FolderPlus, GitBranch, Settings, TerminalSquareIcon } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -9,6 +9,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
 import { wsTransport } from "@/lib/ws-transport";
+import { useTerminalContext } from "@/contexts/TerminalContext";
 import { cn } from "@/lib/utils";
 import type { Project } from "@/types";
 
@@ -55,6 +56,7 @@ export default function Sidebar({
     [projects],
   );
   const { wsId: activeWsId } = useParams();
+  const { activeTerminals } = useTerminalContext();
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
   const [liveWorkspaceStatus, setLiveWorkspaceStatus] = useState<
@@ -177,6 +179,7 @@ export default function Sidebar({
                       <div className="mt-1 space-y-0.5">
                         {(project.workspaces ?? []).map((ws) => {
                           const wsStreaming = liveWorkspaceStatus[ws.id]?.streaming ?? false;
+                          const hasTerminal = activeTerminals.has(ws.id);
                           return (
                             <Link
                               key={ws.id}
@@ -189,6 +192,9 @@ export default function Sidebar({
                               <div className="flex items-center gap-1.5">
                                 <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
                                 <span className="min-w-0 flex-1 truncate text-sm">{ws.branch}</span>
+                                {hasTerminal && (
+                                  <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70" />
+                                )}
                               </div>
                               <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
                                 <span className="truncate">{wsStreaming ? "working..." : ws.name}</span>

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -7,14 +7,17 @@ import "@xterm/xterm/css/xterm.css";
 interface TerminalProps {
   workspaceId: string;
   visible?: boolean;
+  onExit?: () => void;
 }
 
 const encoder = new TextEncoder();
 
-export default function Terminal({ workspaceId, visible = true }: TerminalProps) {
+export default function Terminal({ workspaceId, visible = true, onExit }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
   const termRef = useRef<XTerm | null>(null);
+  const onExitRef = useRef(onExit);
+  onExitRef.current = onExit;
   const [overlay, setOverlay] = useState<string | null>(null);
 
   useEffect(() => {
@@ -66,7 +69,8 @@ export default function Terminal({ workspaceId, visible = true }: TerminalProps)
         try {
           const msg = JSON.parse(event.data as string);
           if (msg.type === "exit") {
-            setOverlay(`Session ended (exit code: ${msg.code})`);
+            onExitRef.current?.();
+            return;
           } else if (msg.type === "error") {
             setOverlay(msg.message ?? "Connection error");
           }

--- a/frontend/src/components/Terminal.tsx
+++ b/frontend/src/components/Terminal.tsx
@@ -6,12 +6,15 @@ import "@xterm/xterm/css/xterm.css";
 
 interface TerminalProps {
   workspaceId: string;
+  visible?: boolean;
 }
 
 const encoder = new TextEncoder();
 
-export default function Terminal({ workspaceId }: TerminalProps) {
+export default function Terminal({ workspaceId, visible = true }: TerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const fitAddonRef = useRef<FitAddon | null>(null);
+  const termRef = useRef<XTerm | null>(null);
   const [overlay, setOverlay] = useState<string | null>(null);
 
   useEffect(() => {
@@ -29,6 +32,8 @@ export default function Terminal({ workspaceId }: TerminalProps) {
     });
 
     const fitAddon = new FitAddon();
+    fitAddonRef.current = fitAddon;
+    termRef.current = term;
     term.loadAddon(fitAddon);
     term.loadAddon(new WebLinksAddon());
     term.open(el);
@@ -99,6 +104,8 @@ export default function Terminal({ workspaceId }: TerminalProps) {
 
     return () => {
       disposed = true;
+      fitAddonRef.current = null;
+      termRef.current = null;
       resizeObserver.disconnect();
       inputDisposable.dispose();
       resizeDisposable.dispose();
@@ -106,6 +113,14 @@ export default function Terminal({ workspaceId }: TerminalProps) {
       term.dispose();
     };
   }, [workspaceId]);
+
+  // Re-fit and focus when becoming visible
+  useEffect(() => {
+    if (visible) {
+      fitAddonRef.current?.fit();
+      termRef.current?.focus();
+    }
+  }, [visible]);
 
   return (
     <div className="relative h-full w-full bg-[#1e1e1e]">

--- a/frontend/src/contexts/TerminalContext.tsx
+++ b/frontend/src/contexts/TerminalContext.tsx
@@ -7,6 +7,8 @@ interface TerminalContextType {
   visibleTerminalWsId: string | null;
   /** Activate terminal for workspace and make it visible */
   openTerminal: (wsId: string) => void;
+  /** Remove terminal for workspace and hide if visible */
+  closeTerminal: (wsId: string) => void;
   /** Show or hide the terminal overlay (null = hide all) */
   setVisibleTerminal: (wsId: string | null) => void;
 }
@@ -27,13 +29,23 @@ export function TerminalProvider({ children }: { children: ReactNode }) {
     setVisibleTerminalWsId(wsId);
   }, []);
 
+  const closeTerminal = useCallback((wsId: string) => {
+    setActiveTerminals((prev) => {
+      if (!prev.has(wsId)) return prev;
+      const next = new Set(prev);
+      next.delete(wsId);
+      return next;
+    });
+    setVisibleTerminalWsId((prev) => (prev === wsId ? null : prev));
+  }, []);
+
   const setVisibleTerminal = useCallback((wsId: string | null) => {
     setVisibleTerminalWsId(wsId);
   }, []);
 
   return (
     <TerminalContext.Provider
-      value={{ activeTerminals, visibleTerminalWsId, openTerminal, setVisibleTerminal }}
+      value={{ activeTerminals, visibleTerminalWsId, openTerminal, closeTerminal, setVisibleTerminal }}
     >
       {children}
     </TerminalContext.Provider>

--- a/frontend/src/contexts/TerminalContext.tsx
+++ b/frontend/src/contexts/TerminalContext.tsx
@@ -1,0 +1,47 @@
+import { createContext, useCallback, useContext, useState, type ReactNode } from "react";
+
+interface TerminalContextType {
+  /** Workspace IDs with a live terminal */
+  activeTerminals: Set<string>;
+  /** Which terminal overlay is currently shown (null = none) */
+  visibleTerminalWsId: string | null;
+  /** Activate terminal for workspace and make it visible */
+  openTerminal: (wsId: string) => void;
+  /** Show or hide the terminal overlay (null = hide all) */
+  setVisibleTerminal: (wsId: string | null) => void;
+}
+
+const TerminalContext = createContext<TerminalContextType | null>(null);
+
+export function TerminalProvider({ children }: { children: ReactNode }) {
+  const [activeTerminals, setActiveTerminals] = useState<Set<string>>(new Set());
+  const [visibleTerminalWsId, setVisibleTerminalWsId] = useState<string | null>(null);
+
+  const openTerminal = useCallback((wsId: string) => {
+    setActiveTerminals((prev) => {
+      if (prev.has(wsId)) return prev;
+      const next = new Set(prev);
+      next.add(wsId);
+      return next;
+    });
+    setVisibleTerminalWsId(wsId);
+  }, []);
+
+  const setVisibleTerminal = useCallback((wsId: string | null) => {
+    setVisibleTerminalWsId(wsId);
+  }, []);
+
+  return (
+    <TerminalContext.Provider
+      value={{ activeTerminals, visibleTerminalWsId, openTerminal, setVisibleTerminal }}
+    >
+      {children}
+    </TerminalContext.Provider>
+  );
+}
+
+export function useTerminalContext(): TerminalContextType {
+  const ctx = useContext(TerminalContext);
+  if (!ctx) throw new Error("useTerminalContext must be used within TerminalProvider");
+  return ctx;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -64,7 +64,7 @@ function renderFileTreeNodes(nodes: WorkspaceFileTreeNode[]) {
 export default function WorkspaceView() {
   const { wsId } = useParams();
   const [view, setView] = useState<"chatbot" | "terminal">("chatbot");
-  const { openTerminal, setVisibleTerminal } = useTerminalContext();
+  const { activeTerminals, openTerminal, setVisibleTerminal } = useTerminalContext();
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [fileTree, setFileTree] = useState<WorkspaceFileTreeNode[]>([]);
   const [fileTreeError, setFileTreeError] = useState<string | null>(null);
@@ -155,6 +155,13 @@ export default function WorkspaceView() {
     setView("chatbot");
     return () => setVisibleTerminal(null);
   }, [wsId, setVisibleTerminal]);
+
+  // Switch to chatbot when terminal exits (e.g. user types "exit")
+  useEffect(() => {
+    if (view === "terminal" && wsId && !activeTerminals.has(wsId)) {
+      setView("chatbot");
+    }
+  }, [view, wsId, activeTerminals]);
 
   // Refresh diff stats and session list when streaming stops
   const prevStreamingRef = useRef(isStreaming);

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -150,8 +150,9 @@ export default function WorkspaceView() {
 
   const effectiveWorkspaceStatus = workspaceStatus ?? workspace?.status;
 
-  // Hide terminal overlay when leaving this workspace
+  // Reset to chatbot view and hide terminal overlay when switching workspaces
   useEffect(() => {
+    setView("chatbot");
     return () => setVisibleTerminal(null);
   }, [wsId, setVisibleTerminal]);
 

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -12,8 +12,8 @@ import {
 } from "@/components/ai-elements/file-tree";
 import ChatConversation from "@/components/ChatConversation";
 import ChatInput from "@/components/ChatInput";
-import Terminal from "@/components/Terminal";
 import { SessionSelector } from "@/components/SessionSelector";
+import { useTerminalContext } from "@/contexts/TerminalContext";
 import { GitDiffModal } from "@/components/diff/GitDiffModal";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
 import { Badge } from "@/components/ui/badge";
@@ -64,6 +64,7 @@ function renderFileTreeNodes(nodes: WorkspaceFileTreeNode[]) {
 export default function WorkspaceView() {
   const { wsId } = useParams();
   const [view, setView] = useState<"chatbot" | "terminal">("chatbot");
+  const { openTerminal, setVisibleTerminal } = useTerminalContext();
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [fileTree, setFileTree] = useState<WorkspaceFileTreeNode[]>([]);
   const [fileTreeError, setFileTreeError] = useState<string | null>(null);
@@ -149,6 +150,11 @@ export default function WorkspaceView() {
 
   const effectiveWorkspaceStatus = workspaceStatus ?? workspace?.status;
 
+  // Hide terminal overlay when leaving this workspace
+  useEffect(() => {
+    return () => setVisibleTerminal(null);
+  }, [wsId, setVisibleTerminal]);
+
   // Refresh diff stats and session list when streaming stops
   const prevStreamingRef = useRef(isStreaming);
   useEffect(() => {
@@ -215,7 +221,7 @@ export default function WorkspaceView() {
       {/* Chat area + right panel */}
       <div className="flex min-h-0 flex-1 overflow-hidden">
         <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-          <div className="flex h-12 items-center gap-2 border-b border-border/50 px-4 backdrop-blur-sm">
+          <div className="relative z-20 flex h-12 items-center gap-2 border-b border-border/50 px-4 backdrop-blur-sm">
             <span className="truncate text-sm font-semibold text-foreground">{workspace?.name}</span>
             <span className="truncate text-xs text-muted-foreground">{workspace?.branch}</span>
             <Badge variant={hasActiveSession ? "default" : "secondary"} className="text-[10px]">
@@ -243,7 +249,10 @@ export default function WorkspaceView() {
                 className={view === "chatbot"
                   ? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary dark:border-primary/40 dark:bg-primary/10"
                   : "hover:bg-transparent hover:text-current"}
-                onClick={() => setView("chatbot")}
+                onClick={() => {
+                  setView("chatbot");
+                  setVisibleTerminal(null);
+                }}
               >
                 <MessageSquareIcon className="mr-1.5 size-3.5" />
                 Chatbot
@@ -254,7 +263,10 @@ export default function WorkspaceView() {
                 className={view === "terminal"
                   ? "border-primary/40 bg-primary/10 text-primary hover:bg-primary/10 hover:text-primary dark:border-primary/40 dark:bg-primary/10"
                   : "hover:bg-transparent hover:text-current"}
-                onClick={() => setView("terminal")}
+                onClick={() => {
+                  setView("terminal");
+                  if (wsId) openTerminal(wsId);
+                }}
               >
                 <TerminalSquareIcon className="mr-1.5 size-3.5" />
                 Terminal
@@ -287,10 +299,8 @@ export default function WorkspaceView() {
               connectionStatus={connectionStatus}
             />
           </div>
-          {view === "terminal" && wsId && (
-            <div className="min-h-0 flex-1 overflow-hidden">
-              <Terminal workspaceId={wsId} />
-            </div>
+          {view === "terminal" && (
+            <div className="min-h-0 flex-1" />
           )}
         </div>
 

--- a/frontend/tests/components/AppLayout.test.tsx
+++ b/frontend/tests/components/AppLayout.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalContext } from "@/contexts/TerminalContext";
+import AppLayout from "@/components/AppLayout";
+
+const mocks = vi.hoisted(() => ({
+  terminalRender: vi.fn(),
+}));
+
+vi.mock("@/components/Sidebar", () => ({
+  default: () => <div data-testid="sidebar">Sidebar</div>,
+}));
+
+vi.mock("@/components/Terminal", () => ({
+  default: ({
+    workspaceId,
+    visible = true,
+    onExit,
+  }: {
+    workspaceId: string;
+    visible?: boolean;
+    onExit?: () => void;
+  }) => {
+    mocks.terminalRender({ workspaceId, visible });
+    return (
+      <button
+        type="button"
+        data-testid={`terminal-${workspaceId}`}
+        data-visible={visible ? "true" : "false"}
+        onClick={onExit}
+      >
+        terminal {workspaceId}
+      </button>
+    );
+  },
+}));
+
+function TerminalControls() {
+  const { activeTerminals, visibleTerminalWsId, openTerminal, setVisibleTerminal } = useTerminalContext();
+  return (
+    <div>
+      <button type="button" onClick={() => openTerminal("ws-1")}>open ws-1</button>
+      <button type="button" onClick={() => openTerminal("ws-2")}>open ws-2</button>
+      <button type="button" onClick={() => setVisibleTerminal("ws-1")}>show ws-1</button>
+      <div data-testid="active-terminals">{[...activeTerminals].sort().join(",")}</div>
+      <div data-testid="visible-terminal">{visibleTerminalWsId ?? "none"}</div>
+    </div>
+  );
+}
+
+function renderLayout() {
+  return render(
+    <MemoryRouter initialEntries={["/workspaces/ws-1"]}>
+      <Routes>
+        <Route
+          element={
+            <AppLayout
+              projects={[]}
+              loading={false}
+              onAddProject={vi.fn()}
+              onAddWorkspace={vi.fn().mockResolvedValue(undefined)}
+            />
+          }
+        >
+          <Route path="/workspaces/:wsId" element={<TerminalControls />} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    mocks.terminalRender.mockClear();
+  });
+
+  it("renders one terminal layer per active workspace and tracks visibility", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "open ws-2" }));
+
+    expect(screen.getByTestId("active-terminals")).toHaveTextContent("ws-1,ws-2");
+    expect(screen.getByTestId("visible-terminal")).toHaveTextContent("ws-2");
+    expect(screen.getByTestId("terminal-ws-1")).toHaveAttribute("data-visible", "false");
+    expect(screen.getByTestId("terminal-ws-2")).toHaveAttribute("data-visible", "true");
+
+    await user.click(screen.getByRole("button", { name: "show ws-1" }));
+    expect(screen.getByTestId("terminal-ws-1")).toHaveAttribute("data-visible", "true");
+    expect(screen.getByTestId("terminal-ws-2")).toHaveAttribute("data-visible", "false");
+  });
+
+  it("removes a terminal when it exits via onExit callback", async () => {
+    const user = userEvent.setup();
+    renderLayout();
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    expect(screen.getByTestId("terminal-ws-1")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("terminal-ws-1"));
+
+    expect(screen.queryByTestId("terminal-ws-1")).not.toBeInTheDocument();
+    expect(screen.getByTestId("active-terminals")).toBeEmptyDOMElement();
+    expect(screen.getByTestId("visible-terminal")).toHaveTextContent("none");
+  });
+});

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -1,8 +1,10 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
+import { useEffect } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Sidebar from "@/components/Sidebar";
+import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
 import type { Project, WsOutgoing } from "@/types";
 
 vi.mock("@/lib/ws-transport", () => {
@@ -47,34 +49,50 @@ const getWsMock = async () =>
     };
   };
 
-function renderSidebar(path: string, projects: Project[], onAddWorkspace = vi.fn()) {
+function ActivateTerminals({ workspaceIds }: { workspaceIds: string[] }) {
+  const { openTerminal } = useTerminalContext();
+  useEffect(() => {
+    for (const workspaceId of workspaceIds) openTerminal(workspaceId);
+  }, [workspaceIds, openTerminal]);
+  return null;
+}
+
+function renderSidebar(
+  path: string,
+  projects: Project[],
+  onAddWorkspace = vi.fn(),
+  activeTerminalWorkspaceIds: string[] = [],
+) {
   return render(
-    <MemoryRouter initialEntries={[path]}>
-      <Routes>
-        <Route
-          path="/projects"
-          element={
-            <Sidebar
-              projects={projects}
-              loading={false}
-              onAddProject={vi.fn()}
-              onAddWorkspace={onAddWorkspace}
-            />
-          }
-        />
-        <Route
-          path="/workspaces/:wsId"
-          element={
-            <Sidebar
-              projects={projects}
-              loading={false}
-              onAddProject={vi.fn()}
-              onAddWorkspace={onAddWorkspace}
-            />
-          }
-        />
-      </Routes>
-    </MemoryRouter>,
+    <TerminalProvider>
+      <ActivateTerminals workspaceIds={activeTerminalWorkspaceIds} />
+      <MemoryRouter initialEntries={[path]}>
+        <Routes>
+          <Route
+            path="/projects"
+            element={
+              <Sidebar
+                projects={projects}
+                loading={false}
+                onAddProject={vi.fn()}
+                onAddWorkspace={onAddWorkspace}
+              />
+            }
+          />
+          <Route
+            path="/workspaces/:wsId"
+            element={
+              <Sidebar
+                projects={projects}
+                loading={false}
+                onAddProject={vi.fn()}
+                onAddWorkspace={onAddWorkspace}
+              />
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </TerminalProvider>,
   );
 }
 
@@ -159,5 +177,17 @@ describe("Sidebar", () => {
 
     expect(screen.queryByText("working...")).not.toBeInTheDocument();
     expect(screen.getByText("tokyo")).toBeInTheDocument();
+  });
+
+  it("shows terminal badge icon for workspaces with an active terminal", () => {
+    renderSidebar("/workspaces/w1", projects, vi.fn(), ["w1"]);
+    const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
+    expect(workspaceLink.querySelectorAll("svg")).toHaveLength(2);
+  });
+
+  it("does not show terminal badge icon when workspace has no active terminal", () => {
+    renderSidebar("/workspaces/w1", projects);
+    const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
+    expect(workspaceLink.querySelectorAll("svg")).toHaveLength(1);
   });
 });

--- a/frontend/tests/components/Terminal.test.tsx
+++ b/frontend/tests/components/Terminal.test.tsx
@@ -1,0 +1,213 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import Terminal from "@/components/Terminal";
+
+const state = vi.hoisted(() => ({
+  terminals: [] as Array<{
+    cols: number;
+    rows: number;
+    loadAddon: ReturnType<typeof vi.fn>;
+    open: ReturnType<typeof vi.fn>;
+    focus: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+    dispose: ReturnType<typeof vi.fn>;
+    onData: ReturnType<typeof vi.fn>;
+    onResize: ReturnType<typeof vi.fn>;
+    emitData: (data: string) => void;
+    emitResize: (cols: number, rows: number) => void;
+  }>,
+  fitAddons: [] as Array<{ fit: ReturnType<typeof vi.fn> }>,
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class TerminalMock {
+    cols = 120;
+    rows = 40;
+    private dataHandler: ((data: string) => void) | null = null;
+    private resizeHandler: ((size: { cols: number; rows: number }) => void) | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    write = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn((handler: (data: string) => void) => {
+      this.dataHandler = handler;
+      return { dispose: vi.fn() };
+    });
+    onResize = vi.fn((handler: (size: { cols: number; rows: number }) => void) => {
+      this.resizeHandler = handler;
+      return { dispose: vi.fn() };
+    });
+
+    constructor() {
+      state.terminals.push(this);
+    }
+
+    emitData(data: string) {
+      this.dataHandler?.(data);
+    }
+
+    emitResize(cols: number, rows: number) {
+      this.resizeHandler?.({ cols, rows });
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class FitAddonMock {
+    fit = vi.fn();
+    constructor() {
+      state.fitAddons.push(this);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-web-links", () => ({
+  WebLinksAddon: class WebLinksAddonMock {},
+}));
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  binaryType = "";
+  readyState = MockWebSocket.OPEN;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  fireOpen() {
+    this.onopen?.(new Event("open"));
+  }
+
+  fireMessage(data: string | ArrayBuffer) {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+
+  fireError() {
+    this.onerror?.(new Event("error"));
+  }
+
+  fireClose() {
+    this.onclose?.({} as CloseEvent);
+  }
+}
+
+function getFirstWebSocket() {
+  const ws = MockWebSocket.instances[0];
+  if (!ws) throw new Error("expected websocket to be created");
+  return ws;
+}
+
+function getFirstTerminal() {
+  const term = state.terminals[0];
+  if (!term) throw new Error("expected terminal instance to be created");
+  return term;
+}
+
+describe("Terminal", () => {
+  beforeEach(() => {
+    state.terminals.length = 0;
+    state.fitAddons.length = 0;
+    MockWebSocket.instances.length = 0;
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("sends initial terminal size when websocket opens", () => {
+    render(<Terminal workspaceId="ws-1" />);
+    const ws = getFirstWebSocket();
+    act(() => {
+      ws.fireOpen();
+    });
+
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "resize", cols: 120, rows: 40 }));
+  });
+
+  it("forwards terminal input as binary websocket payload", () => {
+    render(<Terminal workspaceId="ws-1" />);
+    const ws = getFirstWebSocket();
+    const term = getFirstTerminal();
+
+    act(() => {
+      term.emitData("ls\n");
+    });
+
+    expect(ws.send).toHaveBeenCalledTimes(1);
+    const payload = ws.send.mock.calls[0]?.[0];
+    expect(ArrayBuffer.isView(payload)).toBe(true);
+    expect(new TextDecoder().decode(Uint8Array.from(payload as ArrayLike<number>))).toBe("ls\n");
+  });
+
+  it("calls onExit callback when backend sends exit event", () => {
+    const onExit = vi.fn();
+    render(<Terminal workspaceId="ws-1" onExit={onExit} />);
+    const ws = getFirstWebSocket();
+
+    act(() => {
+      ws.fireMessage(JSON.stringify({ type: "exit", code: 0 }));
+    });
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/Session ended/i)).not.toBeInTheDocument();
+  });
+
+  it("shows backend error message overlay", async () => {
+    render(<Terminal workspaceId="ws-1" />);
+    const ws = getFirstWebSocket();
+
+    act(() => {
+      ws.fireMessage(JSON.stringify({ type: "error", message: "PTY failed" }));
+    });
+
+    expect(await screen.findByText("PTY failed")).toBeInTheDocument();
+  });
+
+  it("shows fallback connection overlay on websocket error", async () => {
+    render(<Terminal workspaceId="ws-1" />);
+    const ws = getFirstWebSocket();
+
+    act(() => {
+      ws.fireError();
+    });
+
+    expect(await screen.findByText("Connection failed")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reconnect" })).toBeInTheDocument();
+  });
+
+  it("re-fits and refocuses when visible turns true", async () => {
+    const { rerender } = render(<Terminal workspaceId="ws-1" visible={false} />);
+    const term = getFirstTerminal();
+    const fitAddon = state.fitAddons[0];
+
+    expect(fitAddon?.fit).toHaveBeenCalledTimes(1);
+    expect(term.focus).toHaveBeenCalledTimes(1);
+
+    rerender(<Terminal workspaceId="ws-1" visible />);
+
+    await waitFor(() => {
+      expect(fitAddon?.fit).toHaveBeenCalledTimes(2);
+      expect(term.focus).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it("cleans up websocket and terminal instance on unmount", () => {
+    const { unmount } = render(<Terminal workspaceId="ws-1" />);
+    const ws = getFirstWebSocket();
+    const term = getFirstTerminal();
+
+    unmount();
+
+    expect(ws.close).toHaveBeenCalledTimes(1);
+    expect(term.dispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/contexts/TerminalContext.test.tsx
+++ b/frontend/tests/contexts/TerminalContext.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it } from "vitest";
+import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
+
+function ContextProbe() {
+  const { activeTerminals, visibleTerminalWsId, openTerminal, closeTerminal, setVisibleTerminal } = useTerminalContext();
+
+  return (
+    <div>
+      <div data-testid="active">{[...activeTerminals].sort().join(",")}</div>
+      <div data-testid="visible">{visibleTerminalWsId ?? "none"}</div>
+      <button type="button" onClick={() => openTerminal("ws-1")}>open ws-1</button>
+      <button type="button" onClick={() => openTerminal("ws-2")}>open ws-2</button>
+      <button type="button" onClick={() => closeTerminal("ws-1")}>close ws-1</button>
+      <button type="button" onClick={() => closeTerminal("ws-2")}>close ws-2</button>
+      <button type="button" onClick={() => setVisibleTerminal("ws-1")}>show ws-1</button>
+      <button type="button" onClick={() => setVisibleTerminal(null)}>hide terminal</button>
+    </div>
+  );
+}
+
+describe("TerminalContext", () => {
+  it("throws when hook is used outside provider", () => {
+    expect(() => render(<ContextProbe />)).toThrow("useTerminalContext must be used within TerminalProvider");
+  });
+
+  it("opens a terminal and marks it visible", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+
+    expect(screen.getByTestId("active")).toHaveTextContent("ws-1");
+    expect(screen.getByTestId("visible")).toHaveTextContent("ws-1");
+  });
+
+  it("keeps one active entry when opening the same workspace repeatedly", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+
+    expect(screen.getByTestId("active")).toHaveTextContent("ws-1");
+  });
+
+  it("updates visible terminal when opening another workspace", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "open ws-2" }));
+
+    expect(screen.getByTestId("active")).toHaveTextContent("ws-1,ws-2");
+    expect(screen.getByTestId("visible")).toHaveTextContent("ws-2");
+  });
+
+  it("hides terminal when closing the currently visible workspace", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "close ws-1" }));
+
+    expect(screen.getByTestId("active")).toBeEmptyDOMElement();
+    expect(screen.getByTestId("visible")).toHaveTextContent("none");
+  });
+
+  it("does not hide visible terminal when closing a different workspace", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "open ws-2" }));
+    await user.click(screen.getByRole("button", { name: "close ws-1" }));
+
+    expect(screen.getByTestId("active")).toHaveTextContent("ws-2");
+    expect(screen.getByTestId("visible")).toHaveTextContent("ws-2");
+  });
+
+  it("can hide overlay without closing active terminals", async () => {
+    const user = userEvent.setup();
+    render(
+      <TerminalProvider>
+        <ContextProbe />
+      </TerminalProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "open ws-1" }));
+    await user.click(screen.getByRole("button", { name: "hide terminal" }));
+
+    expect(screen.getByTestId("active")).toHaveTextContent("ws-1");
+    expect(screen.getByTestId("visible")).toHaveTextContent("none");
+  });
+});

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -1,0 +1,249 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
+import WorkspaceView from "@/pages/WorkspaceView";
+import type { Workspace, WorkspaceFileTreeNode } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  useConversation: vi.fn(),
+  useSessions: vi.fn(),
+  useDiffStat: vi.fn(),
+  sendMessage: vi.fn(),
+  stopStreaming: vi.fn(),
+  clearChat: vi.fn(),
+  switchSession: vi.fn(),
+  answerQuestion: vi.fn(),
+  approvePlan: vi.fn(),
+  rejectToolInput: vi.fn(),
+  createSession: vi.fn(),
+  activateSession: vi.fn(),
+  deleteSession: vi.fn(),
+  refreshSessions: vi.fn(),
+  refreshDiffStat: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: { get: mocks.apiGet },
+}));
+
+vi.mock("@/hooks/useConversation", () => ({
+  useConversation: mocks.useConversation,
+}));
+
+vi.mock("@/hooks/useSessions", () => ({
+  useSessions: mocks.useSessions,
+}));
+
+vi.mock("@/hooks/useDiffStat", () => ({
+  useDiffStat: mocks.useDiffStat,
+}));
+
+vi.mock("@/components/ChatConversation", () => ({
+  default: () => <div data-testid="chat-conversation">chat-conversation</div>,
+}));
+
+vi.mock("@/components/ChatInput", () => ({
+  default: () => <div data-testid="chat-input">chat-input</div>,
+}));
+
+vi.mock("@/components/SessionSelector", () => ({
+  SessionSelector: () => <div data-testid="session-selector">session-selector</div>,
+}));
+
+vi.mock("@/components/diff/GitDiffModal", () => ({
+  GitDiffModal: () => <div data-testid="git-diff-modal">git-diff-modal</div>,
+}));
+
+vi.mock("@/components/diff/ModifiedFileList", () => ({
+  ModifiedFileList: () => <div data-testid="modified-file-list">modified-file-list</div>,
+}));
+
+vi.mock("@/components/ai-elements/file-tree", () => ({
+  FileTree: ({ children }: { children?: ReactNode }) => <div data-testid="file-tree">{children}</div>,
+  FileTreeFile: ({ name }: { name: string }) => <div data-testid={`file-${name}`}>{name}</div>,
+  FileTreeFolder: ({ name, children }: { name: string; children?: ReactNode }) => (
+    <div data-testid={`folder-${name}`}>
+      <span>{name}</span>
+      {children}
+    </div>
+  ),
+}));
+
+const WORKSPACES: Record<string, Workspace> = {
+  "ws-1": {
+    id: "ws-1",
+    name: "tokyo",
+    branch: "workspace/tokyo",
+    status: "idle",
+    createdAt: "2026-02-12T00:00:00.000Z",
+  },
+  "ws-2": {
+    id: "ws-2",
+    name: "kyoto",
+    branch: "workspace/kyoto",
+    status: "idle",
+    createdAt: "2026-02-12T00:00:00.000Z",
+  },
+};
+
+const FILE_TREE: WorkspaceFileTreeNode[] = [
+  {
+    type: "directory",
+    name: "src",
+    path: "src",
+    children: [{ type: "file", name: "index.ts", path: "src/index.ts" }],
+  },
+];
+
+function TestControls() {
+  const { activeTerminals, visibleTerminalWsId, closeTerminal } = useTerminalContext();
+  const navigate = useNavigate();
+  return (
+    <div>
+      <button type="button" onClick={() => closeTerminal("ws-1")}>close ws-1</button>
+      <button type="button" onClick={() => navigate("/workspaces/ws-2")}>go ws-2</button>
+      <div data-testid="ctx-active">{[...activeTerminals].sort().join(",")}</div>
+      <div data-testid="ctx-visible">{visibleTerminalWsId ?? "none"}</div>
+    </div>
+  );
+}
+
+function renderWorkspace(initialEntry = "/workspaces/ws-1") {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <TerminalProvider>
+        <TestControls />
+        <Routes>
+          <Route path="/workspaces/:wsId" element={<WorkspaceView />} />
+        </Routes>
+      </TerminalProvider>
+    </MemoryRouter>,
+  );
+}
+
+describe("WorkspaceView terminal behavior", () => {
+  beforeEach(() => {
+    mocks.apiGet.mockReset();
+    mocks.useConversation.mockReset();
+    mocks.useSessions.mockReset();
+    mocks.useDiffStat.mockReset();
+    mocks.sendMessage.mockReset();
+    mocks.stopStreaming.mockReset();
+    mocks.clearChat.mockReset();
+    mocks.switchSession.mockReset();
+    mocks.answerQuestion.mockReset();
+    mocks.approvePlan.mockReset();
+    mocks.rejectToolInput.mockReset();
+    mocks.createSession.mockReset();
+    mocks.activateSession.mockReset();
+    mocks.deleteSession.mockReset();
+    mocks.refreshSessions.mockReset();
+    mocks.refreshDiffStat.mockReset();
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      if (workspaceMatch) return WORKSPACES[workspaceMatch[1]] ?? null;
+      if (filesMatch) return FILE_TREE;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: undefined,
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+    });
+
+    mocks.useSessions.mockReturnValue({
+      sessions: [],
+      createSession: mocks.createSession,
+      activateSession: mocks.activateSession,
+      deleteSession: mocks.deleteSession,
+      refresh: mocks.refreshSessions,
+    });
+
+    mocks.useDiffStat.mockReturnValue({
+      committed: [],
+      uncommitted: [],
+      totalCount: 0,
+      loading: false,
+      error: null,
+      refresh: mocks.refreshDiffStat,
+    });
+  });
+
+  it("opens terminal for the active workspace when Terminal toggle is clicked", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+
+    expect(screen.getByTestId("ctx-active")).toHaveTextContent("ws-1");
+    expect(screen.getByTestId("ctx-visible")).toHaveTextContent("ws-1");
+  });
+
+  it("hides terminal overlay when Chatbot toggle is clicked", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByTestId("ctx-visible")).toHaveTextContent("ws-1");
+
+    await user.click(screen.getByRole("button", { name: "Chatbot" }));
+
+    expect(screen.getByTestId("ctx-visible")).toHaveTextContent("none");
+    expect(screen.getByTestId("ctx-active")).toHaveTextContent("ws-1");
+  });
+
+  it("switches back to chatbot view when terminal session exits", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    const chatbotButton = screen.getByRole("button", { name: "Chatbot" });
+    const terminalButton = screen.getByRole("button", { name: "Terminal" });
+
+    await user.click(terminalButton);
+    expect(terminalButton.className).toContain("bg-primary/10");
+
+    await user.click(screen.getByRole("button", { name: "close ws-1" }));
+
+    await waitFor(() => {
+      expect(chatbotButton.className).toContain("bg-primary/10");
+    });
+  });
+
+  it("clears visible terminal when navigating to another workspace", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "Terminal" }));
+    expect(screen.getByTestId("ctx-visible")).toHaveTextContent("ws-1");
+
+    await user.click(screen.getByRole("button", { name: "go ws-2" }));
+
+    await screen.findByText("kyoto");
+    expect(screen.getByTestId("ctx-visible")).toHaveTextContent("none");
+  });
+});


### PR DESCRIPTION
## Summary
- add regression tests for terminal persistence context state transitions
- add integration tests for terminal layer behavior in `AppLayout` and terminal lifecycle in `WorkspaceView`
- add component-level terminal websocket/xterm tests and update sidebar tests for active terminal indicators

## Validation
- npm test
- npm run -w frontend lint
- npm run -w frontend typecheck
