### PR TITLE
Add Gemini CLI as third agent provider

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -78,6 +78,10 @@ function resultLine(sessionId = "sess-123", costUsd = 0.01): string {
   return JSON.stringify({ type: "result", session_id: sessionId, cost_usd: costUsd }) + "\n";
 }
 
+function geminiInitLine(sessionId: string, model = "gemini-2.5-pro"): string {
+  return JSON.stringify({ type: "init", session_id: sessionId, model }) + "\n";
+}
+
 function thinkingAssistantLine(thinking: string, text: string): string {
   return JSON.stringify({
     type: "assistant",
@@ -260,6 +264,29 @@ describe("ConversationSession", () => {
     expect(secondArgs).toContain("--resume");
     expect(secondArgs).toContain(preGeneratedId);
     expect(secondArgs).not.toContain("--session-id");
+  });
+
+  it("uses Gemini init session_id for resume on second message", () => {
+    const session = createSession({ sessionId: "gemini-resume" });
+
+    session.sendMessage("First", { model: "gemini:gemini-2.5-pro" });
+
+    const firstArgs = mockSpawn.mock.calls[0][1] as string[];
+    expect(firstArgs).not.toContain("-r");
+
+    mockProc._stdout.push(geminiInitLine("gem-sess-123"));
+    mockProc._emitClose(0);
+
+    const mockProc2 = createMockProcess();
+    mockSpawn.mockReturnValue(mockProc2);
+
+    session.sendMessage("Second", { model: "gemini:gemini-2.5-flash" });
+
+    const secondArgs = mockSpawn.mock.calls[1][1] as string[];
+    const resumeIdx = secondArgs.indexOf("-r");
+    expect(resumeIdx).toBeGreaterThanOrEqual(0);
+    expect(secondArgs[resumeIdx + 1]).toBe("gem-sess-123");
+    expect(session.metadata.claudeSessionId).toBe("gem-sess-123");
   });
 
   it("emits text_delta for assistant text", () => {
@@ -543,6 +570,37 @@ describe("ConversationSession", () => {
     if (errors[0].type === "error") {
       expect(errors[0].message).toContain("stderr:");
       expect(errors[0].message).toContain("something went wrong");
+    }
+  });
+
+  it("suppresses known Gemini stderr noise messages", () => {
+    const session = createSession({ sessionId: "gemini-stderr-noise" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi", { model: "gemini:gemini-2.5-pro" });
+    mockProc._stderr.push("Loaded cached credentials at /tmp/creds");
+    mockProc._stderr.push("YOLO mode is enabled for this run");
+    mockProc._stderr.push("Retrying with backoff in 1000ms");
+    mockProc._stderr.push("GaxiosError: 429 Too Many Requests");
+
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("still emits stderr errors for Gemini when message is not noise", () => {
+    const session = createSession({ sessionId: "gemini-stderr-real" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi", { model: "gemini:gemini-2.5-pro" });
+    mockProc._stderr.push("permission denied");
+
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(1);
+    if (errors[0].type === "error") {
+      expect(errors[0].message).toContain("stderr:");
+      expect(errors[0].message).toContain("permission denied");
     }
   });
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -23,8 +23,13 @@ import type {
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
 
-/** Gemini CLI writes informational messages to stderr; suppress these from error events. */
-const GEMINI_STDERR_NOISE = ["Loaded cached credentials", "YOLO mode is enabled"];
+/** Gemini CLI writes informational/retry messages to stderr; suppress these from error events. */
+const GEMINI_STDERR_NOISE = [
+  "Loaded cached credentials",
+  "YOLO mode is enabled",
+  "Retrying with backoff",
+  "GaxiosError",
+];
 
 /** Map Anthropic server_tool_use names to their Claude Code display names. */
 const serverToolNameMap: Record<string, string> = {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -7,6 +7,7 @@ import sharp from "sharp";
 import { StreamParser } from "./stream-parser.js";
 import { resolveProvider } from "./providers/registry.js";
 import { CodexStreamAdapter } from "./providers/codex-stream-adapter.js";
+import { GeminiStreamAdapter } from "./providers/gemini-stream-adapter.js";
 import type { AgentProvider, StreamAdapter } from "./providers/types.js";
 import type {
   ChatMessage,
@@ -21,6 +22,9 @@ import type {
 } from "../types.js";
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
+
+/** Gemini CLI writes informational messages to stderr; suppress these from error events. */
+const GEMINI_STDERR_NOISE = ["Loaded cached credentials", "YOLO mode is enabled"];
 
 /** Map Anthropic server_tool_use names to their Claude Code display names. */
 const serverToolNameMap: Record<string, string> = {
@@ -469,9 +473,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
     this.process.stderr?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf-8").trim();
-      if (text) {
-        this.emit("message", { type: "error", message: `stderr: ${text}` } as WsOutgoing);
-      }
+      if (!text) return;
+      // Skip known informational stderr noise from Gemini CLI
+      if (GEMINI_STDERR_NOISE.some((n) => text.includes(n))) return;
+      this.emit("message", { type: "error", message: `stderr: ${text}` } as WsOutgoing);
     });
 
     this.process.on("error", (err) => {
@@ -489,6 +494,12 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       if (this.parser instanceof CodexStreamAdapter && this.parser.capturedThreadId) {
         this.cliSessionId = this.parser.capturedThreadId;
         this._metadata.claudeSessionId = this.parser.capturedThreadId;
+      }
+
+      // For Gemini: capture session_id from the init event for --resume continuity
+      if (this.parser instanceof GeminiStreamAdapter && this.parser.capturedSessionId) {
+        this.cliSessionId = this.parser.capturedSessionId;
+        this._metadata.claudeSessionId = this.parser.capturedSessionId;
       }
 
       const exitCode = code ?? 1;

--- a/backend/src/agents/providers/gemini-stream-adapter.test.ts
+++ b/backend/src/agents/providers/gemini-stream-adapter.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { GeminiStreamAdapter } from "./gemini-stream-adapter.js";
+import type { StreamParserEvent } from "../stream-parser.js";
+
+function line(obj: Record<string, unknown>): string {
+  return JSON.stringify(obj) + "\n";
+}
+
+describe("GeminiStreamAdapter", () => {
+  let adapter: GeminiStreamAdapter;
+
+  beforeEach(() => {
+    adapter = new GeminiStreamAdapter();
+  });
+
+  // ── Init event ──────────────────────────────────────────────────────
+
+  it("captures session_id from init event", () => {
+    adapter.write(line({ type: "init", session_id: "sess-abc", model: "gemini-2.5-pro" }));
+    expect(adapter.capturedSessionId).toBe("sess-abc");
+  });
+
+  it("does not emit events for init", () => {
+    const spy = vi.fn();
+    adapter.on("assistant", spy);
+    adapter.on("result", spy);
+    adapter.on("error", spy);
+
+    adapter.write(line({ type: "init", session_id: "sess-abc", model: "gemini-2.5-pro" }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── Message events ──────────────────────────────────────────────────
+
+  it("emits assistant text from assistant message with delta", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({ type: "message", role: "assistant", content: "Hello!", delta: true }));
+
+    expect(messages).toHaveLength(1);
+    const [data] = messages[0];
+    expect(data.type).toBe("assistant");
+    expect(data.message.content).toEqual([{ type: "text", text: "Hello!" }]);
+  });
+
+  it("emits each assistant message chunk separately for streaming", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({ type: "message", role: "assistant", content: "Part 1 ", delta: true }));
+    adapter.write(line({ type: "message", role: "assistant", content: "Part 2", delta: true }));
+
+    expect(messages).toHaveLength(2);
+    expect(messages[0][0].message.content[0]).toMatchObject({ type: "text", text: "Part 1 " });
+    expect(messages[1][0].message.content[0]).toMatchObject({ type: "text", text: "Part 2" });
+  });
+
+  it("skips user messages", () => {
+    const spy = vi.fn();
+    adapter.on("assistant", spy);
+    adapter.on("user", spy);
+
+    adapter.write(line({ type: "message", role: "user", content: "user input" }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("skips assistant messages with empty content", () => {
+    const spy = vi.fn();
+    adapter.on("assistant", spy);
+
+    adapter.write(line({ type: "message", role: "assistant", content: "", delta: true }));
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── Tool use ────────────────────────────────────────────────────────
+
+  it("emits tool_use with mapped tool name for run_shell_command", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "run_shell_command",
+      tool_id: "cmd-123",
+      parameters: { command: "ls -la", description: "List files" },
+    }));
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0][0].message.content[0]).toMatchObject({
+      type: "tool_use",
+      id: "cmd-123",
+      name: "Bash",
+    });
+  });
+
+  it("maps read_file to Read", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "read_file",
+      tool_id: "rf-1",
+      parameters: { path: "/tmp/test.txt" },
+    }));
+
+    expect(messages[0][0].message.content[0]).toMatchObject({ name: "Read" });
+  });
+
+  it("maps replace_in_file to Edit", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "replace_in_file",
+      tool_id: "edit-1",
+      parameters: { path: "app.ts", old_string: "foo", new_string: "bar" },
+    }));
+
+    expect(messages[0][0].message.content[0]).toMatchObject({ name: "Edit" });
+  });
+
+  it("passes through unmapped tool names as-is", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "some_new_tool",
+      tool_id: "new-1",
+      parameters: { foo: "bar" },
+    }));
+
+    expect(messages[0][0].message.content[0]).toMatchObject({ name: "some_new_tool" });
+  });
+
+  it("serializes tool parameters as JSON input", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "run_shell_command",
+      tool_id: "cmd-1",
+      parameters: { command: "echo hi" },
+    }));
+
+    const input = messages[0][0].message.content[0];
+    expect("input" in input && typeof input.input === "string").toBe(true);
+    if ("input" in input) {
+      expect(JSON.parse(input.input as string)).toEqual({ command: "echo hi" });
+    }
+  });
+
+  // ── Tool result ─────────────────────────────────────────────────────
+
+  it("emits tool_result with mapped fields", () => {
+    const userMsgs: StreamParserEvent["user"][] = [];
+    adapter.on("user", (...args) => userMsgs.push(args));
+
+    adapter.write(line({
+      type: "tool_result",
+      tool_id: "cmd-123",
+      status: "success",
+      output: "file1\nfile2",
+    }));
+
+    expect(userMsgs).toHaveLength(1);
+    expect(userMsgs[0][0].message.content[0]).toMatchObject({
+      type: "tool_result",
+      tool_use_id: "cmd-123",
+      content: "file1\nfile2",
+    });
+  });
+
+  // ── Result event ────────────────────────────────────────────────────
+
+  it("emits result with mapped stats", () => {
+    const results: StreamParserEvent["result"][] = [];
+    adapter.on("result", (...args) => results.push(args));
+
+    adapter.write(line({ type: "init", session_id: "sess-xyz", model: "gemini-2.5-flash" }));
+    adapter.write(line({
+      type: "result",
+      status: "success",
+      stats: { total_tokens: 1000, input_tokens: 800, output_tokens: 200, cached: 100, duration_ms: 3000, tool_calls: 1 },
+    }));
+
+    expect(results).toHaveLength(1);
+    const [data] = results[0];
+    expect(data.session_id).toBe("sess-xyz");
+    expect(data.duration_ms).toBe(3000);
+    expect(data.usage).toEqual({ input_tokens: 800, output_tokens: 200 });
+  });
+
+  it("emits result without stats when not provided", () => {
+    const results: StreamParserEvent["result"][] = [];
+    adapter.on("result", (...args) => results.push(args));
+
+    adapter.write(line({ type: "result", status: "success" }));
+
+    expect(results).toHaveLength(1);
+    expect(results[0][0].usage).toBeUndefined();
+  });
+
+  // ── Error events ────────────────────────────────────────────────────
+
+  it("emits error for error event type", () => {
+    const errors: Error[] = [];
+    adapter.on("error", (err) => errors.push(err));
+
+    adapter.write(line({ type: "error", error: "API rate limit" }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe("API rate limit");
+  });
+
+  it("uses message field as fallback for error", () => {
+    const errors: Error[] = [];
+    adapter.on("error", (err) => errors.push(err));
+
+    adapter.write(line({ type: "error", message: "Fallback msg" }));
+
+    expect(errors[0].message).toBe("Fallback msg");
+  });
+
+  it("uses generic message when error has no error or message", () => {
+    const errors: Error[] = [];
+    adapter.on("error", (err) => errors.push(err));
+
+    adapter.write(line({ type: "error" }));
+
+    expect(errors[0].message).toBe("Gemini error");
+  });
+
+  // ── Malformed JSON ──────────────────────────────────────────────────
+
+  it("emits error for malformed JSON lines", () => {
+    const errors: Error[] = [];
+    adapter.on("error", (err) => errors.push(err));
+
+    adapter.write("not json\n");
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain("Malformed Gemini JSON line");
+  });
+
+  // ── Unknown event types ─────────────────────────────────────────────
+
+  it("does not crash on unknown event types", () => {
+    const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    adapter.write(line({ type: "some.unknown.event" }));
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining("[gemini-adapter]"), "some.unknown.event");
+    spy.mockRestore();
+  });
+
+  // ── Line buffering ──────────────────────────────────────────────────
+
+  it("handles partial lines across multiple writes", () => {
+    const messages: StreamParserEvent["assistant"][] = [];
+    adapter.on("assistant", (...args) => messages.push(args));
+
+    const fullLine = JSON.stringify({
+      type: "message",
+      role: "assistant",
+      content: "Split across writes",
+      delta: true,
+    });
+
+    const mid = Math.floor(fullLine.length / 2);
+    adapter.write(fullLine.slice(0, mid));
+    expect(messages).toHaveLength(0);
+
+    adapter.write(fullLine.slice(mid) + "\n");
+    expect(messages).toHaveLength(1);
+  });
+
+  it("skips empty lines", () => {
+    const spy = vi.fn();
+    adapter.on("error", spy);
+
+    adapter.write("\n\n\n");
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  // ── flush() ─────────────────────────────────────────────────────────
+
+  it("processes remaining buffer on flush()", () => {
+    adapter.write(JSON.stringify({ type: "init", session_id: "s1", model: "m" }));
+    expect(adapter.capturedSessionId).toBeUndefined();
+
+    adapter.flush();
+    expect(adapter.capturedSessionId).toBe("s1");
+  });
+
+  // ── Full conversation flow ──────────────────────────────────────────
+
+  it("handles a complete conversation flow", () => {
+    const assistantMsgs: StreamParserEvent["assistant"][] = [];
+    const userMsgs: StreamParserEvent["user"][] = [];
+    const results: StreamParserEvent["result"][] = [];
+    adapter.on("assistant", (...args) => assistantMsgs.push(args));
+    adapter.on("user", (...args) => userMsgs.push(args));
+    adapter.on("result", (...args) => results.push(args));
+
+    // Init
+    adapter.write(line({ type: "init", session_id: "sess-full", model: "gemini-2.5-pro" }));
+
+    // User message (skipped)
+    adapter.write(line({ type: "message", role: "user", content: "list files" }));
+
+    // Assistant text
+    adapter.write(line({ type: "message", role: "assistant", content: "I'll list the files.", delta: true }));
+
+    // Tool call
+    adapter.write(line({
+      type: "tool_use",
+      tool_name: "run_shell_command",
+      tool_id: "cmd-1",
+      parameters: { command: "ls /tmp" },
+    }));
+
+    // Tool result
+    adapter.write(line({
+      type: "tool_result",
+      tool_id: "cmd-1",
+      status: "success",
+      output: "file1\nfile2",
+    }));
+
+    // Final assistant text
+    adapter.write(line({ type: "message", role: "assistant", content: "Found 2 files.", delta: true }));
+
+    // Result
+    adapter.write(line({
+      type: "result",
+      status: "success",
+      stats: { input_tokens: 500, output_tokens: 50, duration_ms: 2000 },
+    }));
+
+    // 2 text messages + 1 tool_use = 3 assistant events
+    expect(assistantMsgs).toHaveLength(3);
+    // 1 tool_result = 1 user event
+    expect(userMsgs).toHaveLength(1);
+    // 1 result
+    expect(results).toHaveLength(1);
+    expect(results[0][0].session_id).toBe("sess-full");
+    expect(adapter.capturedSessionId).toBe("sess-full");
+  });
+});

--- a/backend/src/agents/providers/gemini-stream-adapter.ts
+++ b/backend/src/agents/providers/gemini-stream-adapter.ts
@@ -1,0 +1,178 @@
+import { EventEmitter } from "node:events";
+import type { StreamParserEvent } from "../stream-parser.js";
+import type { StreamAdapter } from "./types.js";
+
+/**
+ * Gemini CLI NDJSON event shapes (from `gemini -p "..." -o stream-json`).
+ * Only the fields we consume are typed.
+ */
+
+interface GeminiInit {
+  type: "init";
+  session_id: string;
+  model: string;
+}
+
+interface GeminiMessage {
+  type: "message";
+  role: "user" | "assistant";
+  content: string;
+  delta?: boolean;
+}
+
+interface GeminiToolUse {
+  type: "tool_use";
+  tool_name: string;
+  tool_id: string;
+  parameters: Record<string, unknown>;
+}
+
+interface GeminiToolResult {
+  type: "tool_result";
+  tool_id: string;
+  status: string;
+  output: string;
+}
+
+interface GeminiResult {
+  type: "result";
+  status: string;
+  stats?: {
+    total_tokens?: number;
+    input_tokens?: number;
+    output_tokens?: number;
+    cached?: number;
+    duration_ms?: number;
+    tool_calls?: number;
+  };
+}
+
+interface GeminiError {
+  type: "error";
+  error?: string;
+  message?: string;
+}
+
+type GeminiJsonLine =
+  | GeminiInit
+  | GeminiMessage
+  | GeminiToolUse
+  | GeminiToolResult
+  | GeminiResult
+  | GeminiError;
+
+/** Map Gemini tool names to display names for the frontend. */
+const TOOL_NAME_MAP: Record<string, string> = {
+  run_shell_command: "Bash",
+  read_file: "Read",
+  write_file: "Write",
+  replace_in_file: "Edit",
+  search_files: "Grep",
+  list_directory: "Ls",
+  web_search: "WebSearch",
+  web_fetch: "WebFetch",
+  glob: "Glob",
+};
+
+/**
+ * Normalizes Gemini CLI NDJSON output into the same StreamParserEvent format
+ * that conversation-session.ts expects (identical to Claude's stream-parser).
+ */
+export class GeminiStreamAdapter extends EventEmitter<StreamParserEvent> implements StreamAdapter {
+  private buffer = "";
+  private sessionId: string | undefined;
+
+  get capturedSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
+  write(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      this.parseLine(trimmed);
+    }
+  }
+
+  flush(): void {
+    const trimmed = this.buffer.trim();
+    this.buffer = "";
+    if (trimmed) this.parseLine(trimmed);
+  }
+
+  private parseLine(line: string): void {
+    let parsed: GeminiJsonLine;
+    try {
+      parsed = JSON.parse(line) as GeminiJsonLine;
+    } catch {
+      this.emit("error", new Error(`Malformed Gemini JSON line: ${line.slice(0, 200)}`));
+      return;
+    }
+
+    switch (parsed.type) {
+      case "init":
+        this.sessionId = parsed.session_id;
+        break;
+
+      case "message":
+        // Only forward assistant messages; user messages are already tracked
+        if (parsed.role === "assistant" && parsed.content) {
+          this.emit("assistant", {
+            type: "assistant" as const,
+            message: {
+              id: `text-${Date.now()}`,
+              role: "assistant" as const,
+              content: [{ type: "text" as const, text: parsed.content }],
+            },
+          });
+        }
+        break;
+
+      case "tool_use": {
+        const displayName = TOOL_NAME_MAP[parsed.tool_name] ?? parsed.tool_name;
+        const input = JSON.stringify(parsed.parameters, null, 2);
+        this.emit("assistant", {
+          type: "assistant" as const,
+          message: {
+            id: parsed.tool_id,
+            role: "assistant" as const,
+            content: [{ type: "tool_use" as const, id: parsed.tool_id, name: displayName, input }],
+          },
+        });
+        break;
+      }
+
+      case "tool_result":
+        this.emit("user", {
+          type: "user" as const,
+          message: {
+            role: "user" as const,
+            content: [{ type: "tool_result" as const, tool_use_id: parsed.tool_id, content: parsed.output }],
+          },
+        });
+        break;
+
+      case "result":
+        this.emit("result", {
+          type: "result" as const,
+          session_id: this.sessionId ?? "",
+          duration_ms: parsed.stats?.duration_ms,
+          usage: parsed.stats
+            ? { input_tokens: parsed.stats.input_tokens ?? 0, output_tokens: parsed.stats.output_tokens ?? 0 }
+            : undefined,
+        });
+        break;
+
+      case "error":
+        this.emit("error", new Error(parsed.error ?? parsed.message ?? "Gemini error"));
+        break;
+
+      default:
+        console.warn("[gemini-adapter] unknown event type:", (parsed as { type: string }).type);
+        break;
+    }
+  }
+}

--- a/backend/src/agents/providers/gemini.test.ts
+++ b/backend/src/agents/providers/gemini.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from "vitest";
+import { GeminiProvider } from "./gemini.js";
+import { GeminiStreamAdapter } from "./gemini-stream-adapter.js";
+import type { ProviderSessionState } from "./types.js";
+
+function baseSession(overrides?: Partial<ProviderSessionState>): ProviderSessionState {
+  return {
+    isFirstMessage: true,
+    sessionId: "gemini-session-id",
+    skipPermissions: true,
+    ...overrides,
+  };
+}
+
+describe("GeminiProvider", () => {
+  const provider = new GeminiProvider();
+
+  // ── Identity ───────────────────────────────────────────────────────
+
+  it("has id 'gemini'", () => {
+    expect(provider.id).toBe("gemini");
+  });
+
+  it("has command 'gemini'", () => {
+    expect(provider.command).toBe("gemini");
+  });
+
+  // ── Models ─────────────────────────────────────────────────────────
+
+  it("exposes a non-empty list of models", () => {
+    expect(provider.models.length).toBeGreaterThan(0);
+  });
+
+  it("has exactly one default model", () => {
+    const defaults = provider.models.filter((m) => m.isDefault);
+    expect(defaults).toHaveLength(1);
+    expect(defaults[0]?.id).toBe("gemini-2.5-pro");
+  });
+
+  it("includes Gemini 3 preview models marked as new", () => {
+    const newModels = provider.models.filter((m) => m.isNew);
+    expect(newModels.map((m) => m.id)).toEqual([
+      "gemini-3-pro-preview",
+      "gemini-3-flash-preview",
+    ]);
+  });
+
+  // ── Capabilities ───────────────────────────────────────────────────
+
+  it("does not expose thinking toggle", () => {
+    expect(provider.capabilities.thinking).toBe(false);
+  });
+
+  it("does not support plan mode", () => {
+    expect(provider.capabilities.planMode).toBe(false);
+  });
+
+  it("does not support blocking tools", () => {
+    expect(provider.capabilities.blockingTools).toBe(false);
+  });
+
+  it("does not support completions", () => {
+    expect(provider.capabilities.completions).toBe(false);
+  });
+
+  // ── buildArgs ──────────────────────────────────────────────────────
+
+  it("builds first-message args with prompt, output format, yolo, and model", () => {
+    const args = provider.buildArgs(
+      "Hello Gemini",
+      { model: "gemini-2.5-flash" },
+      baseSession({ isFirstMessage: true }),
+    );
+
+    expect(args).toContain("-p");
+    expect(args).toContain("Hello Gemini");
+    expect(args).toContain("-o");
+    expect(args).toContain("stream-json");
+    expect(args).toContain("-m");
+    expect(args).toContain("gemini-2.5-flash");
+    expect(args).toContain("-y");
+    expect(args).not.toContain("-r");
+  });
+
+  it("omits model flag when model is unknown", () => {
+    const args = provider.buildArgs("Hello Gemini", { model: "unknown-model" }, baseSession());
+    expect(args).not.toContain("-m");
+  });
+
+  it("adds resume flag on subsequent messages", () => {
+    const args = provider.buildArgs(
+      "Continue",
+      { model: "gemini-2.5-pro" },
+      baseSession({ isFirstMessage: false, sessionId: "gem-sess-123" }),
+    );
+
+    const resumeIndex = args.indexOf("-r");
+    expect(resumeIndex).toBeGreaterThanOrEqual(0);
+    expect(args[resumeIndex + 1]).toBe("gem-sess-123");
+  });
+
+  it("passes prompt content as value of -p", () => {
+    const args = provider.buildArgs("Prompt content", {}, baseSession());
+    const promptIdx = args.indexOf("-p");
+    expect(promptIdx).toBeGreaterThanOrEqual(0);
+    expect(args[promptIdx + 1]).toBe("Prompt content");
+  });
+
+  // ── buildEnv ───────────────────────────────────────────────────────
+
+  it("always returns undefined for env overrides", () => {
+    expect(provider.buildEnv({})).toBeUndefined();
+    expect(provider.buildEnv({ thinkingEnabled: true })).toBeUndefined();
+    expect(provider.buildEnv({ planMode: true })).toBeUndefined();
+  });
+
+  // ── createStreamAdapter ────────────────────────────────────────────
+
+  it("returns a GeminiStreamAdapter instance", () => {
+    const adapter = provider.createStreamAdapter();
+    expect(adapter).toBeInstanceOf(GeminiStreamAdapter);
+  });
+});

--- a/backend/src/agents/providers/gemini.ts
+++ b/backend/src/agents/providers/gemini.ts
@@ -1,0 +1,54 @@
+import { GeminiStreamAdapter } from "./gemini-stream-adapter.js";
+import type {
+  AgentProvider,
+  ModelDefinition,
+  ProviderCapabilities,
+  ProviderMessageOptions,
+  ProviderSessionState,
+  StreamAdapter,
+} from "./types.js";
+
+const GEMINI_MODELS: ModelDefinition[] = [
+  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", cliValue: "gemini-2.5-pro", isDefault: true },
+  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", cliValue: "gemini-2.5-flash" },
+  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", cliValue: "gemini-2.5-flash-lite" },
+  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro", cliValue: "gemini-3-pro-preview", isNew: true },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash", cliValue: "gemini-3-flash-preview", isNew: true },
+];
+
+const GEMINI_CAPABILITIES: ProviderCapabilities = {
+  thinking: true,
+  planMode: false,
+  blockingTools: false,
+  completions: false,
+};
+
+export class GeminiProvider implements AgentProvider {
+  readonly id = "gemini";
+  readonly command = "gemini";
+  readonly models = GEMINI_MODELS;
+  readonly capabilities = GEMINI_CAPABILITIES;
+
+  buildArgs(
+    content: string,
+    options: ProviderMessageOptions,
+    session: ProviderSessionState,
+  ): string[] {
+    const model = this.models.find((m) => m.id === options.model);
+    return [
+      "-p", content,
+      "-o", "stream-json",
+      ...(model ? ["-m", model.cliValue] : []),
+      "-y",
+      ...(session.isFirstMessage ? [] : ["-r", session.sessionId]),
+    ];
+  }
+
+  buildEnv(_options: ProviderMessageOptions): Record<string, string> | undefined {
+    return undefined;
+  }
+
+  createStreamAdapter(): StreamAdapter {
+    return new GeminiStreamAdapter();
+  }
+}

