### PR TITLE
Improve project deletion flow and sidebar hover truncation

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -101,6 +101,8 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  // Let pending fire-and-forget async work (e.g. saveImagesToDisk) settle
+  await new Promise((r) => setTimeout(r, 250));
   for (let attempt = 0; attempt < 5; attempt++) {
     try {
       await rm(tempDir, { recursive: true, force: true });
@@ -1010,7 +1012,7 @@ describe("ConversationSession", () => {
     const session = createSession({ sessionId: "title-truncate" });
     const longMsg = "This is a very long message that definitely exceeds the fifty character limit by a lot";
     session.sendMessage(longMsg);
-    expect(session.metadata.title).toBe("This is a very long message that definitely exce...");
+    expect(session.metadata.title).toBe("This is a very long message that definitely exc...");
     expect(session.metadata.title!.length).toBeLessThanOrEqual(50);
   });
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -123,7 +123,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     };
     // Set conversation title from first user message
     if (!this._metadata.title) {
-      const firstLine = content.trim().replace(/\n.*/s, "");
+      const firstLine = content.trim().replace(/\n.*/s, "").trimEnd();
       this._metadata.title = firstLine.length > 50
         ? firstLine.slice(0, 47).trimEnd() + "..."
         : firstLine;

--- a/backend/src/api/projects.test.ts
+++ b/backend/src/api/projects.test.ts
@@ -4,6 +4,7 @@ import { rm } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { projectRoutes } from "./projects.js";
+import { workspaceRoutes } from "./workspaces.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -21,6 +22,7 @@ beforeEach(async () => {
 
   app = Fastify();
   await app.register((instance: FastifyInstance) => projectRoutes(instance, dataDir));
+  await app.register((instance: FastifyInstance) => workspaceRoutes(instance, dataDir));
   await app.ready();
 });
 
@@ -117,6 +119,19 @@ describe("DELETE /api/projects/:id", () => {
   it("returns 404 for non-existent project", async () => {
     const res = await app.inject({ method: "DELETE", url: "/api/projects/nonexistent" });
     expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 when project has active workspaces", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/api/projects",
+      payload: { url: fixtureRepoUrl },
+    });
+    const { id } = createRes.json();
+    await app.inject({ method: "POST", url: `/api/projects/${id}/workspaces` });
+    const res = await app.inject({ method: "DELETE", url: `/api/projects/${id}` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("active workspaces");
   });
 });
 

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -38,6 +38,9 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
   app.delete<{ Params: { id: string } }>("/api/projects/:id", async (req, reply) => {
     const project = await getProject(req.params.id, dataDir);
     if (!project) return reply.status(404).send({ error: "Project not found" });
+    if (project.workspaces.length > 0) {
+      return reply.status(409).send({ error: "Cannot delete project with active workspaces" });
+    }
     await deleteProject(req.params.id, dataDir);
     return reply.status(204).send();
   });

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -298,6 +298,59 @@ describe("POST /api/workspaces/:wsId/merge", () => {
   });
 });
 
