### PR TITLE
feat: add Notifications settings UI for Telegram config

### DIFF
--- a/backend/src/agents/agent-manager.notifier.test.ts
+++ b/backend/src/agents/agent-manager.notifier.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { AppConfig } from "../state/config.js";
+
+const mocks = vi.hoisted(() => ({
+  notifierCtor: vi.fn(),
+  fromConfig: vi.fn(),
+}));
+
+vi.mock("../notifications/notifier.js", () => ({
+  Notifier: class Notifier {
+    constructor(channels: unknown[]) {
+      mocks.notifierCtor(channels);
+    }
+
+    async notify(): Promise<void> {}
+  },
+}));
+
+vi.mock("../notifications/telegram.js", () => ({
+  TelegramChannel: {
+    fromConfig: mocks.fromConfig,
+  },
+}));
+
+import { rebuildNotifier } from "./agent-manager.js";
+
+function makeConfig(overrides?: Partial<AppConfig["notifications"]["telegram"]>): AppConfig {
+  return {
+    notifications: {
+      telegram: {
+        enabled: false,
+        botToken: "",
+        chatId: "",
+        ...overrides,
+      },
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("rebuildNotifier", () => {
+  it("builds notifier with no channels when telegram is disabled", () => {
+    rebuildNotifier(makeConfig({ enabled: false, botToken: "token", chatId: "chat" }));
+
+    expect(mocks.fromConfig).not.toHaveBeenCalled();
+    expect(mocks.notifierCtor).toHaveBeenCalledWith([]);
+  });
+
+  it("builds notifier with telegram channel when enabled and valid", () => {
+    const channel = { name: "telegram", isEnabled: () => true, send: vi.fn() };
+    mocks.fromConfig.mockReturnValue(channel);
+
+    rebuildNotifier(makeConfig({ enabled: true, botToken: "token", chatId: "chat" }));
+
+    expect(mocks.fromConfig).toHaveBeenCalledWith({ botToken: "token", chatId: "chat", enabled: true });
+    expect(mocks.notifierCtor).toHaveBeenCalledWith([channel]);
+  });
+
+  it("builds notifier with no channels when telegram config is invalid", () => {
+    mocks.fromConfig.mockReturnValue(null);
+
+    rebuildNotifier(makeConfig({ enabled: true, botToken: "", chatId: "" }));
+
+    expect(mocks.fromConfig).toHaveBeenCalledWith({ botToken: "", chatId: "", enabled: true });
+    expect(mocks.notifierCtor).toHaveBeenCalledWith([]);
+  });
+});

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -8,12 +8,24 @@ import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
 import { runNamingTask } from "./naming.js";
 import { NotFoundError } from "../utils/errors.js";
 import type { ChatMessage, SessionMetadata } from "../types.js";
-import type { Notifier } from "../notifications/notifier.js";
+import { Notifier } from "../notifications/notifier.js";
+import { TelegramChannel } from "../notifications/telegram.js";
+import type { AppConfig } from "../state/config.js";
 
 let notifier: Notifier | undefined;
 
 export function setNotifier(n: Notifier): void {
   notifier = n;
+}
+
+export function rebuildNotifier(config: AppConfig): void {
+  const channels = [];
+  const tg = config.notifications.telegram;
+  if (tg.enabled) {
+    const ch = TelegramChannel.fromConfig(tg);
+    if (ch) channels.push(ch);
+  }
+  setNotifier(new Notifier(channels));
 }
 
 const loadedSessionsByWorkspace = new Map<string, Map<string, ConversationSession>>();

--- a/backend/src/api/settings.test.ts
+++ b/backend/src/api/settings.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+const mocks = vi.hoisted(() => ({
+  rebuildNotifier: vi.fn(),
+}));
+
+vi.mock("../agents/agent-manager.js", () => ({
+  rebuildNotifier: mocks.rebuildNotifier,
+}));
+
+import { settingsRoutes } from "./settings.js";
+import { loadConfig } from "../state/config.js";
+import { TelegramChannel } from "../notifications/telegram.js";
+
+let tempDir: string;
+let app: ReturnType<typeof Fastify>;
+let previousDataDir: string | undefined;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "hive-settings-api-test-"));
+  previousDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = tempDir;
+
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => settingsRoutes(instance));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+
+  if (previousDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = previousDataDir;
+  }
+});
+
+describe("settings routes", () => {
+  it("GET /api/settings/notifications returns default config", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/settings/notifications",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      telegram: {
+        enabled: false,
+        botToken: "",
+        chatId: "",
+      },
+    });
+  });
+
+  it("PUT /api/settings/notifications validates payload", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/notifications",
+      payload: { telegram: { enabled: "yes" } },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Invalid payload" });
+  });
+
+  it("PUT /api/settings/notifications saves trimmed values and rebuilds notifier", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/notifications",
+      payload: {
+        telegram: {
+          enabled: true,
+          botToken: "  bot-token  ",
+          chatId: "  chat-id  ",
+        },
+      },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: true });
+
+    const config = await loadConfig(tempDir);
+    expect(config).toEqual({
+      notifications: {
+        telegram: {
+          enabled: true,
+          botToken: "bot-token",
+          chatId: "chat-id",
+        },
+      },
+    });
+
+    expect(mocks.rebuildNotifier).toHaveBeenCalledTimes(1);
+    expect(mocks.rebuildNotifier).toHaveBeenCalledWith(config);
+  });
+
+  it("POST /api/settings/notifications/test validates required fields", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/settings/notifications/test",
+      payload: { botToken: "", chatId: "chat-id" },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ ok: false, error: "Bot token and chat ID are required" });
+  });
+
+  it("POST /api/settings/notifications/test proxies Telegram test result", async () => {
+    const sendTestSpy = vi
+      .spyOn(TelegramChannel, "sendTest")
+      .mockResolvedValue({ ok: false, error: "chat not found" });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/settings/notifications/test",
+      payload: { botToken: " token ", chatId: " chat " },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ ok: false, error: "chat not found" });
+    expect(sendTestSpy).toHaveBeenCalledWith(" token ", " chat ");
+  });
+});

