### PR TITLE
feat: real-time branch name sync via backend polling

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,8 +9,10 @@ import { streamRoutes } from "./ws/stream.js";
 import { terminalRoutes } from "./ws/terminal.js";
 import { createAuthHook } from "./utils/auth.js";
 import { createRateLimitHook } from "./utils/rate-limit.js";
-import { ensureDataDir } from "./state/state.js";
+import { ensureDataDir, getDataDir } from "./state/state.js";
 import type { SessionOptions } from "./agents/agent-manager.js";
+import { BranchSyncService } from "./services/branch-sync.js";
+import { broadcastToWorkspace } from "./ws/stream.js";
 
 const HOST = process.env.HOST ?? "127.0.0.1";
 const PORT = Number(process.env.PORT ?? 3000);
@@ -76,9 +78,22 @@ export async function buildApp() {
   return app;
 }
 
+const BRANCH_SYNC_INTERVAL_MS = 10_000;
+
 async function main() {
-  await ensureDataDir();
+  const dataDir = getDataDir();
+  await ensureDataDir(dataDir);
+
+  const branchSync = new BranchSyncService(dataDir);
+  branchSync.onBranchChange((wsId, info) => {
+    broadcastToWorkspace(wsId, { type: "branch_info", info });
+  });
+
   const app = await buildApp();
+
+  app.addHook("onClose", () => branchSync.stop());
+  branchSync.start(BRANCH_SYNC_INTERVAL_MS);
+
   await app.listen({ host: HOST, port: PORT });
 }
 

