### PR TITLE
Add dev banner + update docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This repository is a monorepo:
 - `frontend/`: React + Vite UI + Tauri desktop app (`frontend/src-tauri/`)
 - `ios/`: SwiftUI iOS app + Live Activity widget
 
-Hive runs Claude conversations in isolated Git workspaces (worktrees) created from a project's bare repo.
+Hive runs AI agent conversations (Claude, Codex) in isolated Git workspaces (worktrees) created from a project's bare repo.
 
 ## Commands
 
@@ -48,7 +48,7 @@ Project -> Workspace -> Session
 
 - **Project**: bare-cloned Git repo (`git clone --bare`)
 - **Workspace**: Git worktree + branch (`workspace/<city-name>`)
-- **Session**: persisted Claude conversation for one workspace
+- **Session**: persisted agent conversation for one workspace
 
 One session is active per workspace, but multiple sessions can coexist and be switched/loaded from disk.
 
@@ -56,69 +56,86 @@ One session is active per workspace, but multiple sessions can coexist and be sw
 
 - `backend/src/index.ts`: app wiring, auth/rate-limit hooks, route registration, git sync + notifier bootstrap, preflight checks
 - `backend/src/api/projects.ts`: project CRUD + fetch
-- `backend/src/api/workspaces.ts`: workspace CRUD + diff/stat + files/file + merge + archive
+- `backend/src/api/workspaces.ts`: workspace CRUD + diff/stat + files/file + merge + archive + PR status endpoint
 - `backend/src/api/agents.ts`: session routes (single + multi-session)
 - `backend/src/api/completions.ts`: completion scanning endpoint
+- `backend/src/api/models.ts`: model catalog endpoint (`GET /api/models`)
 - `backend/src/api/settings.ts`: notification config CRUD + test message
 - `backend/src/api/account.ts`: GitHub OAuth device flow + `gh` CLI integration
 - `backend/src/api/scripts.ts`: workspace setup/run script lifecycle (start/stop/status)
-- `backend/src/ws/stream.ts`: conversation WebSocket protocol
-- `backend/src/ws/terminal.ts`: PTY terminal WebSocket
+- `backend/src/ws/stream.ts`: conversation WebSocket protocol (deferred bootstrap via `setImmediate`)
 - `backend/src/ws/script.ts`: script execution WebSocket (PTY output streaming)
-- `backend/src/services/git-sync.ts`: branch/PR/diff polling and workspace broadcasts
+- `backend/src/services/git-sync.ts`: branch/diff polling and workspace broadcasts (PR status moved to REST)
 - `backend/src/services/script-runner.ts`: PTY-based script execution with status broadcasting
-- `backend/src/agents/conversation-session.ts`: Claude process lifecycle per turn
+- `backend/src/agents/conversation-session.ts`: agent process lifecycle per turn (provider-aware)
 - `backend/src/agents/stream-parser.ts`: NDJSON parser for Claude CLI `--output-format stream-json --verbose`
 - `backend/src/agents/agent-manager.ts`: in-memory session registry, persistence, switching, notification dispatch
 - `backend/src/agents/naming.ts`: branch + session auto-naming via dedicated Claude subprocess
+- `backend/src/agents/providers/types.ts`: `AgentProvider` interface, `ProviderCapabilities`, `ModelDefinition`, `StreamAdapter`
+- `backend/src/agents/providers/registry.ts`: CLI detection, model ID resolution (`"claude:opus-4-6"`), model catalog builder
+- `backend/src/agents/providers/claude.ts`: Claude provider (CLI args, env, thinking tokens)
+- `backend/src/agents/providers/codex.ts`: Codex provider (`codex exec` CLI args, thread resume)
+- `backend/src/agents/providers/codex-stream-adapter.ts`: Codex JSONL→StreamParserEvent normalizer
 - `backend/src/notifications/notifier.ts`: event dispatcher for notification channels
 - `backend/src/notifications/telegram.ts`: Telegram bot API channel
 - `backend/src/state/state.ts`: JSON persistence + per-project locks
 - `backend/src/state/config.ts`: file-based app config (`$DATA_DIR/config.json`)
-- `backend/src/utils/preflight.ts`: startup dependency checks (git >= 2.17, claude, gh)
+- `backend/src/utils/preflight.ts`: startup dependency checks (git >= 2.17, claude, gh; codex optional)
+- `backend/src/utils/github.ts`: GitHub URL parsing, `gh` CLI wrapper, PR status fetching (reviews, checks, merge state)
 - `backend/src/utils/hive-config.ts`: `hive.json` parser for workspace scripts
 - `backend/ecosystem.config.cjs`: pm2 ecosystem config (production + development environments)
 
 ### Important backend behavior
 
