### PR TITLE
🚚 feat: add one-click Conductor-to-Hive migration in Settings

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -16,12 +16,14 @@
   "dependencies": {
     "@fastify/cors": "^11.2.0",
     "@fastify/websocket": "^11.2.0",
+    "better-sqlite3": "^12.6.2",
     "fastify": "^5.7.4",
     "nanoid": "^3.3.11",
     "node-pty": "^1.1.0",
     "ws": "^8.19.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.2.3",
     "@types/ws": "^8.18.1",
     "tsx": "^4.21.0",

--- a/backend/src/api/conductor.test.ts
+++ b/backend/src/api/conductor.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import { conductorRoutes } from "./conductor.js";
+
+let tempDir: string;
+let previousDataDir: string | undefined;
+let previousConductorDbPath: string | undefined;
+let app: ReturnType<typeof Fastify>;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "hive-conductor-api-test-"));
+  previousDataDir = process.env.DATA_DIR;
+  previousConductorDbPath = process.env.CONDUCTOR_DB_PATH;
+  process.env.DATA_DIR = tempDir;
+
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => conductorRoutes(instance));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tempDir, { recursive: true, force: true });
+  vi.restoreAllMocks();
+
+  if (previousDataDir === undefined) delete process.env.DATA_DIR;
+  else process.env.DATA_DIR = previousDataDir;
+  if (previousConductorDbPath === undefined) delete process.env.CONDUCTOR_DB_PATH;
+  else process.env.CONDUCTOR_DB_PATH = previousConductorDbPath;
+});
+
+describe("conductor routes", () => {
+  describe("GET /api/conductor/scan", () => {
+    it("returns found=false when Conductor DB does not exist", async () => {
+      process.env.CONDUCTOR_DB_PATH = join(tempDir, "nonexistent.db");
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/conductor/scan",
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.found).toBe(false);
+      expect(body.projects).toEqual([]);
+    });
+
+    it("returns scan results for valid Conductor DB", async () => {
+      const dbPath = join(tempDir, "conductor.db");
+      createTestConductorDb(dbPath);
+      process.env.CONDUCTOR_DB_PATH = dbPath;
+
+      const res = await app.inject({
+        method: "GET",
+        url: "/api/conductor/scan",
+      });
+
+      expect(res.statusCode).toBe(200);
+      const body = res.json();
+      expect(body.found).toBe(true);
+      expect(body.projects).toHaveLength(1);
+      expect(body.projects[0].name).toBe("test-repo");
+      expect(body.totals.workspaces).toBe(1);
+      expect(body.totals.sessions).toBe(1);
+    });
+  });
+
+  describe("POST /api/conductor/import", () => {
+    it("streams NDJSON progress events", async () => {
+      const dbPath = join(tempDir, "conductor.db");
+      createEmptyConductorDb(dbPath);
+      process.env.CONDUCTOR_DB_PATH = dbPath;
+
+      const res = await app.inject({
+        method: "POST",
+        url: "/api/conductor/import",
+      });
+
+      // The response is raw NDJSON, so check for expected content
+      const body = res.body;
+      const lines = body.trim().split("\n").filter(Boolean);
+
+      expect(lines.length).toBeGreaterThanOrEqual(2);
+      expect(JSON.parse(lines[0])).toMatchObject({ type: "start" });
+      expect(JSON.parse(lines[lines.length - 1])).toMatchObject({ type: "done" });
+    });
+  });
+});
+
+function createEmptyConductorDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY, remote_url TEXT, name TEXT, default_branch TEXT DEFAULT 'main',
+      root_path TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY, repository_id TEXT, directory_name TEXT, branch TEXT,
+      state TEXT DEFAULT 'active', active_session_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, workspace_id TEXT, status TEXT DEFAULT 'idle',
+      title TEXT DEFAULT 'Untitled', claude_session_id TEXT, model TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')), sent_at TEXT,
+      cancelled_at TEXT, turn_id TEXT
+    );
+  `);
+  db.close();
+}
+
+function createTestConductorDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY, remote_url TEXT, name TEXT, default_branch TEXT DEFAULT 'main',
+      root_path TEXT, created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY, repository_id TEXT, directory_name TEXT, branch TEXT,
+      state TEXT DEFAULT 'active', active_session_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY, workspace_id TEXT, status TEXT DEFAULT 'idle',
+      title TEXT DEFAULT 'Untitled', claude_session_id TEXT, model TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY, session_id TEXT, role TEXT, content TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')), sent_at TEXT,
+      cancelled_at TEXT, turn_id TEXT
+    );
+  `);
+
+  db.prepare("INSERT INTO repos VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'))")
+    .run("repo-1", "https://github.com/test/test-repo.git", "test-repo", "main", null);
+
+  db.prepare("INSERT INTO workspaces VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))")
+    .run("ws-1", "repo-1", "montpellier", "main", "active", null);
+
+  db.prepare("INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?, datetime('now'), datetime('now'))")
+    .run("sess-1", "ws-1", "idle", "Test Session", "claude-1", "opus");
+
+  db.prepare("INSERT INTO session_messages VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), NULL, ?)")
+    .run("msg-1", "sess-1", "user", JSON.stringify({ content: "Hello" }), "t-1");
+
+  db.prepare("INSERT INTO session_messages VALUES (?, ?, ?, ?, datetime('now'), datetime('now'), NULL, ?)")
+    .run("msg-2", "sess-1", "assistant", JSON.stringify({
+      type: "assistant", message: { content: [{ type: "text", text: "Hi!" }] },
+    }), "t-1");
+
+  db.close();
+}

