### PR TITLE
fix: restyle chat links as blue and replace streamdown link modal wit…

### DIFF
--- a/frontend/src/components/ExternalLinkDialog.tsx
+++ b/frontend/src/components/ExternalLinkDialog.tsx
@@ -1,0 +1,59 @@
+import { useCallback, useState } from "react";
+import { Copy, Check, ExternalLink } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+interface ExternalLinkDialogProps {
+  url: string;
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function ExternalLinkDialog({ url, open, onClose, onConfirm }: ExternalLinkDialogProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard API unavailable
+    }
+  }, [url]);
+
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Open external link?</AlertDialogTitle>
+          <AlertDialogDescription>
+            You're about to visit an external website.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="break-all rounded-md bg-muted p-3 font-mono text-sm">
+          {url}
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={handleCopy}>
+            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+            {copied ? "Copied" : "Copy link"}
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>
+            <ExternalLink className="size-3.5" />
+            Open link
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -30,6 +30,8 @@ import {
   useState,
 } from "react";
 import { Streamdown } from "streamdown";
+import type { LinkSafetyModalProps } from "streamdown";
+import { ExternalLinkDialog } from "@/components/ExternalLinkDialog";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -324,6 +326,17 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
+const renderLinkModal = (props: LinkSafetyModalProps) => (
+  <ExternalLinkDialog
+    url={props.url}
+    open={props.isOpen}
+    onClose={props.onClose}
+    onConfirm={props.onConfirm}
+  />
+);
+
+const streamdownLinkSafety = { enabled: true, renderModal: renderLinkModal };
+
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
@@ -332,6 +345,7 @@ export const MessageResponse = memo(
         className
       )}
       plugins={streamdownPlugins}
+      linkSafety={streamdownLinkSafety}
       {...props}
     />
   ),

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -166,6 +166,13 @@
   #root {
     height: 100%;
   }
+
+  [data-streamdown="link"] {
+    @apply !text-blue-400 !underline-offset-2;
+  }
+  [data-streamdown="link"]:hover {
+    @apply !text-blue-300;
+  }
 }
 
 @keyframes shimmer {


### PR DESCRIPTION
…h app dialog

Links rendered by streamdown were using the primary/accent color, making them indistinguishable from other UI elements. Now styled as standard blue links. The built-in streamdown link safety modal (which rendered full-width due to stacking context issues) is replaced with our own ExternalLinkDialog using the app's AlertDialog component for consistent design.