### PR TITLE
test: lock autocomplete and completion regressions

### DIFF
--- a/backend/src/api/completions.test.ts
+++ b/backend/src/api/completions.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createFixtureRepo, createTempDir } from "../utils/test-helpers.js";
+import { projectRoutes } from "./projects.js";
+import { workspaceRoutes } from "./workspaces.js";
+import { completionRoutes } from "./completions.js";
+
+let tempDir: string;
+let homeDir: string;
+let dataDir: string;
+let fixtureRepoUrl: string;
+let app: ReturnType<typeof Fastify>;
+let projectId: string;
+let wsId: string;
+let wsName: string;
+let originalHome: string | undefined;
+
+async function writeSkill(baseDir: string, name: string, content: string) {
+  const dir = join(baseDir, ".claude", "skills", name);
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, "SKILL.md"), content, "utf-8");
+}
+
+async function writeAgent(baseDir: string, filename: string, content: string) {
+  const dir = join(baseDir, ".claude", "agents");
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, filename), content, "utf-8");
+}
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-completions-route-");
+  homeDir = join(tempDir, "home");
+  dataDir = join(tempDir, "data");
+  const fixtureDir = join(tempDir, "fixtures");
+
+  await mkdir(homeDir, { recursive: true });
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(fixtureDir, { recursive: true });
+
+  originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+
+  fixtureRepoUrl = await createFixtureRepo(fixtureDir);
+
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => projectRoutes(instance, dataDir));
+  await app.register((instance: FastifyInstance) => workspaceRoutes(instance, dataDir));
+  await app.register((instance: FastifyInstance) => completionRoutes(instance, dataDir));
+  await app.ready();
+
+  const projectRes = await app.inject({
+    method: "POST",
+    url: "/api/projects",
+    payload: { url: fixtureRepoUrl },
+  });
+
+  projectId = projectRes.json().id;
+
+  const wsRes = await app.inject({
+    method: "POST",
+    url: `/api/projects/${projectId}/workspaces`,
+  });
+
+  wsId = wsRes.json().id;
+  wsName = wsRes.json().name;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+
+  await app.close();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("GET /api/workspaces/:wsId/completions", () => {
+  it("returns 404 for unknown workspace", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/workspaces/ws-missing/completions",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Workspace not found" });
+  });
+
+  it("returns builtin, user, and project completions", async () => {
+    const workspaceDir = join(dataDir, projectId, "workspaces", wsName);
+
+    await writeSkill(
+      homeDir,
+      "deploy",
+      `---
+name: deploy
+description: Deploy from home skills
+---
+`,
+    );
+
+    await writeSkill(
+      workspaceDir,
+      "local-lint",
+      `---
+name: local-lint
+description: Lint this workspace
+---
+`,
+    );
+
+    await writeAgent(
+      homeDir,
+      "reviewer.md",
+      `---
+name: reviewer
+description: Global code reviewer
+---
+`,
+    );
+
+    await writeAgent(workspaceDir, "triage.md", "# triage\n");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/completions`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(Array.isArray(body.items)).toBe(true);
+
+    expect(body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "slash_command",
+          name: "help",
+          label: "/help",
+          source: "builtin",
+        }),
+        expect.objectContaining({
+          type: "slash_command",
+          name: "deploy",
+          label: "/deploy",
+          source: "user_skill",
+        }),
+        expect.objectContaining({
+          type: "slash_command",
+          name: "local-lint",
+          label: "/local-lint",
+          source: "project_skill",
+        }),
+        expect.objectContaining({
+          type: "agent",
+          name: "reviewer",
+          label: "@reviewer",
+          source: "user_agent",
+        }),
+        expect.objectContaining({
+          type: "agent",
+          name: "triage",
+          label: "@triage",
+          source: "project_agent",
+        }),
+      ]),
+    );
+  });
+
+  it("reads project skills from the requested workspace path only", async () => {
+    const ws2Res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+
+    const ws2Id = ws2Res.json().id as string;
+    const ws2Name = ws2Res.json().name as string;
+
+    const ws1Path = join(dataDir, projectId, "workspaces", wsName);
+    const ws2Path = join(dataDir, projectId, "workspaces", ws2Name);
+
+    await writeSkill(
+      ws1Path,
+      "ws1-only",
+      `---
+name: ws1-only
+---
+`,
+    );
+
+    await writeSkill(
+      ws2Path,
+      "ws2-only",
+      `---
+name: ws2-only
+---
+`,
+    );
+
+    const ws1Res = await app.inject({ method: "GET", url: `/api/workspaces/${wsId}/completions` });
+    const ws2CompletionsRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${ws2Id}/completions`,
+    });
+
+    const ws1Items = ws1Res.json().items as Array<{ name: string; source: string }>;
+    const ws2Items = ws2CompletionsRes.json().items as Array<{ name: string; source: string }>;
+
+    expect(ws1Items.some((item) => item.name === "ws1-only" && item.source === "project_skill")).toBe(true);
+    expect(ws1Items.some((item) => item.name === "ws2-only")).toBe(false);
+
+    expect(ws2Items.some((item) => item.name === "ws2-only" && item.source === "project_skill")).toBe(true);
+    expect(ws2Items.some((item) => item.name === "ws1-only")).toBe(false);
+  });
+});

