### PR TITLE
feat(ios): add workspace creation from hub

### DIFF
--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -100,6 +100,10 @@ final class APIClient {
         try await get(path: "/api/projects")
     }
 
+    func createWorkspace(projectId: String) async throws -> Workspace {
+        try await post(path: "/api/projects/\(projectId)/workspaces")
+    }
+
     func fetchSessions(workspaceId: String) async throws -> [SessionMetadata] {
         try await get(path: "/api/workspaces/\(workspaceId)/sessions")
     }

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -12,6 +12,7 @@ final class ProjectStore {
     private(set) var projects: [Project] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
+    private(set) var creatingWorkspaceProjectIds: Set<String> = []
 
     let statusMonitor = HubStatusMonitor()
 
@@ -20,6 +21,47 @@ final class ProjectStore {
 
     /// Whether the store has never successfully loaded data yet.
     var isInitialLoad: Bool { !hasFetchedOnce }
+
+    func createWorkspace(in projectId: String) async {
+        guard !creatingWorkspaceProjectIds.contains(projectId) else { return }
+
+        creatingWorkspaceProjectIds.insert(projectId)
+        errorMessage = nil
+        defer { creatingWorkspaceProjectIds.remove(projectId) }
+
+        do {
+            let created = try await api.createWorkspace(projectId: projectId)
+            guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }) else {
+                return
+            }
+
+            let project = projects[projectIndex]
+            let workspace = Workspace(
+                id: created.id,
+                name: created.name,
+                branch: created.branch,
+                status: created.status,
+                createdAt: created.createdAt,
+                activeSessionId: created.activeSessionId,
+                projectName: project.name,
+                defaultBranch: created.defaultBranch,
+                sessionCount: 0,
+                projectId: project.id,
+                hasFavicon: project.hasFavicon
+            )
+
+            if !projects[projectIndex].workspaces.contains(where: { $0.id == workspace.id }) {
+                projects[projectIndex].workspaces.append(workspace)
+            }
+
+            let allWorkspaceIds = projects.flatMap(\.workspaces).map(\.id)
+            statusMonitor.sync(workspaceIds: allWorkspaceIds)
+        } catch is CancellationError {
+            // Ignore cancelled create requests when leaving the screen.
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+    }
 
     /// Refresh projects from the API. Shows existing data while loading.
     func refresh() async {

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -59,6 +59,8 @@ struct HubView: View {
                 Text(project.name)
                     .font(.headline)
                     .foregroundStyle(.secondary)
+                Spacer(minLength: 0)
+                addWorkspaceButton(for: project)
             }
 
             if project.workspaces.isEmpty {
@@ -82,6 +84,35 @@ struct HubView: View {
                     }
                 }
             }
+        }
+    }
+
+    private func addWorkspaceButton(for project: Project) -> some View {
+        let isCreating = store.creatingWorkspaceProjectIds.contains(project.id)
+        return Button {
+            handleCreateWorkspace(for: project.id)
+        } label: {
+            Group {
+                if isCreating {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "plus")
+                        .font(.footnote.weight(.semibold))
+                }
+            }
+            .frame(width: 28, height: 28)
+            .background(.white.opacity(0.08), in: Circle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isCreating)
+        .accessibilityLabel(isCreating ? "Creating workspace for \(project.name)" : "Add workspace to \(project.name)")
+        .accessibilityHint("Creates a new workspace in this project.")
+    }
+
+    private func handleCreateWorkspace(for projectId: String) {
+        Task {
+            await store.createWorkspace(in: projectId)
         }
     }
 


### PR DESCRIPTION
## Summary
- add createWorkspace(projectId:) in iOS APIClient
- add per-project creating state in ProjectStore
- add `+` action on each project in HUB with loading spinner while creating

## Validation
- xcodebuild HiveMobile Debug (iphonesimulator) succeeds