--- a/backend/src/agents/providers/gemini.ts
+++ b/backend/src/agents/providers/gemini.ts
@@ -17,7 +17,7 @@ const GEMINI_MODELS: ModelDefinition[] = [
 ];
 
 const GEMINI_CAPABILITIES: ProviderCapabilities = {
-  thinking: true,
+  thinking: false, // Gemini 2.5 thinks by default; no CLI flag to control it
   planMode: false,
   blockingTools: false,
   completions: false,

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -58,6 +58,12 @@ describe("resolveProvider", () => {
     expect(modelId).toBe("gpt-5.3-codex");
   });
 
+  it("resolves gemini:model-id correctly", () => {
+    const { provider, modelId } = resolveProvider("gemini:gemini-2.5-pro");
+    expect(provider.id).toBe("gemini");
+    expect(modelId).toBe("gemini-2.5-pro");
+  });
+
   it("throws for unknown provider prefix", () => {
     expect(() => resolveProvider("unknown:some-model")).toThrow("Unknown provider: unknown");
   });
@@ -81,6 +87,12 @@ describe("getProvider", () => {
     const provider = getProvider("codex");
     expect(provider).toBeDefined();
     expect(provider!.id).toBe("codex");
+  });
+
+  it("returns gemini provider by ID", () => {
+    const provider = getProvider("gemini");
+    expect(provider).toBeDefined();
+    expect(provider!.id).toBe("gemini");
   });
 
   it("returns undefined for unknown provider", () => {
@@ -132,6 +144,18 @@ describe("getModelCatalog", () => {
     }
   });
 
+  it("includes gemini models when gemini is available", () => {
+    markProviderAvailable("gemini");
+    const catalog = getModelCatalog();
+
+    const geminiModels = catalog.models.filter((m) => m.provider === "gemini");
+    expect(geminiModels.length).toBeGreaterThan(0);
+
+    for (const model of geminiModels) {
+      expect(model.id).toMatch(/^gemini:/);
+    }
+  });
+
   it("sets defaultModelId to claude default when available", () => {
     markProviderAvailable("claude");
     const catalog = getModelCatalog();
@@ -158,6 +182,14 @@ describe("getModelCatalog", () => {
     expect(claudeModel?.providerLabel).toBe("Claude Code");
   });
 
+  it("uses Gemini CLI label for gemini models", () => {
+    markProviderAvailable("gemini");
+    const catalog = getModelCatalog();
+
+    const geminiModel = catalog.models.find((m) => m.provider === "gemini");
+    expect(geminiModel?.providerLabel).toBe("Gemini CLI");
+  });
+
   it("includes capabilities for each model", () => {
     markProviderAvailable("claude");
     const catalog = getModelCatalog();
@@ -169,6 +201,20 @@ describe("getModelCatalog", () => {
       expect(typeof model.capabilities.blockingTools).toBe("boolean");
       expect(typeof model.capabilities.completions).toBe("boolean");
     }
+  });
+
+  it("exposes gemini capabilities with thinking disabled", () => {
+    markProviderAvailable("gemini");
+    const catalog = getModelCatalog();
+
+    const geminiModel = catalog.models.find((m) => m.provider === "gemini");
+    expect(geminiModel).toBeDefined();
+    expect(geminiModel?.capabilities).toEqual({
+      thinking: false,
+      planMode: false,
+      blockingTools: false,
+      completions: false,
+    });
   });
 
   it("includes isNew flag from model definition", () => {
@@ -208,6 +254,7 @@ describe("detectAvailableProviders", () => {
     const providers = new Set(catalog.models.map((m) => m.provider));
     expect(providers.has("claude")).toBe(true);
     expect(providers.has("codex")).toBe(true);
+    expect(providers.has("gemini")).toBe(true);
   });
 
   it("ignores providers whose CLI is not found", async () => {

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -2,6 +2,7 @@ import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
+import { GeminiProvider } from "./gemini.js";
 import type { AgentProvider, ModelCatalogEntry, ModelCatalogResponse } from "./types.js";
 
 const execFile = promisify(execFileCb);
@@ -9,12 +10,14 @@ const execFile = promisify(execFileCb);
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  gemini: "Gemini CLI",
 };
 
 /** All known providers. Availability is checked at runtime via CLI detection. */
 const ALL_PROVIDERS: AgentProvider[] = [
   new ClaudeProvider(),
   new CodexProvider(),
+  new GeminiProvider(),
 ];
 
 const providerMap = new Map<string, AgentProvider>(

--- a/backend/src/utils/preflight.test.ts
+++ b/backend/src/utils/preflight.test.ts
@@ -1,5 +1,17 @@
-import { describe, it, expect } from "vitest";
-import { meetsMinVersion } from "./preflight.js";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:child_process", () => ({
+  execFile: vi.fn(
+    (_cmd: string, _args: string[], cb: (...cbArgs: unknown[]) => void) => {
+      cb(null, { stdout: "ok", stderr: "" });
+    },
+  ),
+}));
+
+import { execFile } from "node:child_process";
+import { meetsMinVersion, preflight } from "./preflight.js";
+
+const mockExecFile = execFile as unknown as ReturnType<typeof vi.fn>;
 
 describe("meetsMinVersion()", () => {
   it("accepts exact match", () => {
@@ -20,5 +32,106 @@ describe("meetsMinVersion()", () => {
 
   it("rejects lower major", () => {
     expect(meetsMinVersion("1.99.0", [2, 17])).toBe(false);
+  });
+});
+
+describe("preflight()", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("continues when optional dependencies (codex, gemini) are missing", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit-${String(code)}`);
+    }) as never);
+
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "codex" || cmd === "gemini") {
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+          return;
+        }
+        if (cmd === "git") {
+          cb(null, { stdout: "git version 2.44.0", stderr: "" });
+          return;
+        }
+        cb(null, { stdout: "1.0.0", stderr: "" });
+      },
+    );
+
+    await preflight();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("optional: 'codex' not found"));
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining("optional: 'gemini' not found"));
+  });
+
+  it("exits when a required dependency is missing", async () => {
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit-${String(code)}`);
+    }) as never);
+
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "claude") {
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+          return;
+        }
+        if (cmd === "git") {
+          cb(null, { stdout: "git version 2.44.0", stderr: "" });
+          return;
+        }
+        cb(null, { stdout: "1.0.0", stderr: "" });
+      },
+    );
+
+    await expect(preflight()).rejects.toThrow("exit-1");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("'claude' not found"));
+  });
+
+  it("exits when git version is below minimum", async () => {
+    vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit-${String(code)}`);
+    }) as never);
+
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "git") {
+          cb(null, { stdout: "git version 2.16.9", stderr: "" });
+          return;
+        }
+        cb(null, { stdout: "1.0.0", stderr: "" });
+      },
+    );
+
+    await expect(preflight()).rejects.toThrow("exit-1");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("git 2.16.9 is too old (need >= 2.17)"));
+  });
+
+  it("does not warn for gemini when gemini CLI exists", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: string | number | null) => {
+      throw new Error(`exit-${String(code)}`);
+    }) as never);
+
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "git") {
+          cb(null, { stdout: "git version 2.44.0", stderr: "" });
+          return;
+        }
+        cb(null, { stdout: "1.0.0", stderr: "" });
+      },
+    );
+
+    await preflight();
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalledWith(expect.stringContaining("'gemini' not found"));
   });
 });

--- a/backend/src/utils/preflight.ts
+++ b/backend/src/utils/preflight.ts
@@ -41,6 +41,12 @@ const DEPENDENCIES: Dependency[] = [
     versionArgs: ["--version"],
     required: false,
   },
+  {
+    name: "gemini",
+    command: "gemini",
+    versionArgs: ["--version"],
+    required: false,
+  },
 ];
 
 export function meetsMinVersion(version: string, min: [number, number]): boolean {

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { CheckIcon, SparklesIcon, StarIcon } from "lucide-react";
+import { CheckIcon, StarIcon } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -30,8 +30,12 @@ function ProviderIcon({ provider, className }: { provider: string; className?: s
       </svg>
     );
   }
-  // Claude: use sparkles as a proxy for the Anthropic asterisk
-  return <SparklesIcon className={cn("size-3.5", className)} />;
+  // Claude: Anthropic asterisk
+  return (
+    <svg className={cn("size-3.5", className)} viewBox="0 0 256 256" fill="currentColor">
+      <path d="M177.888 112.776 128.555 4H100.453l72.238 196.714h28.096L177.888 112.776ZM83.209 200.714 155.447 4h-28.102L55.107 200.714h28.102Z" />
+    </svg>
+  );
 }
 
 interface ModelSelectorProps {

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -14,12 +14,19 @@ import { PromptInputButton } from "@/components/ai-elements/prompt-input";
 import type { ModelCatalogEntry } from "@/types";
 import { cn } from "@/lib/utils";
 
-/** Provider icon: Anthropic asterisk for Claude, OpenAI swirl for Codex. */
+/** Provider icon: Anthropic asterisk for Claude, OpenAI swirl for Codex, Gemini star for Gemini. */
 function ProviderIcon({ provider, className }: { provider: string; className?: string }) {
   if (provider === "codex") {
     return (
       <svg className={cn("size-3.5", className)} viewBox="0 0 24 24" fill="currentColor">
         <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+      </svg>
+    );
+  }
+  if (provider === "gemini") {
+    return (
+      <svg className={cn("size-3.5", className)} viewBox="0 0 24 24" fill="currentColor">
+        <path d="M12 0C12 6.627 6.627 12 0 12c6.627 0 12 5.373 12 12 0-6.627 5.373-12 12-12-6.627 0-12-5.373-12-12Z" />
       </svg>
     );
   }

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -34,6 +34,16 @@ const CODEX_MODELS: ModelCatalogEntry[] = [
   },
 ];
 
+const GEMINI_MODELS: ModelCatalogEntry[] = [
+  {
+    id: "gemini:gemini-2.5-pro",
+    label: "Gemini 2.5 Pro",
+    provider: "gemini",
+    providerLabel: "Gemini CLI",
+    capabilities: { thinking: false, planMode: false, blockingTools: false, completions: false },
+  },
+];
+
 const ALL_MODELS = [...CLAUDE_MODELS, ...CODEX_MODELS];
 
 describe("ModelSelector", () => {
@@ -67,7 +77,7 @@ describe("ModelSelector", () => {
     const user = userEvent.setup();
     render(
       <ModelSelector
-        models={ALL_MODELS}
+        models={[...ALL_MODELS, ...GEMINI_MODELS]}
         selectedModelId="claude:opus-4-6"
         defaultModelId="claude:opus-4-6"
         onSelect={vi.fn()}
@@ -79,10 +89,12 @@ describe("ModelSelector", () => {
     // Provider labels
     expect(screen.getByText("Claude Code")).toBeInTheDocument();
     expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(screen.getByText("Gemini CLI")).toBeInTheDocument();
 
     // Model labels
     expect(screen.getByText("Sonnet 4.6")).toBeInTheDocument();
     expect(screen.getByText("GPT-5.3-Codex")).toBeInTheDocument();
+    expect(screen.getByText("Gemini 2.5 Pro")).toBeInTheDocument();
   });
 
   it("shows NEW badge for models with isNew flag", async () => {
@@ -212,5 +224,50 @@ describe("ModelSelector", () => {
     );
 
     expect(screen.getByRole("button", { name: /Model: Sonnet 4.6/i })).toBeInTheDocument();
+  });
+
+  it("renders Gemini icon when Gemini is selected", () => {
+    render(
+      <ModelSelector
+        models={[...ALL_MODELS, ...GEMINI_MODELS]}
+        selectedModelId="gemini:gemini-2.5-pro"
+        defaultModelId="claude:opus-4-6"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Model: Gemini 2.5 Pro/i });
+    const iconPath = trigger.querySelector("svg path")?.getAttribute("d");
+    expect(iconPath).toContain("M12 0C12 6.627");
+  });
+
+  it("renders Anthropic asterisk icon for Claude", () => {
+    render(
+      <ModelSelector
+        models={ALL_MODELS}
+        selectedModelId="claude:opus-4-6"
+        defaultModelId="claude:opus-4-6"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Model: Opus 4.6/i });
+    const iconPath = trigger.querySelector("svg path")?.getAttribute("d");
+    expect(iconPath).toContain("M177.888 112.776");
+  });
+
+  it("falls back to Claude icon when selected model is missing", () => {
+    render(
+      <ModelSelector
+        models={[...ALL_MODELS, ...GEMINI_MODELS]}
+        selectedModelId="missing:model"
+        defaultModelId="claude:opus-4-6"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: /Model: Select model/i });
+    const iconPath = trigger.querySelector("svg path")?.getAttribute("d");
+    expect(iconPath).toContain("M177.888 112.776");
   });
 });


### PR DESCRIPTION
Integrate Gemini CLI alongside Claude and Codex using the existing provider abstraction. Gemini sessions support provider locking, tool name mapping, session resume via --resume, and stream-json NDJSON parsing. Frontend auto-adapts via capabilities (no plan mode, no completions, thinking toggle enabled).