--- a/backend/src/services/branch-sync.test.ts
+++ b/backend/src/services/branch-sync.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
+import { createProject } from "../projects/project-manager.js";
+import { createWorkspace } from "../workspaces/workspace-manager.js";
+import { git } from "../utils/git.js";
+import { loadProject } from "../state/state.js";
+import { workspacesDir } from "../utils/paths.js";
+import { getBranchName, BranchSyncService } from "./branch-sync.js";
+import type { BranchInfo } from "../types.js";
+
+let tempDir: string;
+let dataDir: string;
+let fixtureRepoUrl: string;
+let projectId: string;
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-branch-sync-test-");
+  dataDir = join(tempDir, "data");
+  const fixtureDir = join(tempDir, "fixtures");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(fixtureDir, { recursive: true });
+  fixtureRepoUrl = await createFixtureRepo(fixtureDir);
+
+  const project = await createProject(fixtureRepoUrl, dataDir);
+  projectId = project.id;
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("getBranchName", () => {
+  it("returns correct branch from a real worktree", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(workspacesDir(dataDir, projectId), ws.name);
+
+    const branchName = await getBranchName(wsPath);
+    expect(branchName).toBe(`workspace/${ws.name}`);
+  });
+
+  it("throws on missing worktree", async () => {
+    const nonExistentPath = join(tempDir, "nonexistent-worktree");
+    await expect(getBranchName(nonExistentPath)).rejects.toThrow();
+  });
+});
+
+describe("BranchSyncService", () => {
+  let service: BranchSyncService;
+
+  beforeEach(() => {
+    service = new BranchSyncService(dataDir);
+  });
+
+  afterEach(() => {
+    service._clearForTests();
+  });
+
+  it("detects branch rename and updates state", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(workspacesDir(dataDir, projectId), ws.name);
+
+    const newBranchName = "renamed-branch";
+    await git(["branch", "-m", newBranchName], wsPath);
+
+    await service.poll();
+
+    const state = await loadProject(projectId, dataDir);
+    const workspace = state!.workspaces.find((w) => w.id === ws.id);
+    expect(workspace!.branch).toBe(newBranchName);
+  });
+
+  it("emits onBranchChange callback with correct BranchInfo", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(workspacesDir(dataDir, projectId), ws.name);
+
+    let callbackWsId: string | undefined;
+    let callbackInfo: BranchInfo | undefined;
+
+    service.onBranchChange((wsId, info) => {
+      callbackWsId = wsId;
+      callbackInfo = info;
+    });
+
+    const newBranchName = "feature-branch";
+    await git(["branch", "-m", newBranchName], wsPath);
+
+    await service.poll();
+
+    expect(callbackWsId).toBe(ws.id);
+    expect(callbackInfo).toBeDefined();
+    expect(callbackInfo!.name).toBe(newBranchName);
+    expect(callbackInfo!.lastSyncedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it("does NOT emit callback when branch has not changed", async () => {
+    await createWorkspace(projectId, dataDir);
+
+    let callCount = 0;
+    service.onBranchChange(() => {
+      callCount++;
+    });
+
+    await service.poll();
+    await service.poll();
+
+    expect(callCount).toBe(0);
+  });
+
+  it("handles deleted worktree without crashing", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(workspacesDir(dataDir, projectId), ws.name);
+
+    await rm(wsPath, { recursive: true, force: true });
+
+    await expect(service.poll()).resolves.not.toThrow();
+  });
+
+  it("start and stop lifecycle manages interval correctly", () => {
+    const setIntervalSpy = vi.spyOn(global, "setInterval");
+    const clearIntervalSpy = vi.spyOn(global, "clearInterval");
+
+    service.start(5000);
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    // start again should be a no-op
+    service.start(5000);
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+
+    service.stop();
+
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    // stop again should be a no-op
+    service.stop();
+    expect(clearIntervalSpy).toHaveBeenCalledTimes(1);
+
+    setIntervalSpy.mockRestore();
+    clearIntervalSpy.mockRestore();
+  });
+
+  it("handles multiple workspaces and only triggers callback for changed ones", async () => {
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws2 = await createWorkspace(projectId, dataDir);
+    const ws1Path = join(workspacesDir(dataDir, projectId), ws1.name);
+
+    const changedWorkspaces: string[] = [];
+    service.onBranchChange((wsId) => {
+      changedWorkspaces.push(wsId);
+    });
+
+    await git(["branch", "-m", "only-ws1-changed"], ws1Path);
+
+    await service.poll();
+
+    expect(changedWorkspaces).toHaveLength(1);
+    expect(changedWorkspaces[0]).toBe(ws1.id);
+
+    const state = await loadProject(projectId, dataDir);
+    const workspace1 = state!.workspaces.find((w) => w.id === ws1.id);
+    const workspace2 = state!.workspaces.find((w) => w.id === ws2.id);
+
+    expect(workspace1!.branch).toBe("only-ws1-changed");
+    expect(workspace2!.branch).toBe(`workspace/${ws2.name}`);
+  });
+});

