### PR TITLE
Fix rate_limit_event log to match actual CLI payload

### DIFF
--- a/backend/src/agents/stream-parser.test.ts
+++ b/backend/src/agents/stream-parser.test.ts
@@ -208,12 +208,16 @@ describe("StreamParser", () => {
 
     parser.write(JSON.stringify({
       type: "rate_limit_event",
-      rate_limit: {
+      rate_limit_info: {
         status: "allowed",
-        five_hour: { utilization: 0.018, status: "allowed", reset: 1764554400 },
-        seven_day: { utilization: 0.737, status: "allowed", reset: 1764615600 },
-        representative_claim: "five_hour",
+        resetsAt: 1771642800,
+        rateLimitType: "five_hour",
+        overageStatus: "rejected",
+        overageDisabledReason: "org_level_disabled_until",
+        isUsingOverage: false,
       },
+      uuid: "5ceca816-9afd-4d1a-a57f-7bc7e117ca0e",
+      session_id: "test-session",
     }) + "\n");
 
     expect(errors).toHaveLength(0);

--- a/backend/src/agents/stream-parser.ts
+++ b/backend/src/agents/stream-parser.ts
@@ -57,18 +57,23 @@ export class StreamParser extends EventEmitter<StreamParserEvent> {
 
     // Handle CLI-internal events before narrowing to CliJsonLine
     if (raw.type === "rate_limit_event") {
-      const rl = raw.rate_limit as Record<string, unknown> | undefined;
-      if (rl) {
-        const fiveH = rl.five_hour as { utilization?: number; status?: string } | undefined;
-        const sevenD = rl.seven_day as { utilization?: number; status?: string } | undefined;
+      const info = raw.rate_limit_info as {
+        status?: string;
+        rateLimitType?: string;
+        resetsAt?: number;
+        overageStatus?: string;
+        isUsingOverage?: boolean;
+      } | undefined;
+      if (info) {
+        const resetsIn = info.resetsAt
+          ? `${Math.max(0, Math.round((info.resetsAt * 1000 - Date.now()) / 60_000))}min`
+          : "?";
         console.log(
-          "[rate-limit] status=%s representative=%s 5h=%s%% (%s) 7d=%s%% (%s)",
-          rl.status ?? "unknown",
-          rl.representative_claim ?? "?",
-          fiveH?.utilization != null ? (fiveH.utilization * 100).toFixed(1) : "?",
-          fiveH?.status ?? "?",
-          sevenD?.utilization != null ? (sevenD.utilization * 100).toFixed(1) : "?",
-          sevenD?.status ?? "?",
+          "[rate-limit] status=%s window=%s resets_in=%s overage=%s",
+          info.status ?? "unknown",
+          info.rateLimitType ?? "?",
+          resetsIn,
+          info.overageStatus ?? "?",
         );
       } else {
         console.log("[rate-limit]", JSON.stringify(raw));


### PR DESCRIPTION
The real payload uses rate_limit_info (not rate_limit) with fields: status, rateLimitType, resetsAt, overageStatus.