### PR TITLE
Add Claude Code tasks tracking UI

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -213,6 +213,28 @@ describe("ConversationSession", () => {
     expect(spawnOpts.env!.MAX_THINKING_TOKENS).toBeUndefined();
   });
 
+  it("merges provider env overrides with existing process env", () => {
+    const key = "HIVE_TEST_KEEP_ENV";
+    const previousValue = process.env[key];
+    process.env[key] = "keep-me";
+
+    try {
+      const session = createSession({ sessionId: "sess-env-merge", command: "claude" });
+      session.sendMessage("Hello", { thinkingEnabled: false });
+
+      const spawnOpts = mockSpawn.mock.calls[0]?.[2] as { env?: Record<string, string | undefined> };
+      expect(spawnOpts.env?.[key]).toBe("keep-me");
+      expect(spawnOpts.env?.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
+      expect(spawnOpts.env?.MAX_THINKING_TOKENS).toBe("0");
+    } finally {
+      if (previousValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = previousValue;
+      }
+    }
+  });
+
   it("uses --resume with pre-generated session ID on second message", () => {
     const session = createSession({ sessionId: "sess-2" });
 

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -202,13 +202,15 @@ describe("ConversationSession", () => {
     expect(spawnOpts.env?.MAX_THINKING_TOKENS).toBe("31999");
   });
 
-  it("does not override env when thinking option is omitted", () => {
+  it("passes env with CLAUDE_CODE_ENABLE_TASKS even when thinking is omitted", () => {
     const session = createSession({ sessionId: "sess-think-default", command: "claude" });
 
     session.sendMessage("Hello");
 
-    const spawnOpts = mockSpawn.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv };
-    expect(spawnOpts).not.toHaveProperty("env");
+    const spawnOpts = mockSpawn.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(spawnOpts.env).toBeDefined();
+    expect(spawnOpts.env!.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
+    expect(spawnOpts.env!.MAX_THINKING_TOKENS).toBeUndefined();
   });
 
   it("uses --resume with pre-generated session ID on second message", () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -458,7 +458,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.process = spawn(command, args, {
       cwd: this.cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      ...(env && { env }),
+      ...(env && { env: { ...process.env, ...env } }),
     });
 
     this.process.stdin?.end();

--- a/backend/src/agents/providers/claude.test.ts
+++ b/backend/src/agents/providers/claude.test.ts
@@ -157,20 +157,22 @@ describe("ClaudeProvider", () => {
 
   // ── buildEnv ───────────────────────────────────────────────────────
 
-  it("returns undefined when thinkingEnabled is not specified", () => {
-    expect(provider.buildEnv({})).toBeUndefined();
+  it("always includes CLAUDE_CODE_ENABLE_TASKS", () => {
+    const env = provider.buildEnv({});
+    expect(env.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
+    expect(env.MAX_THINKING_TOKENS).toBeUndefined();
   });
 
   it("sets MAX_THINKING_TOKENS=31999 when thinking is enabled", () => {
     const env = provider.buildEnv({ thinkingEnabled: true });
-    expect(env).toBeDefined();
-    expect(env!.MAX_THINKING_TOKENS).toBe("31999");
+    expect(env.MAX_THINKING_TOKENS).toBe("31999");
+    expect(env.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
   });
 
   it("sets MAX_THINKING_TOKENS=0 when thinking is disabled", () => {
     const env = provider.buildEnv({ thinkingEnabled: false });
-    expect(env).toBeDefined();
-    expect(env!.MAX_THINKING_TOKENS).toBe("0");
+    expect(env.MAX_THINKING_TOKENS).toBe("0");
+    expect(env.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
   });
 
   // ── createStreamAdapter ────────────────────────────────────────────

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -51,12 +51,14 @@ export class ClaudeProvider implements AgentProvider {
     ];
   }
 
-  buildEnv(options: ProviderMessageOptions): Record<string, string> | undefined {
-    if (options.thinkingEnabled === undefined) return undefined;
-    return {
-      ...process.env as Record<string, string>,
-      MAX_THINKING_TOKENS: options.thinkingEnabled ? "31999" : "0",
+  buildEnv(options: ProviderMessageOptions): Record<string, string> {
+    const env: Record<string, string> = {
+      CLAUDE_CODE_ENABLE_TASKS: "true",
     };
+    if (options.thinkingEnabled !== undefined) {
+      env.MAX_THINKING_TOKENS = options.thinkingEnabled ? "31999" : "0";
+    }
+    return env;
   }
 
   createStreamAdapter(): StreamAdapter {

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -16,9 +16,10 @@ vi.mock("fastify", async (importOriginal) => {
       const instance = originalDefault();
       const originalListen = instance.listen.bind(instance);
       instance.listen = (async (...listenArgs: unknown[]) => {
-        // Only block the main() auto-listen (which uses port 3000)
+        // Only block the main() auto-listen (uses PORT env var or defaults to 3000)
         const opts = listenArgs[0] as { port?: number } | undefined;
-        if (opts?.port === 3000) {
+        const mainPort = Number(process.env.PORT ?? 3000);
+        if (opts?.port === mainPort) {
           return "mocked";
         }
         return originalListen(opts as Parameters<typeof originalListen>[0]);

--- a/frontend/src/components/ChatToolUse.tsx
+++ b/frontend/src/components/ChatToolUse.tsx
@@ -48,6 +48,16 @@ const icons = {
       <path d="M9 13v2" />
     </svg>
   ),
+  listChecks: (
+    <svg {...svgProps}>
+      <path d="M10 6h11" />
+      <path d="M10 12h11" />
+      <path d="M10 18h11" />
+      <polyline points="3 6 4 7 6 5" />
+      <polyline points="3 12 4 13 6 11" />
+      <polyline points="3 18 4 19 6 17" />
+    </svg>
+  ),
   wrench: (
     <svg {...svgProps}>
       <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76Z" />
@@ -62,6 +72,7 @@ export function getToolIcon(toolName: string): ReactNode {
     case "Bash": return icons.terminal;
     case "Grep": case "Glob": return icons.search;
     case "Task": return icons.bot;
+    case "TaskCreate": case "TaskUpdate": case "TaskList": case "TaskGet": return icons.listChecks;
     case "WebFetch": case "WebSearch": return icons.globe;
     default: return icons.wrench;
   }
@@ -228,6 +239,48 @@ function getToolDisplay(tool: ToolCall): ToolDisplay {
         expandedContent: url
           ? `URL: ${url}${prompt ? `\n\nPrompt: ${prompt}` : ""}`
           : `Query: ${query ?? "(none)"}`,
+      };
+    }
+
+    case "TaskCreate": {
+      const subject = input.subject as string | undefined;
+      const description = input.description as string | undefined;
+      return {
+        icon: icons.listChecks,
+        label: "TaskCreate",
+        detail: subject,
+        expandedContent: description
+          ? `Subject: ${subject}\n\nDescription:\n${description}`
+          : `Subject: ${subject ?? "(none)"}`,
+      };
+    }
+
+    case "TaskUpdate": {
+      const taskId = input.taskId as string | undefined;
+      const status = input.status as string | undefined;
+      const detail = [taskId && `#${taskId}`, status].filter(Boolean).join(" → ");
+      return {
+        icon: icons.listChecks,
+        label: "TaskUpdate",
+        detail: detail || undefined,
+        expandedContent: JSON.stringify(input, null, 2),
+      };
+    }
+
+    case "TaskList":
+      return {
+        icon: icons.listChecks,
+        label: "TaskList",
+        expandedContent: "Lists all active tasks",
+      };
+
+    case "TaskGet": {
+      const taskId = input.taskId as string | undefined;
+      return {
+        icon: icons.listChecks,
+        label: "TaskGet",
+        detail: taskId ? `#${taskId}` : undefined,
+        expandedContent: taskId ? `Task ID: ${taskId}` : "No task ID specified",
       };
     }
 

--- a/frontend/src/components/TaskTracker.tsx
+++ b/frontend/src/components/TaskTracker.tsx
@@ -1,0 +1,114 @@
+import { useState, memo } from "react";
+import { ChevronRightIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { TrackedTask, TaskCounts } from "@/hooks/useTasks";
+
+const svgProps = {
+  className: "size-3",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+function StatusIcon({ status }: { status: TrackedTask["status"] }) {
+  switch (status) {
+    case "completed":
+      return (
+        <svg {...svgProps} className="size-3 text-green-500">
+          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+          <polyline points="22 4 12 14.01 9 11.01" />
+        </svg>
+      );
+    case "in_progress":
+      return (
+        <span className="inline-block size-2 animate-pulse rounded-full bg-primary" />
+      );
+    default:
+      return (
+        <svg {...svgProps} className="size-3 text-muted-foreground/40">
+          <circle cx="12" cy="12" r="10" />
+        </svg>
+      );
+  }
+}
+
+interface TaskTrackerProps {
+  tasks: TrackedTask[];
+  currentTask: TrackedTask | undefined;
+  counts: TaskCounts;
+  isStreaming?: boolean;
+}
+
+const TaskTracker = memo(function TaskTracker({
+  tasks,
+  currentTask,
+  counts,
+  isStreaming,
+}: TaskTrackerProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (tasks.length === 0) return null;
+
+  const collapsedLabel = currentTask
+    ? (currentTask.activeForm ?? currentTask.subject)
+    : "All tasks completed";
+
+  return (
+    <div className="border-t border-border/50 bg-background px-4 py-1.5">
+      <button
+        type="button"
+        className="inline-flex w-full items-center gap-2 rounded-md py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        onClick={() => setExpanded(!expanded)}
+      >
+        <ChevronRightIcon
+          className={cn(
+            "size-3.5 shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        <span
+          className={cn(
+            "min-w-0 truncate",
+            currentTask && isStreaming && "animate-shimmer",
+          )}
+        >
+          {collapsedLabel}
+        </span>
+        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/50">
+          {counts.completed}/{counts.total}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="mt-1 space-y-0.5 pb-0.5">
+          {tasks.map((task) => (
+            <div
+              key={task.id}
+              className="flex items-center gap-2 py-0.5 pl-5 text-xs text-muted-foreground"
+            >
+              <span className="flex shrink-0 items-center justify-center" style={{ width: 12 }}>
+                <StatusIcon status={task.status} />
+              </span>
+              <span
+                className={cn(
+                  "min-w-0 truncate",
+                  task.status === "completed" && "line-through text-muted-foreground/50",
+                  task.status === "in_progress" && "text-foreground",
+                )}
+              >
+                {task.status === "in_progress"
+                  ? (task.activeForm ?? task.subject)
+                  : task.subject}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default TaskTracker;

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -258,10 +258,13 @@ export function ToolCallList({
   const planData = hasExitPlanMode ? findPlanContent(toolCalls) : undefined;
   const planContent = planData?.content;
 
+  const HIDDEN_TASK_TOOLS = new Set(["TaskUpdate"]);
+
   const regularTools = toolCalls.filter(
     (t) =>
       !isAskUserQuestion(t) &&
       !isExitPlanMode(t) &&
+      !HIDDEN_TASK_TOOLS.has(t.name) &&
       !(planData?.writeToolId && t.id === planData.writeToolId),
   );
 

--- a/frontend/src/hooks/useTasks.ts
+++ b/frontend/src/hooks/useTasks.ts
@@ -1,0 +1,144 @@
+import { useMemo } from "react";
+import type { ChatMessage, ToolCall } from "@/types";
+
+export interface TrackedTask {
+  id: string;
+  subject: string;
+  description?: string;
+  activeForm?: string;
+  status: "pending" | "in_progress" | "completed";
+  /** True while the TaskCreate tool_use hasn't received its result yet. */
+  isCreating?: boolean;
+}
+
+export interface TaskCounts {
+  total: number;
+  completed: number;
+  inProgress: number;
+  pending: number;
+}
+
+export interface TasksState {
+  tasks: TrackedTask[];
+  currentTask: TrackedTask | undefined;
+  counts: TaskCounts;
+}
+
+const VALID_STATUSES = new Set(["pending", "in_progress", "completed"]);
+
+/**
+ * Try to extract the numeric task ID from a TaskCreate result string.
+ * Expected formats: "Task #1 created successfully: ..." or "Task 1 created: ..."
+ */
+function parseTaskId(output: string): string | null {
+  // Try JSON first (in case CLI ever sends structured output)
+  try {
+    const json = JSON.parse(output);
+    if (json?.task?.id != null) return String(json.task.id);
+  } catch {
+    // not JSON, try text
+  }
+  const match = output.match(/Task\s+#?(\d+)/i);
+  return match ? match[1] : null;
+}
+
+function parseInput(tool: ToolCall): Record<string, unknown> {
+  try {
+    return JSON.parse(tool.input);
+  } catch {
+    return {};
+  }
+}
+
+const EMPTY: TasksState = {
+  tasks: [],
+  currentTask: undefined,
+  counts: { total: 0, completed: 0, inProgress: 0, pending: 0 },
+};
+
+export function useTasks(
+  messages: ChatMessage[],
+  activeToolCalls: ToolCall[],
+): TasksState {
+  return useMemo(() => {
+    // Collect all tool calls in chronological order
+    const allTools: ToolCall[] = [];
+    for (const msg of messages) {
+      if (msg.toolCalls) {
+        for (const tc of msg.toolCalls) allTools.push(tc);
+      }
+    }
+    for (const tc of activeToolCalls) allTools.push(tc);
+
+    // Quick bail: if no task tools at all, return empty
+    const hasTaskTools = allTools.some(
+      (t) => t.name === "TaskCreate" || t.name === "TaskUpdate",
+    );
+    if (!hasTaskTools) return EMPTY;
+
+    const tasks = new Map<string, TrackedTask>();
+    // Track TaskCreate order for fallback ID assignment
+    let createIndex = 0;
+
+    for (const tool of allTools) {
+      if (tool.name === "TaskCreate") {
+        createIndex++;
+        const input = parseInput(tool);
+        const subject = (input.subject as string) ?? `Task ${createIndex}`;
+        const description = input.description as string | undefined;
+        const activeForm = input.activeForm as string | undefined;
+
+        let id: string;
+        let isCreating = false;
+
+        if (tool.output) {
+          const parsed = parseTaskId(tool.output);
+          id = parsed ?? `_idx_${createIndex}`;
+        } else {
+          // Still streaming — use tool_use id as temp key
+          id = `_pending_${tool.id}`;
+          isCreating = true;
+        }
+
+        tasks.set(id, {
+          id,
+          subject,
+          description,
+          activeForm,
+          status: "pending",
+          ...(isCreating && { isCreating }),
+        });
+      } else if (tool.name === "TaskUpdate") {
+        const input = parseInput(tool);
+        const taskId = input.taskId as string | undefined;
+        if (!taskId) continue;
+
+        const task = tasks.get(taskId);
+        if (!task) continue;
+
+        if (input.status === "deleted") {
+          tasks.delete(taskId);
+          continue;
+        }
+
+        if (typeof input.subject === "string") task.subject = input.subject;
+        if (typeof input.description === "string") task.description = input.description;
+        if (typeof input.activeForm === "string") task.activeForm = input.activeForm;
+        if (typeof input.status === "string" && VALID_STATUSES.has(input.status)) {
+          task.status = input.status as TrackedTask["status"];
+        }
+      }
+    }
+
+    const taskList = Array.from(tasks.values());
+    const currentTask = taskList.find((t) => t.status === "in_progress");
+    const counts: TaskCounts = {
+      total: taskList.length,
+      completed: taskList.filter((t) => t.status === "completed").length,
+      inProgress: taskList.filter((t) => t.status === "in_progress").length,
+      pending: taskList.filter((t) => t.status === "pending").length,
+    };
+
+    return { tasks: taskList, currentTask, counts };
+  }, [messages, activeToolCalls]);
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -21,6 +21,8 @@ import { GitDiffModal } from "@/components/diff/GitDiffModal";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
 import { PrStatusSection } from "@/components/PrStatusSection";
 import ScriptPanel from "@/components/ScriptPanel";
+import TaskTracker from "@/components/TaskTracker";
+import { useTasks } from "@/hooks/useTasks";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -224,6 +226,8 @@ export default function WorkspaceView() {
     dismissPlan,
     lockedProvider,
   } = useConversation(wsId);
+
+  const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
 
   const { sessions, createSession, activateSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
 
@@ -489,6 +493,14 @@ export default function WorkspaceView() {
               defaultBranch={workspace?.defaultBranch}
               fileCount={fileCount}
             />
+            {tasks.length > 0 && (
+              <TaskTracker
+                tasks={tasks}
+                currentTask={currentTask}
+                counts={taskCounts}
+                isStreaming={isStreaming}
+              />
+            )}
             {pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") ? (
               <QuestionPanel
                 pendingToolInputs={pendingToolInputs}

--- a/frontend/tests/components/ChatToolUse.test.tsx
+++ b/frontend/tests/components/ChatToolUse.test.tsx
@@ -162,6 +162,51 @@ describe("ChatToolUse", () => {
     expect(screen.getByText("#3 → in_progress")).toBeInTheDocument();
   });
 
+  it("renders TaskList with static helper content", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatToolUse
+        tool={tool({
+          name: "TaskList",
+          input: "{}",
+          output: "[]",
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /tasklist/i }));
+    expect(screen.getByText("Lists all active tasks")).toBeInTheDocument();
+  });
+
+  it("renders TaskGet fallback when taskId is missing", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatToolUse
+        tool={tool({
+          name: "TaskGet",
+          input: "{}",
+        })}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /taskget/i }));
+    expect(screen.getByText("No task ID specified")).toBeInTheDocument();
+  });
+
+  it("renders TaskGet detail when taskId is provided", () => {
+    render(
+      <ChatToolUse
+        tool={tool({
+          name: "TaskGet",
+          input: JSON.stringify({ taskId: "9" }),
+          output: "Task #9",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("#9")).toBeInTheDocument();
+  });
+
   it("delegates click handling when onClick is provided without toggling local expansion", async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/frontend/tests/components/ChatToolUse.test.tsx
+++ b/frontend/tests/components/ChatToolUse.test.tsx
@@ -128,6 +128,40 @@ describe("ChatToolUse", () => {
     expect(screen.getByText("Second finding")).toBeInTheDocument();
   });
 
+  it("renders TaskCreate with subject as detail badge", async () => {
+    const user = userEvent.setup();
+    render(
+      <ChatToolUse
+        tool={tool({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Fix login bug", description: "Auth fails on mobile" }),
+          output: "Task #1 created successfully: Fix login bug",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("TaskCreate")).toBeInTheDocument();
+    expect(screen.getByText("Fix login bug")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /taskcreate/i }));
+    expect(screen.getByText(/Auth fails on mobile/)).toBeInTheDocument();
+  });
+
+  it("renders TaskUpdate with task ID and status", async () => {
+    render(
+      <ChatToolUse
+        tool={tool({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "3", status: "in_progress" }),
+          output: "Task #3 updated",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("TaskUpdate")).toBeInTheDocument();
+    expect(screen.getByText("#3 → in_progress")).toBeInTheDocument();
+  });
+
   it("delegates click handling when onClick is provided without toggling local expansion", async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/frontend/tests/components/TaskTracker.test.tsx
+++ b/frontend/tests/components/TaskTracker.test.tsx
@@ -71,6 +71,15 @@ describe("TaskTracker", () => {
     expect(screen.getByText("1/3")).toBeInTheDocument();
   });
 
+  it("adds shimmer class when current task is streaming", () => {
+    const tasks = [task({ id: "1", subject: "Fix bug", activeForm: "Fixing", status: "in_progress" })];
+    render(
+      <TaskTracker tasks={tasks} currentTask={tasks[0]} counts={counts(tasks)} isStreaming />,
+    );
+
+    expect(screen.getByText("Fixing")).toHaveClass("animate-shimmer");
+  });
+
   it("expands to show all tasks on click", async () => {
     const user = userEvent.setup();
     const tasks = [
@@ -93,5 +102,23 @@ describe("TaskTracker", () => {
     // "Working on second" appears in both collapsed label and expanded list
     expect(screen.getAllByText("Working on second")).toHaveLength(2);
     expect(screen.getByText("Third task")).toBeInTheDocument();
+  });
+
+  it("collapses expanded list on second click", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      task({ id: "1", subject: "First task", status: "completed" }),
+      task({ id: "2", subject: "Second task", status: "pending" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={undefined} counts={counts(tasks)} />,
+    );
+
+    const toggle = screen.getByRole("button");
+    await user.click(toggle);
+    expect(screen.getByText("First task")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByText("First task")).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/TaskTracker.test.tsx
+++ b/frontend/tests/components/TaskTracker.test.tsx
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import TaskTracker from "@/components/TaskTracker";
+import type { TrackedTask, TaskCounts } from "@/hooks/useTasks";
+
+function task(overrides: Partial<TrackedTask> & { id: string; subject: string }): TrackedTask {
+  return { status: "pending", ...overrides };
+}
+
+function counts(tasks: TrackedTask[]): TaskCounts {
+  return {
+    total: tasks.length,
+    completed: tasks.filter((t) => t.status === "completed").length,
+    inProgress: tasks.filter((t) => t.status === "in_progress").length,
+    pending: tasks.filter((t) => t.status === "pending").length,
+  };
+}
+
+describe("TaskTracker", () => {
+  it("renders nothing when tasks array is empty", () => {
+    const { container } = render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows current task activeForm when collapsed", () => {
+    const tasks = [
+      task({ id: "1", subject: "Fix bug", activeForm: "Fixing the bug", status: "in_progress" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={tasks[0]} counts={counts(tasks)} />,
+    );
+    expect(screen.getByText("Fixing the bug")).toBeInTheDocument();
+  });
+
+  it("falls back to subject when no activeForm", () => {
+    const tasks = [
+      task({ id: "1", subject: "Fix bug", status: "in_progress" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={tasks[0]} counts={counts(tasks)} />,
+    );
+    expect(screen.getByText("Fix bug")).toBeInTheDocument();
+  });
+
+  it("shows 'All tasks completed' when none in progress", () => {
+    const tasks = [
+      task({ id: "1", subject: "Done task", status: "completed" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={undefined} counts={counts(tasks)} />,
+    );
+    expect(screen.getByText("All tasks completed")).toBeInTheDocument();
+  });
+
+  it("shows count badge", () => {
+    const tasks = [
+      task({ id: "1", subject: "A", status: "completed" }),
+      task({ id: "2", subject: "B", status: "in_progress" }),
+      task({ id: "3", subject: "C", status: "pending" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={tasks[1]} counts={counts(tasks)} />,
+    );
+    expect(screen.getByText("1/3")).toBeInTheDocument();
+  });
+
+  it("expands to show all tasks on click", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      task({ id: "1", subject: "First task", status: "completed" }),
+      task({ id: "2", subject: "Second task", activeForm: "Working on second", status: "in_progress" }),
+      task({ id: "3", subject: "Third task", status: "pending" }),
+    ];
+    render(
+      <TaskTracker tasks={tasks} currentTask={tasks[1]} counts={counts(tasks)} />,
+    );
+
+    // Before expand: individual task subjects not visible
+    expect(screen.queryByText("First task")).not.toBeInTheDocument();
+    expect(screen.queryByText("Third task")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button"));
+
+    // After expand: all tasks visible
+    expect(screen.getByText("First task")).toBeInTheDocument();
+    // "Working on second" appears in both collapsed label and expanded list
+    expect(screen.getAllByText("Working on second")).toHaveLength(2);
+    expect(screen.getByText("Third task")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/hooks/useTasks.test.ts
+++ b/frontend/tests/hooks/useTasks.test.ts
@@ -1,0 +1,230 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useTasks } from "@/hooks/useTasks";
+import type { ChatMessage, ToolCall } from "@/types";
+
+function msg(toolCalls: ToolCall[]): ChatMessage {
+  return {
+    id: "m-" + Math.random().toString(36).slice(2, 6),
+    sessionId: "s1",
+    role: "assistant",
+    content: "",
+    toolCalls,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function tc(overrides: Partial<ToolCall> & { name: string; input: string }): ToolCall {
+  return { id: "tc-" + Math.random().toString(36).slice(2, 6), ...overrides };
+}
+
+describe("useTasks", () => {
+  it("returns empty state when no messages", () => {
+    const { result } = renderHook(() => useTasks([], []));
+    expect(result.current.tasks).toEqual([]);
+    expect(result.current.currentTask).toBeUndefined();
+    expect(result.current.counts).toEqual({ total: 0, completed: 0, inProgress: 0, pending: 0 });
+  });
+
+  it("returns empty state when no task tools exist", () => {
+    const messages = [msg([tc({ name: "Bash", input: '{"command":"ls"}', output: "ok" })])];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toEqual([]);
+  });
+
+  it("derives a task from TaskCreate with output", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Fix auth bug", description: "Login fails", activeForm: "Fixing auth bug" }),
+          output: "Task #1 created successfully: Fix auth bug",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0]).toMatchObject({
+      id: "1",
+      subject: "Fix auth bug",
+      description: "Login fails",
+      activeForm: "Fixing auth bug",
+      status: "pending",
+    });
+  });
+
+  it("applies TaskUpdate to change status", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Write tests" }),
+          output: "Task #1 created successfully: Write tests",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "in_progress", activeForm: "Writing tests" }),
+          output: "Task #1 updated",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0]).toMatchObject({
+      id: "1",
+      status: "in_progress",
+      activeForm: "Writing tests",
+    });
+    expect(result.current.currentTask?.id).toBe("1");
+  });
+
+  it("handles task deletion", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Temp task" }),
+          output: "Task #1 created successfully: Temp task",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "deleted" }),
+          output: "Task #1 deleted",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toHaveLength(0);
+  });
+
+  it("handles in-flight TaskCreate (no output yet)", () => {
+    const active: ToolCall[] = [
+      tc({
+        id: "tc-live",
+        name: "TaskCreate",
+        input: JSON.stringify({ subject: "New task", activeForm: "Creating new task" }),
+      }),
+    ];
+    const { result } = renderHook(() => useTasks([], active));
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0]).toMatchObject({
+      id: "_pending_tc-live",
+      subject: "New task",
+      isCreating: true,
+      status: "pending",
+    });
+  });
+
+  it("tracks multiple tasks with correct counts", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Task A" }),
+          output: "Task #1 created: Task A",
+        }),
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Task B" }),
+          output: "Task #2 created: Task B",
+        }),
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Task C" }),
+          output: "Task #3 created: Task C",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "completed" }),
+          output: "ok",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "2", status: "in_progress" }),
+          output: "ok",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toHaveLength(3);
+    expect(result.current.counts).toEqual({ total: 3, completed: 1, inProgress: 1, pending: 1 });
+    expect(result.current.currentTask?.id).toBe("2");
+  });
+
+  it("reconstructs state from history hydration", () => {
+    // Simulates loading a past session with multiple messages
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Setup DB" }),
+          output: "Task #1 created: Setup DB",
+        }),
+      ]),
+      msg([
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "in_progress", activeForm: "Setting up DB" }),
+          output: "ok",
+        }),
+      ]),
+      msg([
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "completed" }),
+          output: "ok",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0]).toMatchObject({ id: "1", status: "completed" });
+    expect(result.current.currentTask).toBeUndefined();
+    expect(result.current.counts.completed).toBe(1);
+  });
+
+  it("parses JSON-structured TaskCreate output", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Structured" }),
+          output: JSON.stringify({ task: { id: "42", subject: "Structured" } }),
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0].id).toBe("42");
+  });
+
+  it("ignores TaskUpdate for unknown taskId", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "999", status: "completed" }),
+          output: "ok",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toHaveLength(0);
+  });
+
+  it("ignores invalid status values in TaskUpdate", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Test" }),
+          output: "Task #1 created: Test",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({ taskId: "1", status: "bogus_status" }),
+          output: "ok",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0].status).toBe("pending");
+  });
+});

--- a/frontend/tests/hooks/useTasks.test.ts
+++ b/frontend/tests/hooks/useTasks.test.ts
@@ -227,4 +227,85 @@ describe("useTasks", () => {
     const { result } = renderHook(() => useTasks(messages, []));
     expect(result.current.tasks[0].status).toBe("pending");
   });
+
+  it("uses fallback indexed id when TaskCreate output has no task number", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "No numeric id" }),
+          output: "Task created successfully",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0]).toMatchObject({
+      id: "_idx_1",
+      subject: "No numeric id",
+    });
+  });
+
+  it("uses generated subjects when TaskCreate input is invalid JSON", () => {
+    const messages = [
+      msg([
+        tc({ name: "TaskCreate", input: "{invalid-json", output: "Task #1 created" }),
+        tc({ name: "TaskCreate", input: "{invalid-json", output: "Task #2 created" }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.tasks[0].subject).toBe("Task 1");
+    expect(result.current.tasks[1].subject).toBe("Task 2");
+  });
+
+  it("updates subject/description/activeForm from TaskUpdate", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Old subject", description: "Old description" }),
+          output: "Task #1 created",
+        }),
+        tc({
+          name: "TaskUpdate",
+          input: JSON.stringify({
+            taskId: "1",
+            subject: "New subject",
+            description: "New description",
+            activeForm: "Working on new subject",
+          }),
+          output: "Task #1 updated",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useTasks(messages, []));
+    expect(result.current.tasks[0]).toMatchObject({
+      id: "1",
+      subject: "New subject",
+      description: "New description",
+      activeForm: "Working on new subject",
+    });
+  });
+
+  it("applies active task updates after persisted history", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "TaskCreate",
+          input: JSON.stringify({ subject: "Track me" }),
+          output: "Task #1 created",
+        }),
+      ]),
+    ];
+    const active = [
+      tc({
+        name: "TaskUpdate",
+        input: JSON.stringify({ taskId: "1", status: "in_progress" }),
+        output: "Task #1 updated",
+      }),
+    ];
+    const { result } = renderHook(() => useTasks(messages, active));
+    expect(result.current.tasks[0].status).toBe("in_progress");
+    expect(result.current.currentTask?.id).toBe("1");
+  });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -612,6 +612,63 @@ describe("WorkspaceView behavior", () => {
     expect(screen.getByTestId("chat-input")).toHaveAttribute("data-session-id", "sess-stream");
   });
 
+  it("renders TaskTracker when task tools are present in the conversation", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue({
+      messages: [
+        {
+          id: "msg-task-1",
+          sessionId: "sess-task",
+          role: "assistant",
+          content: "",
+          timestamp: "2026-02-12T00:00:00.000Z",
+          toolCalls: [
+            {
+              id: "tc-create",
+              name: "TaskCreate",
+              input: JSON.stringify({ subject: "Implement auth" }),
+              output: "Task #1 created",
+            },
+            {
+              id: "tc-update",
+              name: "TaskUpdate",
+              input: JSON.stringify({ taskId: "1", status: "in_progress", activeForm: "Implementing auth" }),
+              output: "Task #1 updated",
+            },
+          ],
+        },
+      ],
+      isStreaming: true,
+      streamingStartedAt: 1_700_000_123_456,
+      workspaceStatus: "busy",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: "sess-task",
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.getByText("Implementing auth")).toBeInTheDocument();
+    expect(screen.getByText("0/1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /implementing auth/i }));
+    expect(screen.getAllByText("Implementing auth")).toHaveLength(2);
+  });
+
   it("prefers projectName in header and shows origin default branch when provided", async () => {
     mocks.apiGet.mockImplementation(async (url: string) => {
       const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -324,3 +324,39 @@ struct MessageOptions: Codable {
     let model: String?
     let thinkingLevel: ThinkingLevel?
 }
+
+// MARK: - Task Tracking
+
+enum TaskStatus: String {
+    case pending
+    case inProgress = "in_progress"
+    case completed
+}
+
+struct TrackedTask: Identifiable {
+    let id: String
+    var subject: String
+    var description: String?
+    var activeForm: String?
+    var status: TaskStatus
+    var isCreating: Bool
+}
+
+struct TaskCounts {
+    let total: Int
+    let completed: Int
+    let inProgress: Int
+    let pending: Int
+}
+
+struct TasksState {
+    let tasks: [TrackedTask]
+    let currentTask: TrackedTask?
+    let counts: TaskCounts
+
+    static let empty = TasksState(
+        tasks: [],
+        currentTask: nil,
+        counts: TaskCounts(total: 0, completed: 0, inProgress: 0, pending: 0)
+    )
+}

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -56,6 +56,11 @@ final class ConversationStore {
         )
     }
 
+    /// Derived task tracking state from all TaskCreate/TaskUpdate tool calls.
+    var tasksState: TasksState {
+        deriveTasks(from: messages, activeToolCalls: activeToolCalls)
+    }
+
     /// All messages to display: history + streaming message if active
     var displayMessages: [ChatMessage] {
         if let streaming = streamingMessage {

--- a/ios/HiveMobile/Stores/TaskDerivation.swift
+++ b/ios/HiveMobile/Stores/TaskDerivation.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// MARK: - Task Derivation
+//
+// Pure function that derives task tracking state from tool calls.
+// Direct port of frontend/src/hooks/useTasks.ts.
+
+private let validStatuses: Set<String> = ["pending", "in_progress", "completed"]
+
+/// Parse a task ID from a TaskCreate tool output string.
+/// Tries JSON `{ "task": { "id": "42" } }` first, then regex `Task #1 created...`.
+func parseTaskId(from output: String) -> String? {
+    // Try JSON first
+    if let data = output.data(using: .utf8),
+       let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+       let task = json["task"] as? [String: Any],
+       let id = task["id"] {
+        return "\(id)"
+    }
+    // Regex fallback: case-insensitive "Task #1" or "Task 1"
+    if let match = output.range(of: #"Task\s+#?(\d+)"#, options: [.regularExpression, .caseInsensitive]) {
+        // Extract just the digits from the match
+        let matched = String(output[match])
+        if let digitMatch = matched.range(of: #"\d+"#, options: .regularExpression) {
+            return String(matched[digitMatch])
+        }
+    }
+    return nil
+}
+
+private func parseInput(_ tool: ToolCall) -> [String: Any] {
+    guard let data = tool.input.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return [:]
+    }
+    return obj
+}
+
+/// Derive task tracking state from conversation messages and active (streaming) tool calls.
+/// Mirrors the logic in `frontend/src/hooks/useTasks.ts` exactly.
+func deriveTasks(from messages: [ChatMessage], activeToolCalls: [ToolCall]) -> TasksState {
+    // Collect all tool calls in chronological order
+    var allTools: [ToolCall] = []
+    for msg in messages {
+        if let tools = msg.toolCalls {
+            allTools.append(contentsOf: tools)
+        }
+    }
+    allTools.append(contentsOf: activeToolCalls)
+
+    // Quick bail: no task tools at all
+    let hasTaskTools = allTools.contains { $0.name == "TaskCreate" || $0.name == "TaskUpdate" }
+    guard hasTaskTools else { return .empty }
+
+    // Ordered storage: array of (key, task) pairs + index lookup
+    var tasks: [(key: String, value: TrackedTask)] = []
+    var taskIndex: [String: Int] = [:]
+    var createIndex = 0
+
+    for tool in allTools {
+        if tool.name == "TaskCreate" {
+            createIndex += 1
+            let input = parseInput(tool)
+            let subject = (input["subject"] as? String) ?? "Task \(createIndex)"
+            let description = input["description"] as? String
+            let activeForm = input["activeForm"] as? String
+
+            let id: String
+            var isCreating = false
+
+            if let output = tool.output {
+                let parsed = parseTaskId(from: output)
+                id = parsed ?? "_idx_\(createIndex)"
+            } else {
+                // Still streaming — use tool_use id as temp key
+                id = "_pending_\(tool.id)"
+                isCreating = true
+            }
+
+            let task = TrackedTask(
+                id: id,
+                subject: subject,
+                description: description,
+                activeForm: activeForm,
+                status: .pending,
+                isCreating: isCreating
+            )
+            taskIndex[id] = tasks.count
+            tasks.append((key: id, value: task))
+
+        } else if tool.name == "TaskUpdate" {
+            let input = parseInput(tool)
+            guard let taskId = input["taskId"] as? String,
+                  let idx = taskIndex[taskId] else { continue }
+
+            let statusStr = input["status"] as? String
+            if statusStr == "deleted" {
+                tasks.remove(at: idx)
+                taskIndex.removeValue(forKey: taskId)
+                // Rebuild indices for items after removed position
+                for i in idx..<tasks.count {
+                    taskIndex[tasks[i].key] = i
+                }
+                continue
+            }
+
+            if let s = input["subject"] as? String { tasks[idx].value.subject = s }
+            if let d = input["description"] as? String { tasks[idx].value.description = d }
+            if let a = input["activeForm"] as? String { tasks[idx].value.activeForm = a }
+            if let s = statusStr, validStatuses.contains(s),
+               let status = TaskStatus(rawValue: s) {
+                tasks[idx].value.status = status
+            }
+        }
+    }
+
+    let taskList = tasks.map(\.value)
+    let currentTask = taskList.first { $0.status == .inProgress }
+    let counts = TaskCounts(
+        total: taskList.count,
+        completed: taskList.filter { $0.status == .completed }.count,
+        inProgress: taskList.filter { $0.status == .inProgress }.count,
+        pending: taskList.filter { $0.status == .pending }.count
+    )
+
+    return TasksState(tasks: taskList, currentTask: currentTask, counts: counts)
+}

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -88,38 +88,39 @@ struct ChatView: View {
                 }
             }
 
-            // Task tracker — between conversation scroll and input bar
-            let tasksState = store.tasksState
-            if !tasksState.tasks.isEmpty {
-                TaskTrackerView(
-                    tasks: tasksState.tasks,
-                    currentTask: tasksState.currentTask,
-                    counts: tasksState.counts,
-                    isStreaming: store.isStreaming
-                )
-            }
         }
         .safeAreaInset(edge: .bottom) {
-            ChatInputBar(
-                draft: $draft,
-                draftAttachments: draftAttachments,
-                isBusy: store.isBusy,
-                thinkingEnabled: $thinkingEnabled,
-                planModeEnabled: $planModeEnabled,
-                thinkingLevel: $thinkingLevel,
-                models: modelCatalog.models,
-                groupedModels: modelCatalog.groupedByProvider,
-                selectedModelId: selectedModelId,
-                defaultModelId: modelCatalog.defaultModelId,
-                lockedProvider: lockedProvider,
-                capabilities: selectedCapabilities,
-                onModelSelect: { selectedModelId = $0 },
-                onDraftAttachmentsChange: { draftAttachments = $0 },
-                onSend: sendMessage,
-                onStop: { Task { await wsManager.send(.stop(sessionId: nil)) } }
-            )
-            .padding(.horizontal, 12)
-            .padding(.bottom, 4)
+            VStack(spacing: 0) {
+                let tasksState = store.tasksState
+                if !tasksState.tasks.isEmpty {
+                    TaskTrackerView(
+                        tasks: tasksState.tasks,
+                        currentTask: tasksState.currentTask,
+                        counts: tasksState.counts,
+                        isStreaming: store.isStreaming
+                    )
+                }
+                ChatInputBar(
+                    draft: $draft,
+                    draftAttachments: draftAttachments,
+                    isBusy: store.isBusy,
+                    thinkingEnabled: $thinkingEnabled,
+                    planModeEnabled: $planModeEnabled,
+                    thinkingLevel: $thinkingLevel,
+                    models: modelCatalog.models,
+                    groupedModels: modelCatalog.groupedByProvider,
+                    selectedModelId: selectedModelId,
+                    defaultModelId: modelCatalog.defaultModelId,
+                    lockedProvider: lockedProvider,
+                    capabilities: selectedCapabilities,
+                    onModelSelect: { selectedModelId = $0 },
+                    onDraftAttachmentsChange: { draftAttachments = $0 },
+                    onSend: sendMessage,
+                    onStop: { Task { await wsManager.send(.stop(sessionId: nil)) } }
+                )
+                .padding(.horizontal, 12)
+                .padding(.bottom, 4)
+            }
         }
         .toolbarBackground(.black, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -87,6 +87,17 @@ struct ChatView: View {
                     }
                 }
             }
+
+            // Task tracker — between conversation scroll and input bar
+            let tasksState = store.tasksState
+            if !tasksState.tasks.isEmpty {
+                TaskTrackerView(
+                    tasks: tasksState.tasks,
+                    currentTask: tasksState.currentTask,
+                    counts: tasksState.counts,
+                    isStreaming: store.isStreaming
+                )
+            }
         }
         .safeAreaInset(edge: .bottom) {
             ChatInputBar(

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -232,6 +232,7 @@ private func toolIcon(for name: String) -> String {
     case "Bash": return "terminal"
     case "Grep", "Glob": return "magnifyingglass"
     case "Task": return "arrow.triangle.branch"
+    case "TaskCreate", "TaskUpdate", "TaskList", "TaskGet": return "checklist"
     case "WebSearch", "WebFetch": return "globe"
     case "AskUserQuestion": return "bubble.left"
     default: return "wrench"
@@ -301,6 +302,24 @@ private func getToolDisplay(_ tool: ToolCall, isPending: Bool = false) -> ToolDi
             badgeIcon: isPending ? "clock" : "checkmark.circle",
             overrideSummary: count > 0 ? "\(count) question\(count != 1 ? "s" : "")" : nil
         )
+
+    case "TaskCreate":
+        let subject = input["subject"] as? String
+        return ToolDisplay(icon: "checklist", label: "TaskCreate", detail: subject)
+
+    case "TaskUpdate":
+        let taskId = input["taskId"] as? String
+        let status = input["status"] as? String
+        let parts = [taskId.map { "#\($0)" }, status].compactMap { $0 }
+        let detail = parts.isEmpty ? nil : parts.joined(separator: " → ")
+        return ToolDisplay(icon: "checklist", label: "TaskUpdate", detail: detail)
+
+    case "TaskList":
+        return ToolDisplay(icon: "checklist", label: "TaskList")
+
+    case "TaskGet":
+        let taskId = input["taskId"] as? String
+        return ToolDisplay(icon: "checklist", label: "TaskGet", detail: taskId.map { "#\($0)" })
 
     default:
         return ToolDisplay(icon: toolIcon(for: tool.name), label: tool.name)

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -377,12 +377,18 @@ private struct WhisperToolCallsBlock: View {
     var pendingToolUseIds: Set<String> = []
     @State private var groupExpanded = false
 
+    private static let hiddenTaskTools: Set<String> = ["TaskUpdate"]
+
+    private var visibleTools: [ToolCall] {
+        toolCalls.filter { !Self.hiddenTaskTools.contains($0.name) }
+    }
+
     private var rootTools: [ToolCall] {
-        toolCalls.filter { $0.parentToolUseId == nil }
+        visibleTools.filter { $0.parentToolUseId == nil }
     }
 
     private func children(for parentId: String) -> [ToolCall] {
-        toolCalls.filter { $0.parentToolUseId == parentId }
+        visibleTools.filter { $0.parentToolUseId == parentId }
     }
 
     private var shouldCollapse: Bool {

--- a/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
+++ b/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
@@ -10,40 +10,34 @@ struct TaskTrackerView: View {
 
     var body: some View {
         if !tasks.isEmpty {
-            VStack(alignment: .leading, spacing: 0) {
-                // Collapsed header row
-                Button {
-                    withAnimation(.easeInOut(duration: 0.2)) {
-                        isExpanded.toggle()
-                    }
-                } label: {
-                    collapsedRow
-                }
-                .buttonStyle(.plain)
-
-                // Expanded task list
-                if isExpanded {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(tasks) { task in
-                            taskRow(task)
+            GlassEffectContainer {
+                VStack(alignment: .leading, spacing: 0) {
+                    Button {
+                        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
+                            isExpanded.toggle()
                         }
+                    } label: {
+                        collapsedRow
                     }
-                    .padding(.top, 4)
-                    .padding(.bottom, 2)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
+                    .buttonStyle(.plain)
+
+                    if isExpanded {
+                        VStack(alignment: .leading, spacing: 2) {
+                            ForEach(tasks) { task in
+                                taskRow(task)
+                            }
+                        }
+                        .padding(.top, 6)
+                        .padding(.bottom, 2)
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                    }
                 }
+                .padding(.horizontal, HiveSpacing.lg)
+                .padding(.vertical, HiveSpacing.sm)
+                .glassEffect(.regular, in: RoundedRectangle(cornerRadius: 16))
             }
-            .padding(.horizontal, HiveSpacing.lg)
-            .padding(.vertical, HiveSpacing.sm)
-            .background(
-                Rectangle()
-                    .fill(Color.black.opacity(0.3))
-                    .overlay(alignment: .top) {
-                        Rectangle()
-                            .fill(WhisperColor.border)
-                            .frame(height: 0.5)
-                    }
-            )
+            .padding(.horizontal, HiveSpacing.md)
+            .padding(.vertical, HiveSpacing.xs)
         }
     }
 
@@ -60,7 +54,7 @@ struct TaskTrackerView: View {
         HStack(spacing: HiveSpacing.sm) {
             Image(systemName: "chevron.right")
                 .font(.system(size: 9, weight: .semibold))
-                .foregroundStyle(WhisperColor.textMuted)
+                .foregroundStyle(.tertiary)
                 .rotationEffect(.degrees(isExpanded ? 90 : 0))
 
             Group {
@@ -72,14 +66,14 @@ struct TaskTrackerView: View {
                 }
             }
             .font(WhisperFont.mono(12))
-            .foregroundStyle(WhisperColor.textSecondary)
+            .foregroundStyle(.secondary)
             .lineLimit(1)
             .truncationMode(.tail)
             .frame(maxWidth: .infinity, alignment: .leading)
 
             Text("\(counts.completed)/\(counts.total)")
                 .font(WhisperFont.mono(11))
-                .foregroundStyle(WhisperColor.textMuted.opacity(0.5))
+                .foregroundStyle(.tertiary)
         }
         .contentShape(Rectangle())
         .padding(.vertical, 2)
@@ -96,9 +90,8 @@ struct TaskTrackerView: View {
                  ? (task.activeForm ?? task.subject)
                  : task.subject)
                 .font(WhisperFont.mono(12))
-                .foregroundStyle(foregroundColor(for: task.status))
-                .strikethrough(task.status == .completed,
-                               color: WhisperColor.textMuted.opacity(0.5))
+                .foregroundStyle(textStyle(for: task.status))
+                .strikethrough(task.status == .completed)
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
@@ -122,16 +115,16 @@ struct TaskTrackerView: View {
                 .modifier(PulsingDotModifier())
         case .pending:
             Circle()
-                .stroke(WhisperColor.textMuted.opacity(0.4), lineWidth: 1)
+                .stroke(.tertiary, lineWidth: 1)
                 .frame(width: 9, height: 9)
         }
     }
 
-    private func foregroundColor(for status: TaskStatus) -> Color {
+    private func textStyle(for status: TaskStatus) -> HierarchicalShapeStyle {
         switch status {
-        case .completed: WhisperColor.textMuted.opacity(0.5)
-        case .inProgress: WhisperColor.text
-        case .pending: WhisperColor.textMuted
+        case .completed: .tertiary
+        case .inProgress: .primary
+        case .pending: .secondary
         }
     }
 }

--- a/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
+++ b/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+struct TaskTrackerView: View {
+    let tasks: [TrackedTask]
+    let currentTask: TrackedTask?
+    let counts: TaskCounts
+    let isStreaming: Bool
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        if !tasks.isEmpty {
+            VStack(alignment: .leading, spacing: 0) {
+                // Collapsed header row
+                Button {
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                        isExpanded.toggle()
+                    }
+                } label: {
+                    collapsedRow
+                }
+                .buttonStyle(.plain)
+
+                // Expanded task list
+                if isExpanded {
+                    VStack(alignment: .leading, spacing: 2) {
+                        ForEach(tasks) { task in
+                            taskRow(task)
+                        }
+                    }
+                    .padding(.top, 4)
+                    .padding(.bottom, 2)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+            .padding(.horizontal, HiveSpacing.lg)
+            .padding(.vertical, HiveSpacing.sm)
+            .background(
+                Rectangle()
+                    .fill(Color.black.opacity(0.3))
+                    .overlay(alignment: .top) {
+                        Rectangle()
+                            .fill(WhisperColor.border)
+                            .frame(height: 0.5)
+                    }
+            )
+        }
+    }
+
+    // MARK: - Collapsed Row
+
+    private var collapsedLabel: String {
+        if let current = currentTask {
+            return current.activeForm ?? current.subject
+        }
+        return "All tasks completed"
+    }
+
+    private var collapsedRow: some View {
+        HStack(spacing: HiveSpacing.sm) {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundStyle(WhisperColor.textMuted)
+                .rotationEffect(.degrees(isExpanded ? 90 : 0))
+
+            Group {
+                if currentTask != nil && isStreaming {
+                    Text(collapsedLabel)
+                        .shimmer()
+                } else {
+                    Text(collapsedLabel)
+                }
+            }
+            .font(WhisperFont.mono(12))
+            .foregroundStyle(WhisperColor.textSecondary)
+            .lineLimit(1)
+            .truncationMode(.tail)
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            Text("\(counts.completed)/\(counts.total)")
+                .font(WhisperFont.mono(11))
+                .foregroundStyle(WhisperColor.textMuted.opacity(0.5))
+        }
+        .contentShape(Rectangle())
+        .padding(.vertical, 2)
+    }
+
+    // MARK: - Task Row (expanded)
+
+    private func taskRow(_ task: TrackedTask) -> some View {
+        HStack(spacing: HiveSpacing.sm) {
+            taskStatusIcon(task.status)
+                .frame(width: 14, alignment: .center)
+
+            Text(task.status == .inProgress
+                 ? (task.activeForm ?? task.subject)
+                 : task.subject)
+                .font(WhisperFont.mono(12))
+                .foregroundStyle(foregroundColor(for: task.status))
+                .strikethrough(task.status == .completed,
+                               color: WhisperColor.textMuted.opacity(0.5))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+        .padding(.leading, 20)
+        .padding(.vertical, 1)
+    }
+
+    // MARK: - Status Icons
+
+    @ViewBuilder
+    private func taskStatusIcon(_ status: TaskStatus) -> some View {
+        switch status {
+        case .completed:
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 11))
+                .foregroundStyle(.green)
+        case .inProgress:
+            Circle()
+                .fill(Color.accentColor)
+                .frame(width: 7, height: 7)
+                .modifier(PulsingDotModifier())
+        case .pending:
+            Circle()
+                .stroke(WhisperColor.textMuted.opacity(0.4), lineWidth: 1)
+                .frame(width: 9, height: 9)
+        }
+    }
+
+    private func foregroundColor(for status: TaskStatus) -> Color {
+        switch status {
+        case .completed: WhisperColor.textMuted.opacity(0.5)
+        case .inProgress: WhisperColor.text
+        case .pending: WhisperColor.textMuted
+        }
+    }
+}
+
+// MARK: - Pulsing Dot
+
+private struct PulsingDotModifier: ViewModifier {
+    @State private var isPulsing = false
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isPulsing ? 0.4 : 1.0)
+            .animation(
+                .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                value: isPulsing
+            )
+            .onAppear { isPulsing = true }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 0) {
+        Spacer()
+        TaskTrackerView(
+            tasks: [
+                TrackedTask(id: "1", subject: "Set up database schema", status: .completed, isCreating: false),
+                TrackedTask(id: "2", subject: "Implement API endpoints", activeForm: "Implementing API endpoints", status: .inProgress, isCreating: false),
+                TrackedTask(id: "3", subject: "Write integration tests", status: .pending, isCreating: false),
+            ],
+            currentTask: TrackedTask(id: "2", subject: "Implement API endpoints", activeForm: "Implementing API endpoints", status: .inProgress, isCreating: false),
+            counts: TaskCounts(total: 3, completed: 1, inProgress: 1, pending: 1),
+            isStreaming: true
+        )
+    }
+    .preferredColorScheme(.dark)
+}

--- a/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
+++ b/ios/HiveMobile/Views/Chat/TaskTrackerView.swift
@@ -56,6 +56,7 @@ struct TaskTrackerView: View {
                 .font(.system(size: 9, weight: .semibold))
                 .foregroundStyle(.tertiary)
                 .rotationEffect(.degrees(isExpanded ? 90 : 0))
+                .frame(width: 14, alignment: .center)
 
             Group {
                 if currentTask != nil && isStreaming {
@@ -95,7 +96,6 @@ struct TaskTrackerView: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
         }
-        .padding(.leading, 20)
         .padding(.vertical, 1)
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -804,9 +804,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@csstools/color-helpers": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.1.tgz",
-      "integrity": "sha512-NmXRccUJMk2AWA5A7e5a//3bCIMyOu2hAtdRYrhPPHjDxINuCwX1w6rnIZ4xjLcp0ayv6h8Pc3X0eJUGiAAXHQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
       "dev": true,
       "funding": [
         {
@@ -848,9 +848,9 @@
       }
     },
     "node_modules/@csstools/css-color-parser": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.1.tgz",
-      "integrity": "sha512-vYwO15eRBEkeF6xjAno/KQ61HacNhfQuuU/eGwH67DplL0zD5ZixUa563phQvUelA07yDczIXdtmYojCphKJcw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
       "dev": true,
       "funding": [
         {
@@ -864,8 +864,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@csstools/color-helpers": "^6.0.1",
-        "@csstools/css-calc": "^3.0.0"
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -899,9 +899,9 @@
       }
     },
     "node_modules/@csstools/css-syntax-patches-for-csstree": {
-      "version": "1.0.27",
-      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.27.tgz",
-      "integrity": "sha512-sxP33Jwg1bviSUXAV43cVYdmjt2TLnLXNqCWl9xmxHawWVjGz/kEbdkr7F9pxJNBN2Mh+dq0crgItbW6tQvyow==",
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
       "dev": true,
       "funding": [
         {
@@ -7444,9 +7444,9 @@
       }
     },
     "node_modules/ai": {
-      "version": "6.0.95",
-      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.95.tgz",
-      "integrity": "sha512-10emBqMtiAqyR0xyVdVw2/mZgKWKSWagUHdkE54BNd9b5KSW9ez1BtAmO78nyOtLbOiDfLHUWSUtcJ276/fiKA==",
+      "version": "6.0.97",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-6.0.97.tgz",
+      "integrity": "sha512-eZIAcBymwGhBwncRH/v9pillZNMeRCDkc4BwcvwXerXd7sxjVxRis3ZNCNCpP02pVH4NLs81ljm4cElC4vbNcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/gateway": "3.0.53",
@@ -9987,9 +9987,9 @@
       }
     },
     "node_modules/find-my-way": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.4.0.tgz",
-      "integrity": "sha512-5Ye4vHsypZRYtS01ob/iwHzGRUDELlsoCftI/OZFhcLs1M0tkGPcXldE80TAZC5yYuJMBPJQQ43UHlqbJWiX2w==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.5.0.tgz",
+      "integrity": "sha512-VW2RfnmscZO5KgBY5XVyKREMW5nMZcxDy+buTOsL+zIPnBlbKm+00sgzoQzq1EVh4aALZLfKdwv6atBGcjvjrQ==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -10628,9 +10628,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
-      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
+      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11843,9 +11843,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
-      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",


### PR DESCRIPTION
## Summary
- New `useTasks` hook that parses `TaskCreate`/`TaskUpdate` tool calls from conversation messages into a tracked task state (pending/in_progress/completed)
- New `TaskTracker` component: collapsible progress bar showing current task activity and completion counts, integrated into WorkspaceView sidebar
- Task-related tool rendering in `ChatToolUse` with dedicated checklist icons for `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`
- Backend test updates for `CLAUDE_CODE_ENABLE_TASKS` env var expectations

## Test plan
- [ ] Verify `useTasks` hook correctly tracks task lifecycle from tool call messages
- [ ] Verify `TaskTracker` renders, expands/collapses, and shows correct counts
- [ ] Verify task tool calls render with correct icons and labels in chat
- [ ] Run `npm test` and `npm run typecheck` from repo root