--- a/backend/src/services/branch-sync.ts
+++ b/backend/src/services/branch-sync.ts
@@ -1,0 +1,101 @@
+import { join } from "node:path";
+import { git } from "../utils/git.js";
+import {
+  loadAllProjects,
+  loadProject,
+  saveProject,
+  withProjectStateLock,
+} from "../state/state.js";
+import { workspacesDir } from "../utils/paths.js";
+import type { BranchInfo, Workspace } from "../types.js";
+
+type BranchChangeCallback = (wsId: string, info: BranchInfo) => void;
+
+export async function getBranchName(wsPath: string): Promise<string> {
+  const { stdout } = await git(["rev-parse", "--abbrev-ref", "HEAD"], wsPath);
+  return stdout;
+}
+
+export class BranchSyncService {
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private callbacks: BranchChangeCallback[] = [];
+  private syncing = false;
+
+  constructor(private readonly dataDir: string) {}
+
+  onBranchChange(callback: BranchChangeCallback): void {
+    this.callbacks.push(callback);
+  }
+
+  start(intervalMs: number): void {
+    if (this.interval) return;
+    this.interval = setInterval(() => {
+      void this.poll();
+    }, intervalMs);
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+  }
+
+  /** Run a single sync pass across all workspaces. Exposed for testing. */
+  async poll(): Promise<void> {
+    if (this.syncing) return;
+    this.syncing = true;
+    try {
+      const projects = await loadAllProjects(this.dataDir);
+      for (const project of projects) {
+        for (const workspace of project.workspaces) {
+          await this.syncWorkspace(project.id, workspace);
+        }
+      }
+    } finally {
+      this.syncing = false;
+    }
+  }
+
+  private async syncWorkspace(projectId: string, workspace: Workspace): Promise<void> {
+    const wsPath = join(workspacesDir(this.dataDir, projectId), workspace.name);
+
+    let currentBranch: string;
+    try {
+      currentBranch = await getBranchName(wsPath);
+    } catch {
+      // Worktree may have been deleted or is inaccessible — skip
+      return;
+    }
+
+    if (currentBranch === workspace.branch) return;
+
+    const info: BranchInfo = {
+      name: currentBranch,
+      lastSyncedAt: new Date().toISOString(),
+    };
+
+    await withProjectStateLock(
+      projectId,
+      async () => {
+        const state = await loadProject(projectId, this.dataDir);
+        if (!state) return;
+        const ws = state.workspaces.find((w) => w.id === workspace.id);
+        if (!ws) return;
+        ws.branch = currentBranch;
+        await saveProject(state, this.dataDir);
+      },
+      this.dataDir,
+    );
+
+    for (const cb of this.callbacks) {
+      cb(workspace.id, info);
+    }
+  }
+
+  _clearForTests(): void {
+    this.stop();
+    this.callbacks = [];
+    this.syncing = false;
+  }
+}

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -17,6 +17,23 @@ export interface Workspace {
   activeSessionId?: string;
 }
 