-- Conversation turns use Claude CLI streaming mode (`--print --output-format stream-json -p`).
-- Session continuity uses Claude `--session-id` and `--resume`.
-- Blocking tools (`AskUserQuestion`, `ExitPlanMode`) are intercepted and surfaced as `tool_input_required`.
+- Conversation turns use the provider abstraction: `conversation-session.ts` resolves the provider from compound model IDs (e.g. `"claude:opus-4-6"`, `"codex:o3-pro"`) via `resolveProvider()` and delegates CLI arg building, env config, and stream parsing to the matched provider.
+- Claude provider uses `--print --output-format stream-json -p`. Codex provider uses `codex exec --json`.
+- Session continuity: Claude uses `--session-id` and `--resume`; Codex uses `--thread-id`.
+- Provider is locked per session after the first message (`lockedProvider`). Subsequent messages validate against it. The lock is broadcast via WS status events.
+- Pre-multi-model sessions (created before provider support) default to `"claude"` when they have messages but no `lockedProvider`.
+- Blocking tools (`AskUserQuestion`, `ExitPlanMode`) are intercepted and surfaced as `tool_input_required`. Only providers with `blockingTools` capability support this.
 - Session tool responses are session-scoped; dismiss/approve/reject are routed back to the correct session.
 - `getOrCreateSession()` recovers stale `busy` workspaces lazily (on access).
 - On first message, a lightweight Claude subprocess generates a branch name and session title (`naming.ts`), then renames the branch via `git branch -m`.
 - Workspace merge is executed in a temporary worktree on default branch, then default-branch ref is updated.
 - `archiveWorkspace()` removes worktree and moves matching session folders under `archive/<ws-id>/sessions`.
-- Git sync pushes cached `branch_info` + `diff_stats` snapshots to new WS clients.
-- Preflight checks run at startup and exit with clear errors if git/claude/gh are missing.
+- Git sync pushes cached `branch_info` + `diff_stats` snapshots to new WS clients. PR status is no longer polled here — moved to on-demand `GET /api/workspaces/:wsId/pr-status` with 15s TTL cache.
+- WS bootstrap messages (status, history, branch_info, diff_stats, script_status) are deferred via `setImmediate` so client listeners attach before the initial burst.
+- Preflight checks run at startup and exit with clear errors if git/claude/gh are missing. Codex is optional.
 - Notification config is persisted in `$DATA_DIR/config.json` and hot-reloaded when settings change (no restart needed).
 - Script runner spawns PTY processes for `hive.json` setup/run commands, buffers last 200 lines, and broadcasts status via the workspace WS channel.
-- Stream parser silences `rate_limit_event` CLI events (logged server-side, not forwarded to clients).
+- Stream parser silences `rate_limit_event` CLI events (logged server-side with structured rate_limit_info diagnostics, not forwarded to clients).
 - Server-side tool blocks (`server_tool_use`, `web_search_tool_result`, `web_fetch_tool_result`, `bash_code_execution_tool_result`, `text_editor_code_execution_tool_result`) are mapped to standard `tool_use`/`tool_result` WS events with display-name normalization (`web_search`→`WebSearch`, `web_fetch`→`WebFetch`, `bash_code_execution`→`Bash`, `text_editor_code_execution`→`Edit`).
 - MCP tool blocks (`mcp_tool_use`, `mcp_tool_result`) and `redacted_thinking` are also handled.
-- Image attachments are resized via sharp and stored as files on disk, served via HTTP (`/api/workspaces/:wsId/sessions/:sessionId/attachments/:filename`).
+- Image attachments are resized via sharp (max 1568px, JPEG q80) and stored as files on disk, served via HTTP (`/api/workspaces/:wsId/sessions/:sessionId/attachments/:filename`).
+- PR status endpoint returns enriched data: review state (approved/changes_requested/review_required), checks counts (passed/total), mergeable state (13-state priority ladder), and supports closed/merged/draft PRs via `--state all`.
 
 ## Frontend Architecture
 
 - `frontend/src/App.tsx`: routing and global workspace WS syncing
-- `frontend/src/pages/WorkspaceView.tsx`: chat + terminal + file tree + scripts + modified files + diff modal
+- `frontend/src/pages/WorkspaceView.tsx`: chat + file tree + scripts + modified files + diff modal + PR status
 - `frontend/src/pages/settings/AppearanceSettings.tsx`: accent color picker
 - `frontend/src/pages/settings/ConnectionSettings.tsx`: Tailscale IP/port + health check
 - `frontend/src/pages/settings/AccountSettings.tsx`: GitHub OAuth device flow + profile display
-- `frontend/src/pages/settings/NotificationSettings.tsx`: Telegram enable/disable + test message
+- `frontend/src/pages/settings/NotificationSettings.tsx`: Telegram enable/disable + test message (wrapper + TelegramForm split for race-free init)
 - `frontend/src/pages/settings/ProjectDetail.tsx`: per-repo info + deletion controls
-- `frontend/src/hooks/useConversation.ts`: reducer-driven WS conversation state + tool responses
+- `frontend/src/hooks/useConversation.ts`: reducer-driven WS conversation state + tool responses + `lockedProvider` tracking
 - `frontend/src/hooks/useSessions.ts`: list/create/activate/delete sessions
