### PR TITLE
Stop stripping HOST from workspace child processes

### DIFF
--- a/backend/src/utils/env.test.ts
+++ b/backend/src/utils/env.test.ts
@@ -70,7 +70,6 @@ describe("buildWorkspaceEnv()", () => {
     const env = buildWorkspaceEnv();
     expect(env.NODE_ENV).toBeUndefined();
     expect(env.PORT).toBeUndefined();
-    expect(env.HOST).toBeUndefined();
     expect(env.DATA_DIR).toBeUndefined();
     expect(env.TELEGRAM_BOT_TOKEN).toBeUndefined();
     expect(env.TELEGRAM_CHAT_ID).toBeUndefined();

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -2,7 +2,6 @@
 const STRIPPED_VARS = [
   "NODE_ENV",
   "PORT",
-  "HOST",
   "DATA_DIR",
   "TELEGRAM_BOT_TOKEN",
   "TELEGRAM_CHAT_ID",


### PR DESCRIPTION
HOST is not a secret or backend-internal variable — it's a network binding choice that workspace scripts (hive.json) should be free to inherit or override. Stripping it caused dev servers launched via hive.json scripts to fall back to 127.0.0.1, breaking Tailscale remote access.