+// ── Branch / GitHub sync types ──────────────────────────────────────
+
+export interface PullRequestInfo {
+  number: number;
+  url: string;
+  state: "open" | "draft" | "merged" | "closed";
+  mergeable: boolean | null;
+  mergeableState: "clean" | "conflict" | "unstable" | "unknown";
+  checksStatus: "pending" | "success" | "failure";
+}
+
+export interface BranchInfo {
+  name: string;
+  lastSyncedAt: string;
+  pr?: PullRequestInfo;
+}
+
 export interface WorkspaceFileTreeNode {
   name: string;
   path: string;
@@ -175,4 +192,5 @@ export type WsOutgoing =
   | { type: "cancelled" }
   | { type: "status"; status: WorkspaceStatus; sessionId?: string; streaming?: boolean }
   | { type: "user_message"; message: ChatMessage }
-  | { type: "history"; messages: ChatMessage[] };
+  | { type: "history"; messages: ChatMessage[] }
+  | { type: "branch_info"; info: BranchInfo };

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -15,7 +15,7 @@ import {
   _clearActiveSessions,
 } from "../agents/agent-manager.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
-import { streamRoutes } from "./stream.js";
+import { streamRoutes, broadcastToWorkspace, _getChannelsForTests } from "./stream.js";
 import type { WsOutgoing } from "../types.js";
 
 const CONV_CMD = { command: "bash" };
@@ -447,5 +447,45 @@ describe("WS /ws/session/:wsId", () => {
 
     ws.close();
     await secure.app.close();
+  });
+
+  it("broadcastToWorkspace sends a message to all connected sockets", async () => {
+    const first = connectSessionWs(wsId);
+    const second = connectSessionWs(wsId);
+    const ws1 = await first.wsReady;
+    const ws2 = await second.wsReady;
+
+    await waitForMessage(first.messages, (msgs) => msgs.length >= 1);
+    await waitForMessage(second.messages, (msgs) => msgs.length >= 1);
+
+    const branchInfo: WsOutgoing = {
+      type: "branch_info",
+      info: { name: "feat/new-branch", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+    };
+
+    broadcastToWorkspace(wsId, branchInfo);
+
+    await waitForMessage(first.messages, (msgs) =>
+      msgs.some((m) => m.type === "branch_info"),
+    );
+    await waitForMessage(second.messages, (msgs) =>
+      msgs.some((m) => m.type === "branch_info"),
+    );
+
+    const msg1 = first.messages.find((m) => m.type === "branch_info");
+    const msg2 = second.messages.find((m) => m.type === "branch_info");
+    expect(msg1).toEqual(branchInfo);
+    expect(msg2).toEqual(branchInfo);
+
+    ws1.close();
+    ws2.close();
+  });
+
+  it("broadcastToWorkspace is a no-op for unknown workspace", () => {
+    // Should not throw
+    broadcastToWorkspace("ws-nonexistent", {
+      type: "branch_info",
+      info: { name: "test", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+    });
   });
 });

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -30,9 +30,23 @@ interface WorkspaceChannel {
   detachSession?: () => void;
 }
 
+const channels = new Map<string, WorkspaceChannel>();
+
+/** Send a message to all sockets connected to a workspace channel. */
+export function broadcastToWorkspace(workspaceId: string, msg: WsOutgoing): void {
+  const channel = channels.get(workspaceId);
+  if (!channel) return;
+  for (const socket of channel.sockets) {
+    sendOutgoing(socket, msg);
+  }
+}
+
+export function _getChannelsForTests(): Map<string, WorkspaceChannel> {
+  return channels;
+}
+
 export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptions = {}) {
   const { dataDir, sessionOptions, authToken } = opts;
-  const channels = new Map<string, WorkspaceChannel>();
 
   const getOrCreateChannel = (workspaceId: string): WorkspaceChannel => {
     const existing = channels.get(workspaceId);

--- a/frontend/src/components/BranchLabel.tsx
+++ b/frontend/src/components/BranchLabel.tsx
@@ -1,0 +1,23 @@
+import { GitBranch } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface BranchLabelProps {
+  branch: string;
+  className?: string;
+  showIcon?: boolean;
+}
+
+export function BranchLabel({
+  branch,
+  className,
+  showIcon = true,
+}: BranchLabelProps) {
+  return (
+    <span className={cn("flex items-center gap-1.5", className)}>
+      {showIcon && (
+        <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+      )}
+      <span className="min-w-0 truncate">{branch}</span>
+    </span>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
-import { FolderPlus, GitBranch, Settings, TerminalSquareIcon } from "lucide-react";
+import { useMemo, useState } from "react";
+import { FolderPlus, Settings, TerminalSquareIcon } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -8,8 +8,9 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
-import { wsTransport } from "@/lib/ws-transport";
 import { useTerminalContext } from "@/contexts/TerminalContext";
+import { useWorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
+import { BranchLabel } from "@/components/BranchLabel";
 import { cn } from "@/lib/utils";
 import type { Project } from "@/types";
 
@@ -59,38 +60,7 @@ export default function Sidebar({
   const { activeTerminals } = useTerminalContext();
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
-  const [liveWorkspaceStatus, setLiveWorkspaceStatus] = useState<
-    Record<string, { status: "idle" | "busy"; streaming: boolean }>
-  >({});
-
-  useEffect(() => {
-    const unsubscribers = workspaceIds.map((workspaceId) =>
-      wsTransport.onMessage(workspaceId, (msg) => {
-        if (msg.type !== "status") return;
-        setLiveWorkspaceStatus((prev) => {
-          const next = { status: msg.status, streaming: msg.streaming ?? false };
-          const current = prev[workspaceId];
-          if (current?.status === next.status && current.streaming === next.streaming) {
-            return prev;
-          }
-          return { ...prev, [workspaceId]: next };
-        });
-      }),
-    );
-
-    return () => {
-      for (const sub of unsubscribers) sub.unsubscribe();
-    };
-  }, [workspaceIds]);
-
-  useEffect(() => {
-    const workspaceIdSet = new Set(workspaceIds);
-    setLiveWorkspaceStatus((prev) =>
-      Object.fromEntries(
-        Object.entries(prev).filter(([workspaceId]) => workspaceIdSet.has(workspaceId)),
-      ),
-    );
-  }, [workspaceIds]);
+  const liveData = useWorkspaceLiveData(workspaceIds);
 
   const activeProjectId = projects.find((project) =>
     (project.workspaces ?? []).some((workspace) => workspace.id === activeWsId),
@@ -178,7 +148,9 @@ export default function Sidebar({
                     <CollapsibleContent>
                       <div className="mt-1 space-y-0.5">
                         {(project.workspaces ?? []).map((ws) => {
-                          const wsStreaming = liveWorkspaceStatus[ws.id]?.streaming ?? false;
+                          const wsLive = liveData[ws.id];
+                          const wsStreaming = wsLive?.streaming ?? false;
+                          const displayBranch = wsLive?.branch ?? ws.branch;
                           const hasTerminal = activeTerminals.has(ws.id);
                           return (
                             <Link
@@ -190,8 +162,7 @@ export default function Sidebar({
                               )}
                             >
                               <div className="flex items-center gap-1.5">
-                                <GitBranch className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
-                                <span className="min-w-0 flex-1 truncate text-sm">{ws.branch}</span>
+                                <BranchLabel branch={displayBranch} className="min-w-0 flex-1 text-sm" />
                                 {hasTerminal && (
                                   <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70" />
                                 )}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -173,6 +173,9 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
     case "reset":
       return initialState;
+
+    default:
+      return state;
   }
 }
 

--- a/frontend/src/hooks/useWorkspaceLiveData.ts
+++ b/frontend/src/hooks/useWorkspaceLiveData.ts
@@ -1,0 +1,73 @@
+import { useEffect, useState } from "react";
+import { wsTransport } from "@/lib/ws-transport";
+import type { BranchInfo } from "@/types";
+
+export interface WorkspaceLiveData {
+  status?: "idle" | "busy";
+  streaming?: boolean;
+  branch?: string;
+  branchInfo?: BranchInfo;
+}
+
+export function useWorkspaceLiveData(
+  workspaceIds: string[],
+): Record<string, WorkspaceLiveData> {
+  const [liveData, setLiveData] = useState<Record<string, WorkspaceLiveData>>(
+    {},
+  );
+
+  useEffect(() => {
+    const unsubscribers = workspaceIds.map((wsId) =>
+      wsTransport.onMessage(wsId, (msg) => {
+        if (msg.type === "status") {
+          setLiveData((prev) => {
+            const next = {
+              status: msg.status,
+              streaming: msg.streaming ?? false,
+            };
+            const current = prev[wsId];
+            if (
+              current?.status === next.status &&
+              current.streaming === next.streaming
+            ) {
+              return prev;
+            }
+            return { ...prev, [wsId]: { ...prev[wsId], ...next } };
+          });
+        } else if (msg.type === "branch_info") {
+          setLiveData((prev) => {
+            const current = prev[wsId];
+            if (current?.branch === msg.info.name) return prev;
+            return {
+              ...prev,
+              [wsId]: {
+                ...prev[wsId],
+                branch: msg.info.name,
+                branchInfo: msg.info,
+              },
+            };
+          });
+        }
+      }),
+    );
+
+    return () => {
+      for (const sub of unsubscribers) sub.unsubscribe();
+    };
+  }, [workspaceIds]);
+
+  // Clean up stale entries when workspace IDs change
+  useEffect(() => {
+    const wsSet = new Set(workspaceIds);
+    setLiveData((prev) => {
+      const filtered = Object.fromEntries(
+        Object.entries(prev).filter(([id]) => wsSet.has(id)),
+      );
+      if (Object.keys(filtered).length === Object.keys(prev).length)
+        return prev;
+      return filtered;
+    });
+  }, [workspaceIds]);
+
+  return liveData;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -1,10 +1,11 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
 import { MessageSquareIcon, RefreshCwIcon, TerminalSquareIcon } from "lucide-react";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
 import { useDiffStat } from "@/hooks/useDiffStat";
+import { useWorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
 import {
   FileTree,
   FileTreeFile,
@@ -14,6 +15,7 @@ import ChatConversation from "@/components/ChatConversation";
 import ChatInput from "@/components/ChatInput";
 import QuestionPanel from "@/components/chat/QuestionPanel";
 import { SessionSelector } from "@/components/SessionSelector";
+import { BranchLabel } from "@/components/BranchLabel";
 import { useTerminalContext } from "@/contexts/TerminalContext";
 import { GitDiffModal } from "@/components/diff/GitDiffModal";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
@@ -82,6 +84,11 @@ export default function WorkspaceView() {
 
   // Diff stats for the modified tab
   const { committed: diffCommitted, uncommitted: diffUncommitted, totalCount: diffTotalCount, loading: diffStatsLoading, refresh: refreshDiffStats } = useDiffStat(wsId);
+
+  // Live branch data via WebSocket
+  const liveWsIds = useMemo(() => (wsId ? [wsId] : []), [wsId]);
+  const liveData = useWorkspaceLiveData(liveWsIds);
+  const displayBranch = (wsId && liveData[wsId]?.branch) || workspace?.branch;
 
   const fetchWorkspace = useCallback(async () => {
     if (!wsId) {
@@ -241,7 +248,9 @@ export default function WorkspaceView() {
               {hasActiveSession ? "active" : "idle"}
             </Badge>
             <span className="truncate text-sm font-semibold text-foreground">{workspace?.projectName ?? workspace?.name}</span>
-            <span className="truncate text-xs text-muted-foreground">{workspace?.branch}</span>
+            {displayBranch && (
+              <BranchLabel branch={displayBranch} showIcon={false} className="text-xs text-muted-foreground" />
+            )}
             {workspace?.defaultBranch && (
               <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
             )}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,6 +17,23 @@ export interface Workspace {
   defaultBranch?: string;
 }
 
+// ── Branch / GitHub sync types ──────────────────────────────────────
+
+export interface PullRequestInfo {
+  number: number;
+  url: string;
+  state: "open" | "draft" | "merged" | "closed";
+  mergeable: boolean | null;
+  mergeableState: "clean" | "conflict" | "unstable" | "unknown";
+  checksStatus: "pending" | "success" | "failure";
+}
+
+export interface BranchInfo {
+  name: string;
+  lastSyncedAt: string;
+  pr?: PullRequestInfo;
+}
+
 export interface WorkspaceFileTreeNode {
   name: string;
   path: string;
@@ -154,4 +171,5 @@ export type WsOutgoing =
   | { type: "cancelled" }
   | { type: "status"; status: "idle" | "busy"; sessionId?: string; streaming?: boolean }
   | { type: "user_message"; message: ChatMessage }
-  | { type: "history"; messages: ChatMessage[] };
+  | { type: "history"; messages: ChatMessage[] }
+  | { type: "branch_info"; info: BranchInfo };

--- a/frontend/tests/components/BranchLabel.test.tsx
+++ b/frontend/tests/components/BranchLabel.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { BranchLabel } from "@/components/BranchLabel";
+
+describe("BranchLabel", () => {
+  it("renders branch name text", () => {
+    render(<BranchLabel branch="workspace/tokyo" />);
+    expect(screen.getByText("workspace/tokyo")).toBeDefined();
+  });
+
+  it("shows GitBranch SVG icon by default", () => {
+    const { container } = render(<BranchLabel branch="main" />);
+    expect(container.querySelector("svg")).not.toBeNull();
+  });
+
+  it("hides icon when showIcon={false}", () => {
+    const { container } = render(<BranchLabel branch="main" showIcon={false} />);
+    expect(container.querySelector("svg")).toBeNull();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(
+      <BranchLabel branch="main" className="text-xs text-muted-foreground" />,
+    );
+    const wrapper = container.firstElementChild;
+    expect(wrapper?.className).toContain("text-xs");
+    expect(wrapper?.className).toContain("text-muted-foreground");
+  });
+});

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -190,4 +190,21 @@ describe("Sidebar", () => {
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
     expect(workspaceLink.querySelectorAll("svg")).toHaveLength(1);
   });
+
+  it("displays live branch name from branch_info WS message", async () => {
+    const { __wsMock } = await getWsMock();
+    renderSidebar("/workspaces/w1", projects);
+
+    expect(screen.getByText("workspace/tokyo")).toBeInTheDocument();
+
+    act(() => {
+      __wsMock.emit("w1", {
+        type: "branch_info",
+        info: { name: "feat/login-page", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+      });
+    });
+
+    expect(screen.getByText("feat/login-page")).toBeInTheDocument();
+    expect(screen.queryByText("workspace/tokyo")).not.toBeInTheDocument();
+  });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -665,6 +665,28 @@ describe("useConversation", () => {
     ]);
   });
 
+  it("ignores unrecognized WS message types without corrupting state", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true });
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "branch_info",
+        info: { name: "feat/new", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+      } as any);
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.messages).toHaveLength(0);
+  });
+
   it("does nothing when switchSession is called without workspace id", async () => {
     const { __apiMock } = await getApiMock();
     const { result } = renderHook(() => useConversation(undefined));

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useWorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
+import type { WsOutgoing } from "@/types";
+
+vi.mock("@/lib/ws-transport", () => {
+  const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
+
+  const getSet = (workspaceId: string) => {
+    const existing = messageHandlers.get(workspaceId);
+    if (existing) return existing;
+    const created = new Set<(msg: WsOutgoing) => void>();
+    messageHandlers.set(workspaceId, created);
+    return created;
+  };
+
+  const wsTransport = {
+    onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
+      getSet(workspaceId).add(handler);
+      return {
+        unsubscribe: () => { getSet(workspaceId).delete(handler); },
+        hadBufferedMessages: false,
+      };
+    }),
+  };
+
+  const __wsMock = {
+    emit: (workspaceId: string, msg: WsOutgoing) => {
+      for (const handler of messageHandlers.get(workspaceId) ?? []) handler(msg);
+    },
+    reset: () => {
+      messageHandlers.clear();
+      wsTransport.onMessage.mockClear();
+    },
+    handlerCount: (workspaceId: string) => {
+      return messageHandlers.get(workspaceId)?.size ?? 0;
+    },
+  };
+
+  return { wsTransport, __wsMock };
+});
+
+const getWsMock = async () =>
+  (await import("@/lib/ws-transport")) as unknown as {
+    wsTransport: { onMessage: ReturnType<typeof vi.fn> };
+    __wsMock: {
+      emit: (workspaceId: string, msg: WsOutgoing) => void;
+      reset: () => void;
+      handlerCount: (workspaceId: string) => number;
+    };
+  };
+
+describe("useWorkspaceLiveData", () => {
+  beforeEach(async () => {
+    const { __wsMock } = await getWsMock();
+    __wsMock.reset();
+  });
+
+  it("returns empty object initially for given workspace IDs", () => {
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1", "ws-2"]));
+    expect(result.current).toEqual({});
+  });
+
+  it("updates status on WS status message", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true });
+    });
+
+    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true });
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "idle", streaming: false });
+    });
+
+    expect(result.current["ws-1"]).toEqual({ status: "idle", streaming: false });
+  });
+
+  it("updates branch on WS branch_info message", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    const branchInfo = { name: "workspace/tokyo", lastSyncedAt: "2026-02-13T00:00:00.000Z" };
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "branch_info", info: branchInfo });
+    });
+
+    expect(result.current["ws-1"]).toEqual({
+      branch: "workspace/tokyo",
+      branchInfo,
+    });
+  });
+
+  it("does NOT update state when same branch name is received again", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "branch_info",
+        info: { name: "workspace/tokyo", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+      });
+    });
+
+    const firstReference = result.current;
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "branch_info",
+        info: { name: "workspace/tokyo", lastSyncedAt: "2026-02-13T01:00:00.000Z" },
+      });
+    });
+
+    expect(result.current).toBe(firstReference);
+  });
+
+  it("cleans up stale entries when workspace IDs change", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result, rerender } = renderHook(
+      (ids: string[]) => useWorkspaceLiveData(ids),
+      { initialProps: ["ws-1", "ws-2"] },
+    );
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: false });
+      __wsMock.emit("ws-2", { type: "status", status: "idle", streaming: false });
+    });
+
+    expect(result.current["ws-1"]).toBeDefined();
+    expect(result.current["ws-2"]).toBeDefined();
+
+    rerender(["ws-1"]);
+
+    expect(result.current["ws-1"]).toBeDefined();
+    expect(result.current["ws-2"]).toBeUndefined();
+  });
+
+  it("unsubscribes handlers on unmount", async () => {
+    const { __wsMock } = await getWsMock();
+    const { unmount } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    expect(__wsMock.handlerCount("ws-1")).toBe(1);
+
+    unmount();
+
+    expect(__wsMock.handlerCount("ws-1")).toBe(0);
+  });
+
+  it("handles multiple workspaces independently", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1", "ws-2"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true });
+    });
+
+    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true });
+    expect(result.current["ws-2"]).toBeUndefined();
+
+    act(() => {
+      __wsMock.emit("ws-2", {
+        type: "branch_info",
+        info: { name: "workspace/kyoto", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+      });
+    });
+
+    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true });
+    expect(result.current["ws-2"]).toEqual({
+      branch: "workspace/kyoto",
+      branchInfo: { name: "workspace/kyoto", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
+    });
+  });
+});

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   useConversation: vi.fn(),
   useSessions: vi.fn(),
   useDiffStat: vi.fn(),