-- `frontend/src/hooks/useWorkspaceLiveData.ts`: live status/branch/diff/script data from WS
+- `frontend/src/hooks/useWorkspaceLiveData.ts`: live status/branch/diff/script data from WS (PR status removed, now via REST)
+- `frontend/src/hooks/useModels.ts`: model catalog fetch, selection, provider-aware locking
+- `frontend/src/hooks/usePrStatus.ts`: TanStack Query polling for `GET /api/workspaces/:wsId/pr-status` (15s interval)
 - `frontend/src/hooks/useScripts.ts`: script start/stop/status
 - `frontend/src/hooks/useConnectionStatus.ts`: backend health check
 - `frontend/src/hooks/useTailscaleConfig.ts`: Tailscale connection config
 - `frontend/src/hooks/useServerUrl.ts`: configurable backend URL resolution
 - `frontend/src/hooks/useAccentColor.ts`: theme accent color persistence
 - `frontend/src/hooks/useCompletions.ts`: autocomplete scanning
+- `frontend/src/hooks/useChatInputDraftPersistence.ts`: draft persistence (message, images, thinking, planMode, selectedModelId, thinkingLevel)
 - `frontend/src/lib/ws-transport.ts`: reconnecting WS transport + replay buffer
 - `frontend/src/components/Sidebar.tsx`: project/workspace nav + archive/delete + activity preview
-- `frontend/src/components/Terminal.tsx`: xterm + `/ws/terminal/:wsId`
+- `frontend/src/components/ChatInput.tsx`: message input with provider-adaptive controls (thinking toggle/levels, plan mode gating, completions gating)
+- `frontend/src/components/ChatConversation.tsx`: conversation display with hydration flash fix (visibility:hidden + double-rAF settle)
+- `frontend/src/components/PrStatusSection.tsx`: enriched PR display (13 states: merged, closed, draft, conflicts, blocked, checks, reviews)
+- `frontend/src/components/chat/ModelSelector.tsx`: model picker grouped by provider with icons, badges, and provider lock
 - `frontend/src/components/chat/PlanProposal.tsx`: plan mode proposal card with accept/handoff/copy
 - `frontend/src/lib/terminal.ts`: SSH command builder + terminal app detection (Tauri)
 - `frontend/src/lib/open-external.ts`: VS Code remote SSH URI builder + external app launcher
@@ -127,39 +144,44 @@ One session is active per workspace, but multiple sessions can coexist and be sw
 
 ### Important frontend behavior
 
-- The frontend supports a configurable server URL (Settings > Connection) for remote backend connectivity. All API calls (`useApi.ts`) and WebSockets (`ws-transport.ts`, `Terminal.tsx`) resolve the base URL via `getServerUrl()` from `useServerUrl.ts`.
+- The frontend supports a configurable server URL (Settings > Connection) for remote backend connectivity. All API calls (`useApi.ts`) and WebSockets (`ws-transport.ts`) resolve the base URL via `getServerUrl()` from `useServerUrl.ts`.
 - The app keeps WS channels synced for all known workspace IDs (`wsTransport.syncWorkspaces`).
-- `useConversation` hydrates from REST history and resolves stale replay races with request tokens.
-- Terminal instances are tracked in context; hidden terminals stay alive until explicitly closed.
+- `useConversation` hydrates from REST history and resolves stale replay races with request tokens. It also tracks `lockedProvider` from WS status events.
 - Session tabs support create/switch/delete with live message replay and per-session streaming indicators.
-- Chat input supports image attachments (paste/drag-drop/picker), thinking toggle, plan mode, and `/` + `@` autocomplete.
+- Chat input dynamically adapts controls based on the selected provider's capabilities: thinking toggle for Claude, thinking level cycling (Low/Med/High/xHigh) for Codex, plan mode hidden when unsupported, `/` and `@` autocomplete gated by `completions` capability.
+- Chat input supports image attachments (paste/drag-drop/picker).
 - Plan proposals render as rich markdown cards with accept, hand-off-to-new-session, and copy actions.
 - Workspace sidebar shows script panel with live PTY output when `hive.json` defines setup/run commands.
 - Connection health is checked via `useConnectionStatus`; the "Add Repository" button is gated until a valid connection is configured.
 - File viewer uses Shiki syntax highlighting with github-dark theme and line numbers.
 - VS Code remote SSH: workspace can be opened in VS Code via `vscode://vscode-remote/ssh-remote+` URIs (Tauri desktop only).
+- Chat conversation hides content during initial REST hydration (visibility:hidden + `resize="instant"`) and reveals after scroll position settles via double-rAF, preventing a visible flash-from-top.
+- PR status is fetched via REST polling (`usePrStatus`, 15s interval) instead of WS push. Displays enriched state: review status, check counts, merge conflicts, draft, closed/merged.
+- Draft persistence saves `selectedModelId` and `thinkingLevel` alongside message text, images, and toggles.
 
 ## iOS App (`ios/`)
 
 - `HiveMobile/HiveApp.swift`: app entry point
-- `HiveMobile/Models/Models.swift`: data models (ChatMessage, ToolCall, Workspace, etc.)
+- `HiveMobile/Models/Models.swift`: data models (ChatMessage, ToolCall, Workspace, ModelCatalogEntry, etc.)
 - `HiveMobile/Models/WebSocketTypes.swift`: WS protocol types (mirrors `backend/src/types.ts`)
 - `HiveMobile/Models/StreamingAttributes.swift`: Live Activity attributes