--- a/backend/src/api/completions.ts
+++ b/backend/src/api/completions.ts
@@ -1,0 +1,37 @@
+import type { FastifyInstance } from "fastify";
+import { join } from "node:path";
+import { getWorkspace } from "../workspaces/workspace-manager.js";
+import { workspacesDir } from "../utils/paths.js";
+import { scanCompletions } from "../utils/completion-scanner.js";
+import { getDataDir } from "../state/state.js";
+import { errorMessage, errorStatus } from "../utils/errors.js";
+
+export async function completionRoutes(
+  app: FastifyInstance,
+  dataDir?: string,
+) {
+  app.get<{ Params: { wsId: string } }>(
+    "/api/workspaces/:wsId/completions",
+    async (req, reply) => {
+      try {
+        const dir = dataDir ?? getDataDir();
+        const result = await getWorkspace(req.params.wsId, dir);
+        if (!result) {
+          return reply.status(404).send({ error: "Workspace not found" });
+        }
+
+        const workspaceCwd = join(
+          workspacesDir(dir, result.projectState.id),
+          result.workspace.name,
+        );
+
+        const items = await scanCompletions(workspaceCwd);
+        return reply.send({ items });
+      } catch (err: unknown) {
+        return reply
+          .status(errorStatus(err))
+          .send({ error: errorMessage(err, "Failed to scan completions") });
+      }
+    },
+  );
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -4,6 +4,7 @@ import cors from "@fastify/cors";
 import websocket from "@fastify/websocket";
 import { projectRoutes } from "./api/projects.js";
 import { workspaceRoutes } from "./api/workspaces.js";
+import { completionRoutes } from "./api/completions.js";
 import { sessionRoutes } from "./api/agents.js";
 import { streamRoutes } from "./ws/stream.js";
 import { terminalRoutes } from "./ws/terminal.js";
@@ -68,6 +69,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
 
   await app.register((instance: FastifyInstance) => projectRoutes(instance));
   await app.register((instance: FastifyInstance) => workspaceRoutes(instance));
+  await app.register((instance: FastifyInstance) => completionRoutes(instance));
   await app.register((instance: FastifyInstance) =>
     sessionRoutes(instance, {
       sessionOptions,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -17,6 +17,30 @@ export interface Workspace {
   activeSessionId?: string;
 }
 
+// ── Completion / autocomplete types ─────────────────────────────────
+
+export type CompletionItemType = "slash_command" | "agent";
+export type CompletionSource =
+  | "builtin"
+  | "user_skill"
+  | "project_skill"
+  | "plugin"
+  | "user_agent"
+  | "project_agent";
+
+export interface CompletionItem {
+  type: CompletionItemType;
+  name: string;
+  label: string;
+  description?: string;
+  argumentHint?: string;
+  source: CompletionSource;
+}
+
+export interface CompletionsResponse {
+  items: CompletionItem[];
+}
+
 // ── Branch / GitHub sync types ──────────────────────────────────────
 
 export interface PullRequestInfo {

--- a/backend/src/utils/completion-scanner.test.ts
+++ b/backend/src/utils/completion-scanner.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createTempDir } from "./test-helpers.js";
+import { scanCompletions } from "./completion-scanner.js";
+
+const BUILTIN_LABELS = [
+  "/help",
+  "/clear",
+  "/compact",
+  "/init",
+  "/model",
+  "/context",
+  "/cost",
+  "/status",
+  "/permissions",
+  "/fast",
+];
+
+let tempDir: string;
+let homeDir: string;
+let workspaceCwd: string;
+let originalHome: string | undefined;
+
+async function writeSkill(dir: string, folder: string, content: string) {
+  const skillDir = join(dir, folder);
+  await mkdir(skillDir, { recursive: true });
+  await writeFile(join(skillDir, "SKILL.md"), content, "utf-8");
+}
+
+async function writeAgent(dir: string, filename: string, content: string) {
+  await mkdir(dir, { recursive: true });
+  await writeFile(join(dir, filename), content, "utf-8");
+}
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-completion-scanner-");
+  homeDir = join(tempDir, "home");
+  workspaceCwd = join(tempDir, "workspace");
+  await mkdir(homeDir, { recursive: true });
+  await mkdir(workspaceCwd, { recursive: true });
+
+  originalHome = process.env.HOME;
+  process.env.HOME = homeDir;
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) {
+    delete process.env.HOME;
+  } else {
+    process.env.HOME = originalHome;
+  }
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("scanCompletions", () => {
+  it("returns builtin completions when no skill or agent directories exist", async () => {
+    const items = await scanCompletions(workspaceCwd);
+
+    expect(items).toHaveLength(BUILTIN_LABELS.length);
+    expect(items.map((item) => item.label)).toEqual(BUILTIN_LABELS);
+    expect(items.every((item) => item.source === "builtin")).toBe(true);
+  });
+
+  it("scans user and project skills with frontmatter fields", async () => {
+    const userSkillsDir = join(homeDir, ".claude", "skills");
+    const projectSkillsDir = join(workspaceCwd, ".claude", "skills");
+
+    await writeSkill(
+      userSkillsDir,
+      "deploy",
+      `---
+name: ship
+description: Deploy safely
+argument-hint: <target>
+---
+# Deploy\n`,
+    );
+
+    await writeSkill(
+      userSkillsDir,
+      "hidden",
+      `---
+name: hidden
+user-invocable: false
+---
+`,
+    );
+
+    await writeSkill(
+      projectSkillsDir,
+      "lint-local",
+      `---
+description: Run project lint checks
+---
+`,
+    );
+
+    const items = await scanCompletions(workspaceCwd);
+    const slashItems = items.filter((item) => item.type === "slash_command");
+
+    expect(slashItems.some((item) => item.name === "hidden")).toBe(false);
+
+    expect(slashItems).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "ship",
+          label: "/ship",
+          description: "Deploy safely",
+          argumentHint: "<target>",
+          source: "user_skill",
+        }),
+        expect.objectContaining({
+          name: "lint-local",
+          label: "/lint-local",
+          description: "Run project lint checks",
+          source: "project_skill",
+        }),
+      ]),
+    );
+  });
+
+  it("falls back to folder name when skill frontmatter does not define name", async () => {
+    const userSkillsDir = join(homeDir, ".claude", "skills");
+
+    await writeSkill(userSkillsDir, "fallback-name", "No frontmatter");
+
+    const items = await scanCompletions(workspaceCwd);
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "fallback-name",
+          label: "/fallback-name",
+          source: "user_skill",
+        }),
+      ]),
+    );
+  });
+
+  it("scans user and project agents and ignores non-markdown files", async () => {
+    const userAgentsDir = join(homeDir, ".claude", "agents");
+    const projectAgentsDir = join(workspaceCwd, ".claude", "agents");
+
+    await writeAgent(
+      userAgentsDir,
+      "reviewer.md",
+      `---
+name: code-reviewer
+description: Reviews pull requests
+---
+`,
+    );
+
+    await writeAgent(projectAgentsDir, "triage.md", "# Triage agent");
+    await writeAgent(userAgentsDir, "README.txt", "ignored");
+
+    const items = await scanCompletions(workspaceCwd);
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "agent",
+          name: "code-reviewer",
+          label: "@code-reviewer",
+          description: "Reviews pull requests",
+          source: "user_agent",
+        }),
+        expect.objectContaining({
+          type: "agent",
+          name: "triage",
+          label: "@triage",
+          source: "project_agent",
+        }),
+      ]),
+    );
+
+    expect(items.some((item) => item.name === "README")).toBe(false);
+  });
+
+  it("returns completions in stable source order", async () => {
+    await writeSkill(
+      join(homeDir, ".claude", "skills"),
+      "u-skill",
+      "---\nname: u-skill\n---",
+    );
+    await writeSkill(
+      join(workspaceCwd, ".claude", "skills"),
+      "p-skill",
+      "---\nname: p-skill\n---",
+    );
+    await writeAgent(join(homeDir, ".claude", "agents"), "u-agent.md", "# agent");
+    await writeAgent(join(workspaceCwd, ".claude", "agents"), "p-agent.md", "# agent");
+
+    const items = await scanCompletions(workspaceCwd);
+
+    const firstBuiltinIdx = items.findIndex((item) => item.source === "builtin");
+    const firstUserSkillIdx = items.findIndex((item) => item.source === "user_skill");
+    const firstProjectSkillIdx = items.findIndex((item) => item.source === "project_skill");
+    const firstUserAgentIdx = items.findIndex((item) => item.source === "user_agent");
+    const firstProjectAgentIdx = items.findIndex((item) => item.source === "project_agent");
+
+    expect(firstBuiltinIdx).toBe(0);
+    expect(firstUserSkillIdx).toBeGreaterThan(firstBuiltinIdx);
+    expect(firstProjectSkillIdx).toBeGreaterThan(firstUserSkillIdx);
+    expect(firstUserAgentIdx).toBeGreaterThan(firstProjectSkillIdx);
+    expect(firstProjectAgentIdx).toBeGreaterThan(firstUserAgentIdx);
+  });
+
+  it("skips unreadable skill entries without failing the scan", async () => {
+    const userSkillsDir = join(homeDir, ".claude", "skills");
+    await mkdir(join(userSkillsDir, "broken"), { recursive: true });
+
+    await writeSkill(
+      userSkillsDir,
+      "valid",
+      `---
+name: stable
+---
+`,
+    );
+
+    const items = await scanCompletions(workspaceCwd);
+
+    expect(items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "stable",
+          label: "/stable",
+          source: "user_skill",
+        }),
+      ]),
+    );
+  });
+});

