### PR TITLE
Fix iOS message sync reliability

### DIFF
--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -21,15 +21,30 @@ final class ConversationStore {
         return formatter
     }()
 
+    /// ISO8601 timestamp for the current moment (shared formatter).
+    static func timestamp() -> String {
+        outgoingTimestampFormatter.string(from: Date())
+    }
+
     // MARK: - Public state
 
     /// Send closure wired by HubStatusMonitor to the workspace's WS connection.
-    var send: ((WsIncoming) async -> Void)?
+    /// Returns `true` if the message was handed to the WebSocket, `false` otherwise.
+    var send: ((WsIncoming) async -> Bool)?
 
     var messages: [ChatMessage] = []
 
     /// Session currently displayed in chat.
     var sessionId: String?
+
+    /// Monotonically increasing tokens keyed by session ID.
+    /// Used to discard stale REST history fetches on a per-session basis.
+    private var historyTokenBySession: [String: Int] = [:]
+
+    /// Called when a turn finishes (done/cancelled) with the session ID.
+    /// ChatView wires this to re-fetch messages from REST so client-generated
+    /// UUIDs are replaced with backend-assigned IDs.
+    var onTurnCompleted: ((String) -> Void)?
 
     /// Per-session transient streaming state. Keyed by session ID.
     var sessionStreams: [String: SessionStreamState] = [:]
@@ -128,9 +143,11 @@ final class ConversationStore {
 
         case .done(let sid, _, let durationMs):
             finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: false)
+            onTurnCompleted?(sid)
 
         case .cancelled(let sid):
             finalizeMessage(sessionId: sid, durationMs: nil, cancelled: true)
