### PR TITLE
fix: resume previous session after server restart instead of creating…

### DIFF
--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -124,6 +124,56 @@ describe("getOrCreateSession", () => {
     expect(updatedWs.activeSessionId).toBe(session.sessionId);
   });
 
+  it("resumes previous session from disk after server restart", async () => {
+    // Simulate a session that was active before server restart:
+    // session files exist on disk, workspace is persisted as busy.
+    const claudeSessionId = "claude-uuid-for-resume";
+    await writeSessionFixture("prev-session", wsId, {
+      metadata: {
+        claudeSessionId,
+        messageCount: 5,
+        updatedAt: "2026-02-12T00:00:00.000Z",
+      },
+    });
+
+    const state = await loadProject(projectId, dataDir);
+    const ws = state!.workspaces.find((w) => w.id === wsId)!;
+    ws.status = "busy";
+    ws.activeSessionId = "prev-session";
+    await saveProject(state!, dataDir);
+
+    // No in-memory session (simulates server restart)
+    const { session, created } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+
+    expect(created).toBe(false);
+    expect(session.sessionId).toBe("prev-session");
+    expect(session.metadata.claudeSessionId).toBe(claudeSessionId);
+    expect(session.metadata.messageCount).toBe(5);
+
+    const updatedState = await loadProject(projectId, dataDir);
+    const updatedWs = updatedState!.workspaces.find((w) => w.id === wsId)!;
+    expect(updatedWs.status).toBe("busy");
+    expect(updatedWs.activeSessionId).toBe("prev-session");
+  });
+
+  it("falls back to new session when previous session belongs to different workspace", async () => {
+    const otherWs = await createWorkspace(projectId, dataDir);
+    await writeSessionFixture("other-ws-session", otherWs.id, {
+      metadata: { updatedAt: "2026-02-12T00:00:00.000Z" },
+    });
+
+    const state = await loadProject(projectId, dataDir);
+    const ws = state!.workspaces.find((w) => w.id === wsId)!;
+    ws.status = "busy";
+    ws.activeSessionId = "other-ws-session";
+    await saveProject(state!, dataDir);
+
+    const { session, created } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+
+    expect(created).toBe(true);
+    expect(session.sessionId).not.toBe("other-ws-session");
+  });
+
   it("serializes concurrent creation attempts for the same workspace", async () => {
     const [first, second] = await Promise.all([
       getOrCreateSession(wsId, dataDir, CONV_CMD),

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -57,6 +57,11 @@ export async function getOrCreateSession(
     const { projectState, workspace } = result;
     const projectId = projectState.id;
 
+    // Capture the previous active session ID before recovery clears it.
+    // After a server restart the workspace is still persisted as "busy" with
+    // an activeSessionId pointing to valid session files on disk.
+    const previousActiveSessionId = workspace.activeSessionId;
+
     await withProjectStateLock(
       projectId,
       async () => {
@@ -97,6 +102,48 @@ export async function getOrCreateSession(
         branchRename: {},
         promptsDir: join(dataDir, "prompts"),
       });
+    }
+
+    // After a server restart, try to resume the previous session from disk
+    // instead of creating a brand new one. This preserves the Claude
+    // --resume session ID so the conversation continues seamlessly.
+    if (previousActiveSessionId) {
+      const metaPath = join(sessionDataDir, "sessions", previousActiveSessionId, "metadata.json");
+      try {
+        const raw = await readFile(metaPath, "utf-8");
+        const meta = JSON.parse(raw) as SessionMetadata;
+        if (meta.workspaceId === wsId) {
+          const session = await ConversationSession.load({
+            sessionId: previousActiveSessionId,
+            cwd: wsPath,
+            dataDir: sessionDataDir,
+            workspaceId: wsId,
+            command: options?.command,
+            systemPrompt,
+            skipPermissions: options?.skipPermissions,
+          });
+
+          activeSessions.set(wsId, session);
+
+          await withProjectStateLock(
+            projectId,
+            async () => {
+              const latest = await loadProject(projectId, dataDir);
+              if (!latest) throw new NotFoundError(`Project ${projectId} not found`);
+              const latestWorkspace = latest.workspaces.find((ws) => ws.id === wsId);
+              if (!latestWorkspace) throw new NotFoundError(`Workspace ${wsId} not found`);
+              latestWorkspace.status = "busy";
+              latestWorkspace.activeSessionId = session.sessionId;
+              await saveProject(latest, dataDir);
+            },
+            dataDir,
+          );
+
+          return { session, created: false };
+        }
+      } catch {
+        // Session files missing or corrupt — fall through to create new session.
+      }
     }
 
     const session = new ConversationSession({


### PR DESCRIPTION
… new one

After a backend restart, getOrCreateSession was always creating a brand new session because the recovery code cleared activeSessionId. This meant the Claude --resume session ID was lost and conversations started fresh.

Now captures activeSessionId before recovery clears it and attempts to load the session from disk via ConversationSession.load(), preserving the claudeSessionId for seamless --resume. Falls back to creating a new session if files are missing or corrupt.