--- a/backend/src/api/conductor.ts
+++ b/backend/src/api/conductor.ts
@@ -1,0 +1,30 @@
+import { PassThrough } from "node:stream";
+import type { FastifyInstance } from "fastify";
+import { scanConductor, importFromConductor, type ImportProgressEvent } from "../services/conductor-migrator.js";
+
+export async function conductorRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/api/conductor/scan", async () => {
+    return scanConductor();
+  });
+
+  app.post("/api/conductor/import", (req, reply) => {
+    const stream = new PassThrough();
+
+    void reply
+      .header("Content-Type", "application/x-ndjson")
+      .header("Cache-Control", "no-cache")
+      .header("X-Accel-Buffering", "no")
+      .send(stream);
+
+    const sendEvent = (event: ImportProgressEvent) => {
+      stream.write(JSON.stringify(event) + "\n");
+    };
+
+    importFromConductor(sendEvent)
+      .catch((err: unknown) => {
+        const message = err instanceof Error ? err.message : String(err);
+        sendEvent({ type: "error", message });
+      })
+      .finally(() => stream.end());
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -17,6 +17,7 @@ import { settingsRoutes } from "./api/settings.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
+import { conductorRoutes } from "./api/conductor.js";
 import { loadConfig } from "./state/config.js";
 import { broadcastToWorkspace } from "./ws/stream.js";
 import type { StreamRoutesOptions } from "./ws/stream.js";
@@ -97,6 +98,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   await app.register((instance: FastifyInstance) =>
     scriptWsRoutes(instance, { authToken }),
   );
+  await app.register((instance: FastifyInstance) => conductorRoutes(instance));
 
   return app;
 }

--- a/backend/src/services/conductor-migrator.test.ts
+++ b/backend/src/services/conductor-migrator.test.ts
@@ -1,0 +1,678 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, rm, readFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import Database from "better-sqlite3";
+import {
+  convertConductorMessages,
+  scanConductor,
+  importFromConductor,
+  type ImportProgressEvent,
+} from "./conductor-migrator.js";
+
+// ── convertConductorMessages tests ──────────────────────────────────
+
+describe("convertConductorMessages", () => {
+  it("converts a simple user message", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "user",
+        content: JSON.stringify({ content: "Hello world" }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: "2025-01-01T00:00:01Z",
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toBe("Hello world");
+    expect(result[0].sessionId).toBe("test-session");
+    expect(result[0].timestamp).toBe("2025-01-01T00:00:01Z");
+  });
+
+  it("converts an assistant message with text content", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "Hello from Claude" }],
+          },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: "2025-01-01T00:00:02Z",
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("assistant");
+    expect(result[0].content).toBe("Hello from Claude");
+  });
+
+  it("extracts thinking content from assistant messages", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "thinking", thinking: "Let me think..." },
+              { type: "text", text: "Here is my answer" },
+            ],
+          },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].content).toBe("Here is my answer");
+    expect(result[0].thinkingContent).toBe("Let me think...");
+  });
+
+  it("extracts tool calls from assistant messages", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              {
+                type: "tool_use",
+                id: "toolu_1",
+                name: "Bash",
+                input: { command: "ls -la" },
+              },
+            ],
+          },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].toolCalls).toHaveLength(1);
+    expect(result[0].toolCalls![0].name).toBe("Bash");
+    expect(result[0].toolCalls![0].id).toBe("toolu_1");
+    expect(JSON.parse(result[0].toolCalls![0].input)).toEqual({ command: "ls -la" });
+  });
+
+  it("attaches tool_result outputs to tool calls", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", id: "toolu_1", name: "Bash", input: { command: "echo hi" } },
+            ],
+          },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+      {
+        id: "msg-2",
+        session_id: "s-1",
+        role: "user",
+        content: JSON.stringify({
+          type: "tool_result",
+          tool_use_id: "toolu_1",
+          content: "hi\n",
+        }),
+        created_at: "2025-01-01T00:00:01Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].toolCalls![0].output).toBe("hi\n");
+  });
+
+  it("attaches tool_result from array-format user messages", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "tool_use", id: "toolu_1", name: "Read", input: { file: "test.ts" } },
+            ],
+          },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+      {
+        id: "msg-2",
+        session_id: "s-1",
+        role: "user",
+        content: JSON.stringify({
+          content: [
+            { type: "tool_result", tool_use_id: "toolu_1", content: "file contents here" },
+          ],
+        }),
+        created_at: "2025-01-01T00:00:01Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].toolCalls![0].output).toBe("file contents here");
+  });
+
+  it("attaches duration from result messages", () => {
+    const messages = [
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: { content: [{ type: "text", text: "Done" }] },
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+      {
+        id: "msg-2",
+        session_id: "s-1",
+        role: null,
+        content: JSON.stringify({
+          type: "result",
+          duration_ms: 5000,
+          total_cost_usd: 0.1,
+        }),
+        created_at: "2025-01-01T00:00:05Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].durationMs).toBe(5000);
+  });
+
+  it("skips system init messages", () => {
+    const messages = [
+      {
+        id: "msg-0",
+        session_id: "s-1",
+        role: null,
+        content: JSON.stringify({
+          type: "system",
+          subtype: "init",
+          tools: [],
+        }),
+        created_at: "2025-01-01T00:00:00Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: null,
+      },
+      {
+        id: "msg-1",
+        session_id: "s-1",
+        role: "user",
+        content: JSON.stringify({ content: "Hello" }),
+        created_at: "2025-01-01T00:00:01Z",
+        sent_at: null,
+        cancelled_at: null,
+        turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toBe("Hello");
+  });
+
+  it("handles a full multi-turn conversation", () => {
+    const messages = [
+      // System init (skip)
+      {
+        id: "msg-0", session_id: "s-1", role: null,
+        content: JSON.stringify({ type: "system", subtype: "init" }),
+        created_at: "2025-01-01T00:00:00Z", sent_at: null, cancelled_at: null, turn_id: null,
+      },
+      // User message
+      {
+        id: "msg-1", session_id: "s-1", role: "user",
+        content: JSON.stringify({ content: "Fix the bug in main.ts" }),
+        created_at: "2025-01-01T00:00:01Z", sent_at: "2025-01-01T00:00:01Z", cancelled_at: null, turn_id: "t-1",
+      },
+      // Assistant with tool use
+      {
+        id: "msg-2", session_id: "s-1", role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [
+              { type: "thinking", thinking: "Let me read the file first" },
+              { type: "tool_use", id: "toolu_1", name: "Read", input: { file_path: "main.ts" } },
+            ],
+          },
+        }),
+        created_at: "2025-01-01T00:00:02Z", sent_at: null, cancelled_at: null, turn_id: "t-1",
+      },
+      // Tool result
+      {
+        id: "msg-3", session_id: "s-1", role: "user",
+        content: JSON.stringify({ type: "tool_result", tool_use_id: "toolu_1", content: "const x = 1;" }),
+        created_at: "2025-01-01T00:00:03Z", sent_at: null, cancelled_at: null, turn_id: "t-1",
+      },
+      // Assistant final response
+      {
+        id: "msg-4", session_id: "s-1", role: "assistant",
+        content: JSON.stringify({
+          type: "assistant",
+          message: {
+            content: [{ type: "text", text: "I found and fixed the bug." }],
+          },
+        }),
+        created_at: "2025-01-01T00:00:04Z", sent_at: null, cancelled_at: null, turn_id: "t-1",
+      },
+      // Result
+      {
+        id: "msg-5", session_id: "s-1", role: null,
+        content: JSON.stringify({ type: "result", duration_ms: 12000 }),
+        created_at: "2025-01-01T00:00:05Z", sent_at: null, cancelled_at: null, turn_id: "t-1",
+      },
+    ];
+
+    const result = convertConductorMessages(messages, "test-session");
+
+    expect(result).toHaveLength(3);
+    // User message
+    expect(result[0].role).toBe("user");
+    expect(result[0].content).toBe("Fix the bug in main.ts");
+    // Assistant with tool call
+    expect(result[1].role).toBe("assistant");
+    expect(result[1].thinkingContent).toBe("Let me read the file first");
+    expect(result[1].toolCalls).toHaveLength(1);
+    expect(result[1].toolCalls![0].output).toBe("const x = 1;");
+    // Final assistant
+    expect(result[2].role).toBe("assistant");
+    expect(result[2].content).toBe("I found and fixed the bug.");
+    expect(result[2].durationMs).toBe(12000);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(convertConductorMessages([], "test")).toEqual([]);
+  });
+
+  it("skips messages with null content", () => {
+    const messages = [
+      {
+        id: "msg-1", session_id: "s-1", role: "user",
+        content: null,
+        created_at: "2025-01-01T00:00:00Z", sent_at: null, cancelled_at: null, turn_id: null,
+      },
+    ];
+    expect(convertConductorMessages(messages, "test")).toEqual([]);
+  });
+
+  it("skips messages with invalid JSON content", () => {
+    const messages = [
+      {
+        id: "msg-1", session_id: "s-1", role: "user",
+        content: "not json",
+        created_at: "2025-01-01T00:00:00Z", sent_at: null, cancelled_at: null, turn_id: null,
+      },
+    ];
+    expect(convertConductorMessages(messages, "test")).toEqual([]);
+  });
+});
+
+// ── Scan & Import integration tests ─────────────────────────────────
+
+describe("scanConductor", () => {
+  let tempDir: string;
+  let previousDataDir: string | undefined;
+  let previousConductorDbPath: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-conductor-test-"));
+    previousDataDir = process.env.DATA_DIR;
+    previousConductorDbPath = process.env.CONDUCTOR_DB_PATH;
+    process.env.DATA_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (previousConductorDbPath === undefined) delete process.env.CONDUCTOR_DB_PATH;
+    else process.env.CONDUCTOR_DB_PATH = previousConductorDbPath;
+  });
+
+  it("returns found=false when DB does not exist", async () => {
+    process.env.CONDUCTOR_DB_PATH = join(tempDir, "nonexistent.db");
+
+    const result = await scanConductor(tempDir);
+
+    expect(result.found).toBe(false);
+    expect(result.projects).toEqual([]);
+  });
+
+  it("scans a Conductor DB and returns project summaries", async () => {
+    const dbPath = join(tempDir, "conductor.db");
+    createTestConductorDb(dbPath);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+
+    const result = await scanConductor(tempDir);
+
+    expect(result.found).toBe(true);
+    expect(result.projects).toHaveLength(1);
+    expect(result.projects[0].name).toBe("test-repo");
+    expect(result.projects[0].remoteUrl).toBe("https://github.com/test/test-repo.git");
+    expect(result.projects[0].workspaceCount).toBe(1);
+    expect(result.projects[0].sessionCount).toBe(1);
+    expect(result.projects[0].messageCount).toBe(2);
+    expect(result.projects[0].alreadyImported).toBe(false);
+    expect(result.totals.projects).toBe(1);
+    expect(result.totals.workspaces).toBe(1);
+  });
+
+  it("marks projects as alreadyImported when Hive already has the same URL", async () => {
+    const dbPath = join(tempDir, "conductor.db");
+    createTestConductorDb(dbPath);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+
+    // Create a Hive project with the same URL
+    const projectDir = join(tempDir, "proj-existing");
+    await mkdir(projectDir, { recursive: true });
+    const { writeFile: wf } = await import("node:fs/promises");
+    await wf(
+      join(projectDir, "state.json"),
+      JSON.stringify({
+        id: "proj-existing",
+        name: "test-repo",
+        url: "https://github.com/test/test-repo.git",
+        createdAt: "2025-01-01T00:00:00Z",
+        workspaces: [],
+      }),
+    );
+
+    const result = await scanConductor(tempDir);
+
+    expect(result.projects[0].alreadyImported).toBe(true);
+  });
+});
+
+describe("importFromConductor", () => {
+  let tempDir: string;
+  let previousDataDir: string | undefined;
+  let previousConductorDbPath: string | undefined;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-conductor-import-test-"));
+    previousDataDir = process.env.DATA_DIR;
+    previousConductorDbPath = process.env.CONDUCTOR_DB_PATH;
+    process.env.DATA_DIR = tempDir;
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    if (previousDataDir === undefined) delete process.env.DATA_DIR;
+    else process.env.DATA_DIR = previousDataDir;
+    if (previousConductorDbPath === undefined) delete process.env.CONDUCTOR_DB_PATH;
+    else process.env.CONDUCTOR_DB_PATH = previousConductorDbPath;
+  });
+
+  it("emits start and done events for empty DB", async () => {
+    const dbPath = join(tempDir, "conductor.db");
+    createEmptyConductorDb(dbPath);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+
+    const events: ImportProgressEvent[] = [];
+    await importFromConductor((e) => events.push(e), tempDir);
+
+    expect(events[0]).toEqual({ type: "start", totalProjects: 0, totalWorkspaces: 0 });
+    expect(events[events.length - 1]).toMatchObject({ type: "done" });
+  });
+
+  it("imports sessions and writes messages.jsonl and metadata.json", async () => {
+    const dbPath = join(tempDir, "conductor.db");
+    const fixtureRepo = await createFixtureGitRepo(tempDir);
+    createTestConductorDb(dbPath, fixtureRepo);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+
+    const events: ImportProgressEvent[] = [];
+    const result = await importFromConductor((e) => events.push(e), tempDir);
+
+    expect(result.sessions).toBe(1);
+
+    // Find the project directory
+    const { readdir: rd } = await import("node:fs/promises");
+    const entries = await rd(tempDir, { withFileTypes: true });
+    const projDir = entries.find((e) => e.isDirectory() && e.name.startsWith("proj-"));
+    expect(projDir).toBeTruthy();
+
+    // Check sessions directory
+    const sessionsDir = join(tempDir, projDir!.name, "sessions");
+    const sessionEntries = await rd(sessionsDir, { withFileTypes: true });
+    expect(sessionEntries.length).toBeGreaterThan(0);
+
+    // Check messages.jsonl
+    const sessionDir = join(sessionsDir, sessionEntries[0].name);
+    const messagesRaw = await readFile(join(sessionDir, "messages.jsonl"), "utf-8");
+    const messages = messagesRaw.trim().split("\n").map((l) => JSON.parse(l));
+    expect(messages).toHaveLength(2);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content).toBe("Hello world");
+    expect(messages[1].role).toBe("assistant");
+    expect(messages[1].content).toBe("Hi there!");
+
+    // Check metadata.json
+    const metaRaw = await readFile(join(sessionDir, "metadata.json"), "utf-8");
+    const meta = JSON.parse(metaRaw);
+    expect(meta.messageCount).toBe(2);
+    expect(meta.title).toBe("Test Session");
+  });
+
+  it("emits progress events in correct order", async () => {
+    const dbPath = join(tempDir, "conductor.db");
+    const fixtureRepo = await createFixtureGitRepo(tempDir);
+    createTestConductorDb(dbPath, fixtureRepo);
+    process.env.CONDUCTOR_DB_PATH = dbPath;
+
+    const eventTypes: string[] = [];
+    await importFromConductor((e) => eventTypes.push(e.type), tempDir);
+
+    expect(eventTypes[0]).toBe("start");
+    expect(eventTypes).toContain("project_start");
+    expect(eventTypes).toContain("project_cloning");
+    expect(eventTypes).toContain("project_cloned");
+    expect(eventTypes).toContain("workspace_importing");
+    expect(eventTypes).toContain("workspace_imported");
+    expect(eventTypes).toContain("project_done");
+    expect(eventTypes[eventTypes.length - 1]).toBe("done");
+  });
+});
+
+// ── Test helpers ────────────────────────────────────────────────────
+
+function createEmptyConductorDb(dbPath: string): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      remote_url TEXT,
+      name TEXT,
+      default_branch TEXT DEFAULT 'main',
+      root_path TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      repository_id TEXT,
+      directory_name TEXT,
+      branch TEXT,
+      state TEXT DEFAULT 'active',
+      active_session_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT,
+      status TEXT DEFAULT 'idle',
+      title TEXT DEFAULT 'Untitled',
+      claude_session_id TEXT,
+      model TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      role TEXT,
+      content TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      sent_at TEXT,
+      cancelled_at TEXT,
+      turn_id TEXT
+    );
+  `);
+  db.close();
+}
+
+function createTestConductorDb(dbPath: string, localRepoPath?: string): void {
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE repos (
+      id TEXT PRIMARY KEY,
+      remote_url TEXT,
+      name TEXT,
+      default_branch TEXT DEFAULT 'main',
+      root_path TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      repository_id TEXT,
+      directory_name TEXT,
+      branch TEXT,
+      state TEXT DEFAULT 'active',
+      active_session_id TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      workspace_id TEXT,
+      status TEXT DEFAULT 'idle',
+      title TEXT DEFAULT 'Untitled',
+      claude_session_id TEXT,
+      model TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE TABLE session_messages (
+      id TEXT PRIMARY KEY,
+      session_id TEXT,
+      role TEXT,
+      content TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      sent_at TEXT,
+      cancelled_at TEXT,
+      turn_id TEXT
+    );
+  `);
+
+  db.prepare(`INSERT INTO repos (id, remote_url, name, default_branch, root_path, created_at) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("repo-1", localRepoPath ?? "https://github.com/test/test-repo.git", "test-repo", "main", localRepoPath ?? null, "2025-01-01T00:00:00Z");
+
+  db.prepare(`INSERT INTO workspaces (id, repository_id, directory_name, branch, state, created_at) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("ws-1", "repo-1", "montpellier", "main", "active", "2025-01-01T00:00:00Z");
+
+  db.prepare(`INSERT INTO sessions (id, workspace_id, title, claude_session_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("sess-1", "ws-1", "Test Session", "claude-sess-1", "2025-01-01T00:00:00Z", "2025-01-01T00:01:00Z");
+
+  db.prepare(`INSERT INTO session_messages (id, session_id, role, content, created_at, sent_at) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("msg-1", "sess-1", "user", JSON.stringify({ content: "Hello world" }), "2025-01-01T00:00:01Z", "2025-01-01T00:00:01Z");
+
+  db.prepare(`INSERT INTO session_messages (id, session_id, role, content, created_at, sent_at) VALUES (?, ?, ?, ?, ?, ?)`)
+    .run("msg-2", "sess-1", "assistant", JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "Hi there!" }] },
+    }), "2025-01-01T00:00:02Z", "2025-01-01T00:00:02Z");
+
+  db.close();
+}
+
+async function createFixtureGitRepo(parentDir: string): Promise<string> {
+  const { execFile } = await import("node:child_process");
+  const { promisify } = await import("node:util");
+  const exec = promisify(execFile);
+
+  const repoDir = join(parentDir, "fixture-repo");
+  await mkdir(repoDir, { recursive: true });
+
+  await exec("git", ["init", "-b", "main"], { cwd: repoDir });
+  await exec("git", ["config", "user.email", "test@test.com"], { cwd: repoDir });
+  await exec("git", ["config", "user.name", "Test"], { cwd: repoDir });
+
+  const { writeFile: wf } = await import("node:fs/promises");
+  await wf(join(repoDir, "README.md"), "# Test\n");
+  await exec("git", ["add", "."], { cwd: repoDir });
+  await exec("git", ["commit", "-m", "Initial commit"], { cwd: repoDir });
+
+  return repoDir;
+}

