### PR TITLE
Auto-start setup script on workspace creation and navigate to new workspace

### DIFF
--- a/backend/src/api/workspaces.auto-setup.test.ts
+++ b/backend/src/api/workspaces.auto-setup.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { join } from "node:path";
+import type { Workspace } from "../types.js";
+
+const mocks = vi.hoisted(() => ({
+  createWorkspace: vi.fn(),
+  listWorkspaces: vi.fn(),
+  getWorkspace: vi.fn(),
+  deleteWorkspace: vi.fn(),
+  getWorkspaceDiff: vi.fn(),
+  getWorkspaceDiffStat: vi.fn(),
+  listWorkspaceFiles: vi.fn(),
+  getWorkspaceFileContent: vi.fn(),
+  mergeWorkspace: vi.fn(),
+  archiveWorkspace: vi.fn(),
+  endSession: vi.fn(),
+  parseGitHubRepo: vi.fn(),
+  fetchPrForBranch: vi.fn(),
+  getBranchName: vi.fn(),
+  readHiveConfig: vi.fn(),
+  startScript: vi.fn(),
+  broadcastToWorkspace: vi.fn(),
+}));
+
+vi.mock("../workspaces/workspace-manager.js", () => ({
+  createWorkspace: mocks.createWorkspace,
+  listWorkspaces: mocks.listWorkspaces,
+  getWorkspace: mocks.getWorkspace,
+  deleteWorkspace: mocks.deleteWorkspace,
+  getWorkspaceDiff: mocks.getWorkspaceDiff,
+  getWorkspaceDiffStat: mocks.getWorkspaceDiffStat,
+  listWorkspaceFiles: mocks.listWorkspaceFiles,
+  getWorkspaceFileContent: mocks.getWorkspaceFileContent,
+  mergeWorkspace: mocks.mergeWorkspace,
+  archiveWorkspace: mocks.archiveWorkspace,
+}));
+
+vi.mock("../agents/agent-manager.js", () => ({
+  endSession: mocks.endSession,
+}));
+
+vi.mock("../utils/github.js", () => ({
+  parseGitHubRepo: mocks.parseGitHubRepo,
+  fetchPrForBranch: mocks.fetchPrForBranch,
+}));
+
+vi.mock("../services/git-sync.js", () => ({
+  getBranchName: mocks.getBranchName,
+}));
+
+vi.mock("../utils/hive-config.js", () => ({
+  readHiveConfig: mocks.readHiveConfig,
+}));
+
+vi.mock("../services/script-runner.js", () => ({
+  startScript: mocks.startScript,
+}));
+
+vi.mock("../ws/stream.js", () => ({
+  broadcastToWorkspace: mocks.broadcastToWorkspace,
+}));
+
+import { workspaceRoutes } from "./workspaces.js";
+
+const DATA_DIR = "/tmp/hive-auto-setup-test";
+const PROJECT_ID = "project-1";
+
+const workspace: Workspace = {
+  id: "ws-1",
+  name: "tokyo",
+  projectId: PROJECT_ID,
+  branch: "workspace/tokyo",
+  status: "idle",
+  createdAt: "2026-02-23T00:00:00.000Z",
+};
+
+let app: ReturnType<typeof Fastify>;
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+
+  mocks.createWorkspace.mockResolvedValue(workspace);
+  mocks.readHiveConfig.mockResolvedValue(null);
+  mocks.startScript.mockReturnValue({ exitListeners: new Map<string, (code: number) => void>() });
+
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => workspaceRoutes(instance, DATA_DIR));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe("POST /api/projects/:id/workspaces auto-setup", () => {
+  it("starts setup script when hive.json defines scripts.setup", async () => {
+    const exitListeners = new Map<string, (code: number) => void>();
+    mocks.readHiveConfig.mockResolvedValueOnce({ scripts: { setup: "npm ci" } });
+    mocks.startScript.mockReturnValueOnce({ exitListeners });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${PROJECT_ID}/workspaces`,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(mocks.createWorkspace).toHaveBeenCalledWith(PROJECT_ID, DATA_DIR);
+
+    const wsPath = join(DATA_DIR, PROJECT_ID, "workspaces", workspace.name);
+    expect(mocks.readHiveConfig).toHaveBeenCalledWith(wsPath);
+    expect(mocks.startScript).toHaveBeenCalledWith(workspace.id, "setup", "npm ci", wsPath);
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(workspace.id, {
+      type: "script_status",
+      scriptType: "setup",
+      state: "running",
+    });
+
+    expect(exitListeners.size).toBe(1);
+    const listener = [...exitListeners.values()][0];
+    mocks.broadcastToWorkspace.mockClear();
+    listener(0);
+
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(workspace.id, {
+      type: "script_status",
+      scriptType: "setup",
+      state: "done",
+      exitCode: 0,
+    });
+    expect(exitListeners.size).toBe(0);
+  });
+
+  it("does nothing when scripts.setup is missing", async () => {
+    mocks.readHiveConfig.mockResolvedValueOnce({
+      scripts: { run: { dev: "npm run dev" } },
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${PROJECT_ID}/workspaces`,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(mocks.startScript).not.toHaveBeenCalled();
+    expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("still returns 201 when auto-setup fails", async () => {
+    mocks.readHiveConfig.mockResolvedValueOnce({ scripts: { setup: "npm ci" } });
+    mocks.startScript.mockImplementationOnce(() => {
+      throw new Error("setup launch failed");
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${PROJECT_ID}/workspaces`,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual(workspace);
+  });
+
+  it("still returns 201 when hive config cannot be read", async () => {
+    mocks.readHiveConfig.mockRejectedValueOnce(new Error("cannot read hive.json"));
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${PROJECT_ID}/workspaces`,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(mocks.startScript).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -18,12 +18,44 @@ import { getDataDir } from "../state/state.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
 import { parseGitHubRepo, fetchPrForBranch } from "../utils/github.js";
 import { getBranchName } from "../services/git-sync.js";
+import { readHiveConfig } from "../utils/hive-config.js";
+import { startScript } from "../services/script-runner.js";
+import { broadcastToWorkspace } from "../ws/stream.js";
 import type { PrStatusResponse } from "../types.js";
 
 export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
   app.post<{ Params: { id: string } }>("/api/projects/:id/workspaces", async (req, reply) => {
     try {
       const workspace = await createWorkspace(req.params.id, dataDir);
+
+      // Auto-start setup script if hive.json defines one
+      const dir = dataDir ?? getDataDir();
+      const wsPath = join(workspacesDir(dir, req.params.id), workspace.name);
+      try {
+        const config = await readHiveConfig(wsPath);
+        const setupCmd = config?.scripts?.setup;
+        if (setupCmd) {
+          const proc = startScript(workspace.id, "setup", setupCmd, wsPath);
+          broadcastToWorkspace(workspace.id, {
+            type: "script_status",
+            scriptType: "setup",
+            state: "running",
+          });
+          const listenerId = `auto-setup-${Date.now()}`;
+          proc.exitListeners.set(listenerId, (code) => {
+            broadcastToWorkspace(workspace.id, {
+              type: "script_status",
+              scriptType: "setup",
+              state: code === 0 ? "done" : "error",
+              exitCode: code,
+            });
+            proc.exitListeners.delete(listenerId);
+          });
+        }
+      } catch (err) {
+        app.log.warn({ err, wsId: workspace.id }, "Auto-start setup script failed");
+      }
+
       return reply.status(201).send(workspace);
     } catch (err: unknown) {
       return reply

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -58,8 +58,9 @@ export default function Sidebar({ onAddProject }: SidebarProps) {
     if (creatingProjectId) return;
     setCreatingProjectId(projectId);
     try {
-      await createWorkspace(projectId);
+      const workspace = await createWorkspace(projectId);
       setExpandedProjects((prev) => ({ ...prev, [projectId]: true }));
+      navigate(`/workspaces/${workspace.id}`);
     } finally {
       setCreatingProjectId(null);
     }

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -64,6 +64,16 @@ function SettingsStateProbe() {
   return <div data-testid="settings-from">{from}</div>;
 }
 
+function SidebarRoute() {
+  const location = useLocation();
+  return (
+    <>
+      <Sidebar onAddProject={vi.fn()} />
+      <div data-testid="location-path">{location.pathname}</div>
+    </>
+  );
+}
+
 function renderSidebar(
   path: string,
   projects: Project[],
@@ -96,11 +106,11 @@ function renderSidebar(
           <Routes>
             <Route
               path="/projects"
-              element={<Sidebar onAddProject={vi.fn()} />}
+              element={<SidebarRoute />}
             />
             <Route
               path="/workspaces/:wsId"
-              element={<Sidebar onAddProject={vi.fn()} />}
+              element={<SidebarRoute />}
             />
             <Route path="/settings" element={<SettingsStateProbe />} />
           </Routes>
@@ -190,6 +200,26 @@ describe("Sidebar", () => {
 
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith("/api/projects/p1/workspaces");
+    });
+  });
+
+  it("navigates to the new workspace after creation", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.post).mockResolvedValue({
+      id: "w-new",
+      name: "osaka",
+      branch: "workspace/osaka",
+      status: "idle",
+      createdAt: "2026-02-12T00:00:00.000Z",
+    });
+
+    renderSidebar("/projects", projects);
+    await screen.findByText("Alpha");
+
+    await user.click(screen.getByRole("button", { name: "Add workspace to Alpha" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path")).toHaveTextContent("/workspaces/w-new");
     });
   });
 

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -44,6 +44,12 @@ struct HiveApp: App {
             .onChange(of: scenePhase) { _, phase in
                 handleScenePhase(phase)
             }
+            .onChange(of: projectStore.pendingNavigation) { _, workspace in
+                guard let workspace else { return }
+                selectedTab = .hub
+                hubPath.append(workspace)
+                projectStore.pendingNavigation = nil
+            }
             .onAppear {
                 setupStreamingCallback()
             }

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -16,6 +16,9 @@ final class ProjectStore {
     private(set) var isCreatingProject = false
     private(set) var cloningRepoName: String?
 
+    /// Set after workspace creation so HiveApp can navigate to it.
+    var pendingNavigation: Workspace?
+
     let statusMonitor = HubStatusMonitor()
 
     private let api = APIClient()
@@ -58,6 +61,7 @@ final class ProjectStore {
 
             let allWorkspaceIds = projects.flatMap(\.workspaces).map(\.id)
             statusMonitor.sync(workspaceIds: allWorkspaceIds)
+            pendingNavigation = workspace
         } catch is CancellationError {
             // Ignore cancelled create requests when leaving the screen.
         } catch {
@@ -96,6 +100,7 @@ final class ProjectStore {
 
             let allWorkspaceIds = projects.flatMap(\.workspaces).map(\.id)
             statusMonitor.sync(workspaceIds: allWorkspaceIds)
+            pendingNavigation = workspace
         } catch is CancellationError {
             // Ignore
         } catch {


### PR DESCRIPTION
## Summary
- **Backend**: When a workspace is created and the project has a `hive.json` with `scripts.setup`, the setup script is automatically started and its status broadcast via WebSocket
- **Frontend**: Creating a workspace now navigates directly to it instead of staying on the project view
- **iOS**: Same navigation behavior — `pendingNavigation` on `ProjectStore` triggers `HiveApp` to switch tab and push the workspace route

## Test plan
- [ ] Backend: `workspaces.auto-setup.test.ts` covers setup auto-start, no-op when missing, and graceful failure
- [ ] Frontend: Updated `Sidebar.test.tsx` verifies navigation to the new workspace after creation
- [ ] Create a workspace on a project with `hive.json` `scripts.setup` → setup runs immediately
- [ ] Create a workspace on a project without `hive.json` → no error, workspace created normally
- [ ] iOS: creating a workspace navigates to it