-- `HiveMobile/Services/APIClient.swift`: REST API client
+- `HiveMobile/Services/APIClient.swift`: REST API client (includes `/api/models` and `/api/workspaces/:wsId/pr-status`)
 - `HiveMobile/Services/WebSocketManager.swift`: WS connection handler
 - `HiveMobile/Services/LiveActivityManager.swift`: iOS 16+ Live Activity (streaming indicator on lock screen)
 - `HiveMobile/Services/ImageCache.swift`: image caching
-- `HiveMobile/Stores/ConversationStore.swift`: chat state (mirrors `useConversation.ts`)
-- `HiveMobile/Stores/ChatDraftStore.swift`: draft message persistence
+- `HiveMobile/Stores/ConversationStore.swift`: chat state (mirrors `useConversation.ts`) + `lockedProvider` tracking
+- `HiveMobile/Stores/ChatDraftStore.swift`: draft message persistence (includes `selectedModelId`, `thinkingLevel`)
 - `HiveMobile/Stores/ProjectStore.swift`: project list state
-- `HiveMobile/Stores/HubStatusMonitor.swift`: connectivity monitoring
-- `HiveMobile/Views/Chat/ChatView.swift`: conversation UI
+- `HiveMobile/Stores/ModelCatalog.swift`: dynamic model catalog from API, grouped by provider
+- `HiveMobile/Stores/HubStatusMonitor.swift`: per-workspace WS monitoring + PR status REST polling (15s)
+- `HiveMobile/Views/Chat/ChatView.swift`: conversation UI + provider locking + model selection
+- `HiveMobile/Views/Chat/ChatInputBar.swift`: input bar with provider-adaptive controls (thinking toggle vs level picker)
 - `HiveMobile/Views/Chat/MessageBubble.swift`: message + tool call rendering
 - `HiveMobile/Views/Chat/ToolInputSheet.swift`: AskUserQuestion + ExitPlanMode interactive sheets
 - `HiveMobile/Views/Chat/SessionSheet.swift`: session switching
 - `HiveMobile/Views/Hub/HubView.swift`: project/workspace navigation
 - `HiveMobile/Views/Hub/AddProjectSheet.swift`: new project creation
-- `HiveMobile/Views/Hub/WorkspaceCard.swift`: workspace cards with activity preview
+- `HiveMobile/Views/Hub/WorkspaceCard.swift`: workspace cards with activity preview + enriched PR status display
 - `HiveMobile/Theme/DesignTokens.swift`: design tokens (WhisperColor, WhisperFont)
 - `HiveWidget/`: iOS Live Activity widget (streaming status on lock screen)
 
@@ -170,8 +192,13 @@ One session is active per workspace, but multiple sessions can coexist and be sw
 - Tool rendering mirrors the frontend: same tool names, same icon mapping, same hierarchical display (parentToolUseId).
 - AskUserQuestion renders as a paginated form sheet with multi-select support.
 - ExitPlanMode renders as a markdown preview with approve/reject actions.
-- Chat drafts are persisted per-workspace and restored on app relaunch.
+- Chat drafts are persisted per-workspace and restored on app relaunch (includes `selectedModelId`, `thinkingLevel`).
 - Live Activity shows streaming status on lock screen when a turn is in progress.
+- Model catalog is fetched dynamically from `/api/models`. Picker groups by provider, disables cross-provider items when session is locked.
+- Codex models show thinking level cycling (Low/Med/High/xHigh) instead of boolean toggle. Plan mode hidden for providers that don't support it.
+- `lockedProvider` is read from WS status events (not REST) for instant model locking after first message.
+- Pre-multi-model sessions default to `"claude"` when they have messages but no `lockedProvider`.
+- PR status is polled via REST (15s) with enriched display (reviews, checks, merge state) matching the frontend.
 
 ## Coding Rules
 
@@ -179,6 +206,7 @@ One session is active per workspace, but multiple sessions can coexist and be sw
 - Use English for code/comments/UI copy.
 - Keep backend routes testable by preserving optional `dataDir` injection.
 - Keep state mutations serialized via workspace/project lock helpers.
+- **Before completing any task, run tests (`npm test`) and typecheck (`npm run typecheck`) from the repo root to catch regressions. Do not consider a task done until both pass.**
 
 ## Critical Guardrails
 
@@ -194,12 +222,16 @@ One session is active per workspace, but multiple sessions can coexist and be sw
   - iOS stores (`ConversationStore`, `WebSocketManager`),
   - corresponding tests.
 - When Claude CLI adds new content block types, update `ContentBlock` in `backend/src/types.ts` and the switch in `conversation-session.ts`.
+- When adding a new provider, implement `AgentProvider` from `providers/types.ts`, register it in `providers/registry.ts`, and add a stream adapter if the CLI output format differs from Claude's.
+- Keep provider capabilities (`ProviderCapabilities`) in sync across backend types, frontend types, and iOS models.
 
 ## Testing
 
 - Backend tests live next to source (`backend/src/**/*.test.ts`).
 - Frontend tests live in `frontend/tests/**`.
 - Use `SessionOptions.command = "bash"` in backend tests to avoid local Claude CLI dependency.
