### PR TITLE
Fix conversation scroll glitch on session switch

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -63,6 +63,34 @@ export default function ChatConversation({
     return () => clearInterval(id);
   }, [isStreaming, streamingStartedAt]);
 
+  // Hide the conversation during REST hydration so the user never sees content
+  // flash at the top before StickToBottom repositions the scroll. The sequence:
+  // 1. Messages arrive → render invisible with resize="instant"
+  // 2. StickToBottom's ResizeObserver fires → instant scroll to bottom
+  // 3. Double-rAF ensures scroll is settled → reveal content at correct position
+  const wasEmptyRef = useRef(true);
+  const [hydrated, setHydrated] = useState(false);
+  const isInitialLoad = wasEmptyRef.current && messages.length > 0;
+  const isHydrating = isInitialLoad && !hydrated;
+
+  useEffect(() => {
+    wasEmptyRef.current = messages.length === 0;
+    if (messages.length === 0) setHydrated(false);
+  }, [messages.length]);
+
+  useEffect(() => {
+    if (isInitialLoad) {
+      let raf2: number;
+      const raf1 = requestAnimationFrame(() => {
+        raf2 = requestAnimationFrame(() => setHydrated(true));
+      });
+      return () => {
+        cancelAnimationFrame(raf1);
+        cancelAnimationFrame(raf2);
+      };
+    }
+  }, [isInitialLoad]);
+
   const hasContent = messages.length > 0 || isStreaming;
 
   // A message is interactive if it contains tool calls that match pending tool inputs.
@@ -96,7 +124,7 @@ export default function ChatConversation({
   };
 
   return (
-    <Conversation className="flex-1">
+    <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={isHydrating ? "instant" : "smooth"}>
       <ConversationContent className="gap-4 px-8 py-4">
         {!hasContent &&
           (workspaceName && projectName && branch && defaultBranch ? (

--- a/frontend/src/components/ai-elements/conversation.tsx
+++ b/frontend/src/components/ai-elements/conversation.tsx
@@ -13,7 +13,7 @@ export type ConversationProps = ComponentProps<typeof StickToBottom>;
 export const Conversation = ({ className, ...props }: ConversationProps) => (
   <StickToBottom
     className={cn("relative flex-1 overflow-y-hidden", className)}
-    initial="smooth"
+    initial="instant"
     resize="smooth"
     role="log"
     {...props}


### PR DESCRIPTION
## Summary
- Changed `StickToBottom` initial scroll behavior from `"smooth"` to `"instant"` so users land at the bottom of a conversation immediately without a visible top-to-bottom scroll animation.

## Test plan
- [ ] Open a conversation with existing messages — should render at the bottom instantly
- [ ] Switch between sessions — no visible scroll glitch
- [ ] Verify the "scroll to bottom" button still works with smooth animation when clicked
- [ ] Verify resize behavior remains smooth