### PR TITLE
Add cancellation diagnostics to interrupted turns

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -668,6 +668,31 @@ describe("ConversationSession", () => {
       cancelled: true,
       content: "Generation interrupted before any output.",
     });
+    expect(assistantMsg.errorDetail).toContain("exit code 1");
+  });
+
+  it("persists stderr in cancellation diagnostics", async () => {
+    const session = createSession({ sessionId: "cancel-with-stderr" });
+
+    session.sendMessage("Hi");
+    mockProc._stderr.push("permission denied");
+    mockProc._emitClose(1); // non-zero = cancelled
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const messagesPath = join(tempDir, "sessions", "cancel-with-stderr", "messages.jsonl");
+    const raw = await readFile(messagesPath, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+
+    expect(lines.length).toBe(2);
+    const assistantMsg = JSON.parse(lines[1]);
+    expect(assistantMsg).toMatchObject({
+      role: "assistant",
+      cancelled: true,
+      content: "Generation interrupted before any output.",
+    });
+    expect(assistantMsg.errorDetail).toContain("exit code 1");
+    expect(assistantMsg.errorDetail).toContain("stderr: permission denied");
   });
 
   it("persists user message on send", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -23,6 +23,7 @@ import type {
 } from "../types.js";
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
+const MAX_ERROR_DETAIL_LENGTH = 280;
 
 /** Gemini CLI writes informational/retry messages to stderr; suppress these from error events. */
 const GEMINI_STDERR_NOISE = [
@@ -77,6 +78,17 @@ function formatServerToolResult(block: ServerResultBlock): string {
   }
 
   return JSON.stringify(content);
+}
+
+function sanitizeErrorDetail(detail: string): string {
+  const normalized = detail.replace(/\s+/g, " ").trim();
+  if (normalized.length <= MAX_ERROR_DETAIL_LENGTH) return normalized;
+  return `${normalized.slice(0, MAX_ERROR_DETAIL_LENGTH - 1)}…`;
+}
+
+function buildCancellationErrorDetail(exitCode: number, lastStderr: string | undefined): string {
+  const suffix = lastStderr ? ` | ${lastStderr}` : "";
+  return sanitizeErrorDetail(`exit code ${exitCode}${suffix}`);
 }
 
 type StopReason = "user" | "park";
@@ -346,6 +358,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let thinkingText = "";
     const toolCalls: ToolCall[] = [];
     let resultDurationMs: number | undefined;
+    let lastStderr: string | undefined;
 
     const pendingTaskStack: string[] = [];
     const blockingToolNames = new Set(["AskUserQuestion", "ExitPlanMode"]);
@@ -487,7 +500,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       if (!text) return;
       // Skip known informational stderr noise from Gemini CLI
       if (GEMINI_STDERR_NOISE.some((n) => text.includes(n))) return;
-      this.emit("message", { type: "error", message: `stderr: ${text}`, sessionId: this.sessionId } as WsOutgoing);
+      const stderrLine = `stderr: ${sanitizeErrorDetail(text)}`;
+      lastStderr = stderrLine;
+      this.emit("message", { type: "error", message: stderrLine, sessionId: this.sessionId } as WsOutgoing);
     });
 
     this.process.on("error", (err) => {
@@ -517,6 +532,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       const wasCancelled = exitCode !== 0 && this._status === "streaming" && !killedForBlockingTool;
       const cancelledByPark = wasCancelled && this.stopReason === "park";
       const shouldSurfaceCancelled = wasCancelled && !cancelledByPark;
+      const cancellationErrorDetail = shouldSurfaceCancelled
+        ? buildCancellationErrorDetail(exitCode, lastStderr)
+        : undefined;
 
       this._status = (exitCode === 0 || killedForBlockingTool) ? "idle" : "error";
       this._streamingStartedAt = null;
@@ -534,6 +552,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           thinkingContent: thinkingText || undefined,
           timestamp: new Date().toISOString(),
           cancelled: shouldSurfaceCancelled || undefined,
+          errorDetail: cancellationErrorDetail,
           durationMs: resultDurationMs,
         };
         void this.enqueuePersist(assistantMsg);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -124,6 +124,8 @@ export interface ChatMessage {
   thinkingContent?: string;
   timestamp: string;
   cancelled?: boolean;
+  /** Extra diagnostics for interrupted turns (stderr summary, exit code). */
+  errorDetail?: string;
   durationMs?: number;
 }
 

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -79,8 +79,13 @@ const ChatMessage = memo(function ChatMessage({
               />
             )}
             {message.cancelled && (
-              <div className="mt-2 text-xs italic text-muted-foreground">
-                (cancelled)
+              <div className="mt-2 space-y-1 text-xs">
+                <div className="italic text-muted-foreground">(cancelled)</div>
+                {message.errorDetail && (
+                  <div className="break-words font-mono text-[11px] text-destructive/90">
+                    {message.errorDetail}
+                  </div>
+                )}
               </div>
             )}
             {message.durationMs != null && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -115,6 +115,8 @@ export interface ChatMessage {
   thinkingContent?: string;
   timestamp: string;
   cancelled?: boolean;
+  /** Extra diagnostics for interrupted turns (stderr summary, exit code). */
+  errorDetail?: string;
   durationMs?: number;
 }
 

--- a/frontend/tests/components/ChatMessage.test.tsx
+++ b/frontend/tests/components/ChatMessage.test.tsx
@@ -70,6 +70,21 @@ describe("ChatMessage", () => {
     expect(screen.getByTestId("copy-button")).toBeInTheDocument();
   });
 
+  it("renders cancellation diagnostics when provided", () => {
+    render(
+      <ChatMessage
+        message={assistantMessage({
+          cancelled: true,
+          errorDetail: "exit code 1 | stderr: permission denied",
+        })}
+      />,
+    );
+
+    expect(screen.getByText("(cancelled)")).toBeInTheDocument();
+    expect(screen.getByText(/exit code 1/)).toBeInTheDocument();
+    expect(screen.getByText(/permission denied/)).toBeInTheDocument();
+  });
+
   it("does not render assistant-only affordances for user messages", () => {
     render(
       <ChatMessage


### PR DESCRIPTION
## Summary
- Surface exit code and last stderr line on cancelled assistant messages, giving users visibility into why a turn was interrupted
- Sanitize and cap diagnostic detail at 280 chars to avoid noisy output
- Render the error detail below the `(cancelled)` label in the frontend chat UI

## Test plan
- [x] Backend unit tests: cancellation persists `errorDetail` with exit code and stderr
- [x] Frontend component test: `ChatMessage` renders diagnostics when `errorDetail` is present
- [x] Full typecheck passes
- [x] All 721 tests pass