### PR TITLE
Clean up model list & refine ModelSelector UI

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -78,7 +78,7 @@ function resultLine(sessionId = "sess-123", costUsd = 0.01): string {
   return JSON.stringify({ type: "result", session_id: sessionId, cost_usd: costUsd }) + "\n";
 }
 
-function geminiInitLine(sessionId: string, model = "gemini-2.5-pro"): string {
+function geminiInitLine(sessionId: string, model = "gemini-3.1-pro-preview"): string {
   return JSON.stringify({ type: "init", session_id: sessionId, model }) + "\n";
 }
 
@@ -269,7 +269,7 @@ describe("ConversationSession", () => {
   it("uses Gemini init session_id for resume on second message", () => {
     const session = createSession({ sessionId: "gemini-resume" });
 
-    session.sendMessage("First", { model: "gemini:gemini-2.5-pro" });
+    session.sendMessage("First", { model: "gemini:gemini-3.1-pro-preview" });
 
     const firstArgs = mockSpawn.mock.calls[0][1] as string[];
     expect(firstArgs).not.toContain("-r");
@@ -280,7 +280,7 @@ describe("ConversationSession", () => {
     const mockProc2 = createMockProcess();
     mockSpawn.mockReturnValue(mockProc2);
 
-    session.sendMessage("Second", { model: "gemini:gemini-2.5-flash" });
+    session.sendMessage("Second", { model: "gemini:gemini-3-flash-preview" });
 
     const secondArgs = mockSpawn.mock.calls[1][1] as string[];
     const resumeIdx = secondArgs.indexOf("-r");
@@ -578,7 +578,7 @@ describe("ConversationSession", () => {
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
-    session.sendMessage("Hi", { model: "gemini:gemini-2.5-pro" });
+    session.sendMessage("Hi", { model: "gemini:gemini-3.1-pro-preview" });
     mockProc._stderr.push("Loaded cached credentials at /tmp/creds");
     mockProc._stderr.push("YOLO mode is enabled for this run");
     mockProc._stderr.push("Retrying with backoff in 1000ms");
@@ -593,7 +593,7 @@ describe("ConversationSession", () => {
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
-    session.sendMessage("Hi", { model: "gemini:gemini-2.5-pro" });
+    session.sendMessage("Hi", { model: "gemini:gemini-3.1-pro-preview" });
     mockProc._stderr.push("permission denied");
 
     const errors = messages.filter((m) => m.type === "error");

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -10,7 +10,7 @@ import type {
 
 const CLAUDE_MODELS: ModelDefinition[] = [
   { id: "opus-4-6", label: "Opus 4.6", cliValue: "opus", isDefault: true },
-  { id: "sonnet-4-6", label: "Sonnet 4.6", cliValue: "sonnet", isNew: true },
+  { id: "sonnet-4-6", label: "Sonnet 4.6", cliValue: "sonnet" },
   { id: "haiku-4-5", label: "Haiku 4.5", cliValue: "haiku" },
 ];
 

--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -85,9 +85,9 @@ describe("CodexProvider", () => {
   });
 
   it("includes --model with cli value when model is specified", () => {
-    const args = provider.buildArgs("Hello", { model: "gpt-5.3-codex-spark" }, baseSession());
+    const args = provider.buildArgs("Hello", { model: "gpt-5.3-codex" }, baseSession());
     expect(args).toContain("--model");
-    expect(args).toContain("gpt-5.3-codex-spark");
+    expect(args).toContain("gpt-5.3-codex");
   });
 
   it("omits --model when model is not in the list", () => {

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -10,9 +10,7 @@ import type {
 } from "./types.js";
 
 const CODEX_MODELS: ModelDefinition[] = [
-  { id: "gpt-5.3-codex-spark", label: "GPT-5.3-Codex-Spark", cliValue: "gpt-5.3-codex-spark", isNew: true },
   { id: "gpt-5.3-codex", label: "GPT-5.3-Codex", cliValue: "gpt-5.3-codex", isDefault: true },
-  { id: "gpt-5.2-codex", label: "GPT-5.2-Codex", cliValue: "gpt-5.2-codex" },
 ];
 
 const CODEX_CAPABILITIES: ProviderCapabilities = {

--- a/backend/src/agents/providers/gemini.test.ts
+++ b/backend/src/agents/providers/gemini.test.ts
@@ -34,15 +34,12 @@ describe("GeminiProvider", () => {
   it("has exactly one default model", () => {
     const defaults = provider.models.filter((m) => m.isDefault);
     expect(defaults).toHaveLength(1);
-    expect(defaults[0]?.id).toBe("gemini-2.5-pro");
+    expect(defaults[0]?.id).toBe("gemini-3.1-pro-preview");
   });
 
-  it("includes Gemini 3 preview models marked as new", () => {
+  it("has no models marked as new", () => {
     const newModels = provider.models.filter((m) => m.isNew);
-    expect(newModels.map((m) => m.id)).toEqual([
-      "gemini-3-pro-preview",
-      "gemini-3-flash-preview",
-    ]);
+    expect(newModels).toHaveLength(0);
   });
 
   // ── Capabilities ───────────────────────────────────────────────────
@@ -68,7 +65,7 @@ describe("GeminiProvider", () => {
   it("builds first-message args with prompt, output format, yolo, and model", () => {
     const args = provider.buildArgs(
       "Hello Gemini",
-      { model: "gemini-2.5-flash" },
+      { model: "gemini-3-flash-preview" },
       baseSession({ isFirstMessage: true }),
     );
 
@@ -77,7 +74,7 @@ describe("GeminiProvider", () => {
     expect(args).toContain("-o");
     expect(args).toContain("stream-json");
     expect(args).toContain("-m");
-    expect(args).toContain("gemini-2.5-flash");
+    expect(args).toContain("gemini-3-flash-preview");
     expect(args).toContain("-y");
     expect(args).not.toContain("-r");
   });
@@ -90,7 +87,7 @@ describe("GeminiProvider", () => {
   it("adds resume flag on subsequent messages", () => {
     const args = provider.buildArgs(
       "Continue",
-      { model: "gemini-2.5-pro" },
+      { model: "gemini-3.1-pro-preview" },
       baseSession({ isFirstMessage: false, sessionId: "gem-sess-123" }),
     );
 

--- a/backend/src/agents/providers/gemini.ts
+++ b/backend/src/agents/providers/gemini.ts
@@ -9,11 +9,9 @@ import type {
 } from "./types.js";
 
 const GEMINI_MODELS: ModelDefinition[] = [
-  { id: "gemini-2.5-pro", label: "Gemini 2.5 Pro", cliValue: "gemini-2.5-pro", isDefault: true },
-  { id: "gemini-2.5-flash", label: "Gemini 2.5 Flash", cliValue: "gemini-2.5-flash" },
-  { id: "gemini-2.5-flash-lite", label: "Gemini 2.5 Flash Lite", cliValue: "gemini-2.5-flash-lite" },
-  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro", cliValue: "gemini-3-pro-preview", isNew: true },
-  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash", cliValue: "gemini-3-flash-preview", isNew: true },
+  { id: "gemini-3.1-pro-preview", label: "Gemini 3.1 Pro", cliValue: "gemini-3.1-pro-preview", isDefault: true },
+  { id: "gemini-3-pro-preview", label: "Gemini 3 Pro", cliValue: "gemini-3-pro-preview" },
+  { id: "gemini-3-flash-preview", label: "Gemini 3 Flash", cliValue: "gemini-3-flash-preview" },
 ];
 
 const GEMINI_CAPABILITIES: ProviderCapabilities = {

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -59,9 +59,9 @@ describe("resolveProvider", () => {
   });
 
   it("resolves gemini:model-id correctly", () => {
-    const { provider, modelId } = resolveProvider("gemini:gemini-2.5-pro");
+    const { provider, modelId } = resolveProvider("gemini:gemini-3.1-pro-preview");
     expect(provider.id).toBe("gemini");
-    expect(modelId).toBe("gemini-2.5-pro");
+    expect(modelId).toBe("gemini-3.1-pro-preview");
   });
 
   it("throws for unknown provider prefix", () => {
@@ -221,8 +221,9 @@ describe("getModelCatalog", () => {
     markProviderAvailable("claude");
     const catalog = getModelCatalog();
 
-    const sonnet = catalog.models.find((m) => m.id === "claude:sonnet-4-6");
-    expect(sonnet?.isNew).toBe(true);
+    // No models currently marked as new
+    const newModels = catalog.models.filter((m) => m.isNew);
+    expect(newModels).toHaveLength(0);
   });
 });
 

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -268,7 +268,6 @@ export default function ChatInput({
             <ModelSelector
               models={models}
               selectedModelId={selectedModelId}
-              defaultModelId={defaultModelId}
               onSelect={setSelectedModelId}
               lockedProvider={lockedProvider}
             />

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -40,12 +40,11 @@ function ProviderIcon({ provider, className }: { provider: string; className?: s
 interface ModelSelectorProps {
   models: ModelCatalogEntry[];
   selectedModelId: string;
-  defaultModelId: string;
   onSelect: (modelId: string) => void;
   lockedProvider?: string;
 }
 
-export function ModelSelector({ models, selectedModelId, defaultModelId, onSelect, lockedProvider }: ModelSelectorProps) {
+export function ModelSelector({ models, selectedModelId, onSelect, lockedProvider }: ModelSelectorProps) {
   const selected = models.find((m) => m.id === selectedModelId);
   const label = selected?.label ?? "Select model";
 
@@ -124,8 +123,10 @@ export function ModelSelector({ models, selectedModelId, defaultModelId, onSelec
                         key={model.id}
                         onClick={() => onSelect(model.id)}
                         className={cn(
-                          "gap-2 rounded-sm focus:bg-white/[0.04]",
-                          isSelected && "bg-primary/10 text-primary focus:bg-primary/10",
+                          "gap-2 rounded-sm",
+                          isSelected
+                            ? "bg-primary/10 text-primary focus:bg-primary/10 focus:text-primary"
+                            : "focus:bg-white/[0.04]",
                         )}
                       >
                         <span className="flex-1">{model.label}</span>

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -1,15 +1,14 @@
 import { useMemo } from "react";
-import { CheckIcon, StarIcon } from "lucide-react";
+import { CheckIcon } from "lucide-react";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
   DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
 import { PromptInputButton } from "@/components/ai-elements/prompt-input";
 import type { ModelCatalogEntry } from "@/types";
 import { cn } from "@/lib/utils";
@@ -71,37 +70,51 @@ export function ModelSelector({ models, selectedModelId, defaultModelId, onSelec
           {label}
         </PromptInputButton>
       </DropdownMenuTrigger>
-      <DropdownMenuContent side="top" align="start" className="w-64">
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        className="w-56 border-border/30 p-0 dark:bg-[var(--menu-bg)]"
+        style={{
+          "--menu-bg": "color-mix(in srgb, var(--background), white 3%)",
+          "--header-bg": "color-mix(in srgb, var(--background), white 6%)",
+        } as React.CSSProperties}
+      >
         <TooltipProvider>
-          {grouped.map((group, groupIdx) => {
+          {grouped.map((group) => {
             const isGroupLocked = !!lockedProvider && group.provider !== lockedProvider;
             return (
               <div key={group.provider}>
-                {groupIdx > 0 && <DropdownMenuSeparator />}
-                <DropdownMenuLabel className={cn(
-                  "text-[11px] text-muted-foreground/60 uppercase tracking-wider font-normal",
+                <div className={cn(
+                  "flex items-center gap-1.5 bg-black/5 px-3 py-1.5 dark:bg-[var(--header-bg)]",
                   isGroupLocked && "opacity-40",
                 )}>
-                  {group.providerLabel}
-                </DropdownMenuLabel>
-                <DropdownMenuGroup>
+                  <ProviderIcon provider={group.provider} className="size-2.5 text-muted-foreground" />
+                  <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                    {group.providerLabel}
+                  </span>
+                </div>
+                <DropdownMenuGroup className="p-1">
                   {group.models.map((model) => {
                     const isSelected = model.id === selectedModelId;
-                    const isDefault = model.id === defaultModelId;
                     const isLocked = !!lockedProvider && model.provider !== lockedProvider;
 
                     if (isLocked) {
                       return (
                         <Tooltip key={model.id}>
                           <TooltipTrigger asChild>
-                            <div className="flex items-center gap-2 px-2 py-1.5 text-sm opacity-40 cursor-not-allowed select-none">
-                              <ProviderIcon provider={model.provider} className="size-3.5 shrink-0" />
+                            <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm opacity-30 cursor-not-allowed select-none">
                               <span className="flex-1">{model.label}</span>
                             </div>
                           </TooltipTrigger>
-                          <TooltipContent side="right">
-                            Cannot switch provider mid-session
-                          </TooltipContent>
+                          <TooltipPrimitive.Portal>
+                            <TooltipPrimitive.Content
+                              side="right"
+                              sideOffset={4}
+                              className="animate-in fade-in-0 zoom-in-95 z-50 rounded-md border border-border/30 bg-muted px-3 py-1.5 text-xs text-muted-foreground shadow-md"
+                            >
+                              Cannot switch provider mid-session
+                            </TooltipPrimitive.Content>
+                          </TooltipPrimitive.Portal>
                         </Tooltip>
                       );
                     }
@@ -110,17 +123,16 @@ export function ModelSelector({ models, selectedModelId, defaultModelId, onSelec
                       <DropdownMenuItem
                         key={model.id}
                         onClick={() => onSelect(model.id)}
-                        className={cn("gap-2", isSelected && "bg-accent/50")}
+                        className={cn(
+                          "gap-2 rounded-sm focus:bg-white/[0.04]",
+                          isSelected && "bg-primary/10 text-primary focus:bg-primary/10",
+                        )}
                       >
-                        <ProviderIcon provider={model.provider} className="size-3.5 shrink-0" />
                         <span className="flex-1">{model.label}</span>
                         {model.isNew && (
-                          <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                          <span className="rounded-sm bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary">
                             NEW
                           </span>
-                        )}
-                        {isDefault && !isSelected && (
-                          <StarIcon className="size-3 text-muted-foreground/50" />
                         )}
                         {isSelected && <CheckIcon className="size-3.5 text-primary" />}
                       </DropdownMenuItem>

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -149,10 +149,10 @@ describe("ModelSelector", () => {
 
     await user.click(screen.getByRole("button", { name: /Model: Opus 4.6/i }));
 
-    // Codex models should be visually disabled (opacity-40, cursor-not-allowed)
+    // Codex models should be visually disabled (opacity-30, cursor-not-allowed)
     const codexModelElement = screen.getByText("GPT-5.3-Codex");
     const container = codexModelElement.closest("div");
-    expect(container?.className).toContain("opacity-40");
+    expect(container?.className).toContain("opacity-30");
     expect(container?.className).toContain("cursor-not-allowed");
   });
 

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -52,7 +52,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -65,7 +65,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="nonexistent"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -79,7 +79,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={[...ALL_MODELS, ...GEMINI_MODELS]}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -107,7 +107,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={modelsWithNew}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -124,7 +124,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={onSelect}
       />,
     );
@@ -141,7 +141,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
         lockedProvider="claude"
       />,
@@ -163,7 +163,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={onSelect}
         lockedProvider="claude"
       />,
@@ -187,7 +187,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={onSelect}
         lockedProvider="claude"
       />,
@@ -206,7 +206,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={onSelect}
       />,
     );
@@ -222,7 +222,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:sonnet-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -235,7 +235,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={[...ALL_MODELS, ...GEMINI_MODELS]}
         selectedModelId="gemini:gemini-3.1-pro-preview"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -250,7 +250,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={ALL_MODELS}
         selectedModelId="claude:opus-4-6"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );
@@ -265,7 +265,7 @@ describe("ModelSelector", () => {
       <ModelSelector
         models={[...ALL_MODELS, ...GEMINI_MODELS]}
         selectedModelId="missing:model"
-        defaultModelId="claude:opus-4-6"
+
         onSelect={vi.fn()}
       />,
     );

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -18,7 +18,6 @@ const CLAUDE_MODELS: ModelCatalogEntry[] = [
     label: "Sonnet 4.6",
     provider: "claude",
     providerLabel: "Claude Code",
-    isNew: true,
     capabilities: { thinking: true, planMode: true, blockingTools: true, completions: true },
   },
 ];
@@ -36,10 +35,11 @@ const CODEX_MODELS: ModelCatalogEntry[] = [
 
 const GEMINI_MODELS: ModelCatalogEntry[] = [
   {
-    id: "gemini:gemini-2.5-pro",
-    label: "Gemini 2.5 Pro",
+    id: "gemini:gemini-3.1-pro-preview",
+    label: "Gemini 3.1 Pro",
     provider: "gemini",
     providerLabel: "Gemini CLI",
+    isDefault: true,
     capabilities: { thinking: false, planMode: false, blockingTools: false, completions: false },
   },
 ];
@@ -94,14 +94,18 @@ describe("ModelSelector", () => {
     // Model labels
     expect(screen.getByText("Sonnet 4.6")).toBeInTheDocument();
     expect(screen.getByText("GPT-5.3-Codex")).toBeInTheDocument();
-    expect(screen.getByText("Gemini 2.5 Pro")).toBeInTheDocument();
+    expect(screen.getByText("Gemini 3.1 Pro")).toBeInTheDocument();
   });
 
   it("shows NEW badge for models with isNew flag", async () => {
+    const modelsWithNew: ModelCatalogEntry[] = [
+      ...CLAUDE_MODELS,
+      { ...CODEX_MODELS[0], isNew: true },
+    ];
     const user = userEvent.setup();
     render(
       <ModelSelector
-        models={ALL_MODELS}
+        models={modelsWithNew}
         selectedModelId="claude:opus-4-6"
         defaultModelId="claude:opus-4-6"
         onSelect={vi.fn()}
@@ -230,13 +234,13 @@ describe("ModelSelector", () => {
     render(
       <ModelSelector
         models={[...ALL_MODELS, ...GEMINI_MODELS]}
-        selectedModelId="gemini:gemini-2.5-pro"
+        selectedModelId="gemini:gemini-3.1-pro-preview"
         defaultModelId="claude:opus-4-6"
         onSelect={vi.fn()}
       />,
     );
 
-    const trigger = screen.getByRole("button", { name: /Model: Gemini 2.5 Pro/i });
+    const trigger = screen.getByRole("button", { name: /Model: Gemini 3.1 Pro/i });
     const iconPath = trigger.querySelector("svg path")?.getAttribute("d");
     expect(iconPath).toContain("M12 0C12 6.627");
   });


### PR DESCRIPTION
## Summary
- Trim model catalog: keep all Claude models, Codex 5.3 only, Gemini 3.1 Pro + 3 Pro + 3 Flash
- Remove all `isNew` flags from model definitions
- Redesign ModelSelector dropdown to match app design system (color-mix surfaces, provider group headers with icons, subtle hover, arrowless dark tooltip for provider lock)
- Fix selected item hover to keep stable selected style

## Test plan
- [x] All 721 tests pass across 62 test files
- [x] Typecheck clean
- [ ] Visual check: model dropdown styling, hover states, provider lock tooltip