### PR TITLE
Fix crypto.randomUUID crash on non-secure contexts

### DIFF
--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -155,7 +155,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
     case "done": {
       const assistantMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
         sessionId: action.sessionId,
         role: "assistant",
         content: state.currentText,
@@ -184,7 +184,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         return state;
       }
       const cancelledMsg: ChatMessage = {
-        id: crypto.randomUUID(),
+        id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
         sessionId: action.sessionId,
         role: "assistant",
         content: hasOutput ? state.currentText : CANCELLED_NO_OUTPUT_MESSAGE,


### PR DESCRIPTION
## Summary
- Fix `crypto.randomUUID is not a function` crash when accessing the frontend via non-localhost HTTP (e.g. Tailscale IP), which is a non-secure browser context
- Falls back to `Math.random().toString(36)` for generating UI message IDs when the Web Crypto API is unavailable

## Test plan
- [ ] Access frontend via Tailscale IP over HTTP
- [ ] Send a message and verify no `crypto.randomUUID` errors in console
- [ ] Verify messages still get unique IDs and conversation works normally