+describe("POST /api/workspaces/:wsId/archive", () => {
+  it("archives workspace and returns 204", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const wsId = createRes.json().id;
+
+    const res = await app.inject({ method: "POST", url: `/api/workspaces/${wsId}/archive` });
+    expect(res.statusCode).toBe(204);
+
+    // Workspace should no longer appear in list
+    const listRes = await app.inject({
+      method: "GET",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    expect(listRes.json()).toHaveLength(0);
+  });
+
+  it("returns 404 for non-existent workspace", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/workspaces/nonexistent/archive" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("archived workspace is no longer accessible via GET", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const wsId = createRes.json().id;
+
+    await app.inject({ method: "POST", url: `/api/workspaces/${wsId}/archive` });
+
+    const getRes = await app.inject({ method: "GET", url: `/api/workspaces/${wsId}` });
+    expect(getRes.statusCode).toBe(404);
+  });
+
+  it("preserves archive data on disk", async () => {
+    const { existsSync } = await import("node:fs");
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const ws = createRes.json();
+
+    await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/archive` });
+
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+    expect(existsSync(archiveDir)).toBe(true);
+    expect(existsSync(join(archiveDir, "workspace.json"))).toBe(true);
+  });
+});
+
 describe("GET /api/workspaces/:wsId/file", () => {
   it("returns 404 for non-existent workspace", async () => {
     const res = await app.inject({

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -9,7 +9,9 @@ import {
   listWorkspaceFiles,
   getWorkspaceFileContent,
   mergeWorkspace,
+  archiveWorkspace,
 } from "../workspaces/workspace-manager.js";
+import { endSession } from "../agents/agent-manager.js";
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
@@ -109,6 +111,23 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       return reply
         .status(errorStatus(err))
         .send({ error: errorMessage(err, "Merge failed") });
+    }
+  });
+
+  app.post<{ Params: { wsId: string } }>("/api/workspaces/:wsId/archive", async (req, reply) => {
+    try {
+      // End any active session before archiving
+      try {
+        await endSession(req.params.wsId, dataDir);
+      } catch {
+        // No active session — fine
+      }
+      await archiveWorkspace(req.params.wsId, dataDir);
+      return reply.status(204).send();
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Archive failed") });
     }
   });
 }

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { rm, writeFile, mkdir } from "node:fs/promises";
+import { rm, writeFile, mkdir, readFile, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
@@ -9,6 +9,7 @@ import {
   listWorkspaces,
   getWorkspace,
   deleteWorkspace,
+  archiveWorkspace,
   getWorkspaceDiff,
   getWorkspaceDiffStat,
   mergeWorkspace,
@@ -112,6 +113,125 @@ describe("deleteWorkspace", () => {
 
   it("throws for non-existent workspace", async () => {
     await expect(deleteWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+});
+
+describe("archiveWorkspace", () => {
+  it("removes workspace from state and worktree from disk", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+    expect(existsSync(wsPath)).toBe(true);
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    expect(existsSync(wsPath)).toBe(false);
+    const list = await listWorkspaces(projectId, dataDir);
+    expect(list).toHaveLength(0);
+  });
+
+  it("creates archive directory with workspace metadata", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+    expect(existsSync(archiveDir)).toBe(true);
+
+    const metaRaw = await readFile(join(archiveDir, "workspace.json"), "utf-8");
+    const meta = JSON.parse(metaRaw);
+    expect(meta.id).toBe(ws.id);
+    expect(meta.name).toBe(ws.name);
+    expect(meta.branch).toBe(ws.branch);
+  });
+
+  it("moves session directories belonging to the workspace", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+
+    // Create a session fixture for this workspace
+    const sessionId = "test-session-123";
+    const sessionsRoot = join(dataDir, projectId, "sessions");
+    const sessionDir = join(sessionsRoot, sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, "metadata.json"),
+      JSON.stringify({ sessionId, workspaceId: ws.id }),
+      "utf-8",
+    );
+    await writeFile(join(sessionDir, "messages.jsonl"), '{"role":"user"}\n', "utf-8");
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    // Session should have moved to archive
+    expect(existsSync(join(sessionsRoot, sessionId))).toBe(false);
+    const archivedSessionDir = join(dataDir, projectId, "archive", ws.id, "sessions", sessionId);
+    expect(existsSync(archivedSessionDir)).toBe(true);
+    expect(existsSync(join(archivedSessionDir, "metadata.json"))).toBe(true);
+    expect(existsSync(join(archivedSessionDir, "messages.jsonl"))).toBe(true);
+  });
+
+  it("does not move sessions belonging to other workspaces", async () => {
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws2 = await createWorkspace(projectId, dataDir);
+
+    // Create sessions for both workspaces
+    const sessionsRoot = join(dataDir, projectId, "sessions");
+    for (const [id, wsId] of [["s1", ws1.id], ["s2", ws2.id]] as const) {
+      const dir = join(sessionsRoot, id);
+      await mkdir(dir, { recursive: true });
+      await writeFile(
+        join(dir, "metadata.json"),
+        JSON.stringify({ sessionId: id, workspaceId: wsId }),
+        "utf-8",
+      );
+    }
+
+    await archiveWorkspace(ws1.id, dataDir);
+
+    // ws1's session should be archived, ws2's should stay
+    expect(existsSync(join(sessionsRoot, "s1"))).toBe(false);
+    expect(existsSync(join(sessionsRoot, "s2"))).toBe(true);
+  });
+
+  it("keeps the git branch in bare repo", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const bare = join(dataDir, projectId, "repo.git");
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    // Branch should still exist in bare repo
+    const { stdout } = await git(["branch", "--list", ws.branch], bare);
+    expect(stdout.trim()).toContain(ws.branch);
+  });
+
+  it("throws for non-existent workspace", async () => {
+    await expect(archiveWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+
+  it("works when workspace has no sessions", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+    expect(existsSync(archiveDir)).toBe(true);
+    expect(existsSync(join(archiveDir, "workspace.json"))).toBe(true);
+    // No sessions directory in archive
+    expect(existsSync(join(archiveDir, "sessions"))).toBe(false);
+  });
+
+  it("does not affect other workspaces in the same project", async () => {
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws2 = await createWorkspace(projectId, dataDir);
+
+    await archiveWorkspace(ws1.id, dataDir);
+
+    const list = await listWorkspaces(projectId, dataDir);
+    expect(list).toHaveLength(1);
+    expect(list[0].id).toBe(ws2.id);
+
+    // ws2's worktree should still exist
+    const ws2Path = join(dataDir, projectId, "workspaces", ws2.name);
+    expect(existsSync(ws2Path)).toBe(true);
   });
 });
 

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -1,4 +1,4 @@
-import { rm, readdir, readFile, stat } from "node:fs/promises";
+import { rm, readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
@@ -183,6 +183,77 @@ export async function deleteWorkspace(
       }
 
       // Update state
+      latest.workspaces = latest.workspaces.filter((ws) => ws.id !== wsId);
+      await saveProject(latest, dataDir);
+    },
+    dataDir,
+  );
+}
+
+export async function archiveWorkspace(
+  wsId: string,
+  dataDir = getDataDir()
+): Promise<void> {
+  const result = await getWorkspace(wsId, dataDir);
+  if (!result) throw new NotFoundError(`Workspace ${wsId} not found`);
+
+  const projectId = result.projectState.id;
+  await withProjectStateLock(
+    projectId,
+    async () => {
+      const latest = await loadProject(projectId, dataDir);
+      if (!latest) throw new NotFoundError(`Project ${projectId} not found`);
+      const workspace = latest.workspaces.find((ws) => ws.id === wsId);
+      if (!workspace) throw new NotFoundError(`Workspace ${wsId} not found`);
+
+      const bare = bareRepoPath(dataDir, projectId);
+      const wsPath = join(workspacesDir(dataDir, projectId), workspace.name);
+      const archiveDir = join(dataDir, projectId, "archive", wsId);
+
+      // Create archive directory
+      await mkdir(archiveDir, { recursive: true });
+
+      // Save workspace metadata
+      await writeFile(
+        join(archiveDir, "workspace.json"),
+        JSON.stringify(workspace, null, 2),
+        "utf-8",
+      );
+
+      // Move session directories belonging to this workspace
+      const sessionsRoot = join(dataDir, projectId, "sessions");
+      try {
+        const entries = await readdir(sessionsRoot, { withFileTypes: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          const metaPath = join(sessionsRoot, entry.name, "metadata.json");
+          try {
+            const raw = await readFile(metaPath, "utf-8");
+            const meta = JSON.parse(raw) as { workspaceId?: string };
+            if (meta.workspaceId !== wsId) continue;
+            const archiveSessionsDir = join(archiveDir, "sessions");
+            await mkdir(archiveSessionsDir, { recursive: true });
+            await rename(
+              join(sessionsRoot, entry.name),
+              join(archiveSessionsDir, entry.name),
+            );
+          } catch {
+            // Skip unreadable session metadata
+          }
+        }
+      } catch {
+        // No sessions directory yet
+      }
+
+      // Remove the worktree (keep the branch for potential restore)
+      try {
+        await git(["worktree", "remove", wsPath, "--force"], bare);
+      } catch {
+        await rm(wsPath, { recursive: true, force: true });
+        await git(["worktree", "prune"], bare);
+      }
+
+      // Update state — remove workspace from project
       latest.workspaces = latest.workspaces.filter((ws) => ws.id !== wsId);
       await saveProject(latest, dataDir);
     },

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { useProjects } from "@/hooks/useProjects";
 import { wsTransport } from "@/lib/ws-transport";
 
 export default function App() {
-  const { projects, loading, createWorkspace, createProjectWithWorkspace } = useProjects();
+  const { projects, loading, createWorkspace, createProjectWithWorkspace, archiveWorkspace } = useProjects();
   const [showAddProject, setShowAddProject] = useState(false);
   const workspaceIds = useMemo(
     () =>
@@ -45,6 +45,7 @@ export default function App() {
               loading={loading}
               onAddProject={() => setShowAddProject(true)}
               onAddWorkspace={createWorkspace}
+              onArchiveWorkspace={archiveWorkspace}
             />
           }
         >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { useProjects } from "@/hooks/useProjects";
 import { wsTransport } from "@/lib/ws-transport";
 
 export default function App() {
-  const { projects, loading, createWorkspace, createProjectWithWorkspace, archiveWorkspace } = useProjects();
+  const { projects, loading, createWorkspace, createProjectWithWorkspace, deleteProject, archiveWorkspace } = useProjects();
   const [showAddProject, setShowAddProject] = useState(false);
   const workspaceIds = useMemo(
     () =>
@@ -45,6 +45,7 @@ export default function App() {
               loading={loading}
               onAddProject={() => setShowAddProject(true)}
               onAddWorkspace={createWorkspace}
+              onDeleteProject={deleteProject}
               onArchiveWorkspace={archiveWorkspace}
             />
           }

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -10,6 +10,7 @@ interface AppLayoutProps {
   loading: boolean;
   onAddProject: () => void;
   onAddWorkspace: (projectId: string) => Promise<unknown>;
+  onDeleteProject: (id: string) => Promise<void>;
   onArchiveWorkspace: (wsId: string) => Promise<void>;
 }
 
@@ -42,6 +43,7 @@ export default function AppLayout({
   loading,
   onAddProject,
   onAddWorkspace,
+  onDeleteProject,
   onArchiveWorkspace,
 }: AppLayoutProps) {
   return (
@@ -52,6 +54,7 @@ export default function AppLayout({
           loading={loading}
           onAddProject={onAddProject}
           onAddWorkspace={onAddWorkspace}
+          onDeleteProject={onDeleteProject}
           onArchiveWorkspace={onArchiveWorkspace}
         />
         <main className="relative flex-1 overflow-hidden">

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -10,6 +10,7 @@ interface AppLayoutProps {
   loading: boolean;
   onAddProject: () => void;
   onAddWorkspace: (projectId: string) => Promise<unknown>;
+  onArchiveWorkspace: (wsId: string) => Promise<void>;
 }
 
 function TerminalLayer() {
@@ -41,6 +42,7 @@ export default function AppLayout({
   loading,
   onAddProject,
   onAddWorkspace,
+  onArchiveWorkspace,
 }: AppLayoutProps) {
   return (
     <TerminalProvider>
@@ -50,6 +52,7 @@ export default function AppLayout({
           loading={loading}
           onAddProject={onAddProject}
           onAddWorkspace={onAddWorkspace}
+          onArchiveWorkspace={onArchiveWorkspace}
         />
         <main className="relative flex-1 overflow-hidden">
           <Outlet />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -202,26 +202,28 @@ export default function Sidebar({
                                 <div className="flex items-center gap-1.5">
                                   <BranchLabel branch={displayBranch} className="min-w-0 flex-1 text-sm" />
                                   {hasTerminal && (
-                                    <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70 transition-opacity group-hover/ws:opacity-0" />
+                                    <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70" />
                                   )}
                                 </div>
                                 <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
                                   <span className="truncate">{wsStreaming ? "working..." : ws.name}</span>
                                 </div>
                               </Link>
-                              <button
-                                type="button"
-                                className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
-                                onClick={(e) => {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  void handleArchiveClick(ws.id);
-                                }}
-                                aria-label={`Archive workspace ${ws.name}`}
-                                title="Archive workspace"
-                              >
-                                <ArchiveIcon className="h-3 w-3" />
-                              </button>
+                              {!hasTerminal && (
+                                <button
+                                  type="button"
+                                  className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
+                                  onClick={(e) => {
+                                    e.preventDefault();
+                                    e.stopPropagation();
+                                    void handleArchiveClick(ws.id);
+                                  }}
+                                  aria-label={`Archive workspace ${ws.name}`}
+                                  title="Archive workspace"
+                                >
+                                  <ArchiveIcon className="h-3 w-3" />
+                                </button>
+                              )}
                             </div>
                           );
                         })}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
-import { FolderPlus, Settings, TerminalSquareIcon } from "lucide-react";
-import { Link, useParams } from "react-router-dom";
+import { ArchiveIcon, FolderPlus, Settings, TerminalSquareIcon } from "lucide-react";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
@@ -8,11 +8,22 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
 import { useTerminalContext } from "@/contexts/TerminalContext";
 import { useWorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
 import { BranchLabel } from "@/components/BranchLabel";
+import { api } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
-import type { Project } from "@/types";
+import type { DiffStatResponse, Project } from "@/types";
 
 const AVATAR_COLORS = [
   { bg: "bg-red-500/20", text: "text-red-400" },
@@ -39,6 +50,7 @@ interface SidebarProps {
   loading: boolean;
   onAddProject: () => void;
   onAddWorkspace: (projectId: string) => Promise<unknown>;
+  onArchiveWorkspace: (wsId: string) => Promise<void>;
 }
 
 export default function Sidebar({
@@ -46,6 +58,7 @@ export default function Sidebar({
   loading,
   onAddProject,
   onAddWorkspace,
+  onArchiveWorkspace,
 }: SidebarProps) {
   const workspaceIds = useMemo(
     () =>
@@ -57,9 +70,11 @@ export default function Sidebar({
     [projects],
   );
   const { wsId: activeWsId } = useParams();
+  const navigate = useNavigate();
   const { activeTerminals } = useTerminalContext();
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
+  const [archiveTarget, setArchiveTarget] = useState<string | null>(null);
   const liveData = useWorkspaceLiveData(workspaceIds);
 
   const activeProjectId = projects.find((project) =>
@@ -81,6 +96,29 @@ export default function Sidebar({
     } finally {
       setCreatingProjectId(null);
     }
+  };
+
+  const handleArchiveClick = async (wsId: string) => {
+    let uncommittedCount = liveData[wsId]?.diffStats?.uncommitted?.length;
+    if (uncommittedCount === undefined) {
+      try {
+        const stats = await api.get<DiffStatResponse>(`/api/workspaces/${wsId}/diff/stat`);
+        uncommittedCount = stats.uncommitted.length;
+      } catch {
+        uncommittedCount = 0;
+      }
+    }
+    if (uncommittedCount > 0) {
+      setArchiveTarget(wsId);
+    } else {
+      await doArchive(wsId);
+    }
+  };
+
+  const doArchive = async (wsId: string) => {
+    const wasActive = activeWsId === wsId;
+    await onArchiveWorkspace(wsId);
+    if (wasActive) navigate("/projects");
   };
 
   return (
@@ -153,24 +191,38 @@ export default function Sidebar({
                           const displayBranch = wsLive?.branch ?? ws.branch;
                           const hasTerminal = activeTerminals.has(ws.id);
                           return (
-                            <Link
-                              key={ws.id}
-                              to={`/workspaces/${ws.id}`}
-                              className={cn(
-                                "block rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/60",
-                                activeWsId === ws.id && "bg-primary/8",
-                              )}
-                            >
-                              <div className="flex items-center gap-1.5">
-                                <BranchLabel branch={displayBranch} className="min-w-0 flex-1 text-sm" />
-                                {hasTerminal && (
-                                  <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70" />
+                            <div key={ws.id} className="group/ws relative">
+                              <Link
+                                to={`/workspaces/${ws.id}`}
+                                className={cn(
+                                  "block rounded-md px-2 py-1.5 transition-colors hover:bg-sidebar-accent/60",
+                                  activeWsId === ws.id && "bg-primary/8",
                                 )}
-                              </div>
-                              <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
-                                <span className="truncate">{wsStreaming ? "working..." : ws.name}</span>
-                              </div>
-                            </Link>
+                              >
+                                <div className="flex items-center gap-1.5">
+                                  <BranchLabel branch={displayBranch} className="min-w-0 flex-1 text-sm" />
+                                  {hasTerminal && (
+                                    <TerminalSquareIcon className="h-3 w-3 shrink-0 text-primary/70 transition-opacity group-hover/ws:opacity-0" />
+                                  )}
+                                </div>
+                                <div className="mt-0.5 pl-5 text-[11px] text-muted-foreground">
+                                  <span className="truncate">{wsStreaming ? "working..." : ws.name}</span>
+                                </div>
+                              </Link>
+                              <button
+                                type="button"
+                                className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
+                                onClick={(e) => {
+                                  e.preventDefault();
+                                  e.stopPropagation();
+                                  void handleArchiveClick(ws.id);
+                                }}
+                                aria-label={`Archive workspace ${ws.name}`}
+                                title="Archive workspace"
+                              >
+                                <ArchiveIcon className="h-3 w-3" />
+                              </button>
+                            </div>
                           );
                         })}
                       </div>
@@ -201,6 +253,31 @@ export default function Sidebar({
           <Settings className="h-4 w-4" />
         </Link>
       </div>
+
+      <AlertDialog
+        open={archiveTarget !== null}
+        onOpenChange={(open) => !open && setArchiveTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Archive workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              This workspace has uncommitted changes that will be lost. Are you sure you want to archive it?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (archiveTarget) void doArchive(archiveTarget);
+                setArchiveTarget(null);
+              }}
+            >
+              Archive
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { ArchiveIcon, FolderPlus, Settings, TerminalSquareIcon } from "lucide-react";
+import { ArchiveIcon, FolderPlus, Plus, Settings, TerminalSquareIcon, Trash2 } from "lucide-react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -50,6 +50,7 @@ interface SidebarProps {
   loading: boolean;
   onAddProject: () => void;
   onAddWorkspace: (projectId: string) => Promise<unknown>;
+  onDeleteProject: (id: string) => Promise<void>;
   onArchiveWorkspace: (wsId: string) => Promise<void>;
 }
 
@@ -58,6 +59,7 @@ export default function Sidebar({
   loading,
   onAddProject,
   onAddWorkspace,
+  onDeleteProject,
   onArchiveWorkspace,
 }: SidebarProps) {
   const workspaceIds = useMemo(
@@ -75,6 +77,7 @@ export default function Sidebar({
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
   const [archiveTarget, setArchiveTarget] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const liveData = useWorkspaceLiveData(workspaceIds);
 
   const activeProjectId = projects.find((project) =>
@@ -129,7 +132,7 @@ export default function Sidebar({
         </Link>
       </div>
 
-      <ScrollArea className="flex-1">
+      <ScrollArea className="flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full">
         <div className="p-2">
           {loading ? (
             <div className="space-y-2 px-2">
@@ -148,12 +151,12 @@ export default function Sidebar({
                       setExpandedProjects((prev) => ({ ...prev, [project.id]: open }))
                     }
                   >
-                    <div className="group flex items-center">
+                    <div className="group relative flex w-full items-center">
                       <CollapsibleTrigger asChild>
                         <button
                           type="button"
                           className={cn(
-                            "flex flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors hover:bg-sidebar-accent/60",
+                            "flex w-full min-w-0 items-center gap-2 overflow-hidden rounded-md px-2 py-1.5 text-left text-sm font-medium transition-colors hover:bg-sidebar-accent/60",
                             activeProjectId === project.id && "bg-sidebar-accent/60",
                           )}
                         >
@@ -166,22 +169,35 @@ export default function Sidebar({
                           >
                             {project.name[0]?.toUpperCase() ?? "?"}
                           </span>
-                          <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                          <span
-                            role="button"
-                            tabIndex={-1}
-                            className="shrink-0 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              handleAddWorkspace(project.id);
-                            }}
-                            aria-label={`Add workspace to ${project.name}`}
-                            title={`Add workspace to ${project.name}`}
-                          >
-                            {creatingProjectId === project.id ? "..." : "+"}
+                          <span className="min-w-0 flex-1 truncate pr-0 transition-[padding] group-hover:pr-12">
+                            {project.name}
                           </span>
                         </button>
                       </CollapsibleTrigger>
+                      <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">
+                        {(project.workspaces ?? []).length === 0 && (
+                          <button
+                            type="button"
+                            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:text-destructive"
+                            onClick={() => setDeleteTarget(project.id)}
+                            aria-label={`Delete project ${project.name}`}
+                            title="Delete project"
+                          >
+                            <Trash2 className="h-3 w-3" />
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className="shrink-0 rounded px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:text-sidebar-foreground"
+                          onClick={() => {
+                            void handleAddWorkspace(project.id);
+                          }}
+                          aria-label={`Add workspace to ${project.name}`}
+                          title={`Add workspace to ${project.name}`}
+                        >
+                          {creatingProjectId === project.id ? "..." : <Plus className="h-3 w-3" />}
+                        </button>
+                      </div>
                     </div>
                     <CollapsibleContent>
                       <div className="mt-1 space-y-0.5">
@@ -276,6 +292,31 @@ export default function Sidebar({
               }}
             >
               Archive
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => !open && setDeleteTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete project</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete the repository and all its data. This action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (deleteTarget) void onDeleteProject(deleteTarget);
+                setDeleteTarget(null);
+              }}
+            >
+              Delete
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -48,6 +48,14 @@ export function useProjects() {
     setData((prev) => prev.filter((p) => p.id !== id));
   }, [setData]);
 
+  const archiveWorkspace = useCallback(async (wsId: string) => {
+    await api.post(`/api/workspaces/${wsId}/archive`);
+    setData((prev) => prev.map((project) => ({
+      ...project,
+      workspaces: project.workspaces.filter((ws) => ws.id !== wsId),
+    })));
+  }, [setData]);
+
   return {
     projects,
     loading,
@@ -57,5 +65,6 @@ export function useProjects() {
     createWorkspace,
     createProjectWithWorkspace,
     deleteProject,
+    archiveWorkspace,
   };
 }

--- a/frontend/tests/components/ChatMessage.test.tsx
+++ b/frontend/tests/components/ChatMessage.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/components/chat/ToolCallList", () => ({
 }));
 
 vi.mock("@/components/chat/CopyButton", () => ({
-  CopyButton: ({ content }: { content: string }) => <button data-testid="copy-button">{content}</button>,
+  CopyButton: ({ content }: { content: string }) => <button data-testid="copy-button" data-content={content} />,
 }));
 
 vi.mock("@/components/ai-elements/message", () => ({
@@ -80,7 +80,6 @@ describe("ChatMessage", () => {
     );
 
     expect(screen.getByText("Hi")).toBeInTheDocument();
-    expect(screen.queryByTestId("copy-button")).not.toBeInTheDocument();
     expect(screen.queryByTestId("tool-call-list")).not.toBeInTheDocument();
   });
 

--- a/frontend/tests/components/ChatToolUse.test.tsx
+++ b/frontend/tests/components/ChatToolUse.test.tsx
@@ -22,7 +22,7 @@ describe("ChatToolUse", () => {
     await user.click(screen.getByRole("button", { name: /bash/i }));
 
     expect(screen.getByText("{not-json")).toBeInTheDocument();
-    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
     expect(screen.getByText("result")).toBeInTheDocument();
   });
 
@@ -47,7 +47,7 @@ describe("ChatToolUse", () => {
     expect(screen.getByText("Path: src/app.ts")).toBeInTheDocument();
     expect(screen.getByText("before")).toBeInTheDocument();
     expect(screen.getByText("after")).toBeInTheDocument();
-    expect(screen.queryByText("Result")).not.toBeInTheDocument();
+    expect(screen.queryByText("Output")).not.toBeInTheDocument();
     expect(
       screen.queryByText("this output must stay hidden"),
     ).not.toBeInTheDocument();
@@ -97,7 +97,7 @@ describe("ChatToolUse", () => {
 
     await user.click(screen.getByRole("button", { name: /task/i }));
 
-    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
     expect(screen.getByText(/"agent result"/)).toBeInTheDocument();
   });
 
@@ -123,7 +123,7 @@ describe("ChatToolUse", () => {
 
     await user.click(screen.getByRole("button", { name: /task/i }));
 
-    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("Output")).toBeInTheDocument();
     expect(screen.getByText("First finding")).toBeInTheDocument();
     expect(screen.getByText("Second finding")).toBeInTheDocument();
   });
@@ -147,6 +147,6 @@ describe("ChatToolUse", () => {
 
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(screen.queryByText("Path: src/main.ts")).not.toBeInTheDocument();
-    expect(screen.queryByText("Result")).not.toBeInTheDocument();
+    expect(screen.queryByText("Output")).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -72,6 +72,7 @@ function renderSidebar(
   onAddWorkspace = vi.fn(),
   activeTerminalWorkspaceIds: string[] = [],
   onArchiveWorkspace = vi.fn(),
+  onDeleteProject = vi.fn(),
 ) {
   return render(
     <TerminalProvider>
@@ -86,6 +87,7 @@ function renderSidebar(
                 loading={false}
                 onAddProject={vi.fn()}
                 onAddWorkspace={onAddWorkspace}
+                onDeleteProject={onDeleteProject}
                 onArchiveWorkspace={onArchiveWorkspace}
               />
             }
@@ -98,6 +100,7 @@ function renderSidebar(
                 loading={false}
                 onAddProject={vi.fn()}
                 onAddWorkspace={onAddWorkspace}
+                onDeleteProject={onDeleteProject}
                 onArchiveWorkspace={onArchiveWorkspace}
               />
             }
@@ -365,5 +368,66 @@ describe("Sidebar", () => {
     await waitFor(() => {
       expect(onArchive).toHaveBeenCalledWith("w1");
     });
+  });
+
+  it("shows delete button for projects with no workspaces", () => {
+    renderSidebar("/projects", projects);
+
+    expect(screen.getByRole("button", { name: /delete project beta/i })).toBeInTheDocument();
+  });
+
+  it("does not show delete button for projects with workspaces", () => {
+    renderSidebar("/projects", projects);
+
+    expect(screen.queryByRole("button", { name: /delete project alpha/i })).not.toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog when clicking delete project", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await user.click(screen.getByRole("button", { name: /delete project beta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete project")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/permanently delete/i)).toBeInTheDocument();
+  });
+
+  it("calls onDeleteProject after confirming deletion", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    renderSidebar("/projects", projects, vi.fn(), [], vi.fn(), onDelete);
+
+    await user.click(screen.getByRole("button", { name: /delete project beta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete project")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledWith("p2");
+    });
+  });
+
+  it("does not call onDeleteProject when cancelling deletion", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    renderSidebar("/projects", projects, vi.fn(), [], vi.fn(), onDelete);
+
+    await user.click(screen.getByRole("button", { name: /delete project beta/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Delete project")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Delete project")).not.toBeInTheDocument();
+    });
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -5,7 +5,16 @@ import { useEffect } from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Sidebar from "@/components/Sidebar";
 import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
+import { api } from "@/hooks/useApi";
 import type { Project, WsOutgoing } from "@/types";
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
 
 vi.mock("@/lib/ws-transport", () => {
   const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
@@ -62,6 +71,7 @@ function renderSidebar(
   projects: Project[],
   onAddWorkspace = vi.fn(),
   activeTerminalWorkspaceIds: string[] = [],
+  onArchiveWorkspace = vi.fn(),
 ) {
   return render(
     <TerminalProvider>
@@ -76,6 +86,7 @@ function renderSidebar(
                 loading={false}
                 onAddProject={vi.fn()}
                 onAddWorkspace={onAddWorkspace}
+                onArchiveWorkspace={onArchiveWorkspace}
               />
             }
           />
@@ -87,6 +98,7 @@ function renderSidebar(
                 loading={false}
                 onAddProject={vi.fn()}
                 onAddWorkspace={onAddWorkspace}
+                onArchiveWorkspace={onArchiveWorkspace}
               />
             }
           />
@@ -206,5 +218,152 @@ describe("Sidebar", () => {
 
     expect(screen.getByText("feat/login-page")).toBeInTheDocument();
     expect(screen.queryByText("workspace/tokyo")).not.toBeInTheDocument();
+  });
+
+  it("shows archive button on workspace hover", () => {
+    renderSidebar("/workspaces/w1", projects);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    expect(archiveBtn).toBeInTheDocument();
+  });
+
+  it("hides archive button when terminal is active", () => {
+    renderSidebar("/workspaces/w1", projects, vi.fn(), ["w1"]);
+
+    expect(screen.queryByRole("button", { name: /archive workspace/i })).not.toBeInTheDocument();
+  });
+
+  it("archives clean workspace directly without confirmation", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.get).mockResolvedValueOnce({ committed: [], uncommitted: [] });
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith("w1");
+    });
+
+    // No confirmation dialog should appear
+    expect(screen.queryByText("Archive workspace")).not.toBeInTheDocument();
+  });
+
+  it("shows confirmation dialog for dirty workspace", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      committed: [],
+      uncommitted: [{ file: "dirty.txt", additions: 1, deletions: 0, status: "added" }],
+    });
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Archive workspace")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/uncommitted changes/i)).toBeInTheDocument();
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("confirms archive of dirty workspace via dialog", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      committed: [],
+      uncommitted: [{ file: "dirty.txt", additions: 1, deletions: 0, status: "added" }],
+    });
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Archive workspace")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith("w1");
+    });
+  });
+
+  it("cancels archive of dirty workspace via dialog", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.get).mockResolvedValueOnce({
+      committed: [],
+      uncommitted: [{ file: "dirty.txt", additions: 1, deletions: 0, status: "added" }],
+    });
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText("Archive workspace")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("Archive workspace")).not.toBeInTheDocument();
+    });
+
+    expect(onArchive).not.toHaveBeenCalled();
+  });
+
+  it("uses cached diffStats from live data when available", async () => {
+    const { __wsMock } = await getWsMock();
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    // Emit diff_stats via WS so liveData has cached stats (clean workspace)
+    act(() => {
+      __wsMock.emit("w1", {
+        type: "diff_stats",
+        stats: { committed: [], uncommitted: [] },
+      });
+    });
+
+    // Clear any API calls made during setup/subscription
+    vi.mocked(api.get).mockClear();
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith("w1");
+    });
+
+    // Should NOT have called the API since cached data was available
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("falls back to direct API call when diffStats not cached and API fails", async () => {
+    const user = userEvent.setup();
+    const onArchive = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(api.get).mockRejectedValueOnce(new Error("network error"));
+
+    renderSidebar("/workspaces/w1", projects, vi.fn(), [], onArchive);
+
+    const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
+    await user.click(archiveBtn);
+
+    // When API fails, uncommittedCount falls back to 0 → archives directly
+    await waitFor(() => {
+      expect(onArchive).toHaveBeenCalledWith("w1");
+    });
   });
 });

--- a/frontend/tests/hooks/useProjects.test.ts
+++ b/frontend/tests/hooks/useProjects.test.ts
@@ -117,6 +117,48 @@ describe("useProjects", () => {
     expect(withWorkspace[1]?.workspaces).toEqual([createdWorkspace]);
   });
 
+  it("archives workspace and removes it from project state", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce(undefined);
+
+    const project = makeProject("p1");
+    project.workspaces = [makeWorkspace("w1"), makeWorkspace("w2")];
+    vi.mocked(useResource).mockReturnValue({
+      data: [project],
+      loading: false,
+      error: null,
+      refresh: vi.fn(),
+      setData,
+    });
+
+    const { result } = renderHook(() => useProjects());
+    await result.current.archiveWorkspace("w1");
+
+    expect(api.post).toHaveBeenCalledWith("/api/workspaces/w1/archive");
+    expect(setData).toHaveBeenCalledTimes(1);
+
+    const updater = setData.mock.calls[0]?.[0] as (prev: Project[]) => Project[];
+    const updated = updater([project]);
+    expect(updated[0]?.workspaces).toHaveLength(1);
+    expect(updated[0]?.workspaces[0]?.id).toBe("w2");
+  });
+
+  it("archive only removes workspace from its parent project", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce(undefined);
+
+    const p1 = makeProject("p1");
+    p1.workspaces = [makeWorkspace("w1")];
+    const p2 = makeProject("p2");
+    p2.workspaces = [makeWorkspace("w2")];
+
+    const { result } = renderHook(() => useProjects());
+    await result.current.archiveWorkspace("w1");
+
+    const updater = setData.mock.calls[0]?.[0] as (prev: Project[]) => Project[];
+    const updated = updater([p1, p2]);
+    expect(updated[0]?.workspaces).toHaveLength(0);
+    expect(updated[1]?.workspaces).toHaveLength(1);
+  });
+
   it("rolls back project when workspace creation fails", async () => {
     const createdProject = makeProject("p2");
     const createWorkspaceError = new Error("workspace failed");


### PR DESCRIPTION
## Summary
- prevent deleting projects that still have active workspaces (API returns 409)
- add project delete action in sidebar for projects with no workspaces, with confirmation dialog
- fix sidebar project-row hover layout so action icons overlay without expanding width
- ensure long project names truncate with ellipsis on hover

## Validation
- npm run test --workspace @hive/backend -- projects.test.ts
- npm run test --workspace @hive/frontend -- Sidebar.test.tsx