+- WS tests use Fastify's `injectWS()` (not raw `new WebSocket()`) for deterministic message ordering.
+- CI sets `NODE_ENV=test` explicitly to ensure React 19 exports `act()` in its development bundle.
 
 ## Tauri Desktop App
 
@@ -220,7 +252,8 @@ One session is active per workspace, but multiple sessions can coexist and be sw
 - Completion scanner does not yet include plugin commands (`~/.claude/plugins`).
 - No manual workspace rename/alias UI (auto-naming exists via `naming.ts`).
 - No explicit light/dark theme toggle in settings (only accent color picker).
-- iOS app has no terminal emulator (chat-only, no PTY access).
 - iOS app has no file viewer/diff viewer (tool output shown as raw text).
 - VS Code remote SSH opening is Tauri-desktop only (not available in web or iOS).
 - `redacted_thinking` blocks are logged as `[redacted]` but not visually distinguished from regular thinking in the UI.
+- Codex provider integration is functional but less battle-tested than Claude. Stream adapter edge cases may surface.
+- No Codex session resume verification (thread ID persistence is best-effort).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Hive
 
-Hive is an orchestrator for running multiple Claude Code conversations in parallel across isolated Git workspaces. It can run locally or as a remote backend with a Tauri desktop client connected over Tailscale.
+Hive is an orchestrator for running multiple AI agent conversations (Claude, Codex) in parallel across isolated Git workspaces. It can run locally or as a remote backend with a Tauri desktop client connected over Tailscale.
 
 It manages:
 - projects as bare repositories,
 - workspaces as Git worktrees/branches,
-- sessions as persistent Claude conversations with WebSocket streaming.
+- sessions as persistent agent conversations with WebSocket streaming.
 
 ## Current Capabilities
 
@@ -15,13 +15,23 @@ It manages:
 - Multi-session support per workspace (create, list, activate, delete, switch, replay history).
 - Conversation WebSocket with session focus, history replay, buffered event replay, and per-session streaming status.
 - Interactive Claude tool loop for `AskUserQuestion` and `ExitPlanMode` with plan proposal cards.
-- Image attachments persisted per session (paste, drag-drop, file picker).
-- Per-workspace PTY terminal (`/ws/terminal/:wsId`) with resize and binary I/O.
+- Image attachments resized via sharp (max 1568px, JPEG q80) and persisted per session.
+- SSH terminal access via external terminal apps (replaces previous in-app terminal).
 - File tree + file content viewer with Shiki syntax highlighting.
 - Unified diff + committed/uncommitted/untracked diff stats.
 
+**Multi-provider support**
+- Provider abstraction layer: `AgentProvider` interface with CLI arg building, env config, and stream adapters.
+- Claude provider (streaming JSON) and Codex provider (JSONL with stream adapter normalization).
+- Model catalog API (`GET /api/models`) for frontend/iOS model discovery, grouped by provider.
+- Model selector UI with provider icons, default badges, and NEW indicators.
+- Provider locked per session after first message — prevents mid-conversation provider switches.
+- Provider-aware controls: thinking toggle (Claude) vs thinking level cycling (Codex), plan mode gating, completions gating.
+
 **Live sync**
-- Real-time branch name, PR status, and diff-stat snapshots via background git polling over WebSocket.
+- Real-time branch name and diff-stat snapshots via background git polling over WebSocket.
+- PR status via on-demand REST endpoint (`GET /api/workspaces/:wsId/pr-status`) with 15s TTL cache, reducing GitHub API rate limit consumption.
+- Enriched PR display: review state (approved/changes_requested), checks counts (passed/total), mergeable state (13-state priority ladder including draft, closed, blocked, unstable).
 - Script execution status broadcasting (`script_status` WS messages).
 
 **Automation**
@@ -31,7 +41,7 @@ It manages:
 **Integrations**
 - GitHub OAuth device flow for `gh` CLI authentication and git credential setup.
 - Telegram notifications on agent turn completion (UI-configurable bot token + chat ID).
-- Preflight dependency checks on startup (git, claude, gh).
+- Preflight dependency checks on startup (git, claude, gh required; codex optional).
 
 **Settings**
 - Tailscale connection config (IP + port) with health check indicator.
@@ -44,6 +54,11 @@ It manages:
 - Tauri v2 desktop app (macOS `.dmg`, Windows `.exe`) with native titlebar integration.
 - macOS traffic light positioning, drag regions, and App Transport Security exceptions for Tailscale HTTP.
 
+**iOS**
+- Native SwiftUI app with chat, model selection, session switching, and Live Activity.
+- Dynamic model catalog from API with provider-grouped picker and session locking.
+- PR status polling with enriched display matching the web frontend.
+
 **Security**
 - Optional auth token + in-memory request rate limiting.
 - File content API with path traversal protection and 1 MB size cap.
