### PR TITLE
feat: add VS Code remote SSH opening flow

### DIFF
--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -82,13 +82,15 @@ describe("GET /api/workspaces/:wsId", () => {
       method: "POST",
       url: `/api/projects/${projectId}/workspaces`,
     });
-    const wsId = createRes.json().id;
+    const createdWorkspace = createRes.json();
+    const wsId = createdWorkspace.id;
     const res = await app.inject({ method: "GET", url: `/api/workspaces/${wsId}` });
     const project = await loadProject(projectId, dataDir);
     expect(res.statusCode).toBe(200);
     expect(res.json().id).toBe(wsId);
     expect(res.json().projectName).toBe(project?.name);
     expect(res.json().defaultBranch).toBe("main");
+    expect(res.json().worktreePath).toBe(join(dataDir, projectId, "workspaces", createdWorkspace.name));
   });
 
   it("returns 404 for non-existent workspace", async () => {

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -12,7 +12,8 @@ import {
   archiveWorkspace,
 } from "../workspaces/workspace-manager.js";
 import { endSession } from "../agents/agent-manager.js";
-import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
+import { join } from "node:path";
+import { bareRepoPath, resolveDefaultBranch, workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
 
@@ -41,13 +42,16 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
     const result = await getWorkspace(req.params.wsId, dataDir);
     if (!result) return reply.status(404).send({ error: "Workspace not found" });
 
-    const bare = bareRepoPath(dataDir ?? getDataDir(), result.projectState.id);
+    const dir = dataDir ?? getDataDir();
+    const bare = bareRepoPath(dir, result.projectState.id);
     const defaultBranch = await resolveDefaultBranch(bare);
+    const worktreePath = join(workspacesDir(dir, result.projectState.id), result.workspace.name);
 
     return reply.send({
       ...result.workspace,
       projectName: result.projectState.name,
       defaultBranch,
+      worktreePath,
     });
   });
 

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -9,6 +9,13 @@
     "core:default",
     "core:window:allow-start-dragging",
     "core:window:allow-start-resize-dragging",
-    "opener:default"
+    "opener:default",
+    {
+      "identifier": "opener:allow-open-url",
+      "allow": [
+        { "url": "vscode:*" },
+        { "url": "vscode-insiders:*" }
+      ]
+    }
   ]
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,7 +1,58 @@
+use serde::Serialize;
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Serialize)]
+pub struct TerminalApp {
+  id: String,
+  name: String,
+}
+
+#[tauri::command]
+fn detect_terminals() -> Vec<TerminalApp> {
+  let mut terminals = vec![TerminalApp {
+    id: "terminal_app".into(),
+    name: "Terminal".into(),
+  }];
+
+  if Path::new("/Applications/iTerm.app").exists() {
+    terminals.push(TerminalApp {
+      id: "iterm2".into(),
+      name: "iTerm".into(),
+    });
+  }
+
+  terminals
+}
+
+#[tauri::command]
+fn open_terminal_ssh(terminal_id: String, command: String) -> Result<(), String> {
+  let escaped = command.replace('\\', "\\\\").replace('"', "\\\"");
+
+  let script = match terminal_id.as_str() {
+    "terminal_app" => format!(
+      "if application \"Terminal\" is not running then\ntell application \"Terminal\"\nactivate\ndo script \"{escaped}\" in front window\nend tell\nelse\ntell application \"Terminal\"\ndo script \"{escaped}\"\nactivate\nend tell\nend if"
+    ),
+    "iterm2" => format!(
+      "tell application \"iTerm\"\nactivate\ncreate window with default profile\ntell current session of current window\nwrite text \"{escaped}\"\nend tell\nend tell"
+    ),
+    _ => return Err(format!("Unknown terminal: {terminal_id}")),
+  };
+
+  Command::new("osascript")
+    .arg("-e")
+    .arg(&script)
+    .output()
+    .map_err(|e| format!("Failed to run osascript: {e}"))?;
+
+  Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
     .plugin(tauri_plugin_opener::init())
+    .invoke_handler(tauri::generate_handler![detect_terminals, open_terminal_ssh])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/frontend/src/hooks/useTailscaleConfig.ts
+++ b/frontend/src/hooks/useTailscaleConfig.ts
@@ -3,6 +3,7 @@ import { useCallback, useSyncExternalStore } from "react";
 const IP_KEY = "hive-tailscale-ip";
 const PORT_KEY = "hive-tailscale-port";
 const SERVER_URL_KEY = "hive-server-url";
+const SSH_USER_KEY = "hive-ssh-user";
 
 const listeners = new Set<() => void>();
 
@@ -23,6 +24,10 @@ function getPortSnapshot(): string {
   return localStorage.getItem(PORT_KEY) ?? "";
 }
 
+function getSshUserSnapshot(): string {
+  return localStorage.getItem(SSH_USER_KEY) ?? "";
+}
+
 function getServerSnapshot(): string {
   return "";
 }
@@ -40,12 +45,14 @@ function syncServerUrl(ip: string, port: string) {
 export function getTailscaleConfig() {
   const ip = localStorage.getItem(IP_KEY) ?? "";
   const port = localStorage.getItem(PORT_KEY) ?? "";
-  return { ip, port, isConfigured: ip !== "" && port !== "" };
+  const sshUser = localStorage.getItem(SSH_USER_KEY) ?? "";
+  return { ip, port, sshUser, isConfigured: ip !== "" && port !== "" };
 }
 
 export function useTailscaleConfig() {
   const ip = useSyncExternalStore(subscribe, getIpSnapshot, getServerSnapshot);
   const port = useSyncExternalStore(subscribe, getPortSnapshot, getServerSnapshot);
+  const sshUser = useSyncExternalStore(subscribe, getSshUserSnapshot, getServerSnapshot);
 
   const setIp = useCallback((value: string) => {
     const trimmed = value.trim();
@@ -69,5 +76,15 @@ export function useTailscaleConfig() {
     notify();
   }, []);
 
-  return { ip, port, setIp, setPort, isConfigured: ip !== "" && port !== "" };
+  const setSshUser = useCallback((value: string) => {
+    const trimmed = value.trim();
+    if (trimmed) {
+      localStorage.setItem(SSH_USER_KEY, trimmed);
+    } else {
+      localStorage.removeItem(SSH_USER_KEY);
+    }
+    notify();
+  }, []);
+
+  return { ip, port, sshUser, setIp, setPort, setSshUser, isConfigured: ip !== "" && port !== "" };
 }

--- a/frontend/src/hooks/useTerminalApps.ts
+++ b/frontend/src/hooks/useTerminalApps.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from "react";
+import { detectTerminals, type TerminalApp } from "@/lib/terminal";
+
+/**
+ * Detect available terminal applications (Tauri desktop only).
+ * Returns an empty array in browser mode.
+ * Detection runs once on mount.
+ */
+export function useTerminalApps(): TerminalApp[] {
+  const [terminals, setTerminals] = useState<TerminalApp[]>([]);
+
+  useEffect(() => {
+    detectTerminals().then(setTerminals);
+  }, []);
+
+  return terminals;
+}

--- a/frontend/src/lib/open-external.ts
+++ b/frontend/src/lib/open-external.ts
@@ -37,11 +37,12 @@ export async function openExternal(url: string): Promise<void> {
 export function buildVscodeRemoteUri(host: string, remotePath: string): string {
   const normalizedHost = host.trim();
   const normalizedPath = remotePath.trim().replace(/\\/g, "/");
+  const encodedHost = encodeURIComponent(normalizedHost);
   const pathWithLeadingSlash = normalizedPath.startsWith("/") ? normalizedPath : `/${normalizedPath}`;
   const encodedPath = pathWithLeadingSlash
     .split("/")
     .map((segment) => encodeURIComponent(segment))
     .join("/");
 
-  return `vscode://vscode-remote/ssh-remote+${normalizedHost}${encodedPath}`;
+  return `vscode://vscode-remote/ssh-remote+${encodedHost}${encodedPath}`;
 }

--- a/frontend/src/lib/open-external.ts
+++ b/frontend/src/lib/open-external.ts
@@ -4,10 +4,44 @@
  * falls back to window.open for browser mode.
  */
 export async function openExternal(url: string): Promise<void> {
+  const isHttp = /^https?:\/\//i.test(url);
+  const isTauri = typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+
+  if (!isTauri) {
+    // Keep fallback synchronous in browser mode so popup blockers do not drop it.
+    if (isHttp) {
+      window.open(url, "_blank", "noopener,noreferrer");
+    } else {
+      window.location.assign(url);
+    }
+    return;
+  }
+
   try {
     const { openUrl } = await import("@tauri-apps/plugin-opener");
     await openUrl(url);
-  } catch {
-    window.open(url, "_blank", "noopener,noreferrer");
+  } catch (error) {
+    console.warn("Failed to open external URL via Tauri opener:", error);
+    if (isHttp) {
+      window.open(url, "_blank", "noopener,noreferrer");
+    } else {
+      window.location.assign(url);
+    }
   }
+}
+
+/**
+ * Build a VS Code Remote SSH URI for a given host and remote path.
+ * Format: vscode://vscode-remote/ssh-remote+{host}{path}
+ */
+export function buildVscodeRemoteUri(host: string, remotePath: string): string {
+  const normalizedHost = host.trim();
+  const normalizedPath = remotePath.trim().replace(/\\/g, "/");
+  const pathWithLeadingSlash = normalizedPath.startsWith("/") ? normalizedPath : `/${normalizedPath}`;
+  const encodedPath = pathWithLeadingSlash
+    .split("/")
+    .map((segment) => encodeURIComponent(segment))
+    .join("/");
+
+  return `vscode://vscode-remote/ssh-remote+${normalizedHost}${encodedPath}`;
 }

--- a/frontend/src/lib/terminal.ts
+++ b/frontend/src/lib/terminal.ts
@@ -1,0 +1,51 @@
+export interface TerminalApp {
+  id: string;
+  name: string;
+}
+
+function isTauri(): boolean {
+  return typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
+}
+
+/**
+ * Detect installed terminal applications via Tauri command.
+ * Returns an empty array in browser mode.
+ */
+export async function detectTerminals(): Promise<TerminalApp[]> {
+  if (!isTauri()) return [];
+  try {
+    const { invoke } = await import("@tauri-apps/api/core");
+    return await invoke<TerminalApp[]>("detect_terminals");
+  } catch (error) {
+    console.warn("Failed to detect terminals:", error);
+    return [];
+  }
+}
+
+/**
+ * Build an SSH command that connects to the remote host and cd's into the workspace.
+ *
+ * Output: ssh user@host -t "cd '/escaped/path' && exec \$SHELL -l"
+ *
+ * The path is single-quoted so the remote shell won't expand special chars.
+ * $SHELL is escaped as \$SHELL so the local shell passes it literally to ssh,
+ * and the remote shell expands it to the user's login shell.
+ */
+export function buildSshCommand(sshHost: string, remotePath: string): string {
+  const escapedPath = remotePath.replace(/'/g, "'\\''");
+  return `ssh ${sshHost} -t "cd '${escapedPath}' && exec \\$SHELL -l"`;
+}
+
+/**
+ * Open a terminal application with an SSH session to the workspace.
+ * Only works in Tauri mode.
+ */
+export async function openTerminalSsh(
+  terminalId: string,
+  sshHost: string,
+  remotePath: string,
+): Promise<void> {
+  const { invoke } = await import("@tauri-apps/api/core");
+  const command = buildSshCommand(sshHost, remotePath);
+  await invoke("open_terminal_ssh", { terminalId, command });
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
-import { MessageSquareIcon, TerminalSquareIcon, CodeXmlIcon } from "lucide-react";
+import { MessageSquareIcon, TerminalSquareIcon, CodeXmlIcon, ChevronDownIcon, TerminalIcon } from "lucide-react";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
@@ -28,7 +28,16 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { openExternal, buildVscodeRemoteUri } from "@/lib/open-external";
 import { useTailscaleConfig } from "@/hooks/useTailscaleConfig";
 import { useServerUrl } from "@/hooks/useServerUrl";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useTerminalApps } from "@/hooks/useTerminalApps";
+import { openTerminalSsh } from "@/lib/terminal";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { useScripts } from "@/hooks/useScripts";
@@ -78,6 +87,7 @@ export default function WorkspaceView() {
   const { activeTerminals, openTerminal, setVisibleTerminal } = useTerminalContext();
   const { ip: tailscaleIp, sshUser } = useTailscaleConfig();
   const { serverUrl } = useServerUrl();
+  const terminalApps = useTerminalApps();
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [fileTree, setFileTree] = useState<WorkspaceFileTreeNode[]>([]);
   const [fileTreeError, setFileTreeError] = useState<string | null>(null);
@@ -134,6 +144,7 @@ export default function WorkspaceView() {
       ? "Workspace path unavailable. Restart backend and reload this workspace."
       : null;
   const canOpenVscode = vscodeUri !== null;
+  const canSsh = !!sshHost && !!workspace?.worktreePath;
 
   // Diff stats from WebSocket polling
   const diffCommitted = useMemo(
@@ -478,27 +489,63 @@ export default function WorkspaceView() {
                 Terminal
               </Button>
             </ButtonGroup>
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <span>
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      className="ml-2"
-                      onClick={() => { if (vscodeUri) void openExternal(vscodeUri); }}
-                      disabled={!canOpenVscode}
+            {terminalApps.length > 0 ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="xs" className="ml-2">
+                    <CodeXmlIcon className="mr-1.5 size-3.5" />
+                    Code
+                    <ChevronDownIcon className="ml-1 size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem
+                    disabled={!canOpenVscode}
+                    onSelect={() => { if (vscodeUri) void openExternal(vscodeUri); }}
+                  >
+                    <CodeXmlIcon className="size-3.5" />
+                    Open in VS Code
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  {terminalApps.map((t) => (
+                    <DropdownMenuItem
+                      key={t.id}
+                      disabled={!canSsh}
+                      onSelect={() => {
+                        if (canSsh && workspace?.worktreePath) {
+                          void openTerminalSsh(t.id, sshHost, workspace.worktreePath);
+                        }
+                      }}
                     >
-                      <CodeXmlIcon className="mr-1.5 size-3.5" />
-                      VS Code
-                    </Button>
-                  </span>
-                </TooltipTrigger>
-                {vscodeDisabledReason && (
-                  <TooltipContent>{vscodeDisabledReason}</TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
+                      <TerminalIcon className="size-3.5" />
+                      {t.name} (SSH)
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span>
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        className="ml-2"
+                        onClick={() => { if (vscodeUri) void openExternal(vscodeUri); }}
+                        disabled={!canOpenVscode}
+                      >
+                        <CodeXmlIcon className="mr-1.5 size-3.5" />
+                        VS Code
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  {vscodeDisabledReason && (
+                    <TooltipContent>{vscodeDisabledReason}</TooltipContent>
+                  )}
+                </Tooltip>
+              </TooltipProvider>
+            )}
           </div>
           <ConversationTabs
             sessions={sessions}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useParams } from "react-router-dom";
-import { MessageSquareIcon, TerminalSquareIcon } from "lucide-react";
+import { MessageSquareIcon, TerminalSquareIcon, CodeXmlIcon } from "lucide-react";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
@@ -25,6 +25,10 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ButtonGroup } from "@/components/ui/button-group";
 import { Skeleton } from "@/components/ui/skeleton";
+import { openExternal, buildVscodeRemoteUri } from "@/lib/open-external";
+import { useTailscaleConfig } from "@/hooks/useTailscaleConfig";
+import { useServerUrl } from "@/hooks/useServerUrl";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { useScripts } from "@/hooks/useScripts";
@@ -72,6 +76,8 @@ export default function WorkspaceView() {
   const { wsId } = useParams();
   const [view, setView] = useState<"chatbot" | "terminal">("chatbot");
   const { activeTerminals, openTerminal, setVisibleTerminal } = useTerminalContext();
+  const { ip: tailscaleIp, sshUser } = useTailscaleConfig();
+  const { serverUrl } = useServerUrl();
   const [workspace, setWorkspace] = useState<Workspace | null>(null);
   const [fileTree, setFileTree] = useState<WorkspaceFileTreeNode[]>([]);
   const [fileTreeError, setFileTreeError] = useState<string | null>(null);
@@ -105,6 +111,29 @@ export default function WorkspaceView() {
   const liveData = useWorkspaceLiveData(liveWsIds);
   const displayBranch = (wsId && liveData[wsId]?.branch) || workspace?.branch;
   const branchInfo = wsId ? liveData[wsId]?.branchInfo : undefined;
+
+  // VS Code Remote SSH
+  const backendHost = useMemo(() => {
+    if (!serverUrl) return "";
+    try {
+      const normalized = serverUrl.includes("://") ? serverUrl : `http://${serverUrl}`;
+      return new URL(normalized).hostname;
+    } catch {
+      return "";
+    }
+  }, [serverUrl]);
+  const fallbackWindowHost = typeof window !== "undefined" ? window.location.hostname : "";
+  const sshBaseHost = tailscaleIp || backendHost || fallbackWindowHost;
+  const sshHost = sshUser && sshBaseHost ? `${sshUser}@${sshBaseHost}` : sshBaseHost;
+  const vscodeUri = workspace?.worktreePath && sshHost
+    ? buildVscodeRemoteUri(sshHost, workspace.worktreePath)
+    : null;
+  const vscodeDisabledReason = !sshBaseHost
+    ? "Configure SSH host in Settings first"
+    : !workspace?.worktreePath
+      ? "Workspace path unavailable. Restart backend and reload this workspace."
+      : null;
+  const canOpenVscode = vscodeUri !== null;
 
   // Diff stats from WebSocket polling
   const diffCommitted = useMemo(
@@ -449,6 +478,27 @@ export default function WorkspaceView() {
                 Terminal
               </Button>
             </ButtonGroup>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="ml-2"
+                      onClick={() => { if (vscodeUri) void openExternal(vscodeUri); }}
+                      disabled={!canOpenVscode}
+                    >
+                      <CodeXmlIcon className="mr-1.5 size-3.5" />
+                      VS Code
+                    </Button>
+                  </span>
+                </TooltipTrigger>
+                {vscodeDisabledReason && (
+                  <TooltipContent>{vscodeDisabledReason}</TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
           </div>
           <ConversationTabs
             sessions={sessions}

--- a/frontend/src/pages/settings/ConnectionSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionSettings.tsx
@@ -28,10 +28,11 @@ interface ConnectionSettingsProps {
 }
 
 export default function ConnectionSettings({ onRefreshConnection }: ConnectionSettingsProps) {
-  const { ip, port, setIp, setPort } = useTailscaleConfig();
+  const { ip, port, sshUser, setIp, setPort, setSshUser } = useTailscaleConfig();
   const { status, check } = useConnectionStatus();
   const [ipDraft, setIpDraft] = useState(ip);
   const [portDraft, setPortDraft] = useState(port);
+  const [sshUserDraft, setSshUserDraft] = useState(sshUser);
   const [checking, setChecking] = useState(false);
 
   const save = (nextIp: string, nextPort: string) => {
@@ -41,6 +42,7 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
   };
   const saveIp = () => save(ipDraft, port);
   const savePort = () => save(ip, portDraft);
+  const saveSshUser = () => setSshUser(sshUserDraft);
 
   const handleTest = async () => {
     setChecking(true);
@@ -113,6 +115,24 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
                   className="font-mono text-xs"
                 />
               </div>
+            </div>
+
+            <div>
+              <label htmlFor="ssh-user" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                SSH User <span className="text-muted-foreground/60">(optional)</span>
+              </label>
+              <Input
+                id="ssh-user"
+                value={sshUserDraft}
+                onChange={(e) => setSshUserDraft(e.target.value)}
+                onBlur={saveSshUser}
+                onKeyDown={(e) => { if (e.key === "Enter") saveSshUser(); }}
+                placeholder="root"
+                className="font-mono text-xs"
+              />
+              <p className="mt-1 text-[11px] text-muted-foreground/60">
+                Used for VS Code Remote SSH. Leave blank to use IP only.
+              </p>
             </div>
 
             <button

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -18,6 +18,7 @@ export interface Workspace {
   activeSessionId?: string;
   projectName?: string;
   defaultBranch?: string;
+  worktreePath?: string;
 }
 
 // ── Completion / autocomplete types ─────────────────────────────────

--- a/frontend/tests/hooks/useTailscaleConfig.test.tsx
+++ b/frontend/tests/hooks/useTailscaleConfig.test.tsx
@@ -10,6 +10,8 @@ describe("useTailscaleConfig", () => {
     localStorage.removeItem("hive-server-url");
   });
 
+  // ── Initial state ──────────────────────────────────────────────────────
+
   it("returns empty values when Tailscale config is missing", () => {
     const { result } = renderHook(() => useTailscaleConfig());
 
@@ -19,6 +21,21 @@ describe("useTailscaleConfig", () => {
     expect(result.current.isConfigured).toBe(false);
     expect(getTailscaleConfig()).toEqual({ ip: "", port: "", sshUser: "", isConfigured: false });
   });
+
+  it("hydrates from existing localStorage values", () => {
+    localStorage.setItem("hive-tailscale-ip", "10.0.0.1");
+    localStorage.setItem("hive-tailscale-port", "4000");
+    localStorage.setItem("hive-ssh-user", "admin");
+
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    expect(result.current.ip).toBe("10.0.0.1");
+    expect(result.current.port).toBe("4000");
+    expect(result.current.sshUser).toBe("admin");
+    expect(result.current.isConfigured).toBe(true);
+  });
+
+  // ── IP ─────────────────────────────────────────────────────────────────
 
   it("stores a trimmed IP and keeps server URL empty until port exists", () => {
     const { result } = renderHook(() => useTailscaleConfig());
@@ -32,6 +49,25 @@ describe("useTailscaleConfig", () => {
     expect(result.current.ip).toBe("100.64.0.10");
     expect(result.current.isConfigured).toBe(false);
   });
+
+  it("removes IP and computed server URL when IP is set to empty", () => {
+    localStorage.setItem("hive-tailscale-ip", "100.64.0.10");
+    localStorage.setItem("hive-tailscale-port", "3001");
+    localStorage.setItem("hive-server-url", "http://100.64.0.10:3001");
+
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setIp("   ");
+    });
+
+    expect(localStorage.getItem("hive-tailscale-ip")).toBeNull();
+    expect(localStorage.getItem("hive-server-url")).toBeNull();
+    expect(result.current.ip).toBe("");
+    expect(result.current.isConfigured).toBe(false);
+  });
+
+  // ── Port ───────────────────────────────────────────────────────────────
 
   it("stores a trimmed port and computes hive-server-url when IP exists", () => {
     localStorage.setItem("hive-tailscale-ip", "100.64.0.10");
@@ -53,23 +89,6 @@ describe("useTailscaleConfig", () => {
     });
   });
 
-  it("removes IP and computed server URL when IP is set to empty", () => {
-    localStorage.setItem("hive-tailscale-ip", "100.64.0.10");
-    localStorage.setItem("hive-tailscale-port", "3001");
-    localStorage.setItem("hive-server-url", "http://100.64.0.10:3001");
-
-    const { result } = renderHook(() => useTailscaleConfig());
-
-    act(() => {
-      result.current.setIp("   ");
-    });
-
-    expect(localStorage.getItem("hive-tailscale-ip")).toBeNull();
-    expect(localStorage.getItem("hive-server-url")).toBeNull();
-    expect(result.current.ip).toBe("");
-    expect(result.current.isConfigured).toBe(false);
-  });
-
   it("removes port and computed server URL when port is set to empty", () => {
     localStorage.setItem("hive-tailscale-ip", "100.64.0.10");
     localStorage.setItem("hive-tailscale-port", "3001");
@@ -87,20 +106,7 @@ describe("useTailscaleConfig", () => {
     expect(result.current.isConfigured).toBe(false);
   });
 
-  it("syncs updates across multiple hook subscribers", () => {
-    const first = renderHook(() => useTailscaleConfig());
-    const second = renderHook(() => useTailscaleConfig());
-
-    act(() => {
-      first.result.current.setIp("100.64.0.77");
-      first.result.current.setPort("3000");
-    });
-
-    expect(second.result.current.ip).toBe("100.64.0.77");
-    expect(second.result.current.port).toBe("3000");
-    expect(second.result.current.isConfigured).toBe(true);
-    expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.77:3000");
-  });
+  // ── SSH User ───────────────────────────────────────────────────────────
 
   it("stores a trimmed SSH user and exposes it through snapshots", () => {
     const { result } = renderHook(() => useTailscaleConfig());
@@ -127,6 +133,56 @@ describe("useTailscaleConfig", () => {
     expect(getTailscaleConfig().sshUser).toBe("");
   });
 
+  it("SSH user does not affect isConfigured status", () => {
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setSshUser("root");
+    });
+
+    expect(result.current.isConfigured).toBe(false);
+
+    act(() => {
+      result.current.setIp("10.0.0.1");
+      result.current.setPort("3000");
+    });
+
+    expect(result.current.isConfigured).toBe(true);
+    expect(result.current.sshUser).toBe("root");
+  });
+
+  it("SSH user does not trigger server URL recomputation", () => {
+    localStorage.setItem("hive-tailscale-ip", "10.0.0.1");
+    localStorage.setItem("hive-tailscale-port", "3000");
+    localStorage.setItem("hive-server-url", "http://10.0.0.1:3000");
+
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setSshUser("devops");
+    });
+
+    // Server URL should remain unchanged
+    expect(localStorage.getItem("hive-server-url")).toBe("http://10.0.0.1:3000");
+  });
+
+  // ── Cross-subscriber sync ─────────────────────────────────────────────
+
+  it("syncs updates across multiple hook subscribers", () => {
+    const first = renderHook(() => useTailscaleConfig());
+    const second = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      first.result.current.setIp("100.64.0.77");
+      first.result.current.setPort("3000");
+    });
+
+    expect(second.result.current.ip).toBe("100.64.0.77");
+    expect(second.result.current.port).toBe("3000");
+    expect(second.result.current.isConfigured).toBe(true);
+    expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.77:3000");
+  });
+
   it("syncs SSH user updates across multiple hook subscribers", () => {
     const first = renderHook(() => useTailscaleConfig());
     const second = renderHook(() => useTailscaleConfig());
@@ -136,5 +192,38 @@ describe("useTailscaleConfig", () => {
     });
 
     expect(second.result.current.sshUser).toBe("developer");
+  });
+
+  // ── getTailscaleConfig (non-React) ─────────────────────────────────────
+
+  it("getTailscaleConfig returns all fields including sshUser", () => {
+    localStorage.setItem("hive-tailscale-ip", "10.0.0.1");
+    localStorage.setItem("hive-tailscale-port", "4000");
+    localStorage.setItem("hive-ssh-user", "ubuntu");
+
+    const config = getTailscaleConfig();
+
+    expect(config).toEqual({
+      ip: "10.0.0.1",
+      port: "4000",
+      sshUser: "ubuntu",
+      isConfigured: true,
+    });
+  });
+
+  it("getTailscaleConfig reflects changes made via hook setters", () => {
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setIp("192.168.1.1");
+      result.current.setPort("8080");
+      result.current.setSshUser("admin");
+    });
+
+    const config = getTailscaleConfig();
+    expect(config.ip).toBe("192.168.1.1");
+    expect(config.port).toBe("8080");
+    expect(config.sshUser).toBe("admin");
+    expect(config.isConfigured).toBe(true);
   });
 });

--- a/frontend/tests/hooks/useTailscaleConfig.test.tsx
+++ b/frontend/tests/hooks/useTailscaleConfig.test.tsx
@@ -6,6 +6,7 @@ describe("useTailscaleConfig", () => {
   beforeEach(() => {
     localStorage.removeItem("hive-tailscale-ip");
     localStorage.removeItem("hive-tailscale-port");
+    localStorage.removeItem("hive-ssh-user");
     localStorage.removeItem("hive-server-url");
   });
 
@@ -14,8 +15,9 @@ describe("useTailscaleConfig", () => {
 
     expect(result.current.ip).toBe("");
     expect(result.current.port).toBe("");
+    expect(result.current.sshUser).toBe("");
     expect(result.current.isConfigured).toBe(false);
-    expect(getTailscaleConfig()).toEqual({ ip: "", port: "", isConfigured: false });
+    expect(getTailscaleConfig()).toEqual({ ip: "", port: "", sshUser: "", isConfigured: false });
   });
 
   it("stores a trimmed IP and keeps server URL empty until port exists", () => {
@@ -43,7 +45,12 @@ describe("useTailscaleConfig", () => {
     expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.10:3001");
     expect(result.current.port).toBe("3001");
     expect(result.current.isConfigured).toBe(true);
-    expect(getTailscaleConfig()).toEqual({ ip: "100.64.0.10", port: "3001", isConfigured: true });
+    expect(getTailscaleConfig()).toEqual({
+      ip: "100.64.0.10",
+      port: "3001",
+      sshUser: "",
+      isConfigured: true,
+    });
   });
 
   it("removes IP and computed server URL when IP is set to empty", () => {
@@ -93,5 +100,41 @@ describe("useTailscaleConfig", () => {
     expect(second.result.current.port).toBe("3000");
     expect(second.result.current.isConfigured).toBe(true);
     expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.77:3000");
+  });
+
+  it("stores a trimmed SSH user and exposes it through snapshots", () => {
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setSshUser("  root  ");
+    });
+
+    expect(localStorage.getItem("hive-ssh-user")).toBe("root");
+    expect(result.current.sshUser).toBe("root");
+    expect(getTailscaleConfig()).toEqual({ ip: "", port: "", sshUser: "root", isConfigured: false });
+  });
+
+  it("removes SSH user when set to empty value", () => {
+    localStorage.setItem("hive-ssh-user", "ubuntu");
+    const { result } = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      result.current.setSshUser("   ");
+    });
+
+    expect(localStorage.getItem("hive-ssh-user")).toBeNull();
+    expect(result.current.sshUser).toBe("");
+    expect(getTailscaleConfig().sshUser).toBe("");
+  });
+
+  it("syncs SSH user updates across multiple hook subscribers", () => {
+    const first = renderHook(() => useTailscaleConfig());
+    const second = renderHook(() => useTailscaleConfig());
+
+    act(() => {
+      first.result.current.setSshUser("developer");
+    });
+
+    expect(second.result.current.sshUser).toBe("developer");
   });
 });

--- a/frontend/tests/hooks/useTerminalApps.test.tsx
+++ b/frontend/tests/hooks/useTerminalApps.test.tsx
@@ -50,4 +50,43 @@ describe("useTerminalApps", () => {
 
     expect(result.current).toEqual([]);
   });
+
+  it("calls detectTerminals exactly once on mount", async () => {
+    mocks.detectTerminals.mockResolvedValue([]);
+
+    renderHook(() => useTerminalApps());
+
+    await waitFor(() => {
+      expect(mocks.detectTerminals).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("does not re-detect on rerender", async () => {
+    mocks.detectTerminals.mockResolvedValue([{ id: "terminal_app", name: "Terminal" }]);
+
+    const { result, rerender } = renderHook(() => useTerminalApps());
+
+    await waitFor(() => {
+      expect(result.current).toHaveLength(1);
+    });
+
+    rerender();
+    rerender();
+
+    expect(mocks.detectTerminals).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps empty array when detectTerminals resolves with empty (simulates internal error handling)", async () => {
+    // detectTerminals handles its own errors and returns []. This test confirms
+    // the hook stays stable when the detection layer resolves with nothing.
+    mocks.detectTerminals.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useTerminalApps());
+
+    await waitFor(() => {
+      expect(mocks.detectTerminals).toHaveBeenCalled();
+    });
+
+    expect(result.current).toEqual([]);
+  });
 });

--- a/frontend/tests/hooks/useTerminalApps.test.tsx
+++ b/frontend/tests/hooks/useTerminalApps.test.tsx
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useTerminalApps } from "@/hooks/useTerminalApps";
+
+const mocks = vi.hoisted(() => ({
+  detectTerminals: vi.fn(),
+}));
+
+vi.mock("@/lib/terminal", () => ({
+  detectTerminals: mocks.detectTerminals,
+}));
+
+describe("useTerminalApps", () => {
+  beforeEach(() => {
+    mocks.detectTerminals.mockReset();
+  });
+
+  it("returns detected terminals after mount", async () => {
+    mocks.detectTerminals.mockResolvedValue([
+      { id: "terminal_app", name: "Terminal" },
+      { id: "iterm2", name: "iTerm" },
+    ]);
+
+    const { result } = renderHook(() => useTerminalApps());
+
+    await waitFor(() => {
+      expect(result.current).toEqual([
+        { id: "terminal_app", name: "Terminal" },
+        { id: "iterm2", name: "iTerm" },
+      ]);
+    });
+  });
+
+  it("returns empty array when detection returns nothing", async () => {
+    mocks.detectTerminals.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useTerminalApps());
+
+    await waitFor(() => {
+      expect(mocks.detectTerminals).toHaveBeenCalled();
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("starts with empty array before detection completes", () => {
+    mocks.detectTerminals.mockReturnValue(new Promise(() => {})); // never resolves
+
+    const { result } = renderHook(() => useTerminalApps());
+
+    expect(result.current).toEqual([]);
+  });
+});

--- a/frontend/tests/lib/open-external.test.ts
+++ b/frontend/tests/lib/open-external.test.ts
@@ -9,6 +9,8 @@ vi.mock("@tauri-apps/plugin-opener", () => ({
   openUrl: mocks.openUrl,
 }));
 
+// ─── buildVscodeRemoteUri ────────────────────────────────────────────────────
+
 describe("buildVscodeRemoteUri", () => {
   it("encodes SSH host and each path segment", () => {
     const uri = buildVscodeRemoteUri(" user name@example-host ", " /Users/me/project folder ");
@@ -23,7 +25,92 @@ describe("buildVscodeRemoteUri", () => {
 
     expect(uri).toBe("vscode://vscode-remote/ssh-remote+root%40100.64.0.10/Users/me/repo");
   });
+
+  it("produces a valid URI for simple host and absolute path", () => {
+    const uri = buildVscodeRemoteUri("root@10.0.0.1", "/srv/hive/tokyo");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+root%4010.0.0.1/srv/hive/tokyo");
+  });
+
+  it("handles host without user@ prefix", () => {
+    const uri = buildVscodeRemoteUri("100.64.0.77", "/home/dev/project");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+100.64.0.77/home/dev/project");
+  });
+
+  it("handles path that already has a leading slash", () => {
+    const uri = buildVscodeRemoteUri("host", "/absolute/path");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+host/absolute/path");
+    // Should not double the leading slash
+    expect(uri).not.toContain("//absolute");
+  });
+
+  it("adds leading slash when path has none", () => {
+    const uri = buildVscodeRemoteUri("host", "relative/path");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+host/relative/path");
+  });
+
+  it("encodes special characters in path segments", () => {
+    const uri = buildVscodeRemoteUri("h", "/path/with spaces/and#hash/and@at");
+
+    expect(uri).toContain("with%20spaces");
+    expect(uri).toContain("and%23hash");
+    expect(uri).toContain("and%40at");
+  });
+
+  it("encodes unicode characters in host and path", () => {
+    const uri = buildVscodeRemoteUri("u@hôst", "/données/projet");
+
+    expect(uri).toContain("h%C3%B4st");
+    expect(uri).toContain("donn%C3%A9es");
+  });
+
+  it("handles root path /", () => {
+    const uri = buildVscodeRemoteUri("host", "/");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+host/");
+  });
+
+  it("trims whitespace from both host and path", () => {
+    const uri = buildVscodeRemoteUri("  host  ", "  /path  ");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+host/path");
+  });
+
+  it("encodes + signs in host (user+tag@host)", () => {
+    const uri = buildVscodeRemoteUri("user+tag@host", "/p");
+
+    expect(uri).toContain("user%2Btag%40host");
+  });
+
+  it("encodes colons in host (for IPv6-like hosts)", () => {
+    const uri = buildVscodeRemoteUri("user@[::1]", "/p");
+
+    expect(uri).toContain("user%40%5B%3A%3A1%5D");
+  });
+
+  it("handles empty path after trim (becomes just /)", () => {
+    const uri = buildVscodeRemoteUri("host", "   ");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+host/");
+  });
+
+  it("preserves path hierarchy with deeply nested paths", () => {
+    const uri = buildVscodeRemoteUri("h", "/a/b/c/d/e/f");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+h/a/b/c/d/e/f");
+  });
+
+  it("handles mixed backslash and forward slash path", () => {
+    const uri = buildVscodeRemoteUri("h", "C:\\Users\\dev/projects\\my-app");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+h/C%3A/Users/dev/projects/my-app");
+  });
 });
+
+// ─── openExternal ────────────────────────────────────────────────────────────
 
 describe("openExternal", () => {
   beforeEach(() => {
@@ -31,6 +118,8 @@ describe("openExternal", () => {
     delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
     vi.restoreAllMocks();
   });
+
+  // ── Browser mode ──────────────────────────────────────────────────────
 
   it("uses window.open for HTTP URLs in browser mode", async () => {
     const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
@@ -40,6 +129,61 @@ describe("openExternal", () => {
     expect(openSpy).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
     expect(mocks.openUrl).not.toHaveBeenCalled();
   });
+
+  it("uses window.open for http:// (lowercase) in browser mode", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("http://localhost:3000");
+
+    expect(openSpy).toHaveBeenCalledWith("http://localhost:3000", "_blank", "noopener,noreferrer");
+  });
+
+  it("uses window.open for HTTPS:// (uppercase) in browser mode", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("HTTPS://EXAMPLE.COM");
+
+    expect(openSpy).toHaveBeenCalledWith("HTTPS://EXAMPLE.COM", "_blank", "noopener,noreferrer");
+  });
+
+  it("uses location.assign for non-HTTP URLs in browser mode (vscode://)", async () => {
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("vscode://vscode-remote/ssh-remote+host/path");
+
+    expect(assignFn).toHaveBeenCalledWith("vscode://vscode-remote/ssh-remote+host/path");
+    expect(openSpy).not.toHaveBeenCalled();
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("uses location.assign for non-HTTP URLs in browser mode (custom://)", async () => {
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+
+    await openExternal("custom-app://deep/link");
+
+    expect(assignFn).toHaveBeenCalledWith("custom-app://deep/link");
+  });
+
+  it("does not call Tauri opener in browser mode", async () => {
+    vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("https://example.com");
+
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  // ── Tauri mode ────────────────────────────────────────────────────────
 
   it("uses Tauri opener when running in Tauri", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
@@ -52,7 +196,18 @@ describe("openExternal", () => {
     expect(openSpy).not.toHaveBeenCalled();
   });
 
-  it("falls back to browser behavior when Tauri opener throws", async () => {
+  it("uses Tauri opener for HTTP URLs in Tauri mode", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.openUrl.mockResolvedValue(undefined);
+
+    await openExternal("https://github.com");
+
+    expect(mocks.openUrl).toHaveBeenCalledWith("https://github.com");
+  });
+
+  // ── Tauri fallback ────────────────────────────────────────────────────
+
+  it("falls back to window.open for HTTP URL when Tauri opener throws", async () => {
     (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
     mocks.openUrl.mockRejectedValue(new Error("plugin unavailable"));
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
@@ -66,5 +221,80 @@ describe("openExternal", () => {
       "_blank",
       "noopener,noreferrer",
     );
+  });
+
+  it("falls back to location.assign for non-HTTP URL when Tauri opener throws", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.openUrl.mockRejectedValue(new Error("plugin unavailable"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("vscode://vscode-remote/ssh-remote+host/path");
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(assignFn).toHaveBeenCalledWith("vscode://vscode-remote/ssh-remote+host/path");
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("logs warning with original error when Tauri opener fails", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    const cause = new Error("no permission");
+    mocks.openUrl.mockRejectedValue(cause);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("https://example.com");
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Failed to open external URL via Tauri opener:",
+      cause,
+    );
+  });
+
+  // ── Protocol detection edge cases ─────────────────────────────────────
+
+  it("treats ftp:// as non-HTTP in browser mode", async () => {
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+
+    await openExternal("ftp://files.example.com/doc.pdf");
+
+    expect(assignFn).toHaveBeenCalledWith("ftp://files.example.com/doc.pdf");
+  });
+
+  it("treats mailto: as non-HTTP in browser mode", async () => {
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+
+    await openExternal("mailto:test@example.com");
+
+    expect(assignFn).toHaveBeenCalledWith("mailto:test@example.com");
+  });
+
+  it("treats vscode-insiders:// as non-HTTP in browser mode", async () => {
+    const assignFn = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: { ...window.location, assign: assignFn },
+      writable: true,
+      configurable: true,
+    });
+
+    await openExternal("vscode-insiders://vscode-remote/ssh-remote+host/p");
+
+    expect(assignFn).toHaveBeenCalledWith("vscode-insiders://vscode-remote/ssh-remote+host/p");
   });
 });

--- a/frontend/tests/lib/open-external.test.ts
+++ b/frontend/tests/lib/open-external.test.ts
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildVscodeRemoteUri, openExternal } from "@/lib/open-external";
+
+const mocks = vi.hoisted(() => ({
+  openUrl: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-opener", () => ({
+  openUrl: mocks.openUrl,
+}));
+
+describe("buildVscodeRemoteUri", () => {
+  it("encodes SSH host and each path segment", () => {
+    const uri = buildVscodeRemoteUri(" user name@example-host ", " /Users/me/project folder ");
+
+    expect(uri).toBe(
+      "vscode://vscode-remote/ssh-remote+user%20name%40example-host/Users/me/project%20folder",
+    );
+  });
+
+  it("normalizes windows separators and adds leading slash", () => {
+    const uri = buildVscodeRemoteUri("root@100.64.0.10", "Users\\me\\repo");
+
+    expect(uri).toBe("vscode://vscode-remote/ssh-remote+root%40100.64.0.10/Users/me/repo");
+  });
+});
+
+describe("openExternal", () => {
+  beforeEach(() => {
+    mocks.openUrl.mockReset();
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+    vi.restoreAllMocks();
+  });
+
+  it("uses window.open for HTTP URLs in browser mode", async () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("https://example.com");
+
+    expect(openSpy).toHaveBeenCalledWith("https://example.com", "_blank", "noopener,noreferrer");
+    expect(mocks.openUrl).not.toHaveBeenCalled();
+  });
+
+  it("uses Tauri opener when running in Tauri", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.openUrl.mockResolvedValue(undefined);
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("vscode://vscode-remote/ssh-remote+host/path");
+
+    expect(mocks.openUrl).toHaveBeenCalledWith("vscode://vscode-remote/ssh-remote+host/path");
+    expect(openSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to browser behavior when Tauri opener throws", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.openUrl.mockRejectedValue(new Error("plugin unavailable"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    await openExternal("https://example.com/docs");
+
+    expect(warnSpy).toHaveBeenCalled();
+    expect(openSpy).toHaveBeenCalledWith(
+      "https://example.com/docs",
+      "_blank",
+      "noopener,noreferrer",
+    );
+  });
+});

--- a/frontend/tests/lib/terminal.test.ts
+++ b/frontend/tests/lib/terminal.test.ts
@@ -9,6 +9,8 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: mocks.invoke,
 }));
 
+// ─── buildSshCommand ─────────────────────────────────────────────────────────
+
 describe("buildSshCommand", () => {
   it("builds a basic SSH command", () => {
     const cmd = buildSshCommand("user@host", "/home/user/project");
@@ -41,7 +43,61 @@ describe("buildSshCommand", () => {
       'ssh 100.64.0.10 -t "cd \'/srv/hive/tokyo\' && exec \\$SHELL -l"',
     );
   });
+
+  it("forces a pseudo-terminal with -t flag", () => {
+    const cmd = buildSshCommand("user@host", "/p");
+    expect(cmd).toMatch(/^ssh .+ -t "/);
+  });
+
+  it("wraps the remote command in double quotes", () => {
+    const cmd = buildSshCommand("user@host", "/p");
+    // The cd ... && exec part should be inside double quotes
+    expect(cmd).toMatch(/-t "cd .+ && exec .+"/);
+  });
+
+  it("single-quotes the remote path to prevent shell expansion", () => {
+    const cmd = buildSshCommand("user@host", "/home/$USER/project");
+    // $USER should be inside single quotes, not expanded
+    expect(cmd).toContain("cd '/home/$USER/project'");
+  });
+
+  it("handles paths with backticks", () => {
+    const cmd = buildSshCommand("user@host", "/home/user/`weird`/project");
+    // Backticks are inside single quotes, so they won't be expanded
+    expect(cmd).toContain("cd '/home/user/`weird`/project'");
+  });
+
+  it("handles paths with double quotes", () => {
+    const cmd = buildSshCommand("user@host", '/home/user/"quoted"/project');
+    // Double quotes inside single-quoted strings are literal
+    expect(cmd).toContain('cd \'/home/user/"quoted"/project\'');
+  });
+
+  it("handles paths with multiple consecutive single quotes", () => {
+    const cmd = buildSshCommand("user@host", "/home/it''s");
+    expect(cmd).toContain("'\\''");
+  });
+
+  it("handles empty path", () => {
+    const cmd = buildSshCommand("user@host", "");
+    expect(cmd).toBe('ssh user@host -t "cd \'\' && exec \\$SHELL -l"');
+  });
+
+  it("handles path with only a slash", () => {
+    const cmd = buildSshCommand("user@host", "/");
+    expect(cmd).toBe('ssh user@host -t "cd \'/\' && exec \\$SHELL -l"');
+  });
+
+  it("preserves the full command structure for osascript consumption", () => {
+    const cmd = buildSshCommand("dev@10.0.0.1", "/srv/hive/workspace");
+    // The command should be a single string suitable for passing to a terminal
+    expect(cmd).toBe(
+      'ssh dev@10.0.0.1 -t "cd \'/srv/hive/workspace\' && exec \\$SHELL -l"',
+    );
+  });
 });
+
+// ─── detectTerminals ─────────────────────────────────────────────────────────
 
 describe("detectTerminals", () => {
   beforeEach(() => {
@@ -75,7 +131,54 @@ describe("detectTerminals", () => {
     expect(result).toEqual([]);
     expect(warnSpy).toHaveBeenCalled();
   });
+
+  it("logs the error message when detection fails", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    const error = new Error("command not registered");
+    mocks.invoke.mockRejectedValue(error);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await detectTerminals();
+
+    expect(warnSpy).toHaveBeenCalledWith("Failed to detect terminals:", error);
+  });
+
+  it("returns multiple terminals when detected", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    const apps = [
+      { id: "terminal_app", name: "Terminal" },
+      { id: "iterm2", name: "iTerm" },
+    ];
+    mocks.invoke.mockResolvedValue(apps);
+
+    const result = await detectTerminals();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe("terminal_app");
+    expect(result[1].id).toBe("iterm2");
+  });
+
+  it("returns empty array when Tauri returns empty list", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.invoke.mockResolvedValue([]);
+
+    const result = await detectTerminals();
+
+    expect(result).toEqual([]);
+  });
+
+  it("does not call invoke more than once per call", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.invoke.mockResolvedValue([]);
+
+    await detectTerminals();
+    await detectTerminals();
+
+    expect(mocks.invoke).toHaveBeenCalledTimes(2);
+  });
 });
+
+// ─── openTerminalSsh ─────────────────────────────────────────────────────────
 
 describe("openTerminalSsh", () => {
   beforeEach(() => {
@@ -91,5 +194,45 @@ describe("openTerminalSsh", () => {
       terminalId: "iterm2",
       command: 'ssh user@host -t "cd \'/path/to/workspace\' && exec \\$SHELL -l"',
     });
+  });
+
+  it("passes terminal_app as terminalId", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+
+    await openTerminalSsh("terminal_app", "root@10.0.0.1", "/srv/hive/kyoto");
+
+    expect(mocks.invoke).toHaveBeenCalledWith("open_terminal_ssh", {
+      terminalId: "terminal_app",
+      command: 'ssh root@10.0.0.1 -t "cd \'/srv/hive/kyoto\' && exec \\$SHELL -l"',
+    });
+  });
+
+  it("propagates errors from invoke", async () => {
+    mocks.invoke.mockRejectedValue(new Error("Unknown terminal: wezterm"));
+
+    await expect(
+      openTerminalSsh("wezterm", "user@host", "/p"),
+    ).rejects.toThrow("Unknown terminal: wezterm");
+  });
+
+  it("escapes single quotes in path passed to invoke", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+
+    await openTerminalSsh("iterm2", "user@host", "/home/it's here");
+
+    expect(mocks.invoke).toHaveBeenCalledWith("open_terminal_ssh", {
+      terminalId: "iterm2",
+      command: "ssh user@host -t \"cd '/home/it'\\''s here' && exec \\$SHELL -l\"",
+    });
+  });
+
+  it("uses buildSshCommand internally (command structure matches)", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+
+    await openTerminalSsh("terminal_app", "dev@100.64.0.77", "/workspace/path");
+
+    const call = mocks.invoke.mock.calls[0];
+    expect(call[0]).toBe("open_terminal_ssh");
+    expect(call[1].command).toMatch(/^ssh dev@100\.64\.0\.77 -t "cd '\/workspace\/path' && exec \\\$SHELL -l"$/);
   });
 });

--- a/frontend/tests/lib/terminal.test.ts
+++ b/frontend/tests/lib/terminal.test.ts
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildSshCommand, detectTerminals, openTerminalSsh } from "@/lib/terminal";
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+describe("buildSshCommand", () => {
+  it("builds a basic SSH command", () => {
+    const cmd = buildSshCommand("user@host", "/home/user/project");
+    expect(cmd).toBe(
+      'ssh user@host -t "cd \'/home/user/project\' && exec \\$SHELL -l"',
+    );
+  });
+
+  it("escapes single quotes in the remote path", () => {
+    const cmd = buildSshCommand("root@10.0.0.1", "/home/it's a project");
+    expect(cmd).toBe(
+      "ssh root@10.0.0.1 -t \"cd '/home/it'\\''s a project' && exec \\$SHELL -l\"",
+    );
+  });
+
+  it("handles paths with spaces", () => {
+    const cmd = buildSshCommand("dev@host", "/Users/me/my project");
+    expect(cmd).toContain("cd '/Users/me/my project'");
+  });
+
+  it("escapes $SHELL so it expands on the remote", () => {
+    const cmd = buildSshCommand("user@host", "/path");
+    expect(cmd).toContain("\\$SHELL");
+    expect(cmd).not.toContain("exec $SHELL");
+  });
+
+  it("handles host without user prefix", () => {
+    const cmd = buildSshCommand("100.64.0.10", "/srv/hive/tokyo");
+    expect(cmd).toBe(
+      'ssh 100.64.0.10 -t "cd \'/srv/hive/tokyo\' && exec \\$SHELL -l"',
+    );
+  });
+});
+
+describe("detectTerminals", () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset();
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__;
+  });
+
+  it("returns empty array in browser mode", async () => {
+    const result = await detectTerminals();
+    expect(result).toEqual([]);
+    expect(mocks.invoke).not.toHaveBeenCalled();
+  });
+
+  it("calls Tauri invoke in Tauri mode", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.invoke.mockResolvedValue([{ id: "terminal_app", name: "Terminal" }]);
+
+    const result = await detectTerminals();
+
+    expect(mocks.invoke).toHaveBeenCalledWith("detect_terminals");
+    expect(result).toEqual([{ id: "terminal_app", name: "Terminal" }]);
+  });
+
+  it("returns empty array when invoke throws", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ = {};
+    mocks.invoke.mockRejectedValue(new Error("not available"));
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const result = await detectTerminals();
+
+    expect(result).toEqual([]);
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});
+
+describe("openTerminalSsh", () => {
+  beforeEach(() => {
+    mocks.invoke.mockReset();
+  });
+
+  it("invokes open_terminal_ssh with built command", async () => {
+    mocks.invoke.mockResolvedValue(undefined);
+
+    await openTerminalSsh("iterm2", "user@host", "/path/to/workspace");
+
+    expect(mocks.invoke).toHaveBeenCalledWith("open_terminal_ssh", {
+      terminalId: "iterm2",
+      command: 'ssh user@host -t "cd \'/path/to/workspace\' && exec \\$SHELL -l"',
+    });
+  });
+});

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -30,6 +30,7 @@ describe("ConnectionSettings", () => {
     localStorage.removeItem("hive-server-url");
     localStorage.removeItem("hive-tailscale-ip");
     localStorage.removeItem("hive-tailscale-port");
+    localStorage.removeItem("hive-ssh-user");
   });
 
   it("shows tailscale placeholders and unknown status when not configured", () => {
@@ -38,6 +39,7 @@ describe("ConnectionSettings", () => {
     expect(screen.getByRole("heading", { name: "Connection" }).closest("div")).toHaveAttribute("data-tauri-drag-region");
     expect(screen.getByPlaceholderText("100.x.x.x")).toHaveValue("");
     expect(screen.getByPlaceholderText("3000")).toHaveValue("");
+    expect(screen.getByPlaceholderText("root")).toHaveValue("");
     expect(screen.getByText("Not configured")).toBeInTheDocument();
   });
 
@@ -87,6 +89,28 @@ describe("ConnectionSettings", () => {
     expect(localStorage.getItem("hive-tailscale-ip")).toBe("100.64.0.11");
     expect(localStorage.getItem("hive-tailscale-port")).toBe("3000");
     expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.11:3000");
+  });
+
+  it("persists SSH user on blur without triggering a connection check", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionSettings />);
+
+    const sshUserInput = screen.getByPlaceholderText("root");
+    await user.type(sshUserInput, "  devops  ");
+    await user.tab();
+
+    expect(localStorage.getItem("hive-ssh-user")).toBe("devops");
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("persists SSH user on Enter with trimming", async () => {
+    const user = userEvent.setup();
+    render(<ConnectionSettings />);
+
+    const sshUserInput = screen.getByPlaceholderText("root");
+    await user.type(sshUserInput, "  ubuntu  {Enter}");
+
+    expect(localStorage.getItem("hive-ssh-user")).toBe("ubuntu");
   });
 });
 

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -91,6 +91,8 @@ describe("ConnectionSettings", () => {
     expect(localStorage.getItem("hive-server-url")).toBe("http://100.64.0.11:3000");
   });
 
+  // ── SSH User field ────────────────────────────────────────────────────
+
   it("persists SSH user on blur without triggering a connection check", async () => {
     const user = userEvent.setup();
     render(<ConnectionSettings />);
@@ -111,6 +113,60 @@ describe("ConnectionSettings", () => {
     await user.type(sshUserInput, "  ubuntu  {Enter}");
 
     expect(localStorage.getItem("hive-ssh-user")).toBe("ubuntu");
+  });
+
+  it("shows existing SSH user value from localStorage", () => {
+    localStorage.setItem("hive-ssh-user", "existing-user");
+
+    render(<ConnectionSettings />);
+
+    expect(screen.getByPlaceholderText("root")).toHaveValue("existing-user");
+  });
+
+  it("clears SSH user from localStorage when field is emptied and blurred", async () => {
+    localStorage.setItem("hive-ssh-user", "old-user");
+    const user = userEvent.setup();
+
+    render(<ConnectionSettings />);
+
+    const sshUserInput = screen.getByPlaceholderText("root");
+    await user.clear(sshUserInput);
+    await user.tab();
+
+    expect(localStorage.getItem("hive-ssh-user")).toBeNull();
+  });
+
+  it("renders SSH user label with optional marker", () => {
+    render(<ConnectionSettings />);
+
+    expect(screen.getByText("SSH User")).toBeInTheDocument();
+    expect(screen.getByText("(optional)")).toBeInTheDocument();
+  });
+
+  it("renders SSH user help text about VS Code Remote SSH", () => {
+    render(<ConnectionSettings />);
+
+    expect(screen.getByText(/Used for VS Code Remote SSH/i)).toBeInTheDocument();
+  });
+
+  it("SSH user field has font-mono class for readability", () => {
+    render(<ConnectionSettings />);
+
+    const input = screen.getByPlaceholderText("root");
+    expect(input.className).toContain("font-mono");
+  });
+
+  it("does not affect server URL when SSH user changes", async () => {
+    localStorage.setItem("hive-tailscale-ip", "10.0.0.1");
+    localStorage.setItem("hive-tailscale-port", "3000");
+    localStorage.setItem("hive-server-url", "http://10.0.0.1:3000");
+
+    const user = userEvent.setup();
+    render(<ConnectionSettings />);
+
+    await user.type(screen.getByPlaceholderText("root"), "newuser{Enter}");
+
+    expect(localStorage.getItem("hive-server-url")).toBe("http://10.0.0.1:3000");
   });
 });
 

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { TerminalProvider, useTerminalContext } from "@/contexts/TerminalContext";
 import WorkspaceView from "@/pages/WorkspaceView";
 import type { Workspace, WorkspaceFileTreeNode } from "@/types";
@@ -31,6 +31,7 @@ const mocks = vi.hoisted(() => ({
   stopScript: vi.fn(),
   connectScriptOutput: vi.fn(),
   disconnectScriptOutput: vi.fn(),
+  openExternal: vi.fn(),
 }));
 
 vi.mock("@/hooks/useApi", () => ({
@@ -56,6 +57,14 @@ vi.mock("@/lib/ws-transport", () => ({
 vi.mock("@/hooks/useScripts", () => ({
   useScripts: mocks.useScripts,
 }));
+
+vi.mock("@/lib/open-external", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/open-external")>("@/lib/open-external");
+  return {
+    ...actual,
+    openExternal: mocks.openExternal,
+  };
+});
 
 vi.mock("@/components/ScriptPanel", () => ({
   default: ({ config }: { config: unknown }) => {
@@ -215,6 +224,18 @@ function renderWorkspace(initialEntry = "/workspaces/ws-1") {
   );
 }
 
+beforeEach(() => {
+  localStorage.removeItem("hive-server-url");
+  localStorage.removeItem("hive-tailscale-ip");
+  localStorage.removeItem("hive-tailscale-port");
+  localStorage.removeItem("hive-ssh-user");
+  mocks.openExternal.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("WorkspaceView terminal behavior", () => {
   beforeEach(() => {
     mocks.apiGet.mockReset();
@@ -236,6 +257,7 @@ describe("WorkspaceView terminal behavior", () => {
     mocks.clearCachedData.mockReset();
     mocks.useWorkspaceLiveData.mockReset();
     mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.openExternal.mockReset();
 
     mocks.useScripts.mockReturnValue({
       config: null,
@@ -312,6 +334,76 @@ describe("WorkspaceView terminal behavior", () => {
 
     expect(screen.getByTestId("ctx-visible")).toHaveTextContent("none");
     expect(screen.getByTestId("ctx-active")).toHaveTextContent("ws-1");
+  });
+
+  it("disables VS Code button when workspace path is unavailable", async () => {
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    expect(screen.getByRole("button", { name: "VS Code" })).toBeDisabled();
+  });
+
+  it("opens VS Code URI with tailscale host and SSH user when configured", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("hive-tailscale-ip", "100.64.0.77");
+    localStorage.setItem("hive-ssh-user", "dev user");
+    localStorage.setItem("hive-server-url", "http://backend.internal:3000");
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace ? { ...workspace, worktreePath: "/Users/me/project folder" } : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    const vscodeButton = screen.getByRole("button", { name: "VS Code" });
+    expect(vscodeButton).toBeEnabled();
+
+    await user.click(vscodeButton);
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        "vscode://vscode-remote/ssh-remote+dev%20user%40100.64.0.77/Users/me/project%20folder",
+      );
+    });
+  });
+
+  it("falls back to server URL host for VS Code URI when tailscale IP is not set", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("hive-server-url", "backend.internal:4444");
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace ? { ...workspace, worktreePath: "/srv/hive/tokyo" } : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        "vscode://vscode-remote/ssh-remote+backend.internal/srv/hive/tokyo",
+      );
+    });
   });
 
   it("switches back to chatbot view when terminal session exits", async () => {

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -32,6 +32,8 @@ const mocks = vi.hoisted(() => ({
   connectScriptOutput: vi.fn(),
   disconnectScriptOutput: vi.fn(),
   openExternal: vi.fn(),
+  useTerminalApps: vi.fn().mockReturnValue([]),
+  openTerminalSsh: vi.fn(),
 }));
 
 vi.mock("@/hooks/useApi", () => ({
@@ -65,6 +67,14 @@ vi.mock("@/lib/open-external", async () => {
     openExternal: mocks.openExternal,
   };
 });
+
+vi.mock("@/hooks/useTerminalApps", () => ({
+  useTerminalApps: mocks.useTerminalApps,
+}));
+
+vi.mock("@/lib/terminal", () => ({
+  openTerminalSsh: mocks.openTerminalSsh,
+}));
 
 vi.mock("@/components/ScriptPanel", () => ({
   default: ({ config }: { config: unknown }) => {
@@ -230,6 +240,9 @@ beforeEach(() => {
   localStorage.removeItem("hive-tailscale-port");
   localStorage.removeItem("hive-ssh-user");
   mocks.openExternal.mockReset();
+  mocks.useTerminalApps.mockReset();
+  mocks.useTerminalApps.mockReturnValue([]);
+  mocks.openTerminalSsh.mockReset();
 });
 
 afterEach(() => {
@@ -404,6 +417,92 @@ describe("WorkspaceView terminal behavior", () => {
         "vscode://vscode-remote/ssh-remote+backend.internal/srv/hive/tokyo",
       );
     });
+  });
+
+  it("shows dropdown with terminal options when terminal apps are detected", async () => {
+    const user = userEvent.setup();
+    mocks.useTerminalApps.mockReturnValue([
+      { id: "terminal_app", name: "Terminal" },
+      { id: "iterm2", name: "iTerm" },
+    ]);
+
+    localStorage.setItem("hive-tailscale-ip", "100.64.0.77");
+    localStorage.setItem("hive-ssh-user", "root");
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace ? { ...workspace, worktreePath: "/srv/hive/tokyo" } : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    // Should render dropdown trigger, not simple "VS Code" button
+    const trigger = screen.getByRole("button", { name: /Code/i });
+    expect(trigger).toBeInTheDocument();
+
+    await user.click(trigger);
+
+    // Menu items should appear
+    expect(await screen.findByText("Open in VS Code")).toBeInTheDocument();
+    expect(screen.getByText("Terminal (SSH)")).toBeInTheDocument();
+    expect(screen.getByText("iTerm (SSH)")).toBeInTheDocument();
+  });
+
+  it("calls openTerminalSsh when a terminal menu item is clicked", async () => {
+    const user = userEvent.setup();
+    mocks.useTerminalApps.mockReturnValue([
+      { id: "terminal_app", name: "Terminal" },
+    ]);
+    mocks.openTerminalSsh.mockResolvedValue(undefined);
+
+    localStorage.setItem("hive-tailscale-ip", "100.64.0.77");
+    localStorage.setItem("hive-ssh-user", "dev");
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace ? { ...workspace, worktreePath: "/srv/hive/tokyo" } : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+    await user.click(await screen.findByText("Terminal (SSH)"));
+
+    await waitFor(() => {
+      expect(mocks.openTerminalSsh).toHaveBeenCalledWith(
+        "terminal_app",
+        "dev@100.64.0.77",
+        "/srv/hive/tokyo",
+      );
+    });
+  });
+
+  it("shows simple VS Code button when no terminal apps detected (browser mode)", async () => {
+    mocks.useTerminalApps.mockReturnValue([]);
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    // Should render the simple "VS Code" button, not a dropdown
+    expect(screen.getByRole("button", { name: "VS Code" })).toBeInTheDocument();
   });
 
   it("switches back to chatbot view when terminal session exits", async () => {

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -1219,3 +1219,479 @@ describe("WorkspaceView sidebar split resize", () => {
     expect(fileTreePanel.style.height).toBe("50%");
   });
 });
+
+// ─── SSH Host Resolution & VS Code Button Edge Cases ─────────────────────────
+
+describe("WorkspaceView VS Code SSH host resolution", () => {
+  function setupWithWorktreePath(opts: {
+    tailscaleIp?: string;
+    sshUser?: string;
+    serverUrl?: string;
+    worktreePath?: string;
+  } = {}) {
+    if (opts.tailscaleIp) localStorage.setItem("hive-tailscale-ip", opts.tailscaleIp);
+    if (opts.sshUser) localStorage.setItem("hive-ssh-user", opts.sshUser);
+    if (opts.serverUrl) localStorage.setItem("hive-server-url", opts.serverUrl);
+
+    mocks.useTerminalApps.mockReturnValue([]);
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace
+          ? { ...workspace, worktreePath: opts.worktreePath ?? undefined }
+          : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      streamingStartedAt: null,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: undefined,
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    mocks.useSessions.mockReturnValue({
+      sessions: [],
+      createSession: mocks.createSession,
+      activateSession: mocks.activateSession,
+      deleteSession: mocks.deleteSession,
+      refresh: mocks.refreshSessions,
+    });
+
+    mocks.useScripts.mockReturnValue({
+      config: null,
+      status: { setup: { state: "idle" }, run: { state: "idle" } },
+      startScript: mocks.startScript,
+      stopScript: mocks.stopScript,
+      connectOutput: mocks.connectScriptOutput,
+      disconnectOutput: mocks.disconnectScriptOutput,
+    });
+
+    mocks.useWorkspaceLiveData.mockReturnValue({});
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem("hive-server-url");
+    localStorage.removeItem("hive-tailscale-ip");
+    localStorage.removeItem("hive-tailscale-port");
+    localStorage.removeItem("hive-ssh-user");
+  });
+
+  it("VS Code button is disabled when no SSH host is available", async () => {
+    setupWithWorktreePath({ worktreePath: "/srv/hive/tokyo" });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    // Window.location.hostname in jsdom is "localhost" which is truthy,
+    // but no worktreePath might still cause issues. Let's check with path present.
+    // Actually localhost IS a valid fallback host, so button should be enabled.
+    const btn = screen.getByRole("button", { name: "VS Code" });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("VS Code button disabled when workspace has no worktreePath", async () => {
+    setupWithWorktreePath({ tailscaleIp: "10.0.0.1" });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.getByRole("button", { name: "VS Code" })).toBeDisabled();
+  });
+
+  it("prefers tailscaleIp over serverUrl hostname for SSH host", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      tailscaleIp: "100.64.0.77",
+      serverUrl: "http://backend.internal:3000",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("100.64.0.77"),
+      );
+    });
+    // Should NOT use backend.internal
+    expect(mocks.openExternal).not.toHaveBeenCalledWith(
+      expect.stringContaining("backend.internal"),
+    );
+  });
+
+  it("falls back to serverUrl hostname when tailscaleIp is empty", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      serverUrl: "http://my-server.example.com:4444",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("my-server.example.com"),
+      );
+    });
+  });
+
+  it("extracts hostname from serverUrl without protocol prefix", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      serverUrl: "backend.internal:4444",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("backend.internal"),
+      );
+    });
+  });
+
+  it("prepends sshUser@ to SSH host when SSH user is configured", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      tailscaleIp: "100.64.0.77",
+      sshUser: "devuser",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("devuser%40100.64.0.77"),
+      );
+    });
+  });
+
+  it("does not prepend sshUser when SSH user is empty", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      tailscaleIp: "100.64.0.77",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("ssh-remote+100.64.0.77/"),
+      );
+    });
+  });
+
+  it("encodes spaces in worktreePath segments", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      tailscaleIp: "10.0.0.1",
+      worktreePath: "/Users/me/my workspace",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        expect.stringContaining("my%20workspace"),
+      );
+    });
+  });
+
+  it("builds correct URI with all parts: sshUser, tailscaleIp, worktreePath", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      tailscaleIp: "100.64.0.77",
+      sshUser: "root",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        "vscode://vscode-remote/ssh-remote+root%40100.64.0.77/srv/hive/tokyo",
+      );
+    });
+  });
+
+  it("uses sshUser with serverUrl host when tailscaleIp is empty", async () => {
+    const user = userEvent.setup();
+    setupWithWorktreePath({
+      serverUrl: "http://192.168.1.50:3000",
+      sshUser: "admin",
+      worktreePath: "/data/workspaces/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "VS Code" }));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        "vscode://vscode-remote/ssh-remote+admin%40192.168.1.50/data/workspaces/tokyo",
+      );
+    });
+  });
+});
+
+// ─── Dropdown menu with terminal apps ────────────────────────────────────────
+
+describe("WorkspaceView dropdown terminal interactions", () => {
+  function setupDropdownTest(opts: {
+    terminalApps?: Array<{ id: string; name: string }>;
+    worktreePath?: string;
+    tailscaleIp?: string;
+    sshUser?: string;
+  } = {}) {
+    mocks.useTerminalApps.mockReturnValue(opts.terminalApps ?? []);
+    if (opts.tailscaleIp) localStorage.setItem("hive-tailscale-ip", opts.tailscaleIp);
+    if (opts.sshUser) localStorage.setItem("hive-ssh-user", opts.sshUser);
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace
+          ? { ...workspace, worktreePath: opts.worktreePath ?? undefined }
+          : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      streamingStartedAt: null,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: undefined,
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    mocks.useSessions.mockReturnValue({
+      sessions: [],
+      createSession: mocks.createSession,
+      activateSession: mocks.activateSession,
+      deleteSession: mocks.deleteSession,
+      refresh: mocks.refreshSessions,
+    });
+
+    mocks.useScripts.mockReturnValue({
+      config: null,
+      status: { setup: { state: "idle" }, run: { state: "idle" } },
+      startScript: mocks.startScript,
+      stopScript: mocks.stopScript,
+      connectOutput: mocks.connectScriptOutput,
+      disconnectOutput: mocks.disconnectScriptOutput,
+    });
+
+    mocks.useWorkspaceLiveData.mockReturnValue({});
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.removeItem("hive-server-url");
+    localStorage.removeItem("hive-tailscale-ip");
+    localStorage.removeItem("hive-tailscale-port");
+    localStorage.removeItem("hive-ssh-user");
+  });
+
+  it("shows 'Open in VS Code' as first item in dropdown", async () => {
+    const user = userEvent.setup();
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+      tailscaleIp: "10.0.0.1",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+    expect(await screen.findByText("Open in VS Code")).toBeInTheDocument();
+  });
+
+  it("separates VS Code from terminal apps with a separator", async () => {
+    const user = userEvent.setup();
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+      tailscaleIp: "10.0.0.1",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+    await screen.findByText("Open in VS Code");
+
+    // There should be a separator element in the DOM
+    expect(document.querySelector("[role='separator']")).toBeInTheDocument();
+  });
+
+  it("disables 'Open in VS Code' when vscodeUri is null (no worktreePath)", async () => {
+    const user = userEvent.setup();
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+      tailscaleIp: "10.0.0.1",
+      // no worktreePath
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+
+    const vscodeItem = await screen.findByText("Open in VS Code");
+    // The menu item should be disabled (aria-disabled or data-disabled)
+    expect(vscodeItem.closest("[data-disabled]") ?? vscodeItem.closest("[aria-disabled]")).toBeTruthy();
+  });
+
+  it("disables SSH terminal items when canSsh is false (no worktreePath)", async () => {
+    const user = userEvent.setup();
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+      tailscaleIp: "10.0.0.1",
+      // no worktreePath
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+
+    const terminalItem = await screen.findByText("Terminal (SSH)");
+    expect(terminalItem.closest("[data-disabled]") ?? terminalItem.closest("[aria-disabled]")).toBeTruthy();
+  });
+
+  it("calls openExternal with correct URI from dropdown VS Code item", async () => {
+    const user = userEvent.setup();
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+      tailscaleIp: "10.0.0.1",
+      sshUser: "root",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+    await user.click(await screen.findByText("Open in VS Code"));
+
+    await waitFor(() => {
+      expect(mocks.openExternal).toHaveBeenCalledWith(
+        "vscode://vscode-remote/ssh-remote+root%4010.0.0.1/srv/hive/tokyo",
+      );
+    });
+  });
+
+  it("calls openTerminalSsh with correct args from dropdown terminal item", async () => {
+    const user = userEvent.setup();
+    mocks.openTerminalSsh.mockResolvedValue(undefined);
+    setupDropdownTest({
+      terminalApps: [
+        { id: "terminal_app", name: "Terminal" },
+        { id: "iterm2", name: "iTerm" },
+      ],
+      tailscaleIp: "10.0.0.1",
+      sshUser: "dev",
+      worktreePath: "/srv/hive/tokyo",
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByRole("button", { name: /Code/i }));
+    await user.click(await screen.findByText("iTerm (SSH)"));
+
+    await waitFor(() => {
+      expect(mocks.openTerminalSsh).toHaveBeenCalledWith(
+        "iterm2",
+        "dev@10.0.0.1",
+        "/srv/hive/tokyo",
+      );
+    });
+  });
+
+  it("renders dropdown button label as 'Code' with chevron when terminal apps exist", async () => {
+    setupDropdownTest({
+      terminalApps: [{ id: "terminal_app", name: "Terminal" }],
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    const trigger = screen.getByRole("button", { name: /Code/i });
+    expect(trigger).toBeInTheDocument();
+    expect(trigger.textContent).toContain("Code");
+  });
+
+  it("renders simple 'VS Code' button when no terminal apps detected", async () => {
+    setupDropdownTest({ terminalApps: [] });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.getByRole("button", { name: "VS Code" })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/tauri/Capabilities.test.ts
+++ b/frontend/tests/tauri/Capabilities.test.ts
@@ -3,14 +3,22 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 describe("Tauri default capability", () => {
-  it("allows VS Code URI schemes for opener plugin", async () => {
+  let capability: {
+    permissions: Array<string | { identifier: string; allow?: Array<{ url?: string }> }>;
+  };
+
+  // Load the capability file once
+  async function loadCapability() {
+    if (capability) return;
     const capabilityRaw = await readFile(
       join(process.cwd(), "src-tauri", "capabilities", "default.json"),
       "utf-8",
     );
-    const capability = JSON.parse(capabilityRaw) as {
-      permissions: Array<string | { identifier: string; allow?: Array<{ url?: string }> }>;
-    };
+    capability = JSON.parse(capabilityRaw);
+  }
+
+  it("allows VS Code URI schemes for opener plugin", async () => {
+    await loadCapability();
 
     const openerAllowRule = capability.permissions.find(
       (permission): permission is { identifier: string; allow: Array<{ url?: string }> } =>
@@ -24,5 +32,46 @@ describe("Tauri default capability", () => {
         expect.objectContaining({ url: "vscode-insiders:*" }),
       ]),
     );
+  });
+
+  it("allows exactly two VS Code URL patterns (no extras)", async () => {
+    await loadCapability();
+
+    const openerAllowRule = capability.permissions.find(
+      (permission): permission is { identifier: string; allow: Array<{ url?: string }> } =>
+        typeof permission === "object" && permission.identifier === "opener:allow-open-url",
+    );
+
+    expect(openerAllowRule?.allow).toHaveLength(2);
+  });
+
+  it("includes core:default and opener:default permissions", async () => {
+    await loadCapability();
+
+    const stringPermissions = capability.permissions.filter((p) => typeof p === "string");
+    expect(stringPermissions).toContain("core:default");
+    expect(stringPermissions).toContain("opener:default");
+  });
+
+  it("includes core:window drag permissions", async () => {
+    await loadCapability();
+
+    const stringPermissions = capability.permissions.filter((p) => typeof p === "string");
+    expect(stringPermissions).toContain("core:window:allow-start-dragging");
+    expect(stringPermissions).toContain("core:window:allow-start-resize-dragging");
+  });
+
+  it("opener:allow-open-url uses wildcard patterns for VS Code schemes", async () => {
+    await loadCapability();
+
+    const openerAllowRule = capability.permissions.find(
+      (permission): permission is { identifier: string; allow: Array<{ url?: string }> } =>
+        typeof permission === "object" && permission.identifier === "opener:allow-open-url",
+    );
+
+    // Both patterns should use wildcard to allow any VS Code URI path
+    for (const entry of openerAllowRule?.allow ?? []) {
+      expect(entry.url).toMatch(/^vscode(-insiders)?:\*$/);
+    }
   });
 });

--- a/frontend/tests/tauri/Capabilities.test.ts
+++ b/frontend/tests/tauri/Capabilities.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+describe("Tauri default capability", () => {
+  it("allows VS Code URI schemes for opener plugin", async () => {
+    const capabilityRaw = await readFile(
+      join(process.cwd(), "src-tauri", "capabilities", "default.json"),
+      "utf-8",
+    );
+    const capability = JSON.parse(capabilityRaw) as {
+      permissions: Array<string | { identifier: string; allow?: Array<{ url?: string }> }>;
+    };
+
+    const openerAllowRule = capability.permissions.find(
+      (permission): permission is { identifier: string; allow: Array<{ url?: string }> } =>
+        typeof permission === "object" && permission.identifier === "opener:allow-open-url",
+    );
+
+    expect(openerAllowRule).toBeDefined();
+    expect(openerAllowRule?.allow).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ url: "vscode:*" }),
+        expect.objectContaining({ url: "vscode-insiders:*" }),
+      ]),
+    );
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -268,6 +268,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -900,6 +901,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -940,6 +942,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2290,6 +2293,7 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -6015,8 +6019,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6398,6 +6401,7 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -6424,6 +6428,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -6434,6 +6439,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -6520,6 +6526,7 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -6924,6 +6931,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7265,6 +7273,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -7874,6 +7883,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -8283,6 +8293,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8590,8 +8601,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.3.1",
@@ -8864,6 +8874,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -10145,6 +10156,7 @@
       "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -10665,6 +10677,7 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -11294,7 +11307,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -11732,6 +11744,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -12368,7 +12381,8 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -13215,7 +13229,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -13231,7 +13244,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -13530,6 +13542,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13539,6 +13552,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -13551,8 +13565,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -15183,6 +15196,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15256,6 +15270,7 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -15585,6 +15600,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -16128,6 +16144,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary
- add VS Code Remote SSH open flow from workspace header
- expose backend worktree path and SSH user config needed to build remote URI
- harden URL opening behavior for browser/Tauri environments
- add non-regression coverage across backend/frontend for the new flow

## Testing
- npm test
- npm run typecheck --workspace @hive/backend
- npm run typecheck --workspace @hive/frontend
- npm run lint --workspace @hive/frontend