+            onTurnCompleted?(sid)
 
         case .error(let message, let errorSessionId):
             if let errorSessionId, let currentSessionId = sessionId, errorSessionId != currentSessionId {
@@ -185,7 +202,8 @@ final class ConversationStore {
         case .userMessage(let msg):
             let sid = msg.sessionId
             let isActive = sessionId == nil || sid == sessionId
-            if isActive {
+            let alreadyExists = messages.contains { $0.id == msg.id }
+            if isActive && !alreadyExists {
                 messages.append(msg)
             }
             sessionId = sessionId ?? sid
@@ -203,6 +221,7 @@ final class ConversationStore {
             let activeStream = historySessionId.flatMap { sessionStreams[$0] }
             if activeStream?.isStreaming != true {
                 messages = msgs
+                bumpHistoryToken(for: historySessionId)
                 sessionId = historySessionId ?? sessionId
                 // Derive pending tool inputs from history
                 let derived = derivePendingToolInputsFromHistory(msgs)
@@ -230,14 +249,38 @@ final class ConversationStore {
         sessionStreams[sid]?.pendingToolInputs = []
     }
 
+    /// Current history token for a given session.
+    func historyToken(for sessionId: String?) -> Int {
+        guard let sessionId else { return 0 }
+        return historyTokenBySession[sessionId] ?? 0
+    }
+
+    /// Begin a new REST history request for a session.
+    /// Returns the request token that must still match when applying results.
+    @discardableResult
+    func beginHistoryRequest(for sessionId: String?) -> Int {
+        guard let sessionId else { return 0 }
+        let next = (historyTokenBySession[sessionId] ?? 0) + 1
+        historyTokenBySession[sessionId] = next
+        return next
+    }
+
+    /// Invalidate in-flight REST history requests for a session.
+    func bumpHistoryToken(for sessionId: String?) {
+        _ = beginHistoryRequest(for: sessionId)
+    }
+
     func setFocusedSessionId(_ value: String?) {
         sessionId = value
     }
 
     func prepareSessionSwitch(_ newSessionId: String) {
+        let previousSessionId = sessionId
         sessionId = newSessionId
         messages = []
         lockedProvider = nil
+        bumpHistoryToken(for: previousSessionId)
+        bumpHistoryToken(for: newSessionId)
         // sessionStreams is untouched — background sessions keep accumulating
     }
 

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -35,7 +35,7 @@ final class HubStatusMonitor {
     /// Wire (or re-wire) the send closure for a workspace's store via the hub connection.
     fileprivate func wireSendClosure(for workspaceId: String, on store: ConversationStore) {
         store.send = { [weak self] message in
-            await self?.hubConnection?.send(.workspaceEvent(workspaceId: workspaceId, event: message))
+            await self?.hubConnection?.send(.workspaceEvent(workspaceId: workspaceId, event: message)) ?? false
         }
     }
 
@@ -212,11 +212,18 @@ private final class HubConnection {
     }
 
     /// Send a hub-level message (sync_workspaces or workspace event).
-    func send(_ message: HubIncoming) async {
-        guard let wsTask else { return }
+    /// Returns `true` if the message was successfully handed to the WebSocket.
+    @discardableResult
+    func send(_ message: HubIncoming) async -> Bool {
+        guard let wsTask else { return false }
         guard let data = try? encoder.encode(message),
-              let string = String(data: data, encoding: .utf8) else { return }
-        try? await wsTask.send(.string(string))
+              let string = String(data: data, encoding: .utf8) else { return false }
+        do {
+            try await wsTask.send(.string(string))
+            return true
+        } catch {
+            return false
+        }
     }
 
     /// Send sync_workspaces with the given workspace IDs.
@@ -230,8 +237,18 @@ private final class HubConnection {
         let host = UserDefaults.standard.string(forKey: "serverHost") ?? "localhost"
         let port = UserDefaults.standard.string(forKey: "serverPort") ?? "3000"
         let token = UserDefaults.standard.string(forKey: "authToken") ?? ""
+        guard !host.isEmpty, let portInt = Int(port) else { return }
 
-        guard let url = URL(string: "ws://\(host):\(port)/ws/hub?token=\(token)") else {
+        var components = URLComponents()
+        components.scheme = "ws"
+        components.host = host
+        components.port = portInt
+        components.path = "/ws/hub"
+        if !token.isEmpty {
+            components.queryItems = [URLQueryItem(name: "token", value: token)]
+        }
+
+        guard let url = components.url else {
             return
         }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -166,7 +166,6 @@ struct ChatView: View {
         )) {
             ToolInputSheet(pendingInputs: store.pendingToolInputs) { pending, result in
                 respondToTool(pending: pending, result: result)
-                store.clearPendingToolInputs()
             }
         }
         .task { await setup() }
@@ -186,6 +185,7 @@ struct ChatView: View {
         }
         .onDisappear {
             saveCurrentDraft()
+            store.onTurnCompleted = nil
         }
     }
 
@@ -209,6 +209,32 @@ struct ChatView: View {
 
     private func setup() async {
         projectStore.statusMonitor.clearCompleted(workspace.id)
+
+        // Wire post-turn re-sync: after done/cancelled, re-fetch messages from REST
+        // so client-generated UUIDs are replaced with backend-assigned IDs.
+        store.onTurnCompleted = { [weak store, api, workspace] sessionId in
+            Task { @MainActor [weak store] in
+                guard let store else { return }
+                // Keep A streaming while B is open: only re-sync the visible session.
+                guard store.sessionId == sessionId else { return }
+
+                let requestToken = store.beginHistoryRequest(for: sessionId)
+                do {
+                    let msgs = try await api.fetchMessages(
+                        workspaceId: workspace.id,
+                        sessionId: sessionId
+                    )
+                    guard let store else { return }
+                    guard store.sessionId == sessionId else { return }
+                    guard store.historyToken(for: sessionId) == requestToken else { return }
+                    if store.sessionStreams[sessionId]?.isStreaming != true {
+                        store.messages = msgs
+                    }
+                } catch {
+                    // Best-effort — streamed messages remain as fallback
+                }
+            }
+        }
 
         await loadSessions()
         let initialSessionId = resolveInitialSessionId()
@@ -261,11 +287,28 @@ struct ChatView: View {
             return
         }
         store.setFocusedSessionId(sessionId)
+        let requestToken = store.beginHistoryRequest(for: sessionId)
         do {
-            store.messages = try await api.fetchMessages(
+            let msgs = try await api.fetchMessages(
                 workspaceId: workspace.id,
                 sessionId: sessionId
             )
+            // If the user switched session while this request was in-flight, ignore it.
+            guard activeSessionId == sessionId else {
+                isLoading = false
+                return
+            }
+            // Skip if a newer event (WS history, send, session switch) arrived while
+            // this REST call was in-flight — their data is more authoritative.
+            guard store.historyToken(for: sessionId) == requestToken else {
+                isLoading = false
+                return
+            }
+            // Don't overwrite messages while streaming — the active stream state
+            // would be lost (matches the guard in ConversationStore's .history handler).
+            if store.sessionStreams[sessionId]?.isStreaming != true {
+                store.messages = msgs
+            }
         } catch is CancellationError {
             // View disappeared
         } catch {
@@ -313,6 +356,19 @@ struct ChatView: View {
     private func sendMessage(images: [ImageAttachment]) {
         let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !content.isEmpty || !images.isEmpty else { return }
+
+        let targetSessionId = activeSessionId
+        // Snapshot draft so we can restore on failure
+        let savedDraft = draft
+        let savedAttachments = draftAttachments
+        let savedDraftState = ChatDraftStore.Draft(
+            text: savedDraft,
+            thinkingEnabled: thinkingEnabled,
+            planModeEnabled: planModeEnabled,
+            thinkingLevel: thinkingLevel,
+            selectedModelId: selectedModelId.isEmpty ? nil : selectedModelId,
+            attachments: savedAttachments.map(ChatDraftStore.Attachment.init)
+        )
         draft = ""
         draftAttachments = []
 
@@ -329,23 +385,62 @@ struct ChatView: View {
         )
 
         Task {
-            await store.send?(.userMessage(
+            let sent = await store.send?(.userMessage(
                 content: content,
                 images: images.isEmpty ? nil : images,
                 options: options,
-                sessionId: activeSessionId
-            ))
+                sessionId: targetSessionId
+            )) ?? false
+
+            if sent {
+                // Bump history token so any in-flight REST fetch won't overwrite the
+                // user_message echo that the backend is about to broadcast.
+                store.bumpHistoryToken(for: targetSessionId)
+            } else {
+                // Persist draft for the originating session, even if the user switched away.
+                if let targetSessionId {
+                    draftStore.save(
+                        workspaceId: workspace.id,
+                        sessionId: targetSessionId,
+                        draft: savedDraftState
+                    )
+                }
+                // Restore inline only if the user is still on the same session.
+                guard activeSessionId == targetSessionId else { return }
+                draft = savedDraft
+                draftAttachments = savedAttachments
+                store.messages.append(ChatMessage(
+                    id: UUID().uuidString, sessionId: "", role: .assistant,
+                    content: "Message not sent: disconnected from server.",
+                    images: nil, toolCalls: nil, thinkingContent: nil,
+                    timestamp: ConversationStore.timestamp(),
+                    cancelled: nil, durationMs: nil
+                ))
+            }
         }
     }
 
     private func respondToTool(pending: PendingToolInput, result: ToolInputResult) {
         Task {
-            await store.send?(.toolInputResponse(
+            let sent = await store.send?(.toolInputResponse(
                 requestId: pending.requestId,
                 toolName: pending.toolName,
                 result: result,
                 sessionId: pending.sessionId
-            ))
+            )) ?? false
+
+            if sent {
+                store.clearPendingToolInputs()
+                store.bumpHistoryToken(for: pending.sessionId)
+            } else if pending.sessionId == activeSessionId {
+                store.messages.append(ChatMessage(
+                    id: UUID().uuidString, sessionId: "", role: .assistant,
+                    content: "Tool response not sent: disconnected from server.",
+                    images: nil, toolCalls: nil, thinkingContent: nil,
+                    timestamp: ConversationStore.timestamp(),
+                    cancelled: nil, durationMs: nil
+                ))
+            }
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -116,7 +116,7 @@ struct ChatView: View {
                     onModelSelect: { selectedModelId = $0 },
                     onDraftAttachmentsChange: { draftAttachments = $0 },
                     onSend: sendMessage,
-                    onStop: { Task { await store.send?(.stop(sessionId: activeSessionId)) } }
+                    onStop: { Task { _ = await store.send?(.stop(sessionId: activeSessionId)) } }
                 )
                 .padding(.horizontal, 12)
                 .padding(.bottom, 4)
@@ -224,7 +224,6 @@ struct ChatView: View {
                         workspaceId: workspace.id,
                         sessionId: sessionId
                     )
-                    guard let store else { return }
                     guard store.sessionId == sessionId else { return }
                     guard store.historyToken(for: sessionId) == requestToken else { return }
                     if store.sessionStreams[sessionId]?.isStreaming != true {
@@ -327,7 +326,7 @@ struct ChatView: View {
         store.prepareSessionSwitch(sessionId)
         isLoading = true
         Task {
-            await store.send?(.switchSession(sessionId: sessionId))
+            _ = await store.send?(.switchSession(sessionId: sessionId))
             await loadMessages()
         }
     }


### PR DESCRIPTION
## Summary

- **De-duplicate incoming messages** by checking message ID before appending, preventing the repeated-message bug when backend echoes `userMessage` events
- **Propagate WebSocket send failures** (`send` closure returns `Bool`), restoring the draft and showing an error when a message can't be delivered — fixes the silent drop bug
- **Per-session history tokens** to discard stale REST responses that race with live WS events during session switches or rapid navigation
- **Post-turn REST re-sync** (`onTurnCompleted`) re-fetches messages after `done`/`cancelled` to reconcile client-generated UUIDs with backend-assigned IDs
- **Safer URL construction** in `HubStatusMonitor` via `URLComponents` instead of string interpolation

## Files changed

| File | What |
|------|------|
| `ConversationStore.swift` | Message de-dup, per-session history tokens, `send` returns `Bool`, `onTurnCompleted` callback |
| `HubStatusMonitor.swift` | `send` returns `Bool`, `wireSendClosure` propagates result, `URLComponents` for WS URL |
| `ChatView.swift` | Draft save/restore on send failure, history token guards in `loadMessages`, post-turn re-sync, tool response error handling |

## Test plan

- [ ] Send a message with backend running — appears once, no duplicates
- [ ] Kill backend, send a message — draft is restored, error message shown
- [ ] Switch sessions rapidly — no stale messages from previous session appear
- [ ] Let a turn complete — messages refresh with correct backend IDs
- [ ] Navigate away during streaming, come back — conversation state intact