### PR TITLE
Remove unused fetchDiffStats REST method from iOS APIClient

### DIFF
--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -169,8 +169,4 @@ final class APIClient {
     func archiveWorkspace(workspaceId: String) async throws {
         try await requestVoid("POST", path: "/api/workspaces/\(workspaceId)/archive")
     }
-
-    func fetchDiffStats(workspaceId: String) async throws -> DiffStatResponse {
-        try await get(path: "/api/workspaces/\(workspaceId)/diff-stat")
-    }
 }


### PR DESCRIPTION
Diff stats are received exclusively via WebSocket; this endpoint was never called and had an incorrect path (diff-stat vs diff/stat).