### PR TITLE
Fix devDependencies not installing in worktree environments

### DIFF
--- a/hive.json
+++ b/hive.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "setup": "npm install",
+    "setup": "NODE_ENV=development npm install",
     "run": "cd backend && PORT=3000 DATA_DIR=~/.hive-dev npm run dev"
   }
 }


### PR DESCRIPTION
Worktrees run with NODE_ENV=production, causing npm to skip devDependencies (tsx, vitest, etc). Force development mode in setup.