--- a/backend/src/utils/completion-scanner.ts
+++ b/backend/src/utils/completion-scanner.ts
@@ -1,0 +1,130 @@
+import { homedir } from "node:os";
+import { join, basename } from "node:path";
+import { readdir, readFile } from "node:fs/promises";
+import { parseFrontmatter } from "./frontmatter.js";
+import type { CompletionItem } from "../types.js";
+
+const BUILTIN_COMMANDS: CompletionItem[] = [
+  { type: "slash_command", name: "help", label: "/help", description: "Show available commands", source: "builtin" },
+  { type: "slash_command", name: "clear", label: "/clear", description: "Clear conversation history", source: "builtin" },
+  { type: "slash_command", name: "compact", label: "/compact", description: "Compact conversation context", source: "builtin" },
+  { type: "slash_command", name: "init", label: "/init", description: "Initialize project context", source: "builtin" },
+  { type: "slash_command", name: "model", label: "/model", description: "Switch Claude model", source: "builtin" },
+  { type: "slash_command", name: "context", label: "/context", description: "Manage context files", source: "builtin" },
+  { type: "slash_command", name: "cost", label: "/cost", description: "Show session cost", source: "builtin" },
+  { type: "slash_command", name: "status", label: "/status", description: "Show session status", source: "builtin" },
+  { type: "slash_command", name: "permissions", label: "/permissions", description: "Manage tool permissions", source: "builtin" },
+  { type: "slash_command", name: "fast", label: "/fast", description: "Toggle fast mode", source: "builtin" },
+];
+
+async function scanSkills(
+  dir: string,
+  source: "user_skill" | "project_skill",
+): Promise<CompletionItem[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const items: CompletionItem[] = [];
+
+  for (const entry of entries) {
+    try {
+      const skillPath = join(dir, entry, "SKILL.md");
+      const content = await readFile(skillPath, "utf-8");
+      const fm = parseFrontmatter(content);
+
+      if (fm["user-invocable"] === false) continue;
+
+      const name = typeof fm.name === "string" ? fm.name : entry;
+      const description =
+        typeof fm.description === "string" ? fm.description : undefined;
+      const argumentHint =
+        typeof fm["argument-hint"] === "string"
+          ? fm["argument-hint"]
+          : undefined;
+
+      items.push({
+        type: "slash_command",
+        name,
+        label: `/${name}`,
+        description,
+        argumentHint,
+        source,
+      });
+    } catch {
+      // Skip unreadable entries
+    }
+  }
+
+  return items;
+}
+
+async function scanAgents(
+  dir: string,
+  source: "user_agent" | "project_agent",
+): Promise<CompletionItem[]> {
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return [];
+  }
+
+  const items: CompletionItem[] = [];
+
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    try {
+      const content = await readFile(join(dir, entry), "utf-8");
+      const fm = parseFrontmatter(content);
+
+      const name =
+        typeof fm.name === "string" ? fm.name : basename(entry, ".md");
+      const description =
+        typeof fm.description === "string" ? fm.description : undefined;
+
+      items.push({
+        type: "agent",
+        name,
+        label: `@${name}`,
+        description,
+        source,
+      });
+    } catch {
+      // Skip unreadable entries
+    }
+  }
+
+  return items;
+}
+
+// TODO: Add plugin command scanning from ~/.claude/plugins/installed_plugins.json
+
+export async function scanCompletions(
+  workspaceCwd: string,
+): Promise<CompletionItem[]> {
+  const home = homedir();
+  const userSkillsDir = join(home, ".claude", "skills");
+  const projectSkillsDir = join(workspaceCwd, ".claude", "skills");
+  const userAgentsDir = join(home, ".claude", "agents");
+  const projectAgentsDir = join(workspaceCwd, ".claude", "agents");
+
+  const [userSkills, projectSkills, userAgents, projectAgents] =
+    await Promise.all([
+      scanSkills(userSkillsDir, "user_skill"),
+      scanSkills(projectSkillsDir, "project_skill"),
+      scanAgents(userAgentsDir, "user_agent"),
+      scanAgents(projectAgentsDir, "project_agent"),
+    ]);
+
+  return [
+    ...BUILTIN_COMMANDS,
+    ...userSkills,
+    ...projectSkills,
+    ...userAgents,
+    ...projectAgents,
+  ];
+}

