### PR TITLE
Fix chat scroll flash on workspace switch

### DIFF
--- a/backend/src/api/agents.test.ts
+++ b/backend/src/api/agents.test.ts
@@ -342,41 +342,6 @@ describe("POST /api/workspaces/:wsId/sessions", () => {
   });
 });
 
-describe("POST /api/workspaces/:wsId/sessions/:sessionId/activate", () => {
-  it("activates a persisted session", async () => {
-    await writeSessionFixture("sess-activate", wsId, { messageCount: 3 });
-
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/workspaces/${wsId}/sessions/sess-activate/activate`,
-    });
-
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toMatchObject({
-      sessionId: "sess-activate",
-      workspaceId: wsId,
-      messageCount: 3,
-    });
-
-    const wsRes = await app.inject({
-      method: "GET",
-      url: `/api/workspaces/${wsId}`,
-    });
-    expect(wsRes.json()).toMatchObject({
-      status: "busy",
-      activeSessionId: "sess-activate",
-    });
-  });
-
-  it("returns 404 for missing session id", async () => {
-    const res = await app.inject({
-      method: "POST",
-      url: `/api/workspaces/${wsId}/sessions/missing/activate`,
-    });
-    expect(res.statusCode).toBe(404);
-  });
-});
-
 describe("DELETE /api/workspaces/:wsId/sessions/:sessionId", () => {
   it("hard deletes an inactive session", async () => {
     await writeSessionFixture("sess-delete", wsId);

--- a/backend/src/api/agents.test.ts
+++ b/backend/src/api/agents.test.ts
@@ -342,6 +342,19 @@ describe("POST /api/workspaces/:wsId/sessions", () => {
   });
 });
 
+describe("POST /api/workspaces/:wsId/sessions/:sessionId/activate", () => {
+  it("returns 404 because activation is handled over websocket switch_session", async () => {
+    await writeSessionFixture("sess-activate", wsId, { messageCount: 3 });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${wsId}/sessions/sess-activate/activate`,
+    });
+
+    expect(res.statusCode).toBe(404);
+  });
+});
+
 describe("DELETE /api/workspaces/:wsId/sessions/:sessionId", () => {
   it("hard deletes an inactive session", async () => {
     await writeSessionFixture("sess-delete", wsId);

--- a/backend/src/api/agents.ts
+++ b/backend/src/api/agents.ts
@@ -9,7 +9,6 @@ import {
   getSessionMessages,
   listWorkspaceSessions,
   createNewSession,
-  activateSession,
   hardDeleteSession,
   getSpecificSessionMessages,
   resolveSessionAttachmentPath,
@@ -113,26 +112,6 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
         return reply.status(201).send(session.metadata);
       } catch (err: unknown) {
         const msg = errorMessage(err, "Failed to create session");
-        const code = errorStatus(err);
-        return reply.status(code).send({ error: msg });
-      }
-    },
-  );
-
-  // POST /api/workspaces/:wsId/sessions/:sessionId/activate — switch to a session
-  app.post<{ Params: { wsId: string; sessionId: string } }>(
-    "/api/workspaces/:wsId/sessions/:sessionId/activate",
-    async (req, reply) => {
-      try {
-        const session = await activateSession(
-          req.params.wsId,
-          req.params.sessionId,
-          dataDir,
-          sessionOptions,
-        );
-        return reply.send(session.metadata);
-      } catch (err: unknown) {
-        const msg = errorMessage(err, "Failed to activate session");
         const code = errorStatus(err);
         return reply.status(code).send({ error: msg });
       }

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -12,6 +12,7 @@ import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
 import { ToolCallList } from "@/components/chat/ToolCallList";
 import { WorkspaceWelcome } from "@/components/WorkspaceWelcome";
 import { formatElapsed } from "@/lib/time";
+import { getFallbackInteractiveAssistantIndex, hasExitPlanModeTool } from "@/lib/plan-state";
 import type { ChatMessage as ChatMessageType, ToolCall, QuestionAnswer } from "@/types";
 import type { PendingToolInput } from "@/hooks/useConversation";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
@@ -123,28 +124,21 @@ export default function ChatConversation({
   // Fallback to the old heuristic (last assistant message, no user after) when no pending inputs.
   const hasPendingInputs = pendingToolInputs.length > 0;
   const pendingToolUseIds = new Set(pendingToolInputs.map((p) => p.toolUseId));
-
-  const lastAssistantIdx = isStreaming
-    ? -1
-    : messages.reduce((acc, msg, i) => (msg.role === "assistant" ? i : acc), -1);
-  const hasUserAfterLast =
-    lastAssistantIdx >= 0 &&
-    messages.slice(lastAssistantIdx + 1).some((m) => m.role === "user");
+  const fallbackInteractiveAssistantIdx = getFallbackInteractiveAssistantIndex(messages, isStreaming);
 
   const isMessageInteractive = (msg: ChatMessageType, idx: number): boolean => {
     if (hasPendingInputs) {
       return msg.toolCalls?.some((tc) => pendingToolUseIds.has(tc.id)) ?? false;
     }
-    return idx === lastAssistantIdx && !hasUserAfterLast;
+    return idx === fallbackInteractiveAssistantIdx;
   };
 
   const getPlanStatus = (msg: ChatMessageType, idx: number): PlanStatus | undefined => {
-    const hasExitPlanMode = msg.toolCalls?.some((tc) => tc.name === "ExitPlanMode");
-    if (!hasExitPlanMode) return undefined;
+    if (!hasExitPlanModeTool(msg)) return undefined;
     if (isMessageInteractive(msg, idx)) return "interactive";
     // "Revised" only if a later assistant message also proposes a plan
     const hasLaterPlan = messages.slice(idx + 1).some(
-      (m) => m.role === "assistant" && m.toolCalls?.some((tc) => tc.name === "ExitPlanMode"),
+      (m) => m.role === "assistant" && hasExitPlanModeTool(m),
     );
     return hasLaterPlan ? "revised" : "approved";
   };

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -67,20 +67,25 @@ export default function ChatConversation({
 
   // Hide the conversation during hydration so the user never sees content
   // flash at the top before StickToBottom repositions the scroll. The sequence:
-  // 1. switchCounter changes → reset hydrated synchronously during render
+  // 1. switchCounter changes → reset hydrated+settled synchronously during render
   // 2. Messages arrive → render invisible with resize="instant"
   // 3. StickToBottom's ResizeObserver fires → instant scroll to bottom
   // 4. Double-rAF ensures scroll is settled → reveal content at correct position
+  // 5. Settling period keeps resize="instant" so late layout shifts (Streamdown
+  //    plugin processing, syntax highlighting, images) are absorbed silently
+  // 6. After settling → resize="smooth" for normal interaction
   //
   // Uses React's "set state during render" pattern to detect workspace switches
   // synchronously, even when React 18 batches the switch dispatch with the WS
   // history replay into a single render (which broke the old useEffect approach).
   const [prevSwitchCounter, setPrevSwitchCounter] = useState(switchCounter);
   const [hydrated, setHydrated] = useState(false);
+  const [settled, setSettled] = useState(false);
 
   if (switchCounter !== prevSwitchCounter) {
     setPrevSwitchCounter(switchCounter);
     setHydrated(false);
+    setSettled(false);
   }
 
   const isHydrating = !hydrated && messages.length > 0;
@@ -101,6 +106,16 @@ export default function ChatConversation({
       };
     }
   }, [isHydrating]);
+
+  // Keep resize="instant" for a settling period after reveal so that late
+  // layout shifts (async syntax highlighting, plugin rendering) don't cause
+  // a visible smooth-scroll animation.
+  useEffect(() => {
+    if (hydrated && !settled) {
+      const timer = setTimeout(() => setSettled(true), 300);
+      return () => clearTimeout(timer);
+    }
+  }, [hydrated, settled]);
 
   const hasContent = messages.length > 0 || isStreaming;
 
@@ -135,7 +150,7 @@ export default function ChatConversation({
   };
 
   return (
-    <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={isHydrating ? "instant" : "smooth"}>
+    <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={settled ? "smooth" : "instant"}>
       <ConversationContent className="gap-4 px-8 py-4">
         {!hasContent &&
           (workspaceName && projectName && branch && defaultBranch ? (

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -91,9 +91,13 @@ export default function ChatConversation({
       const raf1 = requestAnimationFrame(() => {
         raf2 = requestAnimationFrame(() => setHydrated(true));
       });
+      // Safety fallback: rAF can stall when the tab/window isn't focused
+      // (background tabs, Tauri window transitions). Force reveal after 200ms.
+      const fallback = setTimeout(() => setHydrated(true), 200);
       return () => {
         cancelAnimationFrame(raf1);
         cancelAnimationFrame(raf2);
+        clearTimeout(fallback);
       };
     }
   }, [isHydrating]);

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -32,6 +32,7 @@ interface ChatConversationProps {
   branch?: string;
   defaultBranch?: string;
   fileCount?: number;
+  switchCounter: number;
 }
 
 export default function ChatConversation({
@@ -50,6 +51,7 @@ export default function ChatConversation({
   branch,
   defaultBranch,
   fileCount,
+  switchCounter,
 }: ChatConversationProps) {
   const [elapsed, setElapsed] = useState(0);
 
@@ -63,23 +65,28 @@ export default function ChatConversation({
     return () => clearInterval(id);
   }, [isStreaming, streamingStartedAt]);
 
-  // Hide the conversation during REST hydration so the user never sees content
+  // Hide the conversation during hydration so the user never sees content
   // flash at the top before StickToBottom repositions the scroll. The sequence:
-  // 1. Messages arrive → render invisible with resize="instant"
-  // 2. StickToBottom's ResizeObserver fires → instant scroll to bottom
-  // 3. Double-rAF ensures scroll is settled → reveal content at correct position
-  const wasEmptyRef = useRef(true);
+  // 1. switchCounter changes → reset hydrated synchronously during render
+  // 2. Messages arrive → render invisible with resize="instant"
+  // 3. StickToBottom's ResizeObserver fires → instant scroll to bottom
+  // 4. Double-rAF ensures scroll is settled → reveal content at correct position
+  //
+  // Uses React's "set state during render" pattern to detect workspace switches
+  // synchronously, even when React 18 batches the switch dispatch with the WS
+  // history replay into a single render (which broke the old useEffect approach).
+  const [prevSwitchCounter, setPrevSwitchCounter] = useState(switchCounter);
   const [hydrated, setHydrated] = useState(false);
-  const isInitialLoad = wasEmptyRef.current && messages.length > 0;
-  const isHydrating = isInitialLoad && !hydrated;
+
+  if (switchCounter !== prevSwitchCounter) {
+    setPrevSwitchCounter(switchCounter);
+    setHydrated(false);
+  }
+
+  const isHydrating = !hydrated && messages.length > 0;
 
   useEffect(() => {
-    wasEmptyRef.current = messages.length === 0;
-    if (messages.length === 0) setHydrated(false);
-  }, [messages.length]);
-
-  useEffect(() => {
-    if (isInitialLoad) {
+    if (isHydrating) {
       let raf2: number;
       const raf1 = requestAnimationFrame(() => {
         raf2 = requestAnimationFrame(() => setHydrated(true));
@@ -89,7 +96,7 @@ export default function ChatConversation({
         cancelAnimationFrame(raf2);
       };
     }
-  }, [isInitialLoad]);
+  }, [isHydrating]);
 
   const hasContent = messages.length > 0 || isStreaming;
 

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -556,7 +556,7 @@ export function useConversation(workspaceId: string | undefined) {
     dispatch({ type: "clear_chat" });
   }, []);
 
-  const switchSession = useCallback(async (sessionId: string) => {
+  const switchSession = useCallback((sessionId: string) => {
     if (!workspaceId) return;
     dispatch({ type: "prepare_session_switch", sessionId });
     dispatch({ type: "status", status: "busy", sessionId, streaming: false });

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -35,6 +35,7 @@ interface ConversationState {
   error?: string;
   sessionId?: string;
   lockedProvider?: string;
+  switchCounter: number;
 }
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
@@ -54,6 +55,7 @@ const initialState: ConversationState = {
   workspaceStatus: undefined,
   error: undefined,
   sessionId: undefined,
+  switchCounter: 0,
 };
 
 function parseToolInput(input: string): unknown {
@@ -371,6 +373,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         workspaceStatus: undefined,
         error: undefined,
         lockedProvider: undefined,
+        switchCounter: state.switchCounter + 1,
         // sessionStreams is untouched — all sessions keep accumulating
       };
 
@@ -611,6 +614,7 @@ export function useConversation(workspaceId: string | undefined) {
     error: state.error,
     sessionId: state.sessionId,
     lockedProvider: state.lockedProvider,
+    switchCounter: state.switchCounter,
     sendMessage,
     stopStreaming,
     clearChat,

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -359,9 +359,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "prepare_session_switch":
       return {
         ...state,
+        messages: [],
         sessionId: action.sessionId,
         error: undefined,
         lockedProvider: undefined,
+        switchCounter: state.switchCounter + 1,
         // sessionStreams is untouched — background sessions keep accumulating
       };
 
@@ -396,6 +398,14 @@ function reducer(state: ConversationState, action: Action): ConversationState {
   }
 }
 
+/** Remembers which session was last viewed per workspace (module-level, survives re-mounts). */
+const savedSessionByWorkspace = new Map<string, string>();
+
+/** @internal Test-only: clear saved session memory between tests. */
+export function _resetSavedSessions() {
+  savedSessionByWorkspace.clear();
+}
+
 function sessionIdField(id: string | undefined): { sessionId: string } | Record<string, never> {
   return id ? { sessionId: id } : {};
 }
@@ -403,6 +413,9 @@ function sessionIdField(id: string | undefined): { sessionId: string } | Record<
 export function useConversation(workspaceId: string | undefined) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const historyRequestTokenRef = useRef(0);
+  // Track latest sessionId so effect cleanup can read it (refs update during render, before effects).
+  const sessionIdRef = useRef<string | undefined>(state.sessionId);
+  sessionIdRef.current = state.sessionId;
   const syncSessionHistory = useCallback(async (sessionId: string) => {
     if (!workspaceId || !sessionId) return;
     const historyRequestToken = historyRequestTokenRef.current + 1;
@@ -428,10 +441,17 @@ export function useConversation(workspaceId: string | undefined) {
       dispatch({ type: "reset" });
       return;
     }
+    const savedSession = savedSessionByWorkspace.get(workspaceId);
     const historyRequestToken = historyRequestTokenRef.current + 1;
     historyRequestTokenRef.current = historyRequestToken;
 
     dispatch({ type: "prepare_workspace_switch" });
+    // Pre-set sessionId so the reducer's mismatch guard rejects replayed history
+    // for a different session (e.g. from stale lastHistory in the WS transport cache).
+    if (savedSession) {
+      dispatch({ type: "prepare_session_switch", sessionId: savedSession });
+    }
+
     wsTransport.connect(workspaceId);
 
     const { unsubscribe, hadBufferedMessages } = wsTransport.onMessage(workspaceId, (msg) => {
@@ -441,6 +461,12 @@ export function useConversation(workspaceId: string | undefined) {
       }
     });
 
+    // Tell the backend to activate the saved session and send its bootstrap.
+    if (savedSession) {
+      const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
+      if (sent) historyRequestTokenRef.current += 1;
+    }
+
     // If the transport replayed buffered messages (events that arrived while we were
     // on another workspace), the reducer already has the most current state. Bump the
     // token so the async REST fetch won't overwrite it with potentially stale disk data.
@@ -448,17 +474,27 @@ export function useConversation(workspaceId: string | undefined) {
       historyRequestTokenRef.current += 1;
     }
 
+    // REST fallback — use session-specific endpoint when we have a saved preference.
+    // Compare against the original historyRequestToken so bumps from
+    // hadBufferedMessages / switch_session correctly invalidate a stale REST response.
     void (async () => {
       try {
-        const messages = await api.get<ChatMessage[]>(`/api/workspaces/${workspaceId}/session/messages`);
+        const url = savedSession
+          ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages`
+          : `/api/workspaces/${workspaceId}/session/messages`;
+        const messages = await api.get<ChatMessage[]>(url);
         if (historyRequestTokenRef.current !== historyRequestToken) return;
-        dispatch({ type: "history", messages });
+        dispatch({ type: "history", sessionId: savedSession, messages });
       } catch {
         // History is still best-effort via websocket replay if API fetch fails.
       }
     })();
 
     return () => {
+      // Remember which session was active before leaving this workspace.
+      if (workspaceId && sessionIdRef.current) {
+        savedSessionByWorkspace.set(workspaceId, sessionIdRef.current);
+      }
       if (historyRequestTokenRef.current === historyRequestToken) {
         historyRequestTokenRef.current = historyRequestToken + 1;
       }

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,6 +1,7 @@
 import { useEffect, useCallback, useReducer, useRef, useSyncExternalStore } from "react";
 import type { ChatMessage, ImageAttachment, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer, QuestionInput } from "@/types";
 import { wsTransport } from "@/lib/ws-transport";
+import type { HistoryMessage } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
 
 export interface PendingToolInput {
@@ -474,21 +475,23 @@ export function useConversation(workspaceId: string | undefined) {
       historyRequestTokenRef.current += 1;
     }
 
-    // REST fallback — use session-specific endpoint when we have a saved preference.
-    // Compare against the original historyRequestToken so bumps from
-    // hadBufferedMessages / switch_session correctly invalidate a stale REST response.
-    void (async () => {
-      try {
-        const url = savedSession
-          ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages`
-          : `/api/workspaces/${workspaceId}/session/messages`;
-        const messages = await api.get<ChatMessage[]>(url);
-        if (historyRequestTokenRef.current !== historyRequestToken) return;
-        dispatch({ type: "history", sessionId: savedSession, messages });
-      } catch {
-        // History is still best-effort via websocket replay if API fetch fails.
-      }
-    })();
+    // REST fallback — only needed on first visit when no cached history exists.
+    // On switch-back the transport cache is kept fresh (see effect below), so
+    // the WS replay already provides current messages.
+    if (!wsTransport.hasCachedHistory(workspaceId)) {
+      void (async () => {
+        try {
+          const url = savedSession
+            ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages`
+            : `/api/workspaces/${workspaceId}/session/messages`;
+          const messages = await api.get<ChatMessage[]>(url);
+          if (historyRequestTokenRef.current !== historyRequestToken) return;
+          dispatch({ type: "history", sessionId: savedSession, messages });
+        } catch {
+          // History is still best-effort via websocket replay if API fetch fails.
+        }
+      })();
+    }
 
     return () => {
       // Remember which session was active before leaving this workspace.
@@ -501,6 +504,19 @@ export function useConversation(workspaceId: string | undefined) {
       unsubscribe();
     };
   }, [workspaceId, syncSessionHistory]);
+
+  // Keep the transport's cached history fresh so switch-back replays are current.
+  // Fires on history/done/cancelled/user_message — NOT on streaming deltas.
+  // Guard: don't write empty messages (prepare_workspace_switch clears them).
+  useEffect(() => {
+    if (!workspaceId || !state.sessionId || state.messages.length === 0) return;
+    const historyMsg: HistoryMessage = {
+      type: "history",
+      sessionId: state.sessionId,
+      messages: state.messages,
+    };
+    wsTransport.updateCachedHistory(workspaceId, historyMsg);
+  }, [workspaceId, state.sessionId, state.messages]);
 
   const sendMessage = useCallback((
     content: string,

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -38,14 +38,6 @@ export function useSessions(workspaceId: string | undefined) {
     onSuccess: invalidate,
   });
 
-  const activateSession = useMutation({
-    mutationFn: (sessionId: string) =>
-      api.post<SessionMetadata>(
-        `/api/workspaces/${workspaceId}/sessions/${sessionId}/activate`,
-      ),
-    onSuccess: invalidate,
-  });
-
   const deleteSession = useMutation({
     mutationFn: (sessionId: string) =>
       api.delete(`/api/workspaces/${workspaceId}/sessions/${sessionId}`),
@@ -59,14 +51,6 @@ export function useSessions(workspaceId: string | undefined) {
       if (!workspaceId) return null;
       try {
         return await createSession.mutateAsync();
-      } catch {
-        return null;
-      }
-    },
-    activateSession: async (sessionId: string): Promise<SessionMetadata | null> => {
-      if (!workspaceId) return null;
-      try {
-        return await activateSession.mutateAsync(sessionId);
       } catch {
         return null;
       }

--- a/frontend/src/lib/plan-state.ts
+++ b/frontend/src/lib/plan-state.ts
@@ -1,0 +1,47 @@
+import type { ChatMessage } from "@/types";
+
+interface PendingToolLike {
+  toolName: string;
+}
+
+export function hasExitPlanModeTool(message: Pick<ChatMessage, "toolCalls"> | undefined): boolean {
+  return message?.toolCalls?.some((tool) => tool.name === "ExitPlanMode") === true;
+}
+
+export function hasPendingExitPlanModeInput(pendingToolInputs: PendingToolLike[]): boolean {
+  return pendingToolInputs.some((input) => input.toolName === "ExitPlanMode");
+}
+
+export function getFallbackInteractiveAssistantIndex(
+  messages: ChatMessage[],
+  isStreaming: boolean,
+): number {
+  if (isStreaming) return -1;
+
+  let lastAssistantIdx = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i]?.role === "assistant") {
+      lastAssistantIdx = i;
+      break;
+    }
+  }
+  if (lastAssistantIdx < 0) return -1;
+
+  const hasUserAfterLastAssistant = messages
+    .slice(lastAssistantIdx + 1)
+    .some((message) => message.role === "user");
+  return hasUserAfterLastAssistant ? -1 : lastAssistantIdx;
+}
+
+export function isPlanAwaitingUserInput(params: {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  pendingToolInputs: PendingToolLike[];
+}): boolean {
+  const { messages, isStreaming, pendingToolInputs } = params;
+  if (hasPendingExitPlanModeInput(pendingToolInputs)) return true;
+
+  const fallbackInteractiveIdx = getFallbackInteractiveAssistantIndex(messages, isStreaming);
+  if (fallbackInteractiveIdx < 0) return false;
+  return hasExitPlanModeTool(messages[fallbackInteractiveIdx]);
+}

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -6,7 +6,7 @@ export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 type MessageHandler = (msg: WsOutgoing) => void;
 type StatusListener = () => void;
 type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
-type HistoryMessage = Extract<WsOutgoing, { type: "history" }>;
+export type HistoryMessage = Extract<WsOutgoing, { type: "history" }>;
 type DiffStatsMessage = Extract<WsOutgoing, { type: "diff_stats" }>;
 type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
@@ -65,6 +65,17 @@ class WsTransport {
         this.removeConnection(workspaceId);
       }
     }
+  }
+
+  /** Update the cached history so switch-back replays are fresh. */
+  updateCachedHistory(workspaceId: string, historyMsg: HistoryMessage): void {
+    const connection = this.connections.get(workspaceId);
+    if (connection) connection.lastHistory = historyMsg;
+  }
+
+  /** Check whether cached history exists for a workspace. */
+  hasCachedHistory(workspaceId: string): boolean {
+    return this.connections.get(workspaceId)?.lastHistory !== undefined;
   }
 
   /** Clear cached status/history for a workspace (e.g. after session deletion). */

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -230,7 +230,7 @@ export default function WorkspaceView() {
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
 
-  const { sessions, createSession, activateSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
+  const { sessions, createSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
 
   // Mirror iOS: fall back to session metadata when WS hasn't delivered lockedProvider yet.
   const effectiveLockedProvider = lockedProvider
@@ -291,13 +291,10 @@ export default function WorkspaceView() {
     }
   }, [createSession, switchSession]);
 
-  const handleActivateSession = useCallback(async (targetSessionId: string) => {
+  const handleActivateSession = useCallback((targetSessionId: string) => {
     setActiveTab("conversation");
-    const meta = await activateSession(targetSessionId);
-    if (meta) {
-      await switchSession(meta.sessionId);
-    }
-  }, [activateSession, switchSession]);
+    switchSession(targetSessionId);
+  }, [switchSession]);
 
   const handleDeleteSession = useCallback(async (targetSessionId: string) => {
     const isActive = targetSessionId === sessionId;

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -41,6 +41,7 @@ import { useTerminalApps } from "@/hooks/useTerminalApps";
 import { openTerminalSsh } from "@/lib/terminal";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
+import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput } from "@/lib/plan-state";
 import { useScripts } from "@/hooks/useScripts";
 import type { DiffStatResponse, ImageAttachment, MessageOptions, Workspace, WorkspaceFileTreeNode } from "@/types";
 
@@ -287,7 +288,7 @@ export default function WorkspaceView() {
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
     if (meta) {
-      await switchSession(meta.sessionId);
+      switchSession(meta.sessionId);
     }
   }, [createSession, switchSession]);
 
@@ -304,7 +305,7 @@ export default function WorkspaceView() {
     if (isActive) {
       const next = sessions.find((s) => s.sessionId !== targetSessionId);
       if (next) {
-        await handleActivateSession(next.sessionId);
+        handleActivateSession(next.sessionId);
       } else {
         clearChat();
         if (wsId) wsTransport.clearCachedData(wsId);
@@ -328,7 +329,7 @@ export default function WorkspaceView() {
     dismissPlan("Plan handed off to a new session.");
     const meta = await createSession();
     if (!meta) return;
-    await switchSession(meta.sessionId);
+    switchSession(meta.sessionId);
     await refreshSessions();
     const handoffPrompt = planPath
       ? `Execute the approved plan from \`${planPath}\`. Read that file and implement it end-to-end.`
@@ -336,25 +337,22 @@ export default function WorkspaceView() {
     sendMessage(handoffPrompt, undefined, undefined, meta.sessionId);
   }, [dismissPlan, createSession, switchSession, refreshSessions, sendMessage]);
 
-  // Detect pending plan from explicit pending tool inputs OR from the last
-  // assistant message having an ExitPlanMode tool (fallback matching the
-  // isMessageInteractive heuristic in ChatConversation).
-  const lastMsg = messages[messages.length - 1];
-  const hasPendingPlan =
-    pendingToolInputs.some((p) => p.toolName === "ExitPlanMode") ||
-    (!isStreaming &&
-      lastMsg?.role === "assistant" &&
-      lastMsg?.toolCalls?.some((tc) => tc.name === "ExitPlanMode") === true);
+  const hasPendingExitPlanInput = hasPendingExitPlanModeInput(pendingToolInputs);
+  const hasPendingPlan = isPlanAwaitingUserInput({
+    messages,
+    isStreaming,
+    pendingToolInputs,
+  });
 
   const handleSend = useCallback(
     (content: string, images?: ImageAttachment[], options?: MessageOptions): boolean => {
-      if (hasPendingPlan && pendingToolInputs.some((p) => p.toolName === "ExitPlanMode")) {
+      if (hasPendingPlan && hasPendingExitPlanInput) {
         rejectToolInput(content);
         return true;
       }
       return sendMessage(content, images, options);
     },
-    [hasPendingPlan, pendingToolInputs, rejectToolInput, sendMessage],
+    [hasPendingPlan, hasPendingExitPlanInput, rejectToolInput, sendMessage],
   );
 
   // sendMessage is already a stable callback from useConversation

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -225,6 +225,7 @@ export default function WorkspaceView() {
     rejectToolInput,
     dismissPlan,
     lockedProvider,
+    switchCounter,
   } = useConversation(wsId);
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
@@ -492,6 +493,7 @@ export default function WorkspaceView() {
               branch={displayBranch}
               defaultBranch={workspace?.defaultBranch}
               fileCount={fileCount}
+              switchCounter={switchCounter}
             />
             {tasks.length > 0 && (
               <TaskTracker

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -48,6 +48,7 @@ const baseConversationProps: ComponentProps<typeof ChatConversation> = {
   currentStreamingText: "",
   currentThinking: "",
   activeToolCalls: [],
+  switchCounter: 0,
 };
 
 function renderConversation(props?: Partial<ComponentProps<typeof ChatConversation>>) {

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -5,7 +5,19 @@ import ChatConversation from "@/components/ChatConversation";
 import type { ChatMessage } from "@/types";
 
 vi.mock("@/components/ai-elements/conversation", () => ({
-  Conversation: ({ children }: { children: ReactNode }) => <div data-testid="conversation">{children}</div>,
+  Conversation: ({
+    children,
+    className,
+    resize,
+  }: {
+    children: ReactNode;
+    className?: string;
+    resize?: "smooth" | "instant";
+  }) => (
+    <div data-testid="conversation" data-resize={resize} className={className}>
+      {children}
+    </div>
+  ),
   ConversationContent: ({ children }: { children: ReactNode }) => (
     <div data-testid="conversation-content">{children}</div>
   ),
@@ -178,5 +190,130 @@ describe("ChatConversation streaming timer", () => {
     });
     expect(screen.getByText("0.0s")).toBeInTheDocument();
     vi.useRealTimers();
+  });
+});
+
+describe("ChatConversation hydration on session/workspace switch", () => {
+  it("keeps resize instant during hydration, then switches to smooth after settling", () => {
+    vi.useFakeTimers();
+    const rafQueue: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", vi.fn((cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    }));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    renderConversation({
+      messages: [{
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "hydrating",
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }],
+      switchCounter: 1,
+    });
+
+    const conversation = screen.getByTestId("conversation");
+    expect(conversation.className).toContain("invisible");
+    expect(conversation).toHaveAttribute("data-resize", "instant");
+
+    act(() => {
+      const raf1 = rafQueue.shift();
+      raf1?.(16);
+    });
+    expect(conversation.className).toContain("invisible");
+
+    act(() => {
+      const raf2 = rafQueue.shift();
+      raf2?.(32);
+    });
+    expect(conversation.className).not.toContain("invisible");
+    expect(conversation).toHaveAttribute("data-resize", "instant");
+
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    expect(conversation).toHaveAttribute("data-resize", "smooth");
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("reveals content after 200ms fallback when requestAnimationFrame stalls", () => {
+    vi.useFakeTimers();
+    vi.stubGlobal("requestAnimationFrame", vi.fn(() => 1));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    renderConversation({
+      messages: [{
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "fallback reveal",
+        timestamp: "2026-02-20T00:00:00.000Z",
+      }],
+      switchCounter: 1,
+    });
+
+    const conversation = screen.getByTestId("conversation");
+    expect(conversation.className).toContain("invisible");
+    expect(conversation).toHaveAttribute("data-resize", "instant");
+
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(conversation.className).not.toContain("invisible");
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("resets hydration immediately when switchCounter changes", () => {
+    vi.useFakeTimers();
+    const rafQueue: FrameRequestCallback[] = [];
+    vi.stubGlobal("requestAnimationFrame", vi.fn((cb: FrameRequestCallback) => {
+      rafQueue.push(cb);
+      return rafQueue.length;
+    }));
+    vi.stubGlobal("cancelAnimationFrame", vi.fn());
+
+    const message: ChatMessage = {
+      id: "a1",
+      sessionId: "sess-1",
+      role: "assistant",
+      content: "ready",
+      timestamp: "2026-02-20T00:00:00.000Z",
+    };
+
+    const { rerender } = renderConversation({ messages: [message], switchCounter: 1 });
+    const conversation = screen.getByTestId("conversation");
+
+    act(() => {
+      const raf1 = rafQueue.shift();
+      raf1?.(16);
+      const raf2 = rafQueue.shift();
+      raf2?.(32);
+    });
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(conversation.className).not.toContain("invisible");
+    expect(conversation).toHaveAttribute("data-resize", "smooth");
+
+    rerender(
+      <ChatConversation
+        {...baseConversationProps}
+        messages={[message]}
+        switchCounter={2}
+      />,
+    );
+
+    expect(conversation.className).toContain("invisible");
+    expect(conversation).toHaveAttribute("data-resize", "instant");
+
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
   });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -37,6 +37,7 @@ vi.mock("@/lib/ws-transport", () => {
   const statusListeners = new Map<string, Set<() => void>>();
   const replayMessages = new Map<string, WsOutgoing[]>();
   const bufferedFlags = new Map<string, boolean>();
+  const cachedHistories = new Map<string, WsOutgoing>();
 
   const getSet = <T,>(source: Map<string, Set<T>>, workspaceId: string) => {
     const existing = source.get(workspaceId);
@@ -83,6 +84,15 @@ vi.mock("@/lib/ws-transport", () => {
       };
     },
     getStatus: (workspaceId: string) => statuses.get(workspaceId) ?? "disconnected",
+    updateCachedHistory: vi.fn((workspaceId: string, historyMsg: WsOutgoing) => {
+      cachedHistories.set(workspaceId, historyMsg);
+    }),
+    hasCachedHistory: vi.fn((workspaceId: string) => cachedHistories.has(workspaceId)),
+    clearCachedData: vi.fn((workspaceId: string) => {
+      cachedHistories.delete(workspaceId);
+      replayMessages.delete(workspaceId);
+      bufferedFlags.delete(workspaceId);
+    }),
   };
 
   const __wsMock = {
@@ -95,12 +105,16 @@ vi.mock("@/lib/ws-transport", () => {
       statusListeners.clear();
       replayMessages.clear();
       bufferedFlags.clear();
+      cachedHistories.clear();
       wsTransport.connect.mockClear();
       wsTransport.disconnect.mockClear();
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
       wsTransport.onMessage.mockClear();
+      wsTransport.updateCachedHistory.mockClear();
+      wsTransport.hasCachedHistory.mockClear();
+      wsTransport.clearCachedData.mockClear();
     },
     setReplay: (workspaceId: string, messages: WsOutgoing[]) => {
       replayMessages.set(workspaceId, messages);
@@ -111,6 +125,11 @@ vi.mock("@/lib/ws-transport", () => {
     sendMock: wsTransport.send,
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
+    updateCachedHistoryMock: wsTransport.updateCachedHistory,
+    hasCachedHistoryMock: wsTransport.hasCachedHistory,
+    setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => {
+      cachedHistories.set(workspaceId, historyMsg);
+    },
   };
 
   return { wsTransport, __wsMock };
@@ -126,6 +145,9 @@ const getWsMock = async () =>
       sendMock: ReturnType<typeof vi.fn>;
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
+      updateCachedHistoryMock: ReturnType<typeof vi.fn>;
+      hasCachedHistoryMock: ReturnType<typeof vi.fn>;
+      setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => void;
     };
   };
 
@@ -1913,5 +1935,93 @@ describe("useConversation", () => {
     });
 
     expect(result.current.lockedProvider).toBe("claude");
+  });
+
+  describe("transport cache freshness", () => {
+    it("updates transport cache when messages change after done event", async () => {
+      const { __wsMock } = await getWsMock();
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      await act(async () => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hello", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "hi back" });
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 100 });
+      });
+
+      // After done, messages should have both user + assistant messages.
+      // The cache-update effect should have pushed them to the transport.
+      expect(result.current.messages).toHaveLength(2);
+      expect(__wsMock.updateCachedHistoryMock).toHaveBeenCalled();
+      const lastCall = __wsMock.updateCachedHistoryMock.mock.calls.at(-1)!;
+      expect(lastCall[0]).toBe("ws-1");
+      expect(lastCall[1].type).toBe("history");
+      expect(lastCall[1].sessionId).toBe("sess-1");
+      expect(lastCall[1].messages).toHaveLength(2);
+    });
+
+    it("does not update cache with empty messages during workspace switch", async () => {
+      const { __wsMock } = await getWsMock();
+
+      const { result, rerender } = renderHook(
+        ({ wsId }) => useConversation(wsId),
+        { initialProps: { wsId: "ws-1" } },
+      );
+
+      // Populate messages for ws-1
+      await act(async () => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+        __wsMock.emit("ws-1", {
+          type: "history",
+          sessionId: "sess-1",
+          messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" }],
+        });
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      __wsMock.updateCachedHistoryMock.mockClear();
+
+      // Switch to ws-2 — messages clear, cache should NOT be overwritten with empty
+      rerender({ wsId: "ws-2" });
+
+      // Check that no call was made with empty messages for ws-1
+      for (const call of __wsMock.updateCachedHistoryMock.mock.calls) {
+        expect(call[1].messages.length).toBeGreaterThan(0);
+      }
+    });
+
+    it("skips REST fetch when transport has cached history", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValue([]);
+
+      // Pre-populate the cache so hasCachedHistory returns true
+      __wsMock.setCachedHistory("ws-1", {
+        type: "history",
+        sessionId: "sess-1",
+        messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" }],
+      });
+
+      renderHook(() => useConversation("ws-1"));
+
+      // REST should NOT have been called since cache exists
+      expect(__apiMock.getMock).not.toHaveBeenCalled();
+    });
+
+    it("fires REST fetch on first visit when no cached history exists", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValue([]);
+
+      renderHook(() => useConversation("ws-1"));
+
+      // REST should fire since there's no cached history
+      expect(__apiMock.getMock).toHaveBeenCalledWith(
+        expect.stringContaining("/api/workspaces/ws-1/"),
+      );
+    });
   });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1,6 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useConversation } from "@/hooks/useConversation";
+import { useConversation, _resetSavedSessions } from "@/hooks/useConversation";
 import type { ChatMessage, WsOutgoing } from "@/types";
 
 vi.mock("@/hooks/useApi", () => {
@@ -143,6 +143,7 @@ describe("useConversation", () => {
     const { __apiMock } = await getApiMock();
     __wsMock.reset();
     __apiMock.reset();
+    _resetSavedSessions();
   });
 
   it("connects on mount and keeps connection alive on unmount", async () => {
@@ -1485,6 +1486,72 @@ describe("useConversation", () => {
 
     rerender({ wsId: "ws-1" });
     expect(result.current.switchCounter).toBe(initial + 2);
+  });
+
+  it("restores last viewed session when switching back to a workspace", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result, rerender } = renderHook(
+      ({ wsId }) => useConversation(wsId),
+      { initialProps: { wsId: "ws-1" } },
+    );
+
+    // Establish session sess-A on ws-1 via a status event
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-A",
+        streaming: false,
+      });
+    });
+    expect(result.current.sessionId).toBe("sess-A");
+
+    // Switch to ws-2 — cleanup saves ws-1 → sess-A
+    rerender({ wsId: "ws-2" });
+    __wsMock.sendMock.mockClear();
+
+    // Switch back to ws-1 — should send switch_session for the saved session
+    __wsMock.setReplay("ws-1", []);
+    rerender({ wsId: "ws-1" });
+
+    expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+      type: "switch_session",
+      sessionId: "sess-A",
+    });
+    expect(result.current.sessionId).toBe("sess-A");
+  });
+
+  it("uses session-specific REST endpoint when restoring saved session", async () => {
+    const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock.mockResolvedValue([]);
+    const { result, rerender } = renderHook(
+      ({ wsId }) => useConversation(wsId),
+      { initialProps: { wsId: "ws-1" } },
+    );
+
+    // Establish session on ws-1
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-B",
+        streaming: false,
+      });
+    });
+
+    // Switch away and back
+    __apiMock.getMock.mockClear();
+    __apiMock.getMock.mockResolvedValue([]);
+    rerender({ wsId: "ws-2" });
+    __wsMock.setReplay("ws-1", []);
+    rerender({ wsId: "ws-1" });
+
+    await waitFor(() => {
+      expect(__apiMock.getMock).toHaveBeenCalledWith(
+        "/api/workspaces/ws-1/sessions/sess-B/messages",
+      );
+    });
   });
 
   it("preserves streaming data across workspace switch", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -846,6 +846,40 @@ describe("useConversation", () => {
     );
   });
 
+  it("falls back to empty object when history tool input is not valid JSON", async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock.mockResolvedValueOnce([
+      {
+        id: "u1",
+        sessionId: "sess-q",
+        role: "user",
+        content: "ask me",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+      {
+        id: "a1",
+        sessionId: "sess-q",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:01.000Z",
+        toolCalls: [
+          {
+            id: "tool-q1",
+            name: "AskUserQuestion",
+            input: "{not-json",
+          },
+        ],
+      },
+    ]);
+
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    await waitFor(() => {
+      expect(result.current.pendingToolInputs).toHaveLength(1);
+    });
+    expect(result.current.pendingToolInputs[0]?.input).toEqual({});
+  });
+
   it("rehydrates ExitPlanMode pending input from history when WS request event was missed", async () => {
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockResolvedValueOnce([
@@ -930,6 +964,59 @@ describe("useConversation", () => {
     expect(result.current.pendingToolInputs).toEqual([]);
   });
 
+  it("keeps active pending tool inputs when a history event arrives during streaming", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+      __wsMock.emit("ws-1", {
+        type: "tool_input_required",
+        sessionId: "sess-1",
+        requestId: "req-live",
+        toolName: "AskUserQuestion",
+        toolUseId: "tool-live",
+        input: { questions: [{ question: "Live?" }] },
+      });
+    });
+    expect(result.current.pendingToolInputs).toEqual([
+      expect.objectContaining({
+        requestId: "req-live",
+        toolUseId: "tool-live",
+      }),
+    ]);
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "history",
+        sessionId: "sess-1",
+        messages: [
+          {
+            id: "a1",
+            sessionId: "sess-1",
+            role: "assistant",
+            content: "",
+            timestamp: "2026-02-12T00:00:01.000Z",
+            toolCalls: [
+              {
+                id: "tool-history",
+                name: "AskUserQuestion",
+                input: JSON.stringify({ questions: [{ question: "stale history" }] }),
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    expect(result.current.pendingToolInputs).toEqual([
+      expect.objectContaining({
+        requestId: "req-live",
+        toolUseId: "tool-live",
+      }),
+    ]);
+  });
+
   it("switches sessions and loads specific session history", async () => {
     const { __apiMock } = await getApiMock();
     const { __wsMock } = await getWsMock();
@@ -963,6 +1050,42 @@ describe("useConversation", () => {
     ]);
     expect(result.current.sessionId).toBe("sess-2");
     expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("keeps target session visible and sets an error when switch_session send fails", async () => {
+    const { __wsMock } = await getWsMock();
+    __wsMock.sendMock.mockReturnValueOnce(false);
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "history",
+        sessionId: "sess-old",
+        messages: [
+          {
+            id: "m-old",
+            sessionId: "sess-old",
+            role: "assistant",
+            content: "old",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+        ],
+      });
+    });
+    expect(result.current.messages).toHaveLength(1);
+
+    await act(async () => {
+      await result.current.switchSession("sess-fail");
+    });
+
+    expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+      type: "switch_session",
+      sessionId: "sess-fail",
+    });
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.sessionId).toBe("sess-fail");
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.error).toBe("Session switch failed: disconnected from server.");
   });
 
   it("keeps selected session id when switched session has no messages", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1472,6 +1472,21 @@ describe("useConversation", () => {
     nowSpy.mockRestore();
   });
 
+  it("increments switchCounter on workspace switch", async () => {
+    const { result, rerender } = renderHook(
+      ({ wsId }) => useConversation(wsId),
+      { initialProps: { wsId: "ws-1" } },
+    );
+
+    const initial = result.current.switchCounter;
+
+    rerender({ wsId: "ws-2" });
+    expect(result.current.switchCounter).toBe(initial + 1);
+
+    rerender({ wsId: "ws-1" });
+    expect(result.current.switchCounter).toBe(initial + 2);
+  });
+
   it("preserves streaming data across workspace switch", async () => {
     const { __wsMock } = await getWsMock();
     const { result, rerender } = renderHook(

--- a/frontend/tests/hooks/useSessions.test.ts
+++ b/frontend/tests/hooks/useSessions.test.ts
@@ -75,7 +75,6 @@ describe("useSessions", () => {
 
     await act(async () => {
       expect(await result.current.createSession()).toBeNull();
-      expect(await result.current.activateSession("sess-1")).toBeNull();
       expect(await result.current.deleteSession("sess-1")).toBe(false);
     });
 
@@ -135,58 +134,6 @@ describe("useSessions", () => {
     });
   });
 
-  it("activates a session then refreshes the list", async () => {
-    vi.mocked(api.get)
-      .mockResolvedValueOnce([makeSession("sess-1")])
-      .mockResolvedValueOnce([makeSession("sess-1"), makeSession("sess-2")]);
-    vi.mocked(api.post).mockResolvedValueOnce(makeSession("sess-2"));
-    const { wrapper } = createWrapper();
-
-    const { result } = renderHook(() => useSessions("ws-1"), { wrapper });
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1));
-
-    let activated: SessionMetadata | null = null;
-    await act(async () => {
-      activated = await result.current.activateSession("sess-2");
-    });
-
-    expect(activated).toEqual(makeSession("sess-2"));
-    expect(api.post).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-2/activate");
-
-    await waitFor(() => {
-      expect(result.current.sessions).toEqual([makeSession("sess-1"), makeSession("sess-2")]);
-    });
-  });
-
-  it("keeps sessions sorted after activateSession refreshes with unsorted data", async () => {
-    vi.mocked(api.get)
-      .mockResolvedValueOnce([makeSession("sess-a", "ws-1", "2026-02-12T00:00:01.000Z")])
-      .mockResolvedValueOnce([
-        makeSession("sess-c", "ws-1", "2026-02-12T00:00:03.000Z"),
-        makeSession("sess-a", "ws-1", "2026-02-12T00:00:01.000Z"),
-        makeSession("sess-b", "ws-1", "2026-02-12T00:00:02.000Z"),
-      ]);
-    vi.mocked(api.post).mockResolvedValueOnce(
-      makeSession("sess-c", "ws-1", "2026-02-12T00:00:03.000Z"),
-    );
-    const { wrapper } = createWrapper();
-
-    const { result } = renderHook(() => useSessions("ws-1"), { wrapper });
-    await waitFor(() => expect(result.current.sessions).toHaveLength(1));
-
-    await act(async () => {
-      await result.current.activateSession("sess-c");
-    });
-
-    await waitFor(() => {
-      expect(result.current.sessions.map((s) => s.sessionId)).toEqual([
-        "sess-a",
-        "sess-b",
-        "sess-c",
-      ]);
-    });
-  });
-
   it("deletes a session then refreshes the list", async () => {
     vi.mocked(api.get)
       .mockResolvedValueOnce([makeSession("sess-1"), makeSession("sess-2")])
@@ -210,7 +157,7 @@ describe("useSessions", () => {
     });
   });
 
-  it("returns safe values on create/activate/delete errors", async () => {
+  it("returns safe values on create/delete errors", async () => {
     vi.mocked(api.get).mockResolvedValue([makeSession("sess-1")]);
     vi.mocked(api.post).mockRejectedValue(new Error("boom"));
     vi.mocked(api.delete).mockRejectedValue(new Error("boom"));
@@ -221,7 +168,6 @@ describe("useSessions", () => {
 
     await act(async () => {
       expect(await result.current.createSession()).toBeNull();
-      expect(await result.current.activateSession("sess-1")).toBeNull();
       expect(await result.current.deleteSession("sess-1")).toBe(false);
     });
   });

--- a/frontend/tests/lib/plan-state.test.ts
+++ b/frontend/tests/lib/plan-state.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import {
+  getFallbackInteractiveAssistantIndex,
+  hasExitPlanModeTool,
+  hasPendingExitPlanModeInput,
+  isPlanAwaitingUserInput,
+} from "@/lib/plan-state";
+import type { ChatMessage } from "@/types";
+
+function userMessage(id: string): ChatMessage {
+  return {
+    id,
+    sessionId: "sess-1",
+    role: "user",
+    content: "hello",
+    timestamp: "2026-02-20T00:00:00.000Z",
+  };
+}
+
+function assistantMessage(id: string, withPlanTool = false): ChatMessage {
+  return {
+    id,
+    sessionId: "sess-1",
+    role: "assistant",
+    content: "response",
+    timestamp: "2026-02-20T00:00:01.000Z",
+    toolCalls: withPlanTool
+      ? [{ id: "tool-plan", name: "ExitPlanMode", input: "{}" }]
+      : undefined,
+  };
+}
+
+describe("plan-state helpers", () => {
+  it("detects ExitPlanMode tool calls", () => {
+    expect(hasExitPlanModeTool(assistantMessage("a1", true))).toBe(true);
+    expect(hasExitPlanModeTool(assistantMessage("a2", false))).toBe(false);
+    expect(hasExitPlanModeTool(undefined)).toBe(false);
+  });
+
+  it("detects explicit pending ExitPlanMode inputs", () => {
+    expect(hasPendingExitPlanModeInput([{ toolName: "AskUserQuestion" }])).toBe(false);
+    expect(hasPendingExitPlanModeInput([{ toolName: "ExitPlanMode" }])).toBe(true);
+  });
+
+  it("returns -1 for fallback interactive assistant index while streaming", () => {
+    const idx = getFallbackInteractiveAssistantIndex([assistantMessage("a1", true)], true);
+    expect(idx).toBe(-1);
+  });
+
+  it("returns last assistant index when no user message comes after it", () => {
+    const messages = [userMessage("u1"), assistantMessage("a1", false), assistantMessage("a2", true)];
+    const idx = getFallbackInteractiveAssistantIndex(messages, false);
+    expect(idx).toBe(2);
+  });
+
+  it("returns -1 when a user message appears after the last assistant", () => {
+    const messages = [assistantMessage("a1", true), userMessage("u1")];
+    const idx = getFallbackInteractiveAssistantIndex(messages, false);
+    expect(idx).toBe(-1);
+  });
+
+  it("considers plan pending when explicit ExitPlanMode input exists", () => {
+    const pending = isPlanAwaitingUserInput({
+      messages: [assistantMessage("a1", false)],
+      isStreaming: true,
+      pendingToolInputs: [{ toolName: "ExitPlanMode" }],
+    });
+    expect(pending).toBe(true);
+  });
+
+  it("falls back to last interactive assistant plan tool when no pending input exists", () => {
+    const pending = isPlanAwaitingUserInput({
+      messages: [userMessage("u1"), assistantMessage("a1", true)],
+      isStreaming: false,
+      pendingToolInputs: [],
+    });
+    expect(pending).toBe(true);
+  });
+
+  it("returns false when there is no pending input and no interactive plan tool", () => {
+    const pending = isPlanAwaitingUserInput({
+      messages: [assistantMessage("a1", false)],
+      isStreaming: false,
+      pendingToolInputs: [],
+    });
+    expect(pending).toBe(false);
+  });
+});

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -112,6 +112,48 @@ describe("wsTransport", () => {
     expect(socket.sent).toEqual([JSON.stringify({ type: "user_message", content: "hello" })]);
   });
 
+  it("tracks cached history via updateCachedHistory and clears it with clearCachedData", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+
+    wsTransport.updateCachedHistory("ws-1", {
+      type: "history",
+      sessionId: "sess-1",
+      messages: [
+        {
+          id: "m1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "cached",
+          timestamp: "2026-02-20T00:00:00.000Z",
+        },
+      ],
+    });
+    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+
+    wsTransport.clearCachedData("ws-1");
+    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+  });
+
+  it("drops cached history after disconnectAll removes connections", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    wsTransport.updateCachedHistory("ws-1", {
+      type: "history",
+      sessionId: "sess-1",
+      messages: [],
+    });
+    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+
+    wsTransport.disconnectAll();
+    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+  });
+
   it("dispatches parsed incoming messages to handlers", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
@@ -341,6 +383,48 @@ describe("wsTransport", () => {
       { type: "text_delta", sessionId: "s-new", text: "fresh" },
       { type: "done", sessionId: "s-new" },
     ]);
+  });
+
+  it("replays latest status per session and resets to global idle status", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    const first = wsTransport.onMessage("ws-1", () => {});
+
+    socket.message(JSON.stringify({
+      type: "status",
+      status: "busy",
+      streaming: true,
+      sessionId: "sess-1",
+    }));
+    socket.message(JSON.stringify({
+      type: "status",
+      status: "busy",
+      streaming: true,
+      sessionId: "sess-2",
+    }));
+    first.unsubscribe();
+
+    const replayedPerSession: WsOutgoing[] = [];
+    const second = wsTransport.onMessage("ws-1", (msg) => {
+      replayedPerSession.push(msg);
+    });
+    const statuses = replayedPerSession.filter((m) => m.type === "status");
+    expect(statuses).toHaveLength(2);
+    expect(statuses).toEqual(expect.arrayContaining([
+      { type: "status", status: "busy", streaming: true, sessionId: "sess-1" },
+      { type: "status", status: "busy", streaming: true, sessionId: "sess-2" },
+    ]));
+
+    socket.message(JSON.stringify({ type: "status", status: "idle", streaming: false }));
+    second.unsubscribe();
+
+    const replayedAfterIdle: WsOutgoing[] = [];
+    wsTransport.onMessage("ws-1", (msg) => {
+      replayedAfterIdle.push(msg);
+    });
+    expect(replayedAfterIdle).toEqual([{ type: "status", status: "idle", streaming: false }]);
   });
 
   it("returns hadBufferedMessages false when no events were missed", () => {

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -524,4 +524,71 @@ describe("wsTransport", () => {
       expect(replayed).toEqual([{ type: "status", status: "idle", streaming: false }]);
     });
   });
+
+  describe("updateCachedHistory / hasCachedHistory", () => {
+    it("replays updated history to next handler", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      // Bootstrap caches original history
+      const first: WsOutgoing[] = [];
+      const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
+      socket.message(JSON.stringify({ type: "history", messages: [{ id: "old" }] }));
+      unsubscribe();
+
+      // Update cache with fresh messages
+      wsTransport.updateCachedHistory("ws-1", {
+        type: "history",
+        sessionId: "s1",
+        messages: [{ id: "old" }, { id: "new" }] as never[],
+      });
+
+      // New handler should receive updated history, not the bootstrap version
+      const replayed: WsOutgoing[] = [];
+      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
+      const history = replayed.find((m) => m.type === "history");
+      expect(history).toBeDefined();
+      expect((history as { messages: { id: string }[] }).messages).toEqual([
+        { id: "old" },
+        { id: "new" },
+      ]);
+    });
+
+    it("hasCachedHistory returns false when no history was received", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    });
+
+    it("hasCachedHistory returns true after updateCachedHistory", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+      wsTransport.updateCachedHistory("ws-1", {
+        type: "history",
+        messages: [],
+      });
+      expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+    });
+
+    it("hasCachedHistory returns false after clearCachedData", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+      wsTransport.updateCachedHistory("ws-1", {
+        type: "history",
+        messages: [],
+      });
+      wsTransport.clearCachedData("ws-1");
+      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    });
+
+    it("is a no-op for unknown workspace", () => {
+      // Should not throw
+      wsTransport.updateCachedHistory("unknown", {
+        type: "history",
+        messages: [],
+      });
+      expect(wsTransport.hasCachedHistory("unknown")).toBe(false);
+    });
+  });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -23,7 +23,6 @@ const mocks = vi.hoisted(() => ({
   rejectToolInput: vi.fn(),
   dismissPlan: vi.fn(),
   createSession: vi.fn(),
-  activateSession: vi.fn(),
   deleteSession: vi.fn(),
   refreshSessions: vi.fn(),
   clearCachedData: vi.fn(),
@@ -273,7 +272,6 @@ describe("WorkspaceView behavior", () => {
     mocks.rejectToolInput.mockReset();
     mocks.dismissPlan.mockReset();
     mocks.createSession.mockReset();
-    mocks.activateSession.mockReset();
     mocks.deleteSession.mockReset();
     mocks.refreshSessions.mockReset();
     mocks.clearCachedData.mockReset();
@@ -326,7 +324,6 @@ describe("WorkspaceView behavior", () => {
     mocks.useSessions.mockReturnValue({
       sessions: [],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession,
       refresh: mocks.refreshSessions,
     });
@@ -822,7 +819,6 @@ describe("WorkspaceView session delete behavior", () => {
     mocks.rejectToolInput.mockReset();
     mocks.dismissPlan.mockReset();
     mocks.createSession.mockReset();
-    mocks.activateSession.mockReset();
     mocks.deleteSession.mockReset();
     mocks.refreshSessions.mockReset();
     mocks.clearCachedData.mockReset();
@@ -881,13 +877,6 @@ describe("WorkspaceView session delete behavior", () => {
         { sessionId: "sess-other", workspaceId: "ws-1", createdAt: "2026-02-12T00:00:00.000Z", updatedAt: "2026-02-12T00:00:00.000Z", messageCount: 2 },
       ],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession.mockResolvedValue({
-        sessionId: "sess-other",
-        workspaceId: "ws-1",
-        createdAt: "2026-02-12T00:00:00.000Z",
-        updatedAt: "2026-02-12T00:00:00.000Z",
-        messageCount: 2,
-      }),
       deleteSession: mocks.deleteSession.mockResolvedValue(true),
       refresh: mocks.refreshSessions,
     });
@@ -899,7 +888,6 @@ describe("WorkspaceView session delete behavior", () => {
 
     await waitFor(() => {
       expect(mocks.deleteSession).toHaveBeenCalledWith("sess-active");
-      expect(mocks.activateSession).toHaveBeenCalledWith("sess-other");
       expect(mocks.switchSession).toHaveBeenCalledWith("sess-other");
     });
 
@@ -915,7 +903,6 @@ describe("WorkspaceView session delete behavior", () => {
         { sessionId: "sess-active", workspaceId: "ws-1", createdAt: "2026-02-12T00:00:00.000Z", updatedAt: "2026-02-12T00:00:01.000Z", messageCount: 5 },
       ],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession.mockResolvedValue(true),
       refresh: mocks.refreshSessions,
     });
@@ -932,7 +919,7 @@ describe("WorkspaceView session delete behavior", () => {
     });
 
     // Should NOT have tried to activate another session
-    expect(mocks.activateSession).not.toHaveBeenCalled();
+
   });
 
   it("does nothing when delete fails", async () => {
@@ -943,7 +930,6 @@ describe("WorkspaceView session delete behavior", () => {
         { sessionId: "sess-other", workspaceId: "ws-1", createdAt: "2026-02-12T00:00:00.000Z", updatedAt: "2026-02-12T00:00:00.000Z", messageCount: 2 },
       ],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession.mockResolvedValue(false),
       refresh: mocks.refreshSessions,
     });
@@ -959,7 +945,7 @@ describe("WorkspaceView session delete behavior", () => {
 
     // Nothing else should happen
     expect(mocks.clearChat).not.toHaveBeenCalled();
-    expect(mocks.activateSession).not.toHaveBeenCalled();
+
     expect(mocks.switchSession).not.toHaveBeenCalled();
     expect(mocks.clearCachedData).not.toHaveBeenCalled();
   });
@@ -972,7 +958,6 @@ describe("WorkspaceView session delete behavior", () => {
         { sessionId: "sess-inactive", workspaceId: "ws-1", createdAt: "2026-02-12T00:00:00.000Z", updatedAt: "2026-02-12T00:00:00.000Z", messageCount: 2 },
       ],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession.mockResolvedValue(true),
       refresh: mocks.refreshSessions,
     });
@@ -988,7 +973,7 @@ describe("WorkspaceView session delete behavior", () => {
 
     // Should NOT switch, clear, or do anything else — inactive session delete is silent
     expect(mocks.clearChat).not.toHaveBeenCalled();
-    expect(mocks.activateSession).not.toHaveBeenCalled();
+
     expect(mocks.switchSession).not.toHaveBeenCalled();
     expect(mocks.clearCachedData).not.toHaveBeenCalled();
   });
@@ -1034,7 +1019,6 @@ describe("WorkspaceView sidebar split resize", () => {
     mocks.useSessions.mockReturnValue({
       sessions: [],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession,
       refresh: mocks.refreshSessions,
     });
@@ -1287,7 +1271,6 @@ describe("WorkspaceView VS Code SSH host resolution", () => {
     mocks.useSessions.mockReturnValue({
       sessions: [],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession,
       refresh: mocks.refreshSessions,
     });
@@ -1541,7 +1524,6 @@ describe("WorkspaceView dropdown terminal interactions", () => {
     mocks.useSessions.mockReturnValue({
       sessions: [],
       createSession: mocks.createSession,
-      activateSession: mocks.activateSession,
       deleteSession: mocks.deleteSession,
       refresh: mocks.refreshSessions,
     });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -565,6 +565,16 @@ describe("WorkspaceView behavior", () => {
     expect(mocks.rejectToolInput).toHaveBeenCalledWith("cancel");
   });
 
+  it("activates a session by calling switchSession directly", async () => {
+    const user = userEvent.setup();
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByTestId("activate-session-btn"));
+
+    expect(mocks.switchSession).toHaveBeenCalledWith("sess-2");
+  });
+
   it("displays live branch name from useWorkspaceLiveData when available", async () => {
     mocks.useWorkspaceLiveData.mockReturnValue({
       "ws-1": { branch: "feature/live-branch", branchInfo: { name: "feature/live-branch", lastSyncedAt: "2026-02-13T00:00:00.000Z" } },

--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -157,10 +157,6 @@ final class APIClient {
         try await post(path: "/api/workspaces/\(workspaceId)/sessions")
     }
 
-    func activateSession(workspaceId: String, sessionId: String) async throws -> SessionMetadata {
-        try await post(path: "/api/workspaces/\(workspaceId)/sessions/\(sessionId)/activate")
-    }
-
     func deleteSession(workspaceId: String, sessionId: String) async throws {
         struct DeleteResponse: Decodable { let success: Bool }
         let _: DeleteResponse = try await delete(path: "/api/workspaces/\(workspaceId)/sessions/\(sessionId)")


### PR DESCRIPTION
## Summary
- Replaces the ref-based hydration detection in `ChatConversation` with a `switchCounter` prop driven by `useConversation`'s reducer
- The counter resets hydration state synchronously during render using React's "set state during render" pattern, fixing the flash-from-top when React 18 batches the workspace switch dispatch with WS history replay into a single render
- The old `useEffect` approach missed the workspace switch because `messages.length` never went to 0 within the batched update

## Test plan
- [x] Added unit test for `switchCounter` increment on workspace switch
- [x] All 673 existing tests pass
- [x] Typecheck passes
- [ ] Manual: switch between workspaces with loaded conversations — no scroll flash visible