--- a/backend/src/api/settings.ts
+++ b/backend/src/api/settings.ts
@@ -1,0 +1,42 @@
+import type { FastifyInstance } from "fastify";
+import { loadConfig, saveConfig } from "../state/config.js";
+import { rebuildNotifier } from "../agents/agent-manager.js";
+import { TelegramChannel } from "../notifications/telegram.js";
+
+export async function settingsRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/api/settings/notifications", async () => {
+    const config = await loadConfig();
+    return config.notifications;
+  });
+
+  app.put<{
+    Body: {
+      telegram: { enabled: boolean; botToken: string; chatId: string };
+    };
+  }>("/api/settings/notifications", async (req, reply) => {
+    const { telegram } = req.body;
+    if (!telegram || typeof telegram.enabled !== "boolean") {
+      return reply.status(400).send({ error: "Invalid payload" });
+    }
+    const config = await loadConfig();
+    config.notifications.telegram = {
+      enabled: telegram.enabled,
+      botToken: telegram.botToken?.trim() ?? "",
+      chatId: telegram.chatId?.trim() ?? "",
+    };
+    await saveConfig(config);
+    rebuildNotifier(config);
+    return { ok: true };
+  });
+
+  app.post<{
+    Body: { botToken: string; chatId: string };
+  }>("/api/settings/notifications/test", async (req, reply) => {
+    const { botToken, chatId } = req.body;
+    if (!botToken?.trim() || !chatId?.trim()) {
+      return reply.status(400).send({ ok: false, error: "Bot token and chat ID are required" });
+    }
+    const result = await TelegramChannel.sendTest(botToken, chatId);
+    return result;
+  });
+}

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 // Prevent the top-level main() from actually listening on a port
 vi.mock("fastify", async (importOriginal) => {
@@ -25,13 +28,27 @@ vi.mock("fastify", async (importOriginal) => {
 import { buildApp } from "./index.js";
 
 let app: Awaited<ReturnType<typeof buildApp>>;
+let tempDataDir: string;
+let previousDataDir: string | undefined;
+
+beforeEach(async () => {
+  tempDataDir = await mkdtemp(join(tmpdir(), "hive-index-test-"));
+  previousDataDir = process.env.DATA_DIR;
+  process.env.DATA_DIR = tempDataDir;
+});
 
 afterEach(async () => {
   delete process.env.HIVE_AUTH_TOKEN;
   delete process.env.HIVE_RATE_LIMIT_MAX;
   delete process.env.HIVE_RATE_LIMIT_WINDOW_MS;
   delete process.env.HIVE_CLAUDE_SKIP_PERMISSIONS;
+  if (previousDataDir === undefined) {
+    delete process.env.DATA_DIR;
+  } else {
+    process.env.DATA_DIR = previousDataDir;
+  }
   await app?.close();
+  await rm(tempDataDir, { recursive: true, force: true });
 });
 
 describe("buildApp", () => {
@@ -59,6 +76,19 @@ describe("buildApp", () => {
     const res = await app.inject({ method: "GET", url: "/api/workspaces/test-ws" });
     expect(res.statusCode).toBe(404);
     expect(res.json().error).toContain("not found");
+  });
+
+  it("registers settings routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/settings/notifications" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      telegram: {
+        enabled: expect.any(Boolean),
+        botToken: expect.any(String),
+        chatId: expect.any(String),
+      },
+    });
   });
 
   it("registers session routes", async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -11,10 +11,10 @@ import { terminalRoutes } from "./ws/terminal.js";
 import { createAuthHook } from "./utils/auth.js";
 import { createRateLimitHook } from "./utils/rate-limit.js";
 import { ensureDataDir, getDataDir } from "./state/state.js";
-import { type SessionOptions, setNotifier } from "./agents/agent-manager.js";
+import { type SessionOptions, rebuildNotifier } from "./agents/agent-manager.js";
 import { GitSyncService } from "./services/git-sync.js";
-import { Notifier } from "./notifications/notifier.js";
-import { TelegramChannel } from "./notifications/telegram.js";
+import { settingsRoutes } from "./api/settings.js";
+import { loadConfig } from "./state/config.js";
 import { broadcastToWorkspace } from "./ws/stream.js";
 import type { StreamRoutesOptions } from "./ws/stream.js";
 
@@ -87,6 +87,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   await app.register((instance: FastifyInstance) =>
     terminalRoutes(instance, { authToken }),
   );
+  await app.register((instance: FastifyInstance) => settingsRoutes(instance));
 
   return app;
 }
@@ -97,10 +98,8 @@ async function main() {
   const dataDir = getDataDir();
   await ensureDataDir(dataDir);
 
-  const channels = [TelegramChannel.fromEnv()].filter(
-    (c): c is NonNullable<typeof c> => c != null,
-  );
-  setNotifier(new Notifier(channels));
+  const config = await loadConfig(dataDir);
+  rebuildNotifier(config);
 
   const gitSync = new GitSyncService(dataDir);
   gitSync.onBranchChange((wsId, info) => {

--- a/backend/src/notifications/telegram.test.ts
+++ b/backend/src/notifications/telegram.test.ts
@@ -56,6 +56,101 @@ describe("TelegramChannel.fromEnv", () => {
   });
 });
 
+describe("TelegramChannel.fromConfig", () => {
+  it("returns null when credentials are blank", () => {
+    expect(TelegramChannel.fromConfig({ botToken: "", chatId: "chat" })).toBeNull();
+    expect(TelegramChannel.fromConfig({ botToken: "token", chatId: "   " })).toBeNull();
+  });
+
+  it("trims credentials before creating channel", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const channel = TelegramChannel.fromConfig({ botToken: " token ", chatId: " chat " });
+    expect(channel).toBeDefined();
+
+    await channel!.send(eventFixture());
+
+    const [url, init] = vi.mocked(fetchMock).mock.calls[0]!;
+    expect(url).toBe("https://api.telegram.org/bottoken/sendMessage");
+    const body = JSON.parse(String(init?.body));
+    expect(body.chat_id).toBe("chat");
+  });
+});
+
+describe("TelegramChannel.sendTest", () => {
+  it("returns validation error when credentials are missing", async () => {
+    await expect(TelegramChannel.sendTest("", "chat")).resolves.toEqual({
+      ok: false,
+      error: "Bot token and chat ID are required",
+    });
+  });
+
+  it("sends a test notification with trimmed credentials", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      text: async () => "",
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await TelegramChannel.sendTest(" token ", " chat ");
+
+    expect(result).toEqual({ ok: true });
+    const [url, init] = vi.mocked(fetchMock).mock.calls[0]!;
+    expect(url).toBe("https://api.telegram.org/bottoken/sendMessage");
+    expect(init?.method).toBe("POST");
+    expect(init?.headers).toEqual({ "Content-Type": "application/json" });
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({
+      chat_id: "chat",
+      text: "✅ Hive test notification — your Telegram integration is working!",
+      parse_mode: "HTML",
+    });
+  });
+
+  it("returns Telegram description when API responds with JSON error", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 401,
+      text: async () => JSON.stringify({ description: "Unauthorized" }),
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await TelegramChannel.sendTest("token", "chat");
+
+    expect(result).toEqual({ ok: false, error: "Unauthorized" });
+  });
+
+  it("returns fallback error when API error body is not JSON", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => "bad gateway",
+    })) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await TelegramChannel.sendTest("token", "chat");
+
+    expect(result).toEqual({ ok: false, error: "Telegram API error (500)" });
+  });
+
+  it("returns network error when fetch throws", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("network down");
+    }) as unknown as typeof fetch;
+    vi.stubGlobal("fetch", fetchMock);
+
+    const result = await TelegramChannel.sendTest("token", "chat");
+
+    expect(result).toEqual({ ok: false, error: "network down" });
+  });
+});
+
 describe("TelegramChannel.send", () => {
   it("posts an escaped HTML message with rounded duration", async () => {
     const fetchMock = vi.fn(async () => ({

--- a/backend/src/notifications/telegram.ts
+++ b/backend/src/notifications/telegram.ts
@@ -35,6 +35,50 @@ export class TelegramChannel implements NotificationChannel {
     return new TelegramChannel(botToken, chatId);
   }
 
+  /** Returns a configured channel from explicit config, or null if credentials are missing. */
+  static fromConfig(cfg: { botToken: string; chatId: string }): TelegramChannel | null {
+    const botToken = cfg.botToken?.trim();
+    const chatId = cfg.chatId?.trim();
+    if (!botToken || !chatId) return null;
+    return new TelegramChannel(botToken, chatId);
+  }
+
+  /** Sends a test message and returns success/failure. */
+  static async sendTest(
+    botToken: string,
+    chatId: string,
+  ): Promise<{ ok: boolean; error?: string }> {
+    const token = botToken.trim();
+    const chat = chatId.trim();
+    if (!token || !chat) return { ok: false, error: "Bot token and chat ID are required" };
+    try {
+      const res = await fetch(
+        `https://api.telegram.org/bot${token}/sendMessage`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            chat_id: chat,
+            text: "✅ Hive test notification — your Telegram integration is working!",
+            parse_mode: "HTML",
+          }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        let errorMsg = `Telegram API error (${res.status})`;
+        try {
+          const parsed = JSON.parse(body) as { description?: string };
+          if (parsed.description) errorMsg = parsed.description;
+        } catch { /* use default */ }
+        return { ok: false, error: errorMsg };
+      }
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, error: err instanceof Error ? err.message : "Network error" };
+    }
+  }
+
   isEnabled(): boolean {
     return true;
   }

--- a/backend/src/state/config.test.ts
+++ b/backend/src/state/config.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { loadConfig, saveConfig, type AppConfig } from "./config.js";
+
+const DEFAULT_CONFIG: AppConfig = {
+  notifications: {
+    telegram: { enabled: false, botToken: "", chatId: "" },
+  },
+};
+
+let dataDir: string;
+
+beforeEach(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), "hive-config-test-"));
+});
+
+afterEach(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe("loadConfig", () => {
+  it("returns defaults when config file is missing", async () => {
+    const config = await loadConfig(dataDir);
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("returns defaults when config file is invalid JSON", async () => {
+    await writeFile(join(dataDir, "config.json"), "{invalid", "utf-8");
+
+    const config = await loadConfig(dataDir);
+
+    expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("fills missing nested values with defaults", async () => {
+    await writeFile(
+      join(dataDir, "config.json"),
+      JSON.stringify({ notifications: { telegram: { enabled: true } } }),
+      "utf-8",
+    );
+
+    const config = await loadConfig(dataDir);
+
+    expect(config).toEqual({
+      notifications: {
+        telegram: {
+          enabled: true,
+          botToken: "",
+          chatId: "",
+        },
+      },
+    });
+  });
+
+  it("returns a fresh default object each time", async () => {
+    const first = await loadConfig(dataDir);
+    first.notifications.telegram.enabled = true;
+
+    const second = await loadConfig(dataDir);
+
+    expect(second.notifications.telegram.enabled).toBe(false);
+  });
+});
+
+describe("saveConfig", () => {
+  it("writes pretty JSON and round-trips through loadConfig", async () => {
+    const config: AppConfig = {
+      notifications: {
+        telegram: {
+          enabled: true,
+          botToken: "bot-token",
+          chatId: "chat-id",
+        },
+      },
+    };
+
+    await saveConfig(config, dataDir);
+
+    const raw = await readFile(join(dataDir, "config.json"), "utf-8");
+    expect(raw).toContain("\n");
+    expect(JSON.parse(raw)).toEqual(config);
+
+    const loaded = await loadConfig(dataDir);
+    expect(loaded).toEqual(config);
+  });
+});

--- a/backend/src/state/config.ts
+++ b/backend/src/state/config.ts
@@ -1,0 +1,54 @@
+import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { getDataDir } from "./state.js";
+
+export interface TelegramConfig {
+  enabled: boolean;
+  botToken: string;
+  chatId: string;
+}
+
+export interface NotificationsConfig {
+  telegram: TelegramConfig;
+}
+
+export interface AppConfig {
+  notifications: NotificationsConfig;
+}
+
+const DEFAULT_CONFIG: AppConfig = {
+  notifications: {
+    telegram: { enabled: false, botToken: "", chatId: "" },
+  },
+};
+
+function configFilePath(dataDir: string): string {
+  return join(dataDir, "config.json");
+}
+
+export async function loadConfig(dataDir = getDataDir()): Promise<AppConfig> {
+  try {
+    const raw = await readFile(configFilePath(dataDir), "utf-8");
+    const parsed = JSON.parse(raw) as Partial<AppConfig>;
+    return {
+      notifications: {
+        telegram: {
+          enabled: parsed.notifications?.telegram?.enabled ?? DEFAULT_CONFIG.notifications.telegram.enabled,
+          botToken: parsed.notifications?.telegram?.botToken ?? DEFAULT_CONFIG.notifications.telegram.botToken,
+          chatId: parsed.notifications?.telegram?.chatId ?? DEFAULT_CONFIG.notifications.telegram.chatId,
+        },
+      },
+    };
+  } catch {
+    return structuredClone(DEFAULT_CONFIG);
+  }
+}
+
+export async function saveConfig(config: AppConfig, dataDir = getDataDir()): Promise<void> {
+  await mkdir(dataDir, { recursive: true });
+  const target = configFilePath(dataDir);
+  const tmp = join(dataDir, `config.${randomUUID()}.tmp`);
+  await writeFile(tmp, JSON.stringify(config, null, 2), "utf-8");
+  await rename(tmp, target);
+}

--- a/conductor.json
+++ b/conductor.json
@@ -1,6 +1,6 @@
 {
     "scripts": {
-        "setup": "cp /Users/0xlenny/conductor/repos/hive/.env .env && npm install",
-        "run": "set -a && source .env && set +a && cd backend && PORT=3000 npm run dev"
+        "setup": "npm install",
+        "run": "cd backend && PORT=3000 npm run dev"
     }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import AppLayout from "@/components/AppLayout";
 import WorkspaceView from "@/pages/WorkspaceView";
 import AppearanceSettings from "@/pages/settings/AppearanceSettings";
 import ConnectionSettings from "@/pages/settings/ConnectionSettings";
+import NotificationSettings from "@/pages/settings/NotificationSettings";
 import ProjectDetail from "@/pages/settings/ProjectDetail";
 import AddProjectDialog from "@/components/AddProjectDialog";
 import EmptyStateLogo from "@/components/EmptyStateLogo";
@@ -63,6 +64,7 @@ export default function App() {
           <Route path="settings" element={<Navigate to="/settings/appearance" replace />} />
           <Route path="settings/appearance" element={<AppearanceSettings />} />
           <Route path="settings/connection" element={<ConnectionSettings onRefreshConnection={() => { wsTransport.disconnectAll(); fetchProjects(); }} />} />
+          <Route path="settings/notifications" element={<NotificationSettings />} />
           <Route path="settings/repositories/:projectId" element={<ProjectDetail projects={projects} onDeleteProject={deleteProject} />} />
         </Route>
       </Routes>

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { ArrowLeft, Paintbrush, Wifi, GitFork } from "lucide-react";
+import { ArrowLeft, Bell, Paintbrush, Wifi, GitFork } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -46,6 +46,12 @@ export default function SettingsSidebar({ projects }: SettingsSidebarProps) {
               label="Connection"
               icon={<Wifi className="h-4 w-4" />}
               active={pathname === "/settings/connection"}
+            />
+            <NavItem
+              to="/settings/notifications"
+              label="Notifications"
+              icon={<Bell className="h-4 w-4" />}
+              active={pathname === "/settings/notifications"}
             />
           </SidebarSection>
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -46,5 +46,7 @@ export const api = {
   get: <T>(url: string) => request<T>(url),
   post: <T>(url: string, body?: unknown) =>
     request<T>(url, { method: "POST", body: body ? JSON.stringify(body) : undefined }),
+  put: <T>(url: string, body?: unknown) =>
+    request<T>(url, { method: "PUT", body: body ? JSON.stringify(body) : undefined }),
   delete: <T>(url: string) => request<T>(url, { method: "DELETE" }),
 };

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -35,6 +35,10 @@ export default function NotificationSettings() {
   }, []);
 
   const clearFeedback = () => setFeedback(null);
+  const showFeedback = (fb: { type: "success" | "error"; message: string }) => {
+    setFeedback(fb);
+    if (fb.type === "success") setTimeout(clearFeedback, 2500);
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -43,9 +47,9 @@ export default function NotificationSettings() {
       await api.put("/api/settings/notifications", {
         telegram: { enabled, botToken, chatId },
       });
-      setFeedback({ type: "success", message: "Saved" });
+      showFeedback({ type: "success", message: "Saved" });
     } catch {
-      setFeedback({ type: "error", message: "Failed to save" });
+      showFeedback({ type: "error", message: "Failed to save" });
     } finally {
       setSaving(false);
     }
@@ -60,12 +64,12 @@ export default function NotificationSettings() {
         { botToken, chatId },
       );
       if (result.ok) {
-        setFeedback({ type: "success", message: "Test message sent!" });
+        showFeedback({ type: "success", message: "Test message sent!" });
       } else {
-        setFeedback({ type: "error", message: result.error ?? "Test failed" });
+        showFeedback({ type: "error", message: result.error ?? "Test failed" });
       }
     } catch {
-      setFeedback({ type: "error", message: "Could not reach backend" });
+      showFeedback({ type: "error", message: "Could not reach backend" });
     } finally {
       setTesting(false);
     }
@@ -88,7 +92,7 @@ export default function NotificationSettings() {
         <section className="rounded-lg border border-border/50 bg-card/50 p-5">
           <div className="flex items-start justify-between">
             <div>
-              <h2 className="text-sm font-medium text-foreground">Telegram</h2>
+              <h2 id="telegram-toggle-label" className="text-sm font-medium text-foreground">Telegram</h2>
               <p className="mt-1 text-xs text-muted-foreground">
                 Receive notifications via a Telegram bot.
               </p>
@@ -97,9 +101,10 @@ export default function NotificationSettings() {
               type="button"
               role="switch"
               aria-checked={enabled}
+              aria-labelledby="telegram-toggle-label"
               onClick={() => setEnabled(!enabled)}
               className={cn(
-                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 enabled ? "bg-primary" : "bg-muted-foreground/30",
               )}
             >
@@ -112,7 +117,7 @@ export default function NotificationSettings() {
             </button>
           </div>
 
-          <div className="mt-5 space-y-4">
+          <div className={cn("mt-5 space-y-4 transition-opacity", !enabled && "pointer-events-none opacity-50")}>
             <div>
               <label htmlFor="tg-token" className="mb-1.5 block text-xs font-medium text-muted-foreground">
                 Bot Token
@@ -185,7 +190,7 @@ export default function NotificationSettings() {
               {feedback && (
                 <span className={cn(
                   "text-xs font-medium",
-                  feedback.type === "success" ? "text-emerald-400" : "text-red-400",
+                  feedback.type === "success" ? "text-emerald-500" : "text-red-500",
                 )}>
                   {feedback.message}
                 </span>

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { Eye, EyeOff, Send, Save, Loader2 } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { api } from "@/hooks/useApi";
+
+interface TelegramConfig {
+  enabled: boolean;
+  botToken: string;
+  chatId: string;
+}
+
+interface NotificationsConfig {
+  telegram: TelegramConfig;
+}
+
+export default function NotificationSettings() {
+  const [loading, setLoading] = useState(true);
+  const [enabled, setEnabled] = useState(false);
+  const [botToken, setBotToken] = useState("");
+  const [chatId, setChatId] = useState("");
+  const [showToken, setShowToken] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [testing, setTesting] = useState(false);
+  const [feedback, setFeedback] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+  useEffect(() => {
+    api.get<NotificationsConfig>("/api/settings/notifications").then((data) => {
+      setEnabled(data.telegram.enabled);
+      setBotToken(data.telegram.botToken);
+      setChatId(data.telegram.chatId);
+    }).catch(() => {
+      // defaults are fine
+    }).finally(() => setLoading(false));
+  }, []);
+
+  const clearFeedback = () => setFeedback(null);
+
+  const handleSave = async () => {
+    setSaving(true);
+    clearFeedback();
+    try {
+      await api.put("/api/settings/notifications", {
+        telegram: { enabled, botToken, chatId },
+      });
+      setFeedback({ type: "success", message: "Saved" });
+    } catch {
+      setFeedback({ type: "error", message: "Failed to save" });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async () => {
+    setTesting(true);
+    clearFeedback();
+    try {
+      const result = await api.post<{ ok: boolean; error?: string }>(
+        "/api/settings/notifications/test",
+        { botToken, chatId },
+      );
+      if (result.ok) {
+        setFeedback({ type: "success", message: "Test message sent!" });
+      } else {
+        setFeedback({ type: "error", message: result.error ?? "Test failed" });
+      }
+    } catch {
+      setFeedback({ type: "error", message: "Could not reach backend" });
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (loading) return null;
+
+  const hasCredentials = botToken.trim() !== "" && chatId.trim() !== "";
+
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      <div className="border-b border-border/50 px-8 py-5">
+        <h1 className="text-base font-semibold">Notifications</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Configure how Hive notifies you when agents finish work.
+        </p>
+      </div>
+
+      <div className="max-w-2xl space-y-6 px-8 py-6">
+        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+          <div className="flex items-start justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-foreground">Telegram</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Receive notifications via a Telegram bot.
+              </p>
+            </div>
+            <button
+              type="button"
+              role="switch"
+              aria-checked={enabled}
+              onClick={() => setEnabled(!enabled)}
+              className={cn(
+                "relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors",
+                enabled ? "bg-primary" : "bg-muted-foreground/30",
+              )}
+            >
+              <span
+                className={cn(
+                  "pointer-events-none block h-4 w-4 rounded-full bg-white shadow-sm transition-transform",
+                  enabled ? "translate-x-4" : "translate-x-0",
+                )}
+              />
+            </button>
+          </div>
+
+          <div className="mt-5 space-y-4">
+            <div>
+              <label htmlFor="tg-token" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Bot Token
+              </label>
+              <div className="relative">
+                <Input
+                  id="tg-token"
+                  type={showToken ? "text" : "password"}
+                  value={botToken}
+                  onChange={(e) => { setBotToken(e.target.value); clearFeedback(); }}
+                  placeholder="123456:ABC-DEF..."
+                  className="pr-9 font-mono text-xs"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowToken(!showToken)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {showToken
+                    ? <EyeOff className="h-3.5 w-3.5" />
+                    : <Eye className="h-3.5 w-3.5" />}
+                </button>
+              </div>
+            </div>
+
+            <div>
+              <label htmlFor="tg-chat" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Chat ID
+              </label>
+              <Input
+                id="tg-chat"
+                value={chatId}
+                onChange={(e) => { setChatId(e.target.value); clearFeedback(); }}
+                placeholder="-1001234567890"
+                className="font-mono text-xs"
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleTest()}
+                disabled={testing || !hasCredentials}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+                  (testing || !hasCredentials) && "pointer-events-none opacity-60",
+                )}
+              >
+                {testing
+                  ? <Loader2 className="h-3 w-3 animate-spin" />
+                  : <Send className="h-3 w-3" />}
+                Test
+              </button>
+
+              <button
+                type="button"
+                onClick={() => void handleSave()}
+                disabled={saving}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+                  saving && "pointer-events-none opacity-60",
+                )}
+              >
+                {saving
+                  ? <Loader2 className="h-3 w-3 animate-spin" />
+                  : <Save className="h-3 w-3" />}
+                Save
+              </button>
+
+              {feedback && (
+                <span className={cn(
+                  "text-xs font-medium",
+                  feedback.type === "success" ? "text-emerald-400" : "text-red-400",
+                )}>
+                  {feedback.message}
+                </span>
+              )}
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -68,6 +68,10 @@ vi.mock("@/pages/settings/ConnectionSettings", () => ({
   ),
 }));
 
+vi.mock("@/pages/settings/NotificationSettings", () => ({
+  default: () => <div>notification settings</div>,
+}));
+
 vi.mock("@/pages/settings/ProjectDetail", () => ({
   default: () => <div>project detail</div>,
 }));
@@ -116,5 +120,13 @@ describe("App", () => {
 
     expect(mocks.disconnectAll).toHaveBeenCalledTimes(1);
     expect(mocks.fetchProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders notification settings route", () => {
+    window.history.pushState({}, "", "/settings/notifications");
+
+    render(<App />);
+
+    expect(screen.getByText("notification settings")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/SettingsSidebar.test.tsx
+++ b/frontend/tests/components/SettingsSidebar.test.tsx
@@ -32,6 +32,7 @@ describe("SettingsSidebar", () => {
         <Routes>
           <Route path="/settings" element={<SettingsShell />}>
             <Route path="appearance" element={<div>Appearance settings</div>} />
+            <Route path="notifications" element={<div>Notification settings</div>} />
             <Route path="repositories/:projectId" element={<div>Repository settings</div>} />
           </Route>
           <Route path="/workspaces/:wsId" element={<div>Workspace w1</div>} />
@@ -57,6 +58,7 @@ describe("SettingsSidebar", () => {
         <Routes>
           <Route path="/settings" element={<SettingsShell />}>
             <Route path="appearance" element={<div>Appearance settings</div>} />
+            <Route path="notifications" element={<div>Notification settings</div>} />
           </Route>
           <Route path="/projects" element={<div>Projects list</div>} />
         </Routes>
@@ -66,6 +68,25 @@ describe("SettingsSidebar", () => {
     await user.click(screen.getByRole("button", { name: "Back" }));
     await waitFor(() => {
       expect(screen.getByText("Projects list")).toBeInTheDocument();
+    });
+  });
+
+  it("navigates to notifications settings", async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="appearance" element={<div>Appearance settings</div>} />
+            <Route path="notifications" element={<div>Notification settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("link", { name: /Notifications/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Notification settings")).toBeInTheDocument();
     });
   });
 });

--- a/frontend/tests/hooks/useApi.test.ts
+++ b/frontend/tests/hooks/useApi.test.ts
@@ -59,6 +59,19 @@ describe("api", () => {
     });
   });
 
+  it("sends JSON body and content-type on PUT", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(jsonResponse({ ok: true }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    await api.put("/api/items/1", { name: "beta" });
+
+    expect(fetchMock).toHaveBeenCalledWith("/api/items/1", {
+      method: "PUT",
+      body: JSON.stringify({ name: "beta" }),
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+
   it("throws ApiError with response body when request fails", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response("bad request", { status: 400, statusText: "Bad Request" }),

--- a/frontend/tests/pages/NotificationSettings.test.tsx
+++ b/frontend/tests/pages/NotificationSettings.test.tsx
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NotificationSettings from "@/pages/settings/NotificationSettings";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  put: vi.fn(),
+  post: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: mocks.get,
+    put: mocks.put,
+    post: mocks.post,
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+async function renderReady(config?: {
+  enabled?: boolean;
+  botToken?: string;
+  chatId?: string;
+}) {
+  mocks.get.mockResolvedValueOnce({
+    telegram: {
+      enabled: config?.enabled ?? false,
+      botToken: config?.botToken ?? "",
+      chatId: config?.chatId ?? "",
+    },
+  });
+
+  render(<NotificationSettings />);
+
+  await screen.findByRole("heading", { name: "Notifications" });
+}
+
+describe("NotificationSettings", () => {
+  it("loads and displays Telegram settings from backend", async () => {
+    await renderReady({ enabled: true, botToken: "token-1", chatId: "chat-1" });
+
+    expect(mocks.get).toHaveBeenCalledWith("/api/settings/notifications");
+    expect(screen.getByRole("switch", { name: "Telegram" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByLabelText("Bot Token")).toHaveValue("token-1");
+    expect(screen.getByLabelText("Chat ID")).toHaveValue("chat-1");
+    expect(screen.getByRole("button", { name: "Test" })).toBeEnabled();
+  });
+
+  it("falls back to default values when initial load fails", async () => {
+    mocks.get.mockRejectedValueOnce(new Error("offline"));
+
+    render(<NotificationSettings />);
+
+    await screen.findByRole("heading", { name: "Notifications" });
+
+    expect(screen.getByRole("switch", { name: "Telegram" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByLabelText("Bot Token")).toHaveValue("");
+    expect(screen.getByLabelText("Chat ID")).toHaveValue("");
+    expect(screen.getByRole("button", { name: "Test" })).toBeDisabled();
+  });
+
+  it("toggles token visibility", async () => {
+    const user = userEvent.setup();
+    await renderReady({ botToken: "secret-token" });
+
+    const tokenInput = screen.getByLabelText("Bot Token") as HTMLInputElement;
+    expect(tokenInput.type).toBe("password");
+
+    const visibilityButton = tokenInput.parentElement?.querySelector("button");
+    expect(visibilityButton).toBeTruthy();
+
+    await user.click(visibilityButton!);
+
+    expect(tokenInput.type).toBe("text");
+  });
+
+  it("keeps Test button disabled until both credentials are non-empty after trim", async () => {
+    const user = userEvent.setup();
+    await renderReady();
+
+    const testButton = screen.getByRole("button", { name: "Test" });
+    expect(testButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText("Bot Token"), "   ");
+    await user.type(screen.getByLabelText("Chat ID"), "   ");
+    expect(testButton).toBeDisabled();
+
+    await user.clear(screen.getByLabelText("Bot Token"));
+    await user.type(screen.getByLabelText("Bot Token"), "token");
+    expect(testButton).toBeDisabled();
+
+    await user.clear(screen.getByLabelText("Chat ID"));
+    await user.type(screen.getByLabelText("Chat ID"), "chat-id");
+    expect(testButton).toBeEnabled();
+  });
+
+  it("saves settings and shows success feedback", async () => {
+    const user = userEvent.setup();
+    mocks.put.mockResolvedValueOnce({ ok: true });
+
+    await renderReady();
+
+    await user.click(screen.getByRole("switch", { name: "Telegram" }));
+    await user.type(screen.getByLabelText("Bot Token"), "token-abc");
+    await user.type(screen.getByLabelText("Chat ID"), "-100123");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(mocks.put).toHaveBeenCalledWith("/api/settings/notifications", {
+        telegram: {
+          enabled: true,
+          botToken: "token-abc",
+          chatId: "-100123",
+        },
+      });
+    });
+    expect(screen.getByText("Saved")).toBeInTheDocument();
+  });
+
+  it("shows save error and clears feedback on input change", async () => {
+    const user = userEvent.setup();
+    mocks.put.mockRejectedValueOnce(new Error("boom"));
+
+    await renderReady({ botToken: "token", chatId: "chat" });
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+    expect(await screen.findByText("Failed to save")).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Chat ID"), "1");
+    expect(screen.queryByText("Failed to save")).not.toBeInTheDocument();
+  });
+
+  it("sends test notification and shows success feedback", async () => {
+    const user = userEvent.setup();
+    mocks.post.mockResolvedValueOnce({ ok: true });
+
+    await renderReady({ botToken: "token", chatId: "chat" });
+
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    await waitFor(() => {
+      expect(mocks.post).toHaveBeenCalledWith("/api/settings/notifications/test", {
+        botToken: "token",
+        chatId: "chat",
+      });
+    });
+    expect(screen.getByText("Test message sent!")).toBeInTheDocument();
+  });
+
+  it("shows backend test error returned by API", async () => {
+    const user = userEvent.setup();
+    mocks.post.mockResolvedValueOnce({ ok: false, error: "chat not found" });
+
+    await renderReady({ botToken: "token", chatId: "chat" });
+
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    expect(await screen.findByText("chat not found")).toBeInTheDocument();
+  });
+
+  it("shows network error when test request fails", async () => {
+    const user = userEvent.setup();
+    mocks.post.mockRejectedValueOnce(new Error("network"));
+
+    await renderReady({ botToken: "token", chatId: "chat" });
+
+    await user.click(screen.getByRole("button", { name: "Test" }));
+
+    expect(await screen.findByText("Could not reach backend")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Migrate Telegram credentials from env vars to a file-based config (~/.hive/config.json) managed through a new Settings > Notifications page. Includes enable/disable toggle, masked bot token, test button, and hot-reload of the notifier on save.