+  useWorkspaceLiveData: vi.fn().mockReturnValue({}),
   sendMessage: vi.fn(),
   stopStreaming: vi.fn(),
   clearChat: vi.fn(),
@@ -41,6 +42,10 @@ vi.mock("@/hooks/useSessions", () => ({
 
 vi.mock("@/hooks/useDiffStat", () => ({
   useDiffStat: mocks.useDiffStat,
+}));
+
+vi.mock("@/hooks/useWorkspaceLiveData", () => ({
+  useWorkspaceLiveData: mocks.useWorkspaceLiveData,
 }));
 
 vi.mock("@/components/ChatConversation", () => ({
@@ -162,6 +167,8 @@ describe("WorkspaceView terminal behavior", () => {
     mocks.deleteSession.mockReset();
     mocks.refreshSessions.mockReset();
     mocks.refreshDiffStat.mockReset();
+    mocks.useWorkspaceLiveData.mockReset();
+    mocks.useWorkspaceLiveData.mockReturnValue({});
 
     mocks.apiGet.mockImplementation(async (url: string) => {
       const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
@@ -341,6 +348,17 @@ describe("WorkspaceView terminal behavior", () => {
 
     await user.click(screen.getByRole("button", { name: "dismiss questions" }));
     expect(mocks.rejectToolInput).toHaveBeenCalledWith("cancel");
+  });
+
+  it("displays live branch name from useWorkspaceLiveData when available", async () => {
+    mocks.useWorkspaceLiveData.mockReturnValue({
+      "ws-1": { branch: "feature/live-branch", branchInfo: { name: "feature/live-branch", lastSyncedAt: "2026-02-13T00:00:00.000Z" } },
+    });
+
+    renderWorkspace();
+
+    await screen.findByText("feature/live-branch");
+    expect(screen.queryByText("workspace/tokyo")).not.toBeInTheDocument();
   });
 
   it("prefers projectName in header and shows origin default branch when provided", async () => {


### PR DESCRIPTION
Add architecture for GitHub sync (branch name, PR status, merge state) and implement the first piece: branch name detection via git polling.

Backend: BranchSyncService polls worktrees every 10s, detects branch renames, updates state.json, and broadcasts branch_info over WebSocket. Frontend: shared useWorkspaceLiveData hook and BranchLabel component replace duplicated logic in Sidebar and WorkspaceView. Fix missing default case in useConversation reducer that crashed on unrecognized WS message types.