@@ -54,6 +69,7 @@ It manages:
 - Git >= 2.20
 - Claude CLI installed and authenticated (`claude` command)
 - Optional: GitHub CLI (`gh`) for PR status in the UI
+- Optional: Codex CLI (`codex`) for OpenAI model support
 - Optional (desktop app): Rust >= 1.77 for Tauri builds
 - Optional (remote setup): Tailscale for secure backend connectivity
 
@@ -210,6 +226,13 @@ npm test
 | `POST` | `/api/workspaces/:wsId/merge` | Merge workspace branch into default branch |
 | `POST` | `/api/workspaces/:wsId/archive` | Archive workspace and remove worktree |
 | `GET` | `/api/workspaces/:wsId/completions` | Completion items for `/` and `@` autocomplete |
+| `GET` | `/api/workspaces/:wsId/pr-status` | PR status (state, checks, reviews, mergeable) with 15s cache |
+
+### Models
+
+| Method | Endpoint | Description |
+|---|---|---|
+| `GET` | `/api/models` | Model catalog (providers, capabilities, defaults) |
 
 ### Sessions
 
@@ -259,12 +282,12 @@ npm test
 
 Client -> server:
 - `{ "type": "switch_session", "sessionId": "..." }`
-- `{ "type": "user_message", "content": "...", "images": [...], "options": { "planMode": boolean, "thinkingEnabled": boolean }, "sessionId": "..." }`
+- `{ "type": "user_message", "content": "...", "images": [...], "options": { "planMode": boolean, "thinkingEnabled": boolean, "thinkingLevel": "low"|"medium"|"high"|"xhigh", "modelId": "provider:model" }, "sessionId": "..." }`
 - `{ "type": "stop", "sessionId": "..." }`
 - `{ "type": "tool_input_response", "requestId": "...", "toolName": "AskUserQuestion|ExitPlanMode", "result": ... , "sessionId": "..." }`
 
 Server -> client (main types):
-- `status`, `history`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `tool_input_required`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `script_status`
+- `status` (includes `lockedProvider` when set), `history`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `tool_input_required`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `script_status`
 
 ### Script stream
 
@@ -272,48 +295,45 @@ Server -> client (main types):
 - Binary frames: PTY output bytes from the running script
 - Server control messages: `ready`, `exit`, `error`
 
-### Terminal stream
-
-- Endpoint: `ws://<host>/ws/terminal/:wsId`
-- Binary frames: PTY input/output bytes
-- JSON control frames: `{ "type": "resize", "cols": number, "rows": number }`
-- Server control messages: `ready`, `exit`, `error`
-
 ## Architecture
 
 Hierarchy:
 - **Project**: bare Git repo
 - **Workspace**: worktree + branch (`workspace/<city-name>`)
-- **Session**: Claude conversation persisted under the project
+- **Session**: agent conversation persisted under the project
 
 Backend key modules:
 - `backend/src/api/projects.ts` project CRUD + fetch
-- `backend/src/api/workspaces.ts` workspace CRUD + diff/stat + files + merge + archive
+- `backend/src/api/workspaces.ts` workspace CRUD + diff/stat + files + merge + archive + PR status
 - `backend/src/api/agents.ts` session routes (single + multi-session)
 - `backend/src/api/completions.ts` completion scanning endpoint
+- `backend/src/api/models.ts` model catalog endpoint
 - `backend/src/api/settings.ts` notification config CRUD
 - `backend/src/api/account.ts` GitHub OAuth device flow + CLI integration
 - `backend/src/api/scripts.ts` setup/run script lifecycle
 - `backend/src/ws/stream.ts` conversation WebSocket protocol
-- `backend/src/ws/terminal.ts` PTY terminal WebSocket
 - `backend/src/ws/script.ts` script execution WebSocket
 - `backend/src/agents/agent-manager.ts` in-memory session registry, persistence, switching
-- `backend/src/agents/conversation-session.ts` Claude process lifecycle per turn
+- `backend/src/agents/conversation-session.ts` agent process lifecycle per turn (provider-aware)
 - `backend/src/agents/naming.ts` branch + session auto-naming via dedicated Claude subprocess
-- `backend/src/services/git-sync.ts` branch/PR/diff polling and workspace broadcasts
+- `backend/src/agents/providers/` provider abstraction (types, registry, claude, codex, codex-stream-adapter)
+- `backend/src/services/git-sync.ts` branch/diff polling and workspace broadcasts
 - `backend/src/services/script-runner.ts` PTY-based script execution with status broadcasting
 - `backend/src/notifications/` Telegram notification channel + event dispatcher
 - `backend/src/state/state.ts` JSON persistence + per-project locks
 - `backend/src/state/config.ts` file-based app config (`config.json`)
-- `backend/src/utils/preflight.ts` startup dependency checks (git, claude, gh)
+- `backend/src/utils/preflight.ts` startup dependency checks (git, claude, gh; codex optional)
+- `backend/src/utils/github.ts` GitHub URL parsing, `gh` CLI wrapper, PR status fetching
 - `backend/src/utils/hive-config.ts` `hive.json` parser for workspace scripts
 
 Frontend key modules:
