### PR TITLE
fix: store chat images as files served via HTTP instead of inline base64

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -654,6 +654,18 @@ export async function getSpecificSessionMessages(
   }
 }
 
+/** Resolve the absolute path to a session attachment file. */
+export async function resolveSessionAttachmentPath(
+  wsId: string,
+  sessionId: string,
+  filename: string,
+  dataDir = getDataDir(),
+): Promise<string | null> {
+  const result = await getWorkspace(wsId, dataDir);
+  if (!result) return null;
+  return join(dataDir, result.projectState.id, "sessions", sessionId, "attachments", filename);
+}
+
 /** Return session IDs currently streaming in a workspace. */
 export function getStreamingSessionIds(wsId: string): string[] {
   return getLoadedSessions(wsId)

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -821,21 +821,31 @@ describe("ConversationSession", () => {
 
   // ── Image attachment tests ──────────────────────────────────────────
 
-  it("emits user_message with images field when images are provided", () => {
+  it("emits user_message with URL-based images after saving to disk", async () => {
     const session = createSession({ sessionId: "img-user-msg" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     const images = [
-      { name: "screenshot.png", mediaType: "image/png", dataUrl: "data:image/png;base64,iVBOR" },
+      { name: "screenshot.png", mediaType: "image/png", dataUrl: `data:image/png;base64,${pngBase64}` },
     ];
     session.sendMessage("Analyze this", undefined, images);
+
+    // Images are saved to disk before emitting — wait for the async save
+    await new Promise((r) => setTimeout(r, 200));
 
     const userEvents = messages.filter((m) => m.type === "user_message");
     expect(userEvents).toHaveLength(1);
     if (userEvents[0].type === "user_message") {
       expect(userEvents[0].message.content).toBe("Analyze this");
-      expect(userEvents[0].message.images).toEqual(images);
+      expect(userEvents[0].message.images).toHaveLength(1);
+      // dataUrl should be an API path, not the original base64
+      expect(userEvents[0].message.images![0].dataUrl).toMatch(
+        /^\/api\/workspaces\/ws-test\/sessions\/img-user-msg\/attachments\/.+\.png$/,
+      );
+      expect(userEvents[0].message.images![0].name).toBe("screenshot.png");
+      expect(userEvents[0].message.images![0].mediaType).toBe("image/png");
     }
   });
 
@@ -964,11 +974,12 @@ describe("ConversationSession", () => {
     expect(files).toHaveLength(2);
   });
 
-  it("persists user message with images to disk", async () => {
+  it("persists user message with API URL paths instead of base64", async () => {
     const session = createSession({ sessionId: "img-persist" });
 
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
     const images = [
-      { name: "test.png", mediaType: "image/png", dataUrl: "data:image/png;base64,abc123" },
+      { name: "test.png", mediaType: "image/png", dataUrl: `data:image/png;base64,${pngBase64}` },
     ];
 
     session.sendMessage("With image", undefined, images);
@@ -981,7 +992,37 @@ describe("ConversationSession", () => {
     const userMsg = JSON.parse(lines[0]);
     expect(userMsg.role).toBe("user");
     expect(userMsg.content).toBe("With image");
-    expect(userMsg.images).toEqual(images);
+    expect(userMsg.images).toHaveLength(1);
+    expect(userMsg.images[0].name).toBe("test.png");
+    expect(userMsg.images[0].mediaType).toBe("image/png");
+    // dataUrl should be an API path, not base64
+    expect(userMsg.images[0].dataUrl).toMatch(/^\/api\/workspaces\//);
+    expect(userMsg.images[0].dataUrl).not.toContain("base64");
+  });
+
+  it("emitted image URL matches the saved attachment filename on disk", async () => {
+    const session = createSession({ sessionId: "img-url-match" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+    const { readdir } = await import("node:fs/promises");
+
+    const pngBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+    const images = [
+      { name: "pixel.png", mediaType: "image/png", dataUrl: `data:image/png;base64,${pngBase64}` },
+    ];
+
+    session.sendMessage("Match test", undefined, images);
+    await new Promise((r) => setTimeout(r, 200));
+
+    const attachmentsDir = join(tempDir, "sessions", "img-url-match", "attachments");
+    const files = await readdir(attachmentsDir);
+    expect(files).toHaveLength(1);
+
+    const userEvents = messages.filter((m) => m.type === "user_message");
+    if (userEvents[0].type === "user_message") {
+      // The URL should end with the same filename that's on disk
+      expect(userEvents[0].message.images![0].dataUrl).toContain(files[0]);
+    }
   });
 
   it("persists durationMs from result event in assistant message", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -128,7 +128,31 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.stopReason = null;
     this._lastPlanMode = msgOptions?.planMode ?? false;
 
-    // Persist user message immediately (include images for history display)
+    const promptContent = cliContent ?? content;
+
+    if (images?.length) {
+      // Save images to disk first, then emit/persist with lightweight URL references
+      void this.saveImagesToDisk(images).then((saved) => {
+        const urlImages = saved.map((s, i) => ({
+          name: images[i].name,
+          mediaType: images[i].mediaType,
+          dataUrl: `/api/workspaces/${this.workspaceId}/sessions/${this.sessionId}/attachments/${s.filename}`,
+        }));
+        this.emitUserMessage(content, msgOptions, urlImages);
+        this.spawnCli(this.buildPromptWithImages(promptContent, saved.map((s) => s.path)), msgOptions);
+      }).catch((err) => {
+        this._status = "error";
+        this._streamingStartedAt = null;
+        this.emit("error", err instanceof Error ? err : new Error(String(err)));
+      });
+    } else {
+      this.emitUserMessage(content, msgOptions);
+      this.spawnCli(promptContent, msgOptions);
+    }
+  }
+
+  /** Emit, persist and count a user message. */
+  private emitUserMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[]): void {
     const userMsg: ChatMessage = {
       id: nanoid(12),
       sessionId: this.sessionId,
@@ -137,43 +161,27 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       images: images?.length ? images : undefined,
       timestamp: new Date().toISOString(),
     };
-    // Set conversation title from first user message
     if (!this._metadata.title) {
       const firstLine = content.trim().replace(/\n.*/s, "").trimEnd();
       this._metadata.title = firstLine.length > 50
         ? firstLine.slice(0, 47).trimEnd() + "..."
         : firstLine;
     }
-
     void this.enqueuePersist(userMsg);
     this.emit("message", { type: "user_message", message: userMsg });
-
     this.messageCount++;
-
     if (this.messageCount === 1) {
       this.emit("first_message", content);
     }
-
-    const promptContent = cliContent ?? content;
-    if (images?.length) {
-      void this.saveImagesToDisk(images).then((paths) => {
-        this.spawnCli(this.buildPromptWithImages(promptContent, paths), msgOptions);
-      }).catch((err) => {
-        this._status = "error";
-        this._streamingStartedAt = null;
-        this.emit("error", err instanceof Error ? err : new Error(String(err)));
-      });
-    } else {
-      this.spawnCli(promptContent, msgOptions);
-    }
   }
 
-  /** Save base64 image data to disk so Claude can read them. */
-  private async saveImagesToDisk(images: ImageAttachment[]): Promise<string[]> {
+  /** Save base64 image data to disk so Claude can read them.
+   *  Returns both the absolute file path (for CLI) and the filename (for URL references). */
+  private async saveImagesToDisk(images: ImageAttachment[]): Promise<{ path: string; filename: string }[]> {
     const attachmentsDir = join(this.sessionDir, "attachments");
     await mkdir(attachmentsDir, { recursive: true });
 
-    const paths: string[] = [];
+    const results: { path: string; filename: string }[] = [];
     for (const img of images) {
       const base64Match = img.dataUrl.match(/^data:[^;]+;base64,(.+)$/);
       if (!base64Match) continue;
@@ -182,9 +190,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       const filename = `${nanoid(8)}.${ext}`;
       const filepath = join(attachmentsDir, filename);
       await writeFile(filepath, buffer);
-      paths.push(filepath);
+      results.push({ path: filepath, filename });
     }
-    return paths;
+    return results;
   }
 
   /** Build a prompt that includes image file paths for Claude to read. */

--- a/backend/src/api/agents.ts
+++ b/backend/src/api/agents.ts
@@ -1,3 +1,6 @@
+import { join, basename } from "node:path";
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
 import type { FastifyInstance } from "fastify";
 import {
   getOrCreateSession,
@@ -9,6 +12,7 @@ import {
   activateSession,
   hardDeleteSession,
   getSpecificSessionMessages,
+  resolveSessionAttachmentPath,
   type SessionOptions,
 } from "../agents/agent-manager.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
@@ -163,6 +167,44 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
         return reply.send(messages);
       } catch (err: unknown) {
         const msg = errorMessage(err, "Failed to load session messages");
+        const code = errorStatus(err);
+        return reply.status(code).send({ error: msg });
+      }
+    },
+  );
+
+  // GET /api/workspaces/:wsId/sessions/:sessionId/attachments/:filename — serve image attachment
+  app.get<{ Params: { wsId: string; sessionId: string; filename: string } }>(
+    "/api/workspaces/:wsId/sessions/:sessionId/attachments/:filename",
+    async (req, reply) => {
+      try {
+        const { filename } = req.params;
+        // Guard against path traversal
+        if (filename !== basename(filename) || filename.includes("..")) {
+          return reply.status(400).send({ error: "Invalid filename" });
+        }
+        const filePath = await resolveSessionAttachmentPath(
+          req.params.wsId,
+          req.params.sessionId,
+          filename,
+          dataDir,
+        );
+        if (!filePath || !existsSync(filePath)) {
+          return reply.status(404).send({ error: "Attachment not found" });
+        }
+        const info = await stat(filePath);
+        const ext = filename.split(".").pop()?.toLowerCase();
+        const mime = ext === "jpg" || ext === "jpeg" ? "image/jpeg"
+          : ext === "png" ? "image/png"
+          : ext === "webp" ? "image/webp"
+          : ext === "gif" ? "image/gif"
+          : "application/octet-stream";
+        reply.header("Content-Type", mime);
+        reply.header("Content-Length", info.size);
+        reply.header("Cache-Control", "public, max-age=31536000, immutable");
+        return reply.send(createReadStream(filePath));
+      } catch (err: unknown) {
+        const msg = errorMessage(err, "Failed to serve attachment");
         const code = errorStatus(err);
         return reply.status(code).send({ error: msg });
       }

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -66,4 +66,35 @@ describe("createAuthHook", () => {
     expect(statusCode).toBe(401);
     expect(payload).toEqual({ error: "Unauthorized" });
   });
+
+  it("accepts matching ?token= query param", async () => {
+    const hook = createAuthHook("secret");
+    const reply = {
+      status: () => reply,
+      send: () => undefined,
+    };
+    await expect(
+      hook(
+        { url: "/api/attachments/img.jpg", headers: {}, query: { token: "secret" } } as never,
+        reply as never,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects request with wrong ?token= query param", async () => {
+    let statusCode: number | undefined;
+    const reply = {
+      status(code: number) {
+        statusCode = code;
+        return this;
+      },
+      send() {},
+    };
+    const hook = createAuthHook("secret");
+    await hook(
+      { url: "/api/attachments/img.jpg", headers: {}, query: { token: "wrong" } } as never,
+      reply as never,
+    );
+    expect(statusCode).toBe(401);
+  });
 });

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -45,7 +45,9 @@ export function createAuthHook(expectedToken?: string) {
   return async (req: FastifyRequest, reply: FastifyReply): Promise<void> => {
     if (!expectedToken) return;
     if (req.url.startsWith("/health")) return;
-    if (isAuthorized(req.headers, expectedToken)) return;
+    // Support ?token= query param for resources loaded via <img src> / AsyncImage
+    const queryToken = (req.query as Record<string, string>)?.token;
+    if (isAuthorized(req.headers, expectedToken, queryToken)) return;
 
     reply.status(401).send({ error: "Unauthorized" });
   };

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -2,6 +2,7 @@ import { memo } from "react";
 import type { ChatMessage as ChatMessageType, QuestionAnswer } from "@/types";
 import { cn } from "@/lib/utils";
 import { formatElapsed } from "@/lib/time";
+import { resolveImageSrc } from "@/lib/image-url";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
 import { ToolCallList } from "@/components/chat/ToolCallList";
@@ -50,7 +51,7 @@ const ChatMessage = memo(function ChatMessage({
                 {message.images.map((img, i) => (
                   <img
                     key={`${message.id}-img-${i}`}
-                    src={img.dataUrl}
+                    src={resolveImageSrc(img.dataUrl)}
                     alt={img.name}
                     className="max-h-48 max-w-xs rounded-md border border-border/30 object-contain"
                   />

--- a/frontend/src/lib/image-url.ts
+++ b/frontend/src/lib/image-url.ts
@@ -1,0 +1,12 @@
+import { getServerUrl } from "@/hooks/useServerUrl";
+
+/** Resolve an image dataUrl to a renderable src.
+ *  - `data:` URIs (legacy base64) are returned as-is.
+ *  - `/api/...` paths are prefixed with the server URL + auth token query param. */
+export function resolveImageSrc(dataUrl: string): string {
+  if (!dataUrl || dataUrl.startsWith("data:")) return dataUrl;
+  const base = getServerUrl();
+  const token = import.meta.env.VITE_HIVE_AUTH_TOKEN?.trim();
+  const sep = dataUrl.includes("?") ? "&" : "?";
+  return `${base}${dataUrl}${token ? `${sep}token=${encodeURIComponent(token)}` : ""}`;
+}

--- a/frontend/tests/components/ChatMessage.test.tsx
+++ b/frontend/tests/components/ChatMessage.test.tsx
@@ -22,6 +22,10 @@ vi.mock("@/components/ai-elements/message", () => ({
   ),
 }));
 
+vi.mock("@/lib/image-url", () => ({
+  resolveImageSrc: (url: string) => url.startsWith("/api/") ? `http://test-server${url}` : url,
+}));
+
 function assistantMessage(overrides: Partial<ChatMessageType> = {}): ChatMessageType {
   return {
     id: "a1",
@@ -162,6 +166,53 @@ describe("ChatMessage", () => {
 
     expect(screen.getByText("Text only")).toBeInTheDocument();
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("resolves API path images via resolveImageSrc", () => {
+    render(
+      <ChatMessage
+        message={{
+          id: "u-api-img",
+          sessionId: "sess-1",
+          role: "user",
+          content: "Server image",
+          timestamp: "2026-02-12T00:00:00.000Z",
+          images: [
+            { name: "photo.jpg", mediaType: "image/jpeg", dataUrl: "/api/workspaces/ws1/sessions/s1/attachments/abc.jpg" },
+          ],
+        }}
+      />,
+    );
+
+    const img = screen.getByRole("img");
+    // resolveImageSrc mock prepends http://test-server for /api/ paths
+    expect(img).toHaveAttribute("src", "http://test-server/api/workspaces/ws1/sessions/s1/attachments/abc.jpg");
+    expect(img).toHaveAttribute("alt", "photo.jpg");
+  });
+
+  it("handles mix of base64 and API path images", () => {
+    render(
+      <ChatMessage
+        message={{
+          id: "u-mixed-img",
+          sessionId: "sess-1",
+          role: "user",
+          content: "",
+          timestamp: "2026-02-12T00:00:00.000Z",
+          images: [
+            { name: "old.png", mediaType: "image/png", dataUrl: "data:image/png;base64,abc" },
+            { name: "new.jpg", mediaType: "image/jpeg", dataUrl: "/api/workspaces/ws1/sessions/s1/attachments/def.jpg" },
+          ],
+        }}
+      />,
+    );
+
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(2);
+    // base64 passed through as-is
+    expect(images[0]).toHaveAttribute("src", "data:image/png;base64,abc");
+    // API path resolved with server URL
+    expect(images[1]).toHaveAttribute("src", "http://test-server/api/workspaces/ws1/sessions/s1/attachments/def.jpg");
   });
 
   // ── Additional assistant message coverage ───────────────────────────

--- a/frontend/tests/lib/image-url.test.ts
+++ b/frontend/tests/lib/image-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Mock getServerUrl and env before importing
+vi.mock("@/hooks/useServerUrl", () => ({
+  getServerUrl: vi.fn(() => "http://192.168.1.10:3000"),
+}));
+
+const originalEnv = { ...import.meta.env };
+
+import { resolveImageSrc } from "@/lib/image-url";
+
+beforeEach(() => {
+  import.meta.env.VITE_HIVE_AUTH_TOKEN = "";
+});
+
+describe("resolveImageSrc", () => {
+  it("returns base64 data URLs unchanged", () => {
+    const dataUrl = "data:image/png;base64,iVBOR...";
+    expect(resolveImageSrc(dataUrl)).toBe(dataUrl);
+  });
+
+  it("returns empty string unchanged", () => {
+    expect(resolveImageSrc("")).toBe("");
+  });
+
+  it("prepends server URL for /api/ paths", () => {
+    const path = "/api/workspaces/ws1/sessions/s1/attachments/abc.png";
+    expect(resolveImageSrc(path)).toBe(`http://192.168.1.10:3000${path}`);
+  });
+
+  it("appends auth token as query param when set", () => {
+    import.meta.env.VITE_HIVE_AUTH_TOKEN = "my-secret";
+    const path = "/api/workspaces/ws1/sessions/s1/attachments/abc.png";
+    const result = resolveImageSrc(path);
+    expect(result).toContain("?token=my-secret");
+    expect(result.startsWith("http://192.168.1.10:3000/api/")).toBe(true);
+  });
+
+  it("does not append token param when token is empty", () => {
+    import.meta.env.VITE_HIVE_AUTH_TOKEN = "";
+    const path = "/api/workspaces/ws1/sessions/s1/attachments/abc.png";
+    expect(resolveImageSrc(path)).not.toContain("token=");
+  });
+});

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -122,6 +122,35 @@ struct ToolCall: Codable, Identifiable {
     let input: String
     let output: String?
     let parentToolUseId: String?
+
+    init(id: String, name: String, input: String, output: String?, parentToolUseId: String?) {
+        self.id = id
+        self.name = name
+        self.input = input
+        self.output = output
+        self.parentToolUseId = parentToolUseId
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        input = try container.decode(String.self, forKey: .input)
+        parentToolUseId = try container.decodeIfPresent(String.self, forKey: .parentToolUseId)
+        // output can be a string or (rarely) a JSON array/object from the CLI — coerce to string
+        if let str = try? container.decodeIfPresent(String.self, forKey: .output) {
+            output = str
+        } else if let raw = try? container.decodeIfPresent(AnyCodableValue.self, forKey: .output),
+                  let data = try? JSONEncoder().encode(raw) {
+            output = String(data: data, encoding: .utf8)
+        } else {
+            output = nil
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, input, output, parentToolUseId
+    }
 }
 
 struct ChatMessage: Codable, Identifiable {
@@ -135,6 +164,47 @@ struct ChatMessage: Codable, Identifiable {
     let timestamp: String
     let cancelled: Bool?
     let durationMs: Int?
+
+    init(id: String, sessionId: String, role: MessageRole, content: String,
+         images: [ImageAttachment]?, toolCalls: [ToolCall]?, thinkingContent: String?,
+         timestamp: String, cancelled: Bool?, durationMs: Int?) {
+        self.id = id
+        self.sessionId = sessionId
+        self.role = role
+        self.content = content
+        self.images = images
+        self.toolCalls = toolCalls
+        self.thinkingContent = thinkingContent
+        self.timestamp = timestamp
+        self.cancelled = cancelled
+        self.durationMs = durationMs
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        sessionId = try container.decode(String.self, forKey: .sessionId)
+        role = try container.decode(MessageRole.self, forKey: .role)
+        content = try container.decode(String.self, forKey: .content)
+        images = try container.decodeIfPresent([ImageAttachment].self, forKey: .images)
+        toolCalls = try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
+        thinkingContent = try container.decodeIfPresent(String.self, forKey: .thinkingContent)
+        timestamp = try container.decode(String.self, forKey: .timestamp)
+        cancelled = try container.decodeIfPresent(Bool.self, forKey: .cancelled)
+        // durationMs may arrive as Int or Double from the backend
+        if let intVal = try? container.decodeIfPresent(Int.self, forKey: .durationMs) {
+            durationMs = intVal
+        } else if let doubleVal = try? container.decodeIfPresent(Double.self, forKey: .durationMs) {
+            durationMs = Int(doubleVal)
+        } else {
+            durationMs = nil
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, sessionId, role, content, images, toolCalls
+        case thinkingContent, timestamp, cancelled, durationMs
+    }
 }
 
 // MARK: - Diff

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -84,12 +84,14 @@ enum WsOutgoing: Decodable {
     case history(messages: [ChatMessage], sessionId: String?)
     case branchInfo(info: BranchInfo)
     case diffStats(stats: DiffStatResponse)
+    case scriptStatus(scriptType: String, state: String, exitCode: Int?)
 
     private enum CodingKeys: String, CodingKey {
         case type, sessionId, text, id, name, input, output
         case parentToolUseId, toolUseId, requestId, toolName
         case costUsd, durationMs, message, status, streaming, streamingStartedAt
         case messages, info, stats
+        case scriptType, state, exitCode
     }
 
     init(from decoder: Decoder) throws {
@@ -139,11 +141,18 @@ enum WsOutgoing: Decodable {
                 toolName: toolName, toolUseId: toolUseId, input: inputString
             )
         case "done":
-            self = .done(
-                sessionId: try container.decode(String.self, forKey: .sessionId),
-                costUsd: try container.decodeIfPresent(Double.self, forKey: .costUsd),
-                durationMs: try container.decodeIfPresent(Int.self, forKey: .durationMs)
-            )
+            let doneSessionId = try container.decode(String.self, forKey: .sessionId)
+            let doneCost = try container.decodeIfPresent(Double.self, forKey: .costUsd)
+            // durationMs may be Int or Double from the backend
+            let doneDuration: Int?
+            if let intVal = try? container.decodeIfPresent(Int.self, forKey: .durationMs) {
+                doneDuration = intVal
+            } else if let doubleVal = try? container.decodeIfPresent(Double.self, forKey: .durationMs) {
+                doneDuration = Int(doubleVal)
+            } else {
+                doneDuration = nil
+            }
+            self = .done(sessionId: doneSessionId, costUsd: doneCost, durationMs: doneDuration)
         case "error":
             self = .error(message: try container.decode(String.self, forKey: .message))
         case "cancelled":
@@ -166,11 +175,16 @@ enum WsOutgoing: Decodable {
             self = .branchInfo(info: try container.decode(BranchInfo.self, forKey: .info))
         case "diff_stats":
             self = .diffStats(stats: try container.decode(DiffStatResponse.self, forKey: .stats))
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type, in: container,
-                debugDescription: "Unknown WsOutgoing type: \(type)"
+        case "script_status":
+            self = .scriptStatus(
+                scriptType: try container.decode(String.self, forKey: .scriptType),
+                state: try container.decode(String.self, forKey: .state),
+                exitCode: try container.decodeIfPresent(Int.self, forKey: .exitCode)
             )
+        default:
+            // Silently ignore unknown types instead of throwing — the backend
+            // may add new event types that the iOS client doesn't handle yet.
+            self = .error(message: "Unknown WS event type: \(type)")
         }
     }
 }

--- a/ios/HiveMobile/Services/WebSocketManager.swift
+++ b/ios/HiveMobile/Services/WebSocketManager.swift
@@ -74,6 +74,7 @@ final class WebSocketManager {
 
         connectionState = .connecting
         let wsTask = URLSession.shared.webSocketTask(with: url)
+        wsTask.maximumMessageSize = 10 * 1024 * 1024 // 10 MB – match backend maxPayload
         self.task = wsTask
         wsTask.resume()
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -119,6 +119,9 @@ final class ConversationStore {
 
         case .diffStats(let stats):
             diffStats = stats
+
+        case .scriptStatus:
+            break // Handled by sidebar, not relevant to chat
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -155,7 +155,8 @@ struct ChatInputBar: View {
 
     private func handleSend() {
         let imageAttachments = attachedImages.compactMap { item -> ImageAttachment? in
-            guard let data = item.image.jpegData(compressionQuality: 0.8) else { return nil }
+            let resized = item.image.constrainedTo(maxDimension: 1536)
+            guard let data = resized.jpegData(compressionQuality: 0.7) else { return nil }
             return ImageAttachment(
                 name: "image.jpg",
                 mediaType: "image/jpeg",
@@ -241,6 +242,19 @@ private struct AttachmentChip: View {
             }
             .offset(x: 4, y: -4)
         }
+    }
+}
+
+// MARK: - UIImage Resizing
+
+private extension UIImage {
+    func constrainedTo(maxDimension: CGFloat) -> UIImage {
+        let longest = max(size.width, size.height)
+        guard longest > maxDimension else { return self }
+        let scale = maxDimension / longest
+        let newSize = CGSize(width: size.width * scale, height: size.height * scale)
+        let renderer = UIGraphicsImageRenderer(size: newSize)
+        return renderer.image { _ in draw(in: CGRect(origin: .zero, size: newSize)) }
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -126,20 +126,22 @@ struct ChatView: View {
     // MARK: - Setup
 
     private func setup() async {
-        activeSessionId = workspace.activeSessionId
         wsManager.connect(workspaceId: workspace.id)
-        async let messagesLoad: () = loadMessages()
-        async let sessionsLoad: () = loadSessions()
-        await messagesLoad
-        await sessionsLoad
         listenToWebSocket()
+
+        await loadSessions()
+        activeSessionId = workspace.activeSessionId ?? sessions.first?.sessionId
+
+        await loadMessages()
     }
 
     private func loadSessions() async {
         do {
             sessions = try await api.fetchSessions(workspaceId: workspace.id)
+        } catch is CancellationError {
+            // View disappeared
         } catch {
-            // non-critical — chat still works without session list
+            // Non-critical — chat still works without session list
         }
     }
 
@@ -153,8 +155,10 @@ struct ChatView: View {
                 workspaceId: workspace.id,
                 sessionId: sessionId
             )
+        } catch is CancellationError {
+            // View disappeared
         } catch {
-            // empty state for now
+            // Fall through to WS history
         }
         isLoading = false
     }
@@ -174,26 +178,18 @@ struct ChatView: View {
 
     private func createSession() {
         Task {
-            do {
-                let session = try await api.createSession(workspaceId: workspace.id)
-                sessions.append(session)
-                switchSession(session.sessionId)
-            } catch {
-                print("[ChatView] createSession failed:", error)
-            }
+            guard let session = try? await api.createSession(workspaceId: workspace.id) else { return }
+            sessions.append(session)
+            switchSession(session.sessionId)
         }
     }
 
     private func deleteSession(_ sessionId: String) {
         Task {
-            do {
-                try await api.deleteSession(workspaceId: workspace.id, sessionId: sessionId)
-                sessions.removeAll { $0.sessionId == sessionId }
-                if sessionId == activeSessionId, let first = sessions.first {
-                    switchSession(first.sessionId)
-                }
-            } catch {
-                print("[ChatView] deleteSession failed:", error)
+            guard (try? await api.deleteSession(workspaceId: workspace.id, sessionId: sessionId)) != nil else { return }
+            sessions.removeAll { $0.sessionId == sessionId }
+            if sessionId == activeSessionId, let first = sessions.first {
+                switchSession(first.sessionId)
             }
         }
     }

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -90,8 +90,12 @@ struct MessageBubble: View {
         let host = UserDefaults.standard.string(forKey: "serverHost") ?? "localhost"
         let port = UserDefaults.standard.string(forKey: "serverPort") ?? "3000"
         let token = UserDefaults.standard.string(forKey: "authToken") ?? ""
-        let sep = dataUrl.contains("?") ? "&" : "?"
-        return URL(string: "http://\(host):\(port)\(dataUrl)\(sep)token=\(token)")
+        var urlString = "http://\(host):\(port)\(dataUrl)"
+        if !token.isEmpty {
+            let sep = dataUrl.contains("?") ? "&" : "?"
+            urlString += "\(sep)token=\(token)"
+        }
+        return URL(string: urlString)
     }
 
     private func decodeBase64Image(_ dataUrl: String) -> UIImage? {

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -36,6 +36,33 @@ struct MessageBubble: View {
 
     @ViewBuilder
     private var messageContent: some View {
+        // Image attachments (user messages only)
+        if message.role == .user, let images = message.images, !images.isEmpty {
+            ForEach(Array(images.enumerated()), id: \.offset) { _, img in
+                if img.dataUrl.hasPrefix("data:"), let uiImage = decodeBase64Image(img.dataUrl) {
+                    Image(uiImage: uiImage)
+                        .resizable()
+                        .scaledToFit()
+                        .frame(maxHeight: 200)
+                        .clipShape(RoundedRectangle(cornerRadius: 12))
+                } else if let url = resolveImageURL(img.dataUrl) {
+                    AsyncImage(url: url) { phase in
+                        switch phase {
+                        case .success(let image):
+                            image.resizable().scaledToFit()
+                                .frame(maxHeight: 200)
+                                .clipShape(RoundedRectangle(cornerRadius: 12))
+                        case .failure:
+                            Label(img.name, systemImage: "photo")
+                                .font(.caption).foregroundStyle(.secondary)
+                        default:
+                            ProgressView().frame(height: 80)
+                        }
+                    }
+                }
+            }
+        }
+
         if message.content.isEmpty { EmptyView() }
         else {
             switch message.role {
@@ -56,6 +83,22 @@ struct MessageBubble: View {
                     .textSelection(.enabled)
             }
         }
+    }
+
+    private func resolveImageURL(_ dataUrl: String) -> URL? {
+        guard dataUrl.hasPrefix("/api/") else { return nil }
+        let host = UserDefaults.standard.string(forKey: "serverHost") ?? "localhost"
+        let port = UserDefaults.standard.string(forKey: "serverPort") ?? "3000"
+        let token = UserDefaults.standard.string(forKey: "authToken") ?? ""
+        let sep = dataUrl.contains("?") ? "&" : "?"
+        return URL(string: "http://\(host):\(port)\(dataUrl)\(sep)token=\(token)")
+    }
+
+    private func decodeBase64Image(_ dataUrl: String) -> UIImage? {
+        guard let range = dataUrl.range(of: ";base64,") else { return nil }
+        let base64 = String(dataUrl[range.upperBound...])
+        guard let data = Data(base64Encoded: base64) else { return nil }
+        return UIImage(data: data)
     }
 
     private func formatTimestamp(_ ts: String) -> String {


### PR DESCRIPTION
Images sent in chat were stored as base64 data URLs in messages, causing WebSocket frame size issues (iOS default 1MB limit vs ~2MB encoded images) and infinite reconnect loops when history replay included large payloads.

Now images are saved to disk on send and referenced by lightweight API paths (/api/workspaces/:wsId/sessions/:sessionId/attachments/:filename). A new attachment-serving route handles delivery with proper MIME types and caching. Auth hook supports ?token= query params for <img src> contexts.

All three clients (web, desktop, iOS) handle both legacy base64 and new URL-based image formats. iOS additionally resizes images before sending and raises the WS max message size to 10MB to match the backend.

Includes regression tests for image persistence, auth token flow, and frontend image URL resolution.