--- a/backend/src/utils/frontmatter.ts
+++ b/backend/src/utils/frontmatter.ts
@@ -1,0 +1,76 @@
+/**
+ * Lightweight YAML frontmatter parser for SKILL.md and agent .md files.
+ * Handles the flat key-value subset used by Claude Code: strings, booleans,
+ * and bracket/comma-separated arrays. No external dependency needed.
+ */
+
+export interface Frontmatter {
+  [key: string]: string | boolean | string[];
+}
+
+export function parseFrontmatter(content: string): Frontmatter {
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) return {};
+
+  const result: Frontmatter = {};
+
+  for (const line of match[1].split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) continue;
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    let value = trimmed.slice(colonIdx + 1).trim();
+
+    if (!key || !value) continue;
+
+    // Boolean
+    if (value === "true") {
+      result[key] = true;
+      continue;
+    }
+    if (value === "false") {
+      result[key] = false;
+      continue;
+    }
+
+    // Bracket array: [Task, Read, Glob]
+    if (value.startsWith("[") && value.endsWith("]")) {
+      result[key] = value
+        .slice(1, -1)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      continue;
+    }
+
+    // Strip surrounding quotes
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    // YAML folded scalar indicator (>) — just store what follows on this line
+    if (value === ">") {
+      value = "";
+    }
+
+    // Comma-separated string that looks like an array (e.g. "Read, Grep, Glob")
+    // Heuristic: contains commas and no spaces-without-commas pattern typical of prose
+    if (key === "allowed-tools" && value.includes(",")) {
+      result[key] = value
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+      continue;
+    }
+
+    result[key] = value;
+  }
+
+  return result;
+}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -166,9 +166,9 @@ export default function ChatInput({
   const showPopup = autocomplete !== null && filteredItems.length > 0;
 
   return (
-    <div className="border-t border-border/30 bg-background p-4">
+    <div className="relative z-50 border-t border-border/30 bg-background p-4">
       <div className={cn(
-        "relative",
+        "relative [&_[data-slot=input-group]]:!border-border/30",
         showPopup && "[&_[data-slot=input-group]]:rounded-t-none [&_[data-slot=input-group]]:!border-t-transparent",
       )}>
         {showPopup && (

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -166,7 +166,10 @@ export default function ChatInput({
   const showPopup = autocomplete !== null && filteredItems.length > 0;
 
   return (
-    <div className="relative border-t border-border/30 bg-background p-4">
+    <div className={cn(
+      "relative border-t border-border/30 bg-background p-4",
+      showPopup && "[&_[data-slot=input-group]]:rounded-t-none [&_[data-slot=input-group]]:!border-t-transparent",
+    )}>
       {showPopup && (
         <AutocompletePopup
           items={filteredItems}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -166,19 +166,20 @@ export default function ChatInput({
   const showPopup = autocomplete !== null && filteredItems.length > 0;
 
   return (
-    <div className={cn(
-      "relative border-t border-border/30 bg-background p-4",
-      showPopup && "[&_[data-slot=input-group]]:rounded-t-none [&_[data-slot=input-group]]:!border-t-transparent",
-    )}>
-      {showPopup && (
-        <AutocompletePopup
-          items={filteredItems}
-          selectedIndex={selectedIndex}
-          onSelect={selectItem}
-          onHover={setSelectedIndex}
-        />
-      )}
-      <PromptInput onSubmit={handleSubmit} accept="image/*" multiple>
+    <div className="border-t border-border/30 bg-background p-4">
+      <div className={cn(
+        "relative",
+        showPopup && "[&_[data-slot=input-group]]:rounded-t-none [&_[data-slot=input-group]]:!border-t-transparent",
+      )}>
+        {showPopup && (
+          <AutocompletePopup
+            items={filteredItems}
+            selectedIndex={selectedIndex}
+            onSelect={selectItem}
+            onHover={setSelectedIndex}
+          />
+        )}
+        <PromptInput onSubmit={handleSubmit} accept="image/*" multiple>
         <PromptInputBody>
           <ChatInputAttachments onFileCountChange={setFileCount} attachmentsRef={attachmentsRef} />
           <PromptInputTextarea
@@ -248,7 +249,8 @@ export default function ChatInput({
             />
           </PromptInputTools>
         </PromptInputFooter>
-      </PromptInput>
+        </PromptInput>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, type MutableRefObject } from "react";
+import { useState, useRef, useEffect, useMemo, useCallback, type MutableRefObject, type KeyboardEvent, type ChangeEvent } from "react";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   PromptInput,
@@ -11,17 +11,26 @@ import {
   usePromptInputAttachments,
   type AttachmentsContext,
 } from "@/components/ai-elements/prompt-input";
-import type { ImageAttachment, MessageOptions } from "@/types";
+import type { CompletionItem, ImageAttachment, MessageOptions } from "@/types";
 import { cn } from "@/lib/utils";
 import { BrainIcon, BookOpenIcon, PlusIcon, SparklesIcon } from "lucide-react";
 import { AttachmentPreview } from "@/components/chat/AttachmentPreview";
+import { AutocompletePopup } from "@/components/chat/AutocompletePopup";
+import { useCompletions } from "@/hooks/useCompletions";
 
 interface ChatInputProps {
+  wsId?: string;
   onSend: (content: string, images?: ImageAttachment[], options?: MessageOptions) => boolean;
   onStop: () => void;
   disabled: boolean;
   isStreaming: boolean;
   connectionStatus: "connecting" | "connected" | "disconnected";
+}
+
+interface AutocompleteState {
+  trigger: "/" | "@";
+  query: string;
+  triggerIndex: number;
 }
 
 const MODEL_LABEL = "Opus 4.6";
@@ -46,6 +55,7 @@ function ChatInputAttachments({
 }
 
 export default function ChatInput({
+  wsId,
   onSend,
   onStop,
   disabled,
@@ -56,10 +66,83 @@ export default function ChatInput({
   const [thinkingEnabled, setThinkingEnabled] = useState(true);
   const [planMode, setPlanMode] = useState(false);
   const [fileCount, setFileCount] = useState(0);
+  const [autocomplete, setAutocomplete] = useState<AutocompleteState | null>(null);
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const attachmentsRef = useRef<AttachmentsContext | null>(null);
   const isDisconnected = connectionStatus === "disconnected";
   const isInputDisabled = disabled || isStreaming || isDisconnected;
   const canSubmit = !isInputDisabled && (value.trim().length > 0 || fileCount > 0);
+
+  const completionItems = useCompletions(wsId);
+
+  const filteredItems = useMemo(() => {
+    if (!autocomplete) return [];
+    const type = autocomplete.trigger === "/" ? "slash_command" : "agent";
+    return completionItems
+      .filter((item) => item.type === type)
+      .filter(
+        (item) =>
+          autocomplete.query === "" ||
+          item.name.toLowerCase().startsWith(autocomplete.query.toLowerCase()),
+      );
+  }, [autocomplete, completionItems]);
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>) => {
+      const text = e.target.value;
+      setValue(text);
+
+      const cursor = e.target.selectionStart ?? text.length;
+      const beforeCursor = text.slice(0, cursor);
+      const match = beforeCursor.match(/(^|[\s])([/@])(\S*)$/);
+
+      if (match) {
+        const trigger = match[2] as "/" | "@";
+        const query = match[3];
+        const triggerIndex = beforeCursor.length - match[2].length - match[3].length;
+        setAutocomplete({ trigger, query, triggerIndex });
+        setSelectedIndex(0);
+      } else {
+        setAutocomplete(null);
+      }
+    },
+    [],
+  );
+
+  const selectItem = useCallback(
+    (item: CompletionItem) => {
+      if (!autocomplete) return;
+      const before = value.slice(0, autocomplete.triggerIndex);
+      const after = value.slice(
+        autocomplete.triggerIndex + 1 + autocomplete.query.length,
+      );
+      const insertion = item.label + " ";
+      setValue(before + insertion + after);
+      setAutocomplete(null);
+    },
+    [autocomplete, value],
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (!autocomplete || filteredItems.length === 0) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i + 1) % filteredItems.length);
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSelectedIndex((i) => (i - 1 + filteredItems.length) % filteredItems.length);
+      } else if (e.key === "Enter" || e.key === "Tab") {
+        e.preventDefault();
+        selectItem(filteredItems[selectedIndex]);
+      } else if (e.key === "Escape") {
+        e.preventDefault();
+        setAutocomplete(null);
+      }
+    },
+    [autocomplete, filteredItems, selectedIndex, selectItem],
+  );
 
   const handleSubmit = ({ text, files }: PromptInputMessage) => {
     const trimmed = text.trim();
@@ -77,10 +160,21 @@ export default function ChatInput({
     const sent = onSend(trimmed, images, { planMode, thinkingEnabled });
     if (!sent) throw new Error("Message send failed");
     setValue("");
+    setAutocomplete(null);
   };
 
+  const showPopup = autocomplete !== null && filteredItems.length > 0;
+
   return (
-    <div className="border-t border-border/30 bg-background p-4">
+    <div className="relative border-t border-border/30 bg-background p-4">
+      {showPopup && (
+        <AutocompletePopup
+          items={filteredItems}
+          selectedIndex={selectedIndex}
+          onSelect={selectItem}
+          onHover={setSelectedIndex}
+        />
+      )}
       <PromptInput onSubmit={handleSubmit} accept="image/*" multiple>
         <PromptInputBody>
           <ChatInputAttachments onFileCountChange={setFileCount} attachmentsRef={attachmentsRef} />
@@ -88,7 +182,8 @@ export default function ChatInput({
             className="min-h-[100px] max-h-40 text-sm placeholder:text-muted-foreground/40"
             placeholder={isDisconnected ? "Reconnecting..." : "Send a message..."}
             value={value}
-            onChange={(e) => setValue(e.target.value)}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
             disabled={isInputDisabled}
             rows={1}
           />

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -66,12 +66,13 @@ export function AutocompletePopup({
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 z-50 max-h-[240px] overflow-y-auto rounded-t-md border border-b-0 border-ring/40 bg-popover shadow-lg"
+      className="absolute bottom-full left-0 right-0 z-50 max-h-[240px] overflow-y-auto rounded-t-md border border-b-0 border-border/30 bg-background dark:bg-[var(--input-group-bg)] shadow-lg"
+      style={{ "--input-group-bg": "color-mix(in srgb, var(--background), white 3%)" } as React.CSSProperties}
     >
       {grouped.map(({ source, items: groupItems }) => (
         <div key={source}>
           {grouped.length > 1 && (
-            <div className="sticky top-0 bg-popover/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground backdrop-blur-sm">
+            <div className="sticky top-0 bg-muted px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
               {SOURCE_LABELS[source] ?? source}
             </div>
           )}

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -1,0 +1,107 @@
+import { useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import type { CompletionItem, CompletionSource } from "@/types";
+
+const SOURCE_LABELS: Record<CompletionSource, string> = {
+  builtin: "Commands",
+  user_skill: "Skills",
+  project_skill: "Project Skills",
+  plugin: "Plugin Commands",
+  user_agent: "Agents",
+  project_agent: "Project Agents",
+};
+
+const SOURCE_ORDER: CompletionSource[] = [
+  "builtin",
+  "user_skill",
+  "project_skill",
+  "plugin",
+  "user_agent",
+  "project_agent",
+];
+
+interface AutocompletePopupProps {
+  items: CompletionItem[];
+  selectedIndex: number;
+  onSelect: (item: CompletionItem) => void;
+  onHover: (index: number) => void;
+}
+
+export function AutocompletePopup({
+  items,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: AutocompletePopupProps) {
+  const listRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (items.length === 0) return null;
+
+  // Group items by source in display order
+  const grouped: { source: CompletionSource; items: { item: CompletionItem; globalIndex: number }[] }[] = [];
+
+  for (const source of SOURCE_ORDER) {
+    const sourceItems = items
+      .map((item, i) => ({ item, globalIndex: i }))
+      .filter(({ item }) => item.source === source);
+    if (sourceItems.length > 0) {
+      grouped.push({ source, items: sourceItems });
+    }
+  }
+
+  // If grouping missed any items (unknown sources), append them
+  const knownSources = new Set(SOURCE_ORDER);
+  const ungrouped = items
+    .map((item, i) => ({ item, globalIndex: i }))
+    .filter(({ item }) => !knownSources.has(item.source));
+  if (ungrouped.length > 0) {
+    grouped.push({ source: ungrouped[0].item.source, items: ungrouped });
+  }
+
+  return (
+    <div
+      ref={listRef}
+      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg"
+    >
+      {grouped.map(({ source, items: groupItems }) => (
+        <div key={source}>
+          {grouped.length > 1 && (
+            <div className="sticky top-0 bg-popover/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground backdrop-blur-sm">
+              {SOURCE_LABELS[source] ?? source}
+            </div>
+          )}
+          {groupItems.map(({ item, globalIndex }) => (
+            <button
+              key={`${item.source}-${item.name}`}
+              ref={globalIndex === selectedIndex ? selectedRef : undefined}
+              type="button"
+              className={cn(
+                "flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm transition-colors",
+                globalIndex === selectedIndex
+                  ? "bg-accent text-accent-foreground"
+                  : "text-foreground hover:bg-accent/50",
+              )}
+              onMouseDown={(e) => {
+                e.preventDefault(); // Prevent textarea blur
+                onSelect(item);
+              }}
+              onMouseEnter={() => onHover(globalIndex)}
+            >
+              <span className="shrink-0 font-medium">{item.label}</span>
+              {item.description && (
+                <span className="truncate text-xs text-muted-foreground">
+                  {item.description}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -67,12 +67,15 @@ export function AutocompletePopup({
     <div
       ref={listRef}
       className="absolute bottom-full left-0 right-0 z-50 max-h-[240px] overflow-y-auto rounded-t-md border border-b-0 border-border/30 bg-background dark:bg-[var(--input-group-bg)] shadow-lg"
-      style={{ "--input-group-bg": "color-mix(in srgb, var(--background), white 3%)" } as React.CSSProperties}
+      style={{
+        "--input-group-bg": "color-mix(in srgb, var(--background), white 3%)",
+        "--header-bg": "color-mix(in srgb, var(--background), white 6%)",
+      } as React.CSSProperties}
     >
       {grouped.map(({ source, items: groupItems }) => (
         <div key={source}>
           {grouped.length > 1 && (
-            <div className="sticky top-0 bg-muted px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            <div className="sticky top-0 bg-black/5 dark:bg-[var(--header-bg)] px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
               {SOURCE_LABELS[source] ?? source}
             </div>
           )}

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -66,7 +66,7 @@ export function AutocompletePopup({
   return (
     <div
       ref={listRef}
-      className="absolute bottom-full left-0 right-0 z-50 mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-border/50 bg-popover shadow-lg"
+      className="absolute bottom-full left-0 right-0 z-50 max-h-[240px] overflow-y-auto rounded-t-md border border-b-0 border-ring/40 bg-popover shadow-lg"
     >
       {grouped.map(({ source, items: groupItems }) => (
         <div key={source}>

--- a/frontend/src/hooks/useCompletions.ts
+++ b/frontend/src/hooks/useCompletions.ts
@@ -1,0 +1,32 @@
+import { useState, useEffect } from "react";
+import { api } from "./useApi";
+import type { CompletionItem } from "@/types";
+
+interface CompletionsResponse {
+  items: CompletionItem[];
+}
+
+export function useCompletions(wsId: string | undefined): CompletionItem[] {
+  const [items, setItems] = useState<CompletionItem[]>([]);
+
+  useEffect(() => {
+    if (!wsId) {
+      setItems([]);
+      return;
+    }
+    let cancelled = false;
+    api
+      .get<CompletionsResponse>(`/api/workspaces/${wsId}/completions`)
+      .then((res) => {
+        if (!cancelled) setItems(res.items);
+      })
+      .catch(() => {
+        // Autocomplete is optional UX — silently ignore errors
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [wsId]);
+
+  return items;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -402,6 +402,7 @@ export default function WorkspaceView() {
               />
             ) : (
               <ChatInput
+                wsId={wsId}
                 onSend={sendMessage}
                 onStop={stopStreaming}
                 disabled={false}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -17,6 +17,26 @@ export interface Workspace {
   defaultBranch?: string;
 }
 
+// ── Completion / autocomplete types ─────────────────────────────────
+
+export type CompletionItemType = "slash_command" | "agent";
+export type CompletionSource =
+  | "builtin"
+  | "user_skill"
+  | "project_skill"
+  | "plugin"
+  | "user_agent"
+  | "project_agent";
+
+export interface CompletionItem {
+  type: CompletionItemType;
+  name: string;
+  label: string;
+  description?: string;
+  argumentHint?: string;
+  source: CompletionSource;
+}
+
 // ── Branch / GitHub sync types ──────────────────────────────────────
 
 export interface PullRequestInfo {

--- a/frontend/tests/components/AutocompletePopup.test.tsx
+++ b/frontend/tests/components/AutocompletePopup.test.tsx
@@ -1,0 +1,169 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { AutocompletePopup } from "@/components/chat/AutocompletePopup";
+import type { CompletionItem } from "@/types";
+
+function makeItem(
+  name: string,
+  source: CompletionItem["source"],
+  description?: string,
+): CompletionItem {
+  return {
+    type: name.startsWith("agent") ? "agent" : "slash_command",
+    name,
+    label: source.includes("agent") ? `@${name}` : `/${name}`,
+    description,
+    source,
+  };
+}
+
+describe("AutocompletePopup", () => {
+  it("renders nothing when there are no items", () => {
+    const { container } = render(
+      <AutocompletePopup
+        items={[]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("groups items by source using the expected display order", () => {
+    const { container } = render(
+      <AutocompletePopup
+        items={[
+          makeItem("agent-z", "project_agent"),
+          makeItem("help", "builtin"),
+          makeItem("deploy", "user_skill"),
+          makeItem("agent-a", "user_agent"),
+          makeItem("local", "project_skill"),
+        ]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    const headerTexts = Array.from(container.querySelectorAll(".sticky")).map((el) =>
+      el.textContent?.trim(),
+    );
+    expect(headerTexts).toEqual([
+      "Commands",
+      "Skills",
+      "Project Skills",
+      "Agents",
+      "Project Agents",
+    ]);
+  });
+
+  it("falls back to raw source label for unknown sources", () => {
+    render(
+      <AutocompletePopup
+        items={[
+          makeItem("help", "builtin"),
+          makeItem("custom", "plugin"),
+          {
+            ...makeItem("x", "builtin"),
+            source: "custom_source" as CompletionItem["source"],
+            label: "/custom-source",
+          },
+        ]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("custom_source")).toBeInTheDocument();
+  });
+
+  it("uses opaque header backgrounds to avoid scroll bleed", () => {
+    render(
+      <AutocompletePopup
+        items={[makeItem("help", "builtin"), makeItem("agent-a", "user_agent")]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    const commandsHeader = screen.getByText("Commands");
+    expect(commandsHeader.className).toContain("bg-black/5");
+    expect(commandsHeader.className).toContain("dark:bg-[var(--header-bg)]");
+  });
+
+  it("marks the selected item using selectedIndex", () => {
+    render(
+      <AutocompletePopup
+        items={[makeItem("help", "builtin"), makeItem("deploy", "user_skill")]}
+        selectedIndex={1}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    const selected = screen.getByRole("button", { name: /\/deploy/i });
+    const unselected = screen.getByRole("button", { name: /\/help/i });
+
+    expect(selected.className).toContain("bg-accent");
+    expect(unselected.className).toContain("hover:bg-accent/50");
+  });
+
+  it("calls onSelect on mousedown and prevents default", () => {
+    const onSelect = vi.fn();
+    const item = makeItem("help", "builtin", "Show available commands");
+
+    render(
+      <AutocompletePopup
+        items={[item]}
+        selectedIndex={0}
+        onSelect={onSelect}
+        onHover={vi.fn()}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /\/help/i });
+    const notCancelled = fireEvent.mouseDown(button);
+
+    expect(notCancelled).toBe(false);
+    expect(onSelect).toHaveBeenCalledWith(item);
+  });
+
+  it("calls onHover with global item index", () => {
+    const onHover = vi.fn();
+
+    render(
+      <AutocompletePopup
+        items={[
+          makeItem("help", "builtin"),
+          makeItem("deploy", "user_skill"),
+          makeItem("agent-a", "user_agent"),
+        ]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={onHover}
+      />,
+    );
+
+    const thirdButton = screen.getByRole("button", { name: /@agent-a/i });
+    fireEvent.mouseEnter(thirdButton);
+
+    expect(onHover).toHaveBeenCalledWith(2);
+  });
+
+  it("renders description text when provided", () => {
+    render(
+      <AutocompletePopup
+        items={[makeItem("help", "builtin", "Show available commands")]}
+        selectedIndex={0}
+        onSelect={vi.fn()}
+        onHover={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Show available commands")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/ChatInput.autocomplete.test.tsx
+++ b/frontend/tests/components/ChatInput.autocomplete.test.tsx
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatInput from "@/components/ChatInput";
+import { useCompletions } from "@/hooks/useCompletions";
+import type { CompletionItem } from "@/types";
+
+vi.mock("@/hooks/useCompletions", () => ({
+  useCompletions: vi.fn(),
+}));
+
+function makeItem(
+  name: string,
+  type: CompletionItem["type"],
+  source: CompletionItem["source"],
+): CompletionItem {
+  return {
+    type,
+    name,
+    label: type === "agent" ? `@${name}` : `/${name}`,
+    source,
+  };
+}
+
+describe("ChatInput autocomplete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows slash-command suggestions for '/' trigger", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("clear", "slash_command", "builtin"),
+      makeItem("reviewer", "agent", "user_agent"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "/he");
+
+    expect(screen.getByRole("button", { name: /\/help/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /@reviewer/i })).not.toBeInTheDocument();
+  });
+
+  it("shows agent suggestions for '@' trigger", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("reviewer", "agent", "user_agent"),
+      makeItem("planner", "agent", "project_agent"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "@re");
+
+    expect(screen.getByRole("button", { name: /@reviewer/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /\/help/i })).not.toBeInTheDocument();
+  });
+
+  it("inserts selected completion on click and closes popup", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("clear", "slash_command", "builtin"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Send a message...");
+    await user.type(input, "please /he");
+    await user.click(screen.getByRole("button", { name: /\/help/i }));
+
+    expect(input).toHaveValue("please /help ");
+    expect(screen.queryByRole("button", { name: /\/help/i })).not.toBeInTheDocument();
+  });
+
+  it("supports keyboard navigation and Enter selection", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("hello", "slash_command", "builtin"),
+    ]);
+
+    const user = userEvent.setup();
+    const onSend = vi.fn(() => true);
+
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={onSend}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    const input = screen.getByPlaceholderText("Send a message...");
+    await user.type(input, "/");
+    await user.keyboard("{ArrowDown}{Enter}");
+
+    expect(input).toHaveValue("/hello ");
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("closes autocomplete on Escape", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("clear", "slash_command", "builtin"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "/h");
+    expect(screen.getByRole("button", { name: /\/help/i })).toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+
+    expect(screen.queryByRole("button", { name: /\/help/i })).not.toBeInTheDocument();
+  });
+
+  it("does not trigger autocomplete when marker is not at word boundary", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("help", "slash_command", "builtin"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "abc/help");
+
+    expect(screen.queryByRole("button", { name: /\/help/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/hooks/useCompletions.test.ts
+++ b/frontend/tests/hooks/useCompletions.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useCompletions } from "@/hooks/useCompletions";
+import { api } from "@/hooks/useApi";
+import type { CompletionItem } from "@/types";
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: vi.fn(),
+  },
+}));
+
+function makeItem(name: string, source: CompletionItem["source"]): CompletionItem {
+  return {
+    type: "slash_command",
+    name,
+    label: `/${name}`,
+    source,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe("useCompletions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty list and skips fetch when workspace id is missing", () => {
+    const { result } = renderHook(() => useCompletions(undefined));
+
+    expect(result.current).toEqual([]);
+    expect(api.get).not.toHaveBeenCalled();
+  });
+
+  it("fetches completions for workspace and exposes items", async () => {
+    const items = [makeItem("help", "builtin"), makeItem("deploy", "user_skill")];
+    vi.mocked(api.get).mockResolvedValueOnce({ items });
+
+    const { result } = renderHook(() => useCompletions("ws-1"));
+
+    await waitFor(() => {
+      expect(result.current).toEqual(items);
+    });
+
+    expect(api.get).toHaveBeenCalledWith("/api/workspaces/ws-1/completions");
+  });
+
+  it("re-fetches when workspace id changes", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ items: [makeItem("help", "builtin")] })
+      .mockResolvedValueOnce({ items: [makeItem("local", "project_skill")] });
+
+    const { result, rerender } = renderHook(({ wsId }: { wsId: string | undefined }) => useCompletions(wsId), {
+      initialProps: { wsId: "ws-1" },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([makeItem("help", "builtin")]);
+    });
+
+    rerender({ wsId: "ws-2" });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([makeItem("local", "project_skill")]);
+    });
+
+    expect(api.get).toHaveBeenNthCalledWith(1, "/api/workspaces/ws-1/completions");
+    expect(api.get).toHaveBeenNthCalledWith(2, "/api/workspaces/ws-2/completions");
+  });
+
+  it("resets to empty list when workspace id becomes undefined", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({ items: [makeItem("help", "builtin")] });
+
+    const { result, rerender } = renderHook(({ wsId }: { wsId: string | undefined }) => useCompletions(wsId), {
+      initialProps: { wsId: "ws-1" },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([makeItem("help", "builtin")]);
+    });
+
+    rerender({ wsId: undefined });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([]);
+    });
+  });
+
+  it("silently keeps previous value when fetch fails", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce({ items: [makeItem("help", "builtin")] })
+      .mockRejectedValueOnce(new Error("network"));
+
+    const { result, rerender } = renderHook(({ wsId }: { wsId: string | undefined }) => useCompletions(wsId), {
+      initialProps: { wsId: "ws-1" },
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([makeItem("help", "builtin")]);
+    });
+
+    rerender({ wsId: "ws-2" });
+
+    await waitFor(() => {
+      expect(api.get).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current).toEqual([makeItem("help", "builtin")]);
+  });
+
+  it("ignores stale responses when workspace changes quickly", async () => {
+    const first = deferred<{ items: CompletionItem[] }>();
+    const second = deferred<{ items: CompletionItem[] }>();
+
+    vi.mocked(api.get)
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+
+    const { result, rerender } = renderHook(({ wsId }: { wsId: string | undefined }) => useCompletions(wsId), {
+      initialProps: { wsId: "ws-1" },
+    });
+
+    rerender({ wsId: "ws-2" });
+
+    await act(async () => {
+      first.resolve({ items: [makeItem("stale", "user_skill")] });
+      await Promise.resolve();
+    });
+
+    expect(result.current).toEqual([]);
+
+    await act(async () => {
+      second.resolve({ items: [makeItem("fresh", "project_skill")] });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(result.current).toEqual([makeItem("fresh", "project_skill")]);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add backend regression tests for completion scanning across builtin/user/project sources
- add backend API coverage for `/api/workspaces/:wsId/completions`
- add frontend hook tests for `useCompletions` fetch/cancel/error behavior
- add frontend component tests for `AutocompletePopup` and ChatInput autocomplete keyboard/mouse flows

## Validation
- npm run test --workspace @hive/backend
- npm run test --workspace @hive/frontend