-- `frontend/src/pages/WorkspaceView.tsx` main chat/terminal/file tree/diff/scripts UI
+- `frontend/src/pages/WorkspaceView.tsx` main chat/file tree/diff/scripts/PR status UI
 - `frontend/src/pages/settings/` settings pages (Appearance, Connection, Account, Notifications, ProjectDetail)
-- `frontend/src/hooks/useConversation.ts` reducer-driven conversation state + tool responses
+- `frontend/src/hooks/useConversation.ts` reducer-driven conversation state + tool responses + lockedProvider
 - `frontend/src/hooks/useSessions.ts` multi-session operations
 - `frontend/src/hooks/useWorkspaceLiveData.ts` live status/branch/diff/script data from WS
+- `frontend/src/hooks/useModels.ts` model catalog fetch + selection + provider lock
+- `frontend/src/hooks/usePrStatus.ts` PR status REST polling (15s)
 - `frontend/src/hooks/useProjects.ts` project/workspace state
 - `frontend/src/hooks/useScripts.ts` script start/stop/status
 - `frontend/src/hooks/useConnectionStatus.ts` backend health check
@@ -321,7 +341,8 @@ Frontend key modules:
 - `frontend/src/hooks/useServerUrl.ts` configurable backend URL resolution
 - `frontend/src/lib/ws-transport.ts` resilient WS transport + replay buffer
 - `frontend/src/components/Sidebar.tsx` project/workspace nav + archive/delete
-- `frontend/src/components/Terminal.tsx` xterm + `/ws/terminal/:wsId`
+- `frontend/src/components/chat/ModelSelector.tsx` provider-grouped model picker
+- `frontend/src/components/PrStatusSection.tsx` enriched PR status display
 - `frontend/src-tauri/` Tauri v2 desktop app (Rust shell, config, icons)
 
 ## Data Layout
@@ -354,6 +375,7 @@ $DATA_DIR/
 - Frontend tests: `frontend/tests/**/*.test.ts(x)`
 - Framework: Vitest
 - CI (`.github/workflows/ci.yml`) runs lint, typecheck, build, and tests on push/PR to `main`
+- CI sets `NODE_ENV=test` explicitly (React 19 only exports `act()` in development bundle)
 
 ## License
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # Hive — TODO
 
-_Last cleanup: February 17, 2026._
+_Last cleanup: February 21, 2026._
 
 This list only contains open items. Completed and obsolete items were removed.
 
@@ -38,15 +38,22 @@ This list only contains open items. Completed and obsolete items were removed.
 - [ ] **Mobile sidebar behavior**
   Add collapse/drawer behavior for smaller viewports.
 
+- [ ] **Codex session resume verification**
+  Verify that Codex thread IDs are correctly persisted and resumed across session reloads. Currently best-effort.
+
+- [ ] **Distinguish redacted thinking in UI**
+  `redacted_thinking` blocks are logged as `[redacted]` but rendered identically to regular thinking. Add visual distinction.
+
 ## P2 (Infra + Platform)
 
 - [ ] Add `.env.example` for backend/frontend env vars.
 - [ ] Add retention/cleanup policy for old sessions/logs/archives.
 - [ ] Add system status endpoint (disk usage, project/workspace/session counts).
+- [ ] iOS file viewer/diff viewer (currently tool output is shown as raw text).
 
 ## P3 (Security + Extensibility)
 
 - [ ] Add optional per-user auth model (current token is global/shared).
-- [ ] Add session/terminal access audit trail.
+- [ ] Add session access audit trail.
 - [ ] Add optional execution sandbox policy beyond CLI permission flags.
 - [ ] Add plugin command scanning in completions (`~/.claude/plugins/installed_plugins.json`).

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -65,7 +65,9 @@ describe("buildApp", () => {
     app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/health" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: "ok" });
+    const body = res.json();
+    expect(body.status).toBe("ok");
+    expect(body).toHaveProperty("env");
   });
 
   it("registers project routes", async () => {
@@ -220,7 +222,9 @@ describe("buildApp", () => {
 
     const res = await app.inject({ method: "GET", url: "/health" });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ status: "ok" });
+    const body = res.json();
+    expect(body.status).toBe("ok");
+    expect(body).toHaveProperty("env");
   });
 
   it("rate-limits API requests when threshold is exceeded", async () => {

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -72,7 +72,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     }),
   );
 
-  app.get("/health", async () => ({ status: "ok" }));
+  app.get("/health", async () => ({ status: "ok", env: process.env.NODE_ENV ?? "development" }));
 
   await app.register((instance: FastifyInstance) => projectRoutes(instance));
   await app.register((instance: FastifyInstance) => workspaceRoutes(instance));

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, useLocation } from "react-router-dom";
 import Sidebar from "./Sidebar";
 import SettingsSidebar from "./SettingsSidebar";