--- a/backend/src/services/conductor-migrator.ts
+++ b/backend/src/services/conductor-migrator.ts
@@ -1,0 +1,709 @@
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { access, mkdir, writeFile } from "node:fs/promises";
+import Database from "better-sqlite3";
+import { nanoid } from "nanoid";
+import { git } from "../utils/git.js";
+import { bareRepoPath, workspacesDir } from "../utils/paths.js";
+import { pickCityName } from "../utils/city-names.js";
+import { loadProject, saveProject, getDataDir, loadAllProjects, withProjectStateLock } from "../state/state.js";
+import type { ChatMessage, ToolCall, ProjectState, Workspace, SessionMetadata } from "../types.js";
+
+// ── Conductor DB path ───────────────────────────────────────────────
+
+const DEFAULT_CONDUCTOR_DB_PATH = join(
+  homedir(),
+  "Library",
+  "Application Support",
+  "com.conductor.app",
+  "conductor.db",
+);
+
+export function getConductorDbPath(): string {
+  return process.env.CONDUCTOR_DB_PATH ?? DEFAULT_CONDUCTOR_DB_PATH;
+}
+
+// ── Conductor row types ─────────────────────────────────────────────
+
+interface ConductorRepo {
+  id: string;
+  remote_url: string | null;
+  name: string | null;
+  default_branch: string | null;
+  root_path: string | null;
+  created_at: string;
+}
+
+interface ConductorWorkspace {
+  id: string;
+  repository_id: string;
+  directory_name: string | null;
+  branch: string | null;
+  state: string | null;
+  active_session_id: string | null;
+  created_at: string;
+}
+
+interface ConductorSession {
+  id: string;
+  workspace_id: string;
+  title: string | null;
+  claude_session_id: string | null;
+  model: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface ConductorMessage {
+  id: string;
+  session_id: string;
+  role: string | null;
+  content: string | null;
+  created_at: string;
+  sent_at: string | null;
+  cancelled_at: string | null;
+  turn_id: string | null;
+}
+
+// ── Scan result types ───────────────────────────────────────────────
+
+export interface ConductorProjectSummary {
+  id: string;
+  name: string;
+  remoteUrl: string;
+  defaultBranch: string;
+  rootPath: string | null;
+  workspaceCount: number;
+  sessionCount: number;
+  messageCount: number;
+  alreadyImported: boolean;
+}
+
+export interface ConductorScanResult {
+  found: boolean;
+  dbPath: string;
+  projects: ConductorProjectSummary[];
+  totals: {
+    projects: number;
+    workspaces: number;
+    sessions: number;
+    messages: number;
+  };
+}
+
+// ── Import progress types ───────────────────────────────────────────
+
+export type ImportProgressEvent =
+  | { type: "start"; totalProjects: number; totalWorkspaces: number }
+  | { type: "project_start"; projectIndex: number; projectName: string; workspaceCount: number }
+  | { type: "project_cloning"; projectIndex: number; projectName: string }
+  | { type: "project_cloned"; projectIndex: number; projectName: string }
+  | { type: "workspace_importing"; projectIndex: number; workspaceName: string; branch: string }
+  | { type: "workspace_imported"; projectIndex: number; workspaceName: string; sessionCount: number }
+  | { type: "workspace_skipped"; projectIndex: number; workspaceName: string; reason: string }
+  | { type: "project_done"; projectIndex: number; projectName: string }
+  | { type: "done"; imported: { projects: number; workspaces: number; sessions: number } }
+  | { type: "error"; message: string; projectName?: string };
+
+export interface ImportResult {
+  projects: number;
+  workspaces: number;
+  sessions: number;
+}
+
+// ── Scan ─────────────────────────────────────────────────────────────
+
+export async function scanConductor(dataDir = getDataDir()): Promise<ConductorScanResult> {
+  const dbPath = getConductorDbPath();
+
+  try {
+    await access(dbPath);
+  } catch {
+    return {
+      found: false,
+      dbPath,
+      projects: [],
+      totals: { projects: 0, workspaces: 0, sessions: 0, messages: 0 },
+    };
+  }
+
+  const db = new Database(dbPath, { readonly: true });
+  try {
+    const repos = db.prepare("SELECT * FROM repos").all() as ConductorRepo[];
+
+    // Load existing Hive projects to detect already-imported repos
+    const hiveProjects = await loadAllProjects(dataDir);
+    const hiveUrls = new Set(hiveProjects.map((p) => normalizeGitUrl(p.url)));
+
+    const projects: ConductorProjectSummary[] = [];
+    let totalWorkspaces = 0;
+    let totalSessions = 0;
+    let totalMessages = 0;
+
+    for (const repo of repos) {
+      if (!repo.remote_url) continue;
+
+      const workspaces = db
+        .prepare("SELECT * FROM workspaces WHERE repository_id = ? AND state IN ('active', 'ready')")
+        .all(repo.id) as ConductorWorkspace[];
+
+      const wsIds = workspaces.map((ws) => ws.id);
+      let sessionCount = 0;
+      let messageCount = 0;
+
+      if (wsIds.length > 0) {
+        const placeholders = wsIds.map(() => "?").join(",");
+        const sessions = db
+          .prepare(`SELECT id FROM sessions WHERE workspace_id IN (${placeholders})`)
+          .all(...wsIds) as Array<{ id: string }>;
+        sessionCount = sessions.length;
+
+        if (sessions.length > 0) {
+          const sessionIds = sessions.map((s) => s.id);
+          const msgPlaceholders = sessionIds.map(() => "?").join(",");
+          const msgResult = db
+            .prepare(`SELECT COUNT(*) as count FROM session_messages WHERE session_id IN (${msgPlaceholders}) AND cancelled_at IS NULL`)
+            .get(...sessionIds) as { count: number };
+          messageCount = msgResult.count;
+        }
+      }
+
+      const alreadyImported = hiveUrls.has(normalizeGitUrl(repo.remote_url));
+
+      projects.push({
+        id: repo.id,
+        name: repo.name ?? extractRepoName(repo.remote_url),
+        remoteUrl: repo.remote_url,
+        defaultBranch: repo.default_branch ?? "main",
+        rootPath: repo.root_path,
+        workspaceCount: workspaces.length,
+        sessionCount,
+        messageCount,
+        alreadyImported,
+      });
+
+      totalWorkspaces += workspaces.length;
+      totalSessions += sessionCount;
+      totalMessages += messageCount;
+    }
+
+    return {
+      found: true,
+      dbPath,
+      projects,
+      totals: {
+        projects: projects.length,
+        workspaces: totalWorkspaces,
+        sessions: totalSessions,
+        messages: totalMessages,
+      },
+    };
+  } finally {
+    db.close();
+  }
+}
+
+// ── Import ──────────────────────────────────────────────────────────
+
+export async function importFromConductor(
+  onProgress: (event: ImportProgressEvent) => void,
+  dataDir = getDataDir(),
+): Promise<ImportResult> {
+  const dbPath = getConductorDbPath();
+  const db = new Database(dbPath, { readonly: true });
+
+  try {
+    const repos = db.prepare("SELECT * FROM repos").all() as ConductorRepo[];
+    const importableRepos = repos.filter((r) => r.remote_url);
+
+    // Load existing Hive projects to skip already-imported repos
+    const hiveProjects = await loadAllProjects(dataDir);
+    const hiveUrlMap = new Map<string, ProjectState>();
+    for (const p of hiveProjects) {
+      hiveUrlMap.set(normalizeGitUrl(p.url), p);
+    }
+
+    // Filter out already-imported repos — the scan UI already shows them as imported
+    const newRepos = importableRepos.filter(
+      (r) => !hiveUrlMap.has(normalizeGitUrl(r.remote_url!)),
+    );
+
+    // Count total workspaces only for new repos
+    let totalWorkspaces = 0;
+    for (const repo of newRepos) {
+      const count = db
+        .prepare("SELECT COUNT(*) as count FROM workspaces WHERE repository_id = ? AND state IN ('active', 'ready')")
+        .get(repo.id) as { count: number };
+      totalWorkspaces += count.count;
+    }
+
+    onProgress({ type: "start", totalProjects: newRepos.length, totalWorkspaces });
+
+    let importedProjects = 0;
+    let importedWorkspaces = 0;
+    let importedSessions = 0;
+
+    for (let pi = 0; pi < newRepos.length; pi++) {
+      const repo = newRepos[pi];
+      const projectName = repo.name ?? extractRepoName(repo.remote_url!);
+
+      const workspaces = db
+        .prepare("SELECT * FROM workspaces WHERE repository_id = ? AND state IN ('active', 'ready')")
+        .all(repo.id) as ConductorWorkspace[];
+
+      onProgress({
+        type: "project_start",
+        projectIndex: pi,
+        projectName,
+        workspaceCount: workspaces.length,
+      });
+
+      try {
+        // Clone bare repo
+        onProgress({ type: "project_cloning", projectIndex: pi, projectName });
+
+        const projectId = `proj-${nanoid(8)}`;
+        const bare = bareRepoPath(dataDir, projectId);
+        const wsDir = join(dataDir, projectId, "workspaces");
+        const sessionsDir = join(dataDir, projectId, "sessions");
+
+        await mkdir(join(dataDir, projectId), { recursive: true });
+
+        // Prefer cloning from local path (much faster) if available
+        const cloneSource = await resolveCloneSource(repo);
+        await git(["clone", "--bare", cloneSource, bare]);
+        await mkdir(wsDir, { recursive: true });
+        await mkdir(sessionsDir, { recursive: true });
+
+        const projectState: ProjectState = {
+          id: projectId,
+          name: projectName,
+          url: repo.remote_url!,
+          createdAt: repo.created_at || new Date().toISOString(),
+          workspaces: [],
+        };
+        await saveProject(projectState, dataDir);
+
+        onProgress({ type: "project_cloned", projectIndex: pi, projectName });
+
+        // Import workspaces
+        for (const ws of workspaces) {
+          if (!ws.branch) {
+            onProgress({
+              type: "workspace_skipped",
+              projectIndex: pi,
+              workspaceName: ws.directory_name ?? ws.id,
+              reason: "no branch",
+            });
+            continue;
+          }
+
+          const wsName = ws.directory_name ?? ws.id;
+          onProgress({
+            type: "workspace_importing",
+            projectIndex: pi,
+            workspaceName: wsName,
+            branch: ws.branch,
+          });
+
+          try {
+            const sessionCount = await importWorkspace(
+              db,
+              ws,
+              projectState,
+              dataDir,
+            );
+            importedWorkspaces++;
+            importedSessions += sessionCount;
+
+            onProgress({
+              type: "workspace_imported",
+              projectIndex: pi,
+              workspaceName: wsName,
+              sessionCount,
+            });
+          } catch (err: unknown) {
+            const msg = err instanceof Error ? err.message : String(err);
+            onProgress({
+              type: "workspace_skipped",
+              projectIndex: pi,
+              workspaceName: wsName,
+              reason: msg,
+            });
+          }
+        }
+
+        importedProjects++;
+        onProgress({ type: "project_done", projectIndex: pi, projectName });
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        onProgress({ type: "error", message: msg, projectName });
+      }
+    }
+
+    const result: ImportResult = {
+      projects: importedProjects,
+      workspaces: importedWorkspaces,
+      sessions: importedSessions,
+    };
+    onProgress({ type: "done", imported: result });
+    return result;
+  } finally {
+    db.close();
+  }
+}
+
+// ── Workspace import ────────────────────────────────────────────────
+
+async function importWorkspace(
+  db: Database.Database,
+  conductorWs: ConductorWorkspace,
+  projectState: ProjectState,
+  dataDir: string,
+): Promise<number> {
+  const bare = bareRepoPath(dataDir, projectState.id);
+  const branch = conductorWs.branch!;
+
+  // Check if a workspace already exists for this branch
+  const existingWs = projectState.workspaces.find((ws) => ws.branch === branch);
+  if (existingWs) {
+    // Import sessions only, workspace already exists
+    return importWorkspaceSessions(db, conductorWs, existingWs.id, projectState.id, dataDir);
+  }
+
+  // Pick a city name for the workspace
+  const usedNames = projectState.workspaces.map((ws) => ws.name);
+  const cityName = pickCityName(usedNames);
+  const wsPath = join(workspacesDir(dataDir, projectState.id), cityName);
+
+  // Check if branch exists in the bare repo
+  const branchExists = await checkBranchExists(bare, branch);
+
+  if (branchExists) {
+    // Create worktree for existing branch
+    await git(["worktree", "add", wsPath, branch], bare);
+  } else {
+    // Branch doesn't exist — try to find it on remote
+    try {
+      await git(["fetch", "origin", branch], bare);
+      await git(
+        ["branch", branch, `FETCH_HEAD`],
+        bare,
+      );
+      await git(["worktree", "add", wsPath, branch], bare);
+    } catch {
+      // Branch not found anywhere — create from default branch
+      const defaultBranch = projectState.workspaces.length > 0
+        ? "main"
+        : await resolveDefaultBranchSafe(bare);
+      await git(["worktree", "add", "-b", branch, wsPath, defaultBranch], bare);
+    }
+  }
+
+  const workspace: Workspace = {
+    id: `ws-${nanoid(8)}`,
+    name: cityName,
+    projectId: projectState.id,
+    branch,
+    status: "idle",
+    createdAt: conductorWs.created_at || new Date().toISOString(),
+  };
+
+  // Save workspace to project state
+  await withProjectStateLock(
+    projectState.id,
+    async () => {
+      projectState.workspaces.push(workspace);
+      await saveProject(projectState, dataDir);
+    },
+    dataDir,
+  );
+
+  // Import sessions
+  return importWorkspaceSessions(db, conductorWs, workspace.id, projectState.id, dataDir);
+}
+
+// ── Session import ──────────────────────────────────────────────────
+
+async function importWorkspaceSessions(
+  db: Database.Database,
+  conductorWs: ConductorWorkspace,
+  hiveWsId: string,
+  hiveProjectId: string,
+  dataDir: string,
+): Promise<number> {
+  const sessions = db
+    .prepare("SELECT * FROM sessions WHERE workspace_id = ? ORDER BY created_at ASC")
+    .all(conductorWs.id) as ConductorSession[];
+
+  let imported = 0;
+
+  for (const session of sessions) {
+    try {
+      await importSession(db, session, hiveWsId, hiveProjectId, dataDir);
+      imported++;
+    } catch {
+      // Skip corrupt sessions
+    }
+  }
+
+  // Update activeSessionId to the last imported session
+  if (imported > 0 && sessions.length > 0) {
+    const lastSession = sessions[sessions.length - 1];
+    const sessionId = toHiveSessionId(lastSession.id);
+
+    await withProjectStateLock(
+      hiveProjectId,
+      async () => {
+        const state = await loadProject(hiveProjectId, dataDir);
+        if (!state) return;
+        const workspace = state.workspaces.find((w) => w.id === hiveWsId);
+        if (workspace) {
+          workspace.activeSessionId = sessionId;
+          await saveProject(state, dataDir);
+        }
+      },
+      dataDir,
+    );
+  }
+
+  return imported;
+}
+
+async function importSession(
+  db: Database.Database,
+  conductorSession: ConductorSession,
+  hiveWsId: string,
+  hiveProjectId: string,
+  dataDir: string,
+): Promise<void> {
+  const sessionId = toHiveSessionId(conductorSession.id);
+  const sessionDir = join(dataDir, hiveProjectId, "sessions", sessionId);
+  await mkdir(sessionDir, { recursive: true });
+
+  // Convert messages
+  const messages = db
+    .prepare(
+      `SELECT * FROM session_messages
+       WHERE session_id = ? AND cancelled_at IS NULL
+       ORDER BY COALESCE(sent_at, created_at) ASC`,
+    )
+    .all(conductorSession.id) as ConductorMessage[];
+
+  const hiveMessages = convertConductorMessages(messages, sessionId);
+
+  // Write messages.jsonl
+  if (hiveMessages.length > 0) {
+    const jsonl = hiveMessages.map((m) => JSON.stringify(m)).join("\n") + "\n";
+    await writeFile(join(sessionDir, "messages.jsonl"), jsonl, "utf-8");
+  }
+
+  // Write metadata
+  const metadata: SessionMetadata = {
+    sessionId,
+    claudeSessionId: conductorSession.claude_session_id ?? undefined,
+    workspaceId: hiveWsId,
+    title: conductorSession.title && conductorSession.title !== "Untitled"
+      ? conductorSession.title
+      : undefined,
+    createdAt: conductorSession.created_at || new Date().toISOString(),
+    updatedAt: conductorSession.updated_at || conductorSession.created_at || new Date().toISOString(),
+    messageCount: hiveMessages.length,
+  };
+  await writeFile(
+    join(sessionDir, "metadata.json"),
+    JSON.stringify(metadata, null, 2),
+    "utf-8",
+  );
+}
+
+// ── Message conversion ──────────────────────────────────────────────
+
+export function convertConductorMessages(
+  messages: ConductorMessage[],
+  hiveSessionId: string,
+): ChatMessage[] {
+  const hiveMessages: ChatMessage[] = [];
+  let pendingAssistant: ChatMessage | null = null;
+
+  for (const msg of messages) {
+    if (!msg.content) continue;
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(msg.content);
+    } catch {
+      continue;
+    }
+
+    // System init messages → skip
+    if (parsed.type === "system") continue;
+
+    // Result messages → attach duration to pending assistant and flush
+    if (parsed.type === "result") {
+      if (pendingAssistant) {
+        pendingAssistant.durationMs = typeof parsed.duration_ms === "number"
+          ? parsed.duration_ms
+          : undefined;
+        hiveMessages.push(pendingAssistant);
+        pendingAssistant = null;
+      }
+      continue;
+    }
+
+    // User messages with tool_result content → attach to pending assistant's tool calls
+    if (msg.role === "user" && parsed.type === "tool_result") {
+      if (pendingAssistant?.toolCalls) {
+        const toolUseId = parsed.tool_use_id as string;
+        const tc = pendingAssistant.toolCalls.find((t) => t.id === toolUseId);
+        if (tc) {
+          tc.output = typeof parsed.content === "string"
+            ? parsed.content
+            : JSON.stringify(parsed.content);
+        }
+      }
+      continue;
+    }
+
+    // User messages (role array with tool_result blocks)
+    if (msg.role === "user" && Array.isArray(parsed.content)) {
+      // This is a tool_result array — attach each to pending assistant
+      for (const block of parsed.content as Array<Record<string, unknown>>) {
+        if (block.type === "tool_result" && pendingAssistant?.toolCalls) {
+          const tc = pendingAssistant.toolCalls.find((t) => t.id === block.tool_use_id);
+          if (tc) {
+            tc.output = typeof block.content === "string"
+              ? block.content
+              : JSON.stringify(block.content);
+          }
+        }
+      }
+      continue;
+    }
+
+    // Regular user messages
+    if (msg.role === "user" && typeof parsed.content === "string") {
+      // Flush pending assistant
+      if (pendingAssistant) {
+        hiveMessages.push(pendingAssistant);
+        pendingAssistant = null;
+      }
+
+      hiveMessages.push({
+        id: `msg-${nanoid(12)}`,
+        sessionId: hiveSessionId,
+        role: "user",
+        content: parsed.content,
+        timestamp: msg.sent_at ?? msg.created_at,
+      });
+      continue;
+    }
+
+    // Assistant messages
+    if (parsed.type === "assistant" && parsed.message) {
+      // Flush pending assistant
+      if (pendingAssistant) {
+        hiveMessages.push(pendingAssistant);
+        pendingAssistant = null;
+      }
+
+      const msgData = parsed.message as Record<string, unknown>;
+      const blocks = (msgData.content ?? []) as Array<Record<string, unknown>>;
+
+      let text = "";
+      let thinking = "";
+      const toolCalls: ToolCall[] = [];
+
+      for (const block of blocks) {
+        switch (block.type) {
+          case "text":
+            text += block.text ?? "";
+            break;
+          case "thinking":
+            thinking += block.thinking ?? "";
+            break;
+          case "tool_use":
+            toolCalls.push({
+              id: (block.id as string) ?? nanoid(8),
+              name: (block.name as string) ?? "unknown",
+              input: typeof block.input === "string"
+                ? block.input
+                : JSON.stringify(block.input ?? {}, null, 2),
+            });
+            break;
+        }
+      }
+
+      pendingAssistant = {
+        id: `msg-${nanoid(12)}`,
+        sessionId: hiveSessionId,
+        role: "assistant",
+        content: text,
+        toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
+        thinkingContent: thinking || undefined,
+        timestamp: msg.sent_at ?? msg.created_at,
+      };
+      continue;
+    }
+  }
+
+  // Flush any remaining pending assistant
+  if (pendingAssistant) {
+    hiveMessages.push(pendingAssistant);
+  }
+
+  return hiveMessages;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function normalizeGitUrl(url: string): string {
+  return url
+    .replace(/\.git$/, "")
+    .replace(/^git@github\.com:/, "https://github.com/")
+    .replace(/^ssh:\/\/git@github\.com\//, "https://github.com/")
+    .replace(/\/$/, "")
+    .toLowerCase();
+}
+
+function extractRepoName(url: string): string {
+  const match = url.match(/\/([^/]+?)(?:\.git)?$/);
+  return match?.[1] ?? "unnamed";
+}
+
+async function resolveCloneSource(repo: ConductorRepo): Promise<string> {
+  // Prefer local path for faster cloning
+  if (repo.root_path) {
+    try {
+      await git(["rev-parse", "--git-dir"], repo.root_path);
+      return repo.root_path;
+    } catch {
+      // Not a valid git repo, fall through to remote
+    }
+  }
+  return repo.remote_url!;
+}
+
+async function checkBranchExists(bare: string, branch: string): Promise<boolean> {
+  try {
+    await git(["rev-parse", "--verify", `refs/heads/${branch}`], bare);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveDefaultBranchSafe(bare: string): Promise<string> {
+  try {
+    const { stdout: headRef } = await git(["symbolic-ref", "HEAD"], bare);
+    return headRef.replace("refs/heads/", "");
+  } catch {
+    return "main";
+  }
+}
+
+function toHiveSessionId(conductorSessionId: string): string {
+  // Use a deterministic but shorter ID based on the conductor ID
+  // This ensures re-imports don't duplicate sessions
+  return `cnd-${conductorSessionId.slice(0, 12)}`;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import AccountSettings from "@/pages/settings/AccountSettings";
 import AppearanceSettings from "@/pages/settings/AppearanceSettings";
 import ConnectionSettings from "@/pages/settings/ConnectionSettings";
 import NotificationSettings from "@/pages/settings/NotificationSettings";
+import ConductorMigration from "@/pages/settings/ConductorMigration";
 import ProjectDetail from "@/pages/settings/ProjectDetail";
 import AddProjectDialog from "@/components/AddProjectDialog";
 import EmptyStateLogo from "@/components/EmptyStateLogo";
@@ -67,6 +68,7 @@ export default function App() {
           <Route path="settings/appearance" element={<AppearanceSettings />} />
           <Route path="settings/connection" element={<ConnectionSettings onRefreshConnection={() => { wsTransport.disconnectAll(); fetchProjects(); }} />} />
           <Route path="settings/notifications" element={<NotificationSettings />} />
+          <Route path="settings/conductor" element={<ConductorMigration />} />
           <Route path="settings/repositories/:projectId" element={<ProjectDetail projects={projects} onDeleteProject={deleteProject} />} />
         </Route>
       </Routes>

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { ArrowLeft, Bell, CircleUser, Paintbrush, Wifi, GitFork } from "lucide-react";
+import { ArrowLeft, ArrowDownToLine, Bell, CircleUser, Paintbrush, Wifi, GitFork } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -58,6 +58,12 @@ export default function SettingsSidebar({ projects }: SettingsSidebarProps) {
               label="Notifications"
               icon={<Bell className="h-4 w-4" />}
               active={pathname === "/settings/notifications"}
+            />
+            <NavItem
+              to="/settings/conductor"
+              label="Import from Conductor"
+              icon={<ArrowDownToLine className="h-4 w-4" />}
+              active={pathname === "/settings/conductor"}
             />
           </SidebarSection>
 

--- a/frontend/src/pages/settings/ConductorMigration.tsx
+++ b/frontend/src/pages/settings/ConductorMigration.tsx
@@ -1,0 +1,443 @@
+import { useEffect, useState, useCallback } from "react";
+import { ArrowDownToLine, CheckCircle2, Loader2, AlertCircle, Package, GitBranch, MessageSquare } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { api } from "@/hooks/useApi";
+import { getServerUrl } from "@/hooks/useServerUrl";
+
+// ── Types ───────────────────────────────────────────────────────────
+
+interface ConductorProjectSummary {
+  id: string;
+  name: string;
+  remoteUrl: string;
+  workspaceCount: number;
+  sessionCount: number;
+  messageCount: number;
+  alreadyImported: boolean;
+}
+
+interface ScanResult {
+  found: boolean;
+  dbPath: string;
+  projects: ConductorProjectSummary[];
+  totals: {
+    projects: number;
+    workspaces: number;
+    sessions: number;
+    messages: number;
+  };
+}
+
+type ImportProgressEvent =
+  | { type: "start"; totalProjects: number; totalWorkspaces: number }
+  | { type: "project_start"; projectIndex: number; projectName: string; workspaceCount: number }
+  | { type: "project_cloning"; projectIndex: number; projectName: string }
+  | { type: "project_cloned"; projectIndex: number; projectName: string }
+  | { type: "workspace_importing"; projectIndex: number; workspaceName: string; branch: string }
+  | { type: "workspace_imported"; projectIndex: number; workspaceName: string; sessionCount: number }
+  | { type: "workspace_skipped"; projectIndex: number; workspaceName: string; reason: string }
+  | { type: "project_done"; projectIndex: number; projectName: string }
+  | { type: "done"; imported: { projects: number; workspaces: number; sessions: number } }
+  | { type: "error"; message: string; projectName?: string };
+
+type Phase = "scanning" | "ready" | "importing" | "done" | "error" | "not_found";
+
+interface ProjectProgress {
+  name: string;
+  workspaceCount: number;
+  status: "pending" | "cloning" | "importing" | "done" | "error";
+  importedWorkspaces: number;
+  importedSessions: number;
+  errorMessage?: string;
+}
+
+// ── Component ───────────────────────────────────────────────────────
+
+export default function ConductorMigration() {
+  const [phase, setPhase] = useState<Phase>("scanning");
+  const [scan, setScan] = useState<ScanResult | null>(null);
+  const [projectProgress, setProjectProgress] = useState<ProjectProgress[]>([]);
+  const [importResult, setImportResult] = useState<{ projects: number; workspaces: number; sessions: number } | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    api.get<ScanResult>("/api/conductor/scan")
+      .then((data) => {
+        setScan(data);
+        setPhase(data.found ? "ready" : "not_found");
+      })
+      .catch(() => {
+        setPhase("not_found");
+      });
+  }, []);
+
+  const startImport = useCallback(async () => {
+    if (!scan) return;
+
+    setPhase("importing");
+    setErrorMessage(null);
+
+    // Initialize progress state
+    const initialProgress: ProjectProgress[] = scan.projects
+      .filter((p) => !p.alreadyImported)
+      .map((p) => ({
+        name: p.name,
+        workspaceCount: p.workspaceCount,
+        status: "pending" as const,
+        importedWorkspaces: 0,
+        importedSessions: 0,
+      }));
+    setProjectProgress(initialProgress);
+
+    try {
+      const base = getServerUrl();
+      const authToken = import.meta.env.VITE_HIVE_AUTH_TOKEN?.trim();
+      const headers: Record<string, string> = {};
+      if (authToken) headers.Authorization = `Bearer ${authToken}`;
+
+      const response = await fetch(`${base}/api/conductor/import`, {
+        method: "POST",
+        headers,
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error("Import request failed");
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split("\n");
+        buffer = lines.pop() ?? "";
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const event: ImportProgressEvent = JSON.parse(line);
+            handleProgressEvent(event, setProjectProgress, setImportResult, setPhase, setErrorMessage);
+          } catch {
+            // Skip malformed lines
+          }
+        }
+      }
+
+      // Process remaining buffer
+      if (buffer.trim()) {
+        try {
+          const event: ImportProgressEvent = JSON.parse(buffer);
+          handleProgressEvent(event, setProjectProgress, setImportResult, setPhase, setErrorMessage);
+        } catch {
+          // Skip
+        }
+      }
+    } catch (err: unknown) {
+      setErrorMessage(err instanceof Error ? err.message : "Import failed");
+      setPhase("error");
+    }
+  }, [scan]);
+
+  if (phase === "scanning") {
+    return (
+      <PageShell>
+        <div className="flex items-center gap-3 py-12 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Scanning for Conductor data...</span>
+        </div>
+      </PageShell>
+    );
+  }
+
+  if (phase === "not_found") {
+    return (
+      <PageShell>
+        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+            <div>
+              <h2 className="text-sm font-medium text-foreground">No Conductor installation found</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Could not find a Conductor database. Make sure Conductor is installed and has been used at least once.
+              </p>
+            </div>
+          </div>
+        </section>
+      </PageShell>
+    );
+  }
+
+  const importableProjects = scan?.projects.filter((p) => !p.alreadyImported) ?? [];
+  const alreadyImportedProjects = scan?.projects.filter((p) => p.alreadyImported) ?? [];
+
+  return (
+    <PageShell>
+      {/* Summary card */}
+      {phase === "ready" && scan && (
+        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+          <div className="flex items-start justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-foreground">
+                {scan.totals.projects} project{scan.totals.projects !== 1 ? "s" : ""} detected on Conductor
+              </h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {scan.totals.workspaces} workspace{scan.totals.workspaces !== 1 ? "s" : ""},{" "}
+                {scan.totals.sessions} session{scan.totals.sessions !== 1 ? "s" : ""},{" "}
+                {scan.totals.messages.toLocaleString()} messages
+              </p>
+            </div>
+          </div>
+
+          {/* Project list */}
+          <div className="mt-4 space-y-2">
+            {importableProjects.map((project) => (
+              <ProjectCard key={project.id} project={project} />
+            ))}
+            {alreadyImportedProjects.map((project) => (
+              <ProjectCard key={project.id} project={project} imported />
+            ))}
+          </div>
+
+          {/* Import button */}
+          {importableProjects.length > 0 ? (
+            <div className="mt-5">
+              <button
+                type="button"
+                onClick={() => void startImport()}
+                className="inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+              >
+                <ArrowDownToLine className="h-4 w-4" />
+                Import {importableProjects.length} project{importableProjects.length !== 1 ? "s" : ""} to Hive
+              </button>
+            </div>
+          ) : (
+            <p className="mt-4 text-xs text-muted-foreground">
+              All projects are already imported.
+            </p>
+          )}
+        </section>
+      )}
+
+      {/* Import progress */}
+      {(phase === "importing" || phase === "done" || phase === "error") && (
+        <section className="space-y-3">
+          {projectProgress.map((proj, i) => (
+            <ImportProgressCard key={i} project={proj} />
+          ))}
+
+          {phase === "done" && importResult && (
+            <div className="mt-4 flex items-center gap-2 rounded-lg border border-emerald-500/30 bg-emerald-500/5 p-4">
+              <CheckCircle2 className="h-4 w-4 shrink-0 text-emerald-500" />
+              <p className="text-sm text-emerald-500">
+                Migration complete — {importResult.projects} project{importResult.projects !== 1 ? "s" : ""},{" "}
+                {importResult.workspaces} workspace{importResult.workspaces !== 1 ? "s" : ""},{" "}
+                {importResult.sessions} session{importResult.sessions !== 1 ? "s" : ""} imported.
+                Refresh the app to see your workspaces.
+              </p>
+            </div>
+          )}
+
+          {phase === "error" && errorMessage && (
+            <div className="mt-4 flex items-center gap-2 rounded-lg border border-red-500/30 bg-red-500/5 p-4">
+              <AlertCircle className="h-4 w-4 shrink-0 text-red-500" />
+              <p className="text-sm text-red-500">{errorMessage}</p>
+            </div>
+          )}
+        </section>
+      )}
+    </PageShell>
+  );
+}
+
+// ── Sub-components ──────────────────────────────────────────────────
+
+function PageShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      <div className="border-b border-border/50 px-8 py-5" data-tauri-drag-region>
+        <h1 className="text-base font-semibold">Import from Conductor</h1>
+        <p className="mt-1 text-xs text-muted-foreground">
+          Migrate your Conductor projects, workspaces, and chat history to Hive.
+        </p>
+      </div>
+      <div className="max-w-2xl space-y-6 px-8 py-6">{children}</div>
+    </div>
+  );
+}
+
+function ProjectCard({ project, imported }: { project: ConductorProjectSummary; imported?: boolean }) {
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-between rounded-md border px-3 py-2.5",
+        imported
+          ? "border-border/30 bg-muted/20 opacity-60"
+          : "border-border/50 bg-background/50",
+      )}
+    >
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Package className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+          <span className="truncate text-sm font-medium">{project.name}</span>
+          {imported && (
+            <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium text-muted-foreground">
+              Already imported
+            </span>
+          )}
+        </div>
+        <div className="mt-1 flex items-center gap-3 pl-5.5 text-[11px] text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <GitBranch className="h-3 w-3" />
+            {project.workspaceCount} workspace{project.workspaceCount !== 1 ? "s" : ""}
+          </span>
+          <span className="flex items-center gap-1">
+            <MessageSquare className="h-3 w-3" />
+            {project.sessionCount} session{project.sessionCount !== 1 ? "s" : ""}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ImportProgressCard({ project }: { project: ProjectProgress }) {
+  const progress = project.workspaceCount > 0
+    ? Math.round((project.importedWorkspaces / project.workspaceCount) * 100)
+    : project.status === "done" ? 100 : 0;
+
+  return (
+    <div className="rounded-lg border border-border/50 bg-card/50 p-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {project.status === "done" ? (
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          ) : project.status === "error" ? (
+            <AlertCircle className="h-4 w-4 text-red-500" />
+          ) : project.status === "pending" ? (
+            <Package className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <Loader2 className="h-4 w-4 animate-spin text-primary" />
+          )}
+          <span className="text-sm font-medium">{project.name}</span>
+        </div>
+        <span className="text-xs text-muted-foreground">
+          {project.status === "cloning" && "Cloning repository..."}
+          {project.status === "importing" && `${project.importedWorkspaces}/${project.workspaceCount} workspaces`}
+          {project.status === "done" && `${project.importedWorkspaces} workspaces, ${project.importedSessions} sessions`}
+          {project.status === "error" && project.errorMessage}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      {(project.status === "cloning" || project.status === "importing" || project.status === "done") && (
+        <div className="mt-2.5 h-1.5 overflow-hidden rounded-full bg-muted/40">
+          <div
+            className={cn(
+              "h-full rounded-full transition-all duration-300",
+              project.status === "done" ? "bg-emerald-500" : "bg-primary",
+              project.status === "cloning" && "animate-pulse",
+            )}
+            style={{ width: `${project.status === "cloning" ? 15 : progress}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Progress event handler ──────────────────────────────────────────
+
+function handleProgressEvent(
+  event: ImportProgressEvent,
+  setProjectProgress: React.Dispatch<React.SetStateAction<ProjectProgress[]>>,
+  setImportResult: React.Dispatch<React.SetStateAction<{ projects: number; workspaces: number; sessions: number } | null>>,
+  setPhase: React.Dispatch<React.SetStateAction<Phase>>,
+  setErrorMessage: React.Dispatch<React.SetStateAction<string | null>>,
+) {
+  switch (event.type) {
+    case "project_start":
+      setProjectProgress((prev) => {
+        const next = [...prev];
+        if (next[event.projectIndex]) {
+          next[event.projectIndex] = {
+            ...next[event.projectIndex],
+            status: "pending",
+            workspaceCount: event.workspaceCount,
+          };
+        }
+        return next;
+      });
+      break;
+
+    case "project_cloning":
+      setProjectProgress((prev) => {
+        const next = [...prev];
+        if (next[event.projectIndex]) {
+          next[event.projectIndex] = { ...next[event.projectIndex], status: "cloning" };
+        }
+        return next;
+      });
+      break;
+
+    case "project_cloned":
+      setProjectProgress((prev) => {
+        const next = [...prev];
+        if (next[event.projectIndex]) {
+          next[event.projectIndex] = { ...next[event.projectIndex], status: "importing" };
+        }
+        return next;
+      });
+      break;
+
+    case "workspace_imported":
+      setProjectProgress((prev) => {
+        const next = [...prev];
+        if (next[event.projectIndex]) {
+          next[event.projectIndex] = {
+            ...next[event.projectIndex],
+            status: "importing",
+            importedWorkspaces: next[event.projectIndex].importedWorkspaces + 1,
+            importedSessions: next[event.projectIndex].importedSessions + event.sessionCount,
+          };
+        }
+        return next;
+      });
+      break;
+
+    case "project_done":
+      setProjectProgress((prev) => {
+        const next = [...prev];
+        if (next[event.projectIndex]) {
+          next[event.projectIndex] = { ...next[event.projectIndex], status: "done" };
+        }
+        return next;
+      });
+      break;
+
+    case "done":
+      setImportResult(event.imported);
+      setPhase("done");
+      break;
+
+    case "error":
+      if (event.projectName) {
+        setProjectProgress((prev) => {
+          const idx = prev.findIndex((p) => p.name === event.projectName);
+          if (idx >= 0) {
+            const next = [...prev];
+            next[idx] = { ...next[idx], status: "error", errorMessage: event.message };
+            return next;
+          }
+          return prev;
+        });
+      } else {
+        setErrorMessage(event.message);
+        setPhase("error");
+      }
+      break;
+  }
+}

--- a/frontend/tests/pages/ConductorMigration.test.tsx
+++ b/frontend/tests/pages/ConductorMigration.test.tsx
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ConductorMigration from "@/pages/settings/ConductorMigration";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: mocks.get,
+  },
+}));
+
+vi.mock("@/hooks/useServerUrl", () => ({
+  getServerUrl: () => "http://localhost:3000",
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useRealTimers();
+});
+
+describe("ConductorMigration", () => {
+  it("shows scanning state initially", () => {
+    mocks.get.mockReturnValue(new Promise(() => {})); // never resolves
+    render(<ConductorMigration />);
+    expect(screen.getByText("Scanning for Conductor data...")).toBeInTheDocument();
+  });
+
+  it("shows not-found message when no Conductor DB exists", async () => {
+    mocks.get.mockResolvedValueOnce({
+      found: false,
+      dbPath: "/path/to/db",
+      projects: [],
+      totals: { projects: 0, workspaces: 0, sessions: 0, messages: 0 },
+    });
+
+    render(<ConductorMigration />);
+
+    await screen.findByText("No Conductor installation found");
+    expect(screen.getByText(/Could not find a Conductor database/)).toBeInTheDocument();
+  });
+
+  it("shows not-found on API error", async () => {
+    mocks.get.mockRejectedValueOnce(new Error("network error"));
+
+    render(<ConductorMigration />);
+
+    await screen.findByText("No Conductor installation found");
+  });
+
+  it("displays detected projects with counts", async () => {
+    mocks.get.mockResolvedValueOnce({
+      found: true,
+      dbPath: "/path/to/conductor.db",
+      projects: [
+        {
+          id: "repo-1",
+          name: "avnu-saas",
+          remoteUrl: "git@github.com:avnu/avnu-saas.git",
+          workspaceCount: 3,
+          sessionCount: 5,
+          messageCount: 150,
+          alreadyImported: false,
+        },
+        {
+          id: "repo-2",
+          name: "avnu-swap",
+          remoteUrl: "git@github.com:avnu/avnu-swap.git",
+          workspaceCount: 2,
+          sessionCount: 3,
+          messageCount: 80,
+          alreadyImported: true,
+        },
+      ],
+      totals: { projects: 2, workspaces: 5, sessions: 8, messages: 230 },
+    });
+
+    render(<ConductorMigration />);
+
+    await screen.findByText("2 projects detected on Conductor");
+    expect(screen.getByText(/5 workspaces, 8 sessions, 230 messages/)).toBeInTheDocument();
+
+    expect(screen.getByText("avnu-saas")).toBeInTheDocument();
+    expect(screen.getByText("avnu-swap")).toBeInTheDocument();
+    expect(screen.getByText("Already imported")).toBeInTheDocument();
+    expect(screen.getByText("Import 1 project to Hive")).toBeInTheDocument();
+  });
+
+  it("shows all-imported message when every project is already imported", async () => {
+    mocks.get.mockResolvedValueOnce({
+      found: true,
+      dbPath: "/path/to/conductor.db",
+      projects: [
+        {
+          id: "repo-1",
+          name: "avnu-saas",
+          remoteUrl: "git@github.com:avnu/avnu-saas.git",
+          workspaceCount: 3,
+          sessionCount: 5,
+          messageCount: 150,
+          alreadyImported: true,
+        },
+      ],
+      totals: { projects: 1, workspaces: 3, sessions: 5, messages: 150 },
+    });
+
+    render(<ConductorMigration />);
+
+    await screen.findByText("All projects are already imported.");
+  });
+
+  it("renders page header correctly", async () => {
+    mocks.get.mockResolvedValueOnce({
+      found: false,
+      dbPath: "/path/to/db",
+      projects: [],
+      totals: { projects: 0, workspaces: 0, sessions: 0, messages: 0 },
+    });
+
+    render(<ConductorMigration />);
+
+    await screen.findByRole("heading", { name: "Import from Conductor" });
+    expect(screen.getByText(/Migrate your Conductor projects/)).toBeInTheDocument();
+  });
+
+  it("title bar has tauri drag region", async () => {
+    mocks.get.mockResolvedValueOnce({
+      found: false,
+      dbPath: "/path/to/db",
+      projects: [],
+      totals: { projects: 0, workspaces: 0, sessions: 0, messages: 0 },
+    });
+
+    render(<ConductorMigration />);
+
+    const heading = await screen.findByRole("heading", { name: "Import from Conductor" });
+    expect(heading.closest("div")).toHaveAttribute("data-tauri-drag-region");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,14 @@
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/websocket": "^11.2.0",
+        "better-sqlite3": "^12.6.2",
         "fastify": "^5.7.4",
         "nanoid": "^3.3.11",
         "node-pty": "^1.1.0",
         "ws": "^8.19.0"
       },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.2.3",
         "@types/ws": "^8.18.1",
         "tsx": "^4.21.0",
@@ -6063,6 +6065,16 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -7159,6 +7171,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -7169,6 +7201,20 @@
         "baseline-browser-mapping": "dist/cli.js"
       }
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.6.2",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.6.2.tgz",
+      "integrity": "sha512-8VYKM3MjCa9WcaSAI3hzwhmyHVlH8tiGFwf0RlTsZPWJ1I5MkzjiudCo4KC4DxOaL/53A5B1sI/IbldNFDbsKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bidi-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
@@ -7177,6 +7223,26 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
       }
     },
     "node_modules/body-parser": {
@@ -7277,6 +7343,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/bundle-name": {
@@ -7475,6 +7565,12 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
       "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
       "license": "MIT"
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -8444,6 +8540,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.1.tgz",
@@ -8457,6 +8568,15 @@
         "babel-plugin-macros": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/deep-is": {
@@ -8551,7 +8671,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9118,6 +9237,15 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -9463,6 +9591,12 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -9582,6 +9716,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.3",
@@ -9759,6 +9899,12 @@
       "funding": {
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/glob-parent": {
       "version": "6.0.2",
@@ -10253,6 +10399,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -10304,6 +10470,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/inline-style-parser": {
@@ -12447,6 +12619,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/min-indent": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -12474,11 +12658,16 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.0",
@@ -12571,6 +12760,12 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -12586,6 +12781,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.87.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
+      "integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -13199,6 +13406,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -13327,6 +13560,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
+      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -13523,6 +13766,30 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/react": {
@@ -14521,6 +14788,51 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -14889,6 +15201,34 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
@@ -15121,6 +15461,18 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/tw-animate-css": {


### PR DESCRIPTION
Adds a new Settings page that scans the Conductor SQLite database, displays detected projects with workspace/session counts, and imports everything into Hive (bare clone, worktrees, chat history conversion) with live NDJSON-streamed progress bars per project.

- Backend: conductor-migrator service (scan + import + message conversion)
- Backend: /api/conductor/scan and /api/conductor/import endpoints
- Frontend: ConductorMigration settings page with streaming progress UI
- 28 tests across backend service, API routes, and frontend component