+import { useConnectionStatus } from "@/hooks/useConnectionStatus";
 
 interface AppLayoutProps {
   onAddProject: () => void;
@@ -9,19 +10,27 @@ interface AppLayoutProps {
 export default function AppLayout({ onAddProject }: AppLayoutProps) {
   const { pathname } = useLocation();
   const isSettings = pathname.startsWith("/settings");
+  const { backendEnv } = useConnectionStatus();
 
   return (
-    <div className="flex h-screen">
-      {isSettings ? (
-        <SettingsSidebar />
-      ) : (
-        <Sidebar onAddProject={onAddProject} />
-      )}
-      <main className="relative flex flex-1 flex-col overflow-hidden">
-        <div className="relative min-h-0 flex-1 overflow-hidden">
-          <Outlet />
+    <div className="flex h-screen flex-col">
+      {import.meta.env.DEV && (
+        <div className="shrink-0 bg-amber-500/90 px-3 py-0.5 text-center text-xs font-medium text-black">
+          Dev frontend → {backendEnv ? `${backendEnv} backend` : "connecting…"}
         </div>
-      </main>
+      )}
+      <div className="flex min-h-0 flex-1">
+        {isSettings ? (
+          <SettingsSidebar />
+        ) : (
+          <Sidebar onAddProject={onAddProject} />
+        )}
+        <main className="relative flex flex-1 flex-col overflow-hidden">
+          <div className="relative min-h-0 flex-1 overflow-hidden">
+            <Outlet />
+          </div>
+        </main>
+      </div>
     </div>
   );
 }

--- a/frontend/src/hooks/useConnectionStatus.ts
+++ b/frontend/src/hooks/useConnectionStatus.ts
@@ -3,14 +3,21 @@ import { getServerUrl } from "./useServerUrl";
 
 export type ConnectionStatus = "unknown" | "connected" | "disconnected";
 
-async function checkHealth(): Promise<ConnectionStatus> {
+interface HealthResult {
+  status: ConnectionStatus;
+  backendEnv: string | null;
+}
+
+async function checkHealth(): Promise<HealthResult> {
   const base = getServerUrl();
-  if (!base) return "unknown";
+  if (!base) return { status: "unknown", backendEnv: null };
   try {
     const res = await fetch(`${base}/health`, { signal: AbortSignal.timeout(3000) });
-    return res.ok ? "connected" : "disconnected";
+    if (!res.ok) return { status: "disconnected", backendEnv: null };
+    const data = await res.json();
+    return { status: "connected", backendEnv: data.env ?? null };
   } catch {
-    return "disconnected";
+    return { status: "disconnected", backendEnv: null };
   }
 }
 
@@ -26,7 +33,8 @@ export function useConnectionStatus() {
   });
 
   return {
-    status: query.data ?? ("unknown" as ConnectionStatus),
+    status: query.data?.status ?? ("unknown" as ConnectionStatus),
+    backendEnv: query.data?.backendEnv ?? null,
     check: () => queryClient.refetchQueries({ queryKey: ["health"] }),
   };
 }

--- a/frontend/tests/hooks/useConnectionStatus.test.tsx
+++ b/frontend/tests/hooks/useConnectionStatus.test.tsx
@@ -30,7 +30,7 @@ describe("useConnectionStatus", () => {
 
   it("becomes connected when health endpoint replies with ok=true", async () => {
     mocks.getServerUrl.mockReturnValue("http://100.64.0.10:3000");
-    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response);
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve({ status: "ok", env: "development" }) } as unknown as Response);
 
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useConnectionStatus(), { wrapper });
@@ -38,6 +38,7 @@ describe("useConnectionStatus", () => {
     await waitFor(() => {
       expect(result.current.status).toBe("connected");
     });
+    expect(result.current.backendEnv).toBe("development");
     expect(fetch).toHaveBeenCalledWith(
       "http://100.64.0.10:3000/health",
       expect.objectContaining({ signal: expect.anything() }),
@@ -79,7 +80,7 @@ describe("useConnectionStatus", () => {
     expect(fetch).not.toHaveBeenCalled();
 
     mocks.getServerUrl.mockReturnValue("http://100.64.0.10:3000");
-    vi.mocked(fetch).mockResolvedValue({ ok: true } as Response);
+    vi.mocked(fetch).mockResolvedValue({ ok: true, json: () => Promise.resolve({ status: "ok", env: "production" }) } as unknown as Response);
 
     await act(async () => {
       await result.current.check();


### PR DESCRIPTION
## Summary

- **Dev banner**: When running the frontend in dev mode (`npm run dev`), an amber banner at the top shows which backend is connected (e.g. "Dev frontend → development backend"). Gated by `import.meta.env.DEV` so it's stripped from production builds.
- **Docs update**: CLAUDE.md, README.md, TODO.md refreshed to reflect recent changes (providers, PR status, terminal removal).

## Changes

- `backend/src/index.ts`: `/health` now returns `{ status: "ok", env: "development"|"production" }`
- `frontend/src/hooks/useConnectionStatus.ts`: parses backend env from health check
- `frontend/src/components/AppLayout.tsx`: conditional amber banner in dev mode
- `CLAUDE.md`, `README.md`, `TODO.md`: docs refresh

## Test plan

- [ ] Run frontend in dev mode → banner visible with correct backend env
- [ ] Build frontend for production → no banner present
- [ ] Verify `/health` returns env field