### PR TITLE
Fix context token display showing cumulative turn tokens instead of a…

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1586,13 +1586,13 @@ describe("ConversationSession", () => {
     });
   });
 
-  it("result event usage overrides earlier assistant usage (last write wins)", async () => {
+  it("result event does NOT override assistant usage (assistant takes priority)", async () => {
     const session = createSession({ sessionId: "tok-override" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
     session.sendMessage("Hi");
-    // Assistant event with usage
+    // Assistant event with usage (actual context-window usage for last sub-call)
     mockProc._stdout.push(
       JSON.stringify({
         type: "assistant",
@@ -1604,7 +1604,7 @@ describe("ConversationSession", () => {
         },
       }) + "\n",
     );
-    // Result event with different usage
+    // Result event with higher (cumulative) usage — should be ignored
     mockProc._stdout.push(
       JSON.stringify({
         type: "result",
@@ -1618,9 +1618,320 @@ describe("ConversationSession", () => {
 
     const doneMsgs = messages.filter((m) => m.type === "done");
     expect(doneMsgs[0]).toMatchObject({
-      inputTokens: 3000,
-      outputTokens: 250,
+      inputTokens: 1000,
+      outputTokens: 50,
     });
+  });
+
+  it("result event usage is used as fallback when assistant has cache tokens but result has different values", async () => {
+    const session = createSession({ sessionId: "tok-cache-priority" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    // Assistant event with cache tokens — sets resultInputTokens to a defined value
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-cp",
+          role: "assistant",
+          content: [{ type: "text", text: "Hello" }],
+          usage: {
+            input_tokens: 500,
+            output_tokens: 80,
+            cache_creation_input_tokens: 200,
+            cache_read_input_tokens: 100,
+          },
+        },
+      }) + "\n",
+    );
+    // Result event with larger cumulative values — should be ignored
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: { input_tokens: 5000, output_tokens: 400 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 800, // 500 + 200 + 100 from assistant event
+      outputTokens: 80,
+    });
+  });
+
+  it("multiple assistant events: last assistant usage wins (tool use cycles)", async () => {
+    const session = createSession({ sessionId: "tok-multi-assistant" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+
+    // First assistant event — initial sub-call
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-1",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu1", name: "Read", input: { path: "/tmp" } }],
+          usage: { input_tokens: 120_000, output_tokens: 100 },
+        },
+      }) + "\n",
+    );
+
+    // Tool result
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "user",
+        message: { role: "user", content: [{ type: "tool_result", tool_use_id: "tu1", content: "file content" }] },
+      }) + "\n",
+    );
+
+    // Second assistant event — larger context after tool result
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-2",
+          role: "assistant",
+          content: [{ type: "text", text: "Here's the file" }],
+          usage: { input_tokens: 140_000, output_tokens: 200 },
+        },
+      }) + "\n",
+    );
+
+    // Result event with cumulative total — should be ignored since assistant had usage
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: { input_tokens: 260_000, output_tokens: 300 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    // Should use the LAST assistant event (140K), not the cumulative result (260K)
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 140_000,
+      outputTokens: 200,
+    });
+  });
+
+  it("three tool call cycles: reports last sub-call context, not cumulative total", async () => {
+    const session = createSession({ sessionId: "tok-3-cycles" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+
+    // Cycle 1: 120K tokens
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-c1",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu1", name: "Read", input: {} }],
+          usage: { input_tokens: 120_000, output_tokens: 50 },
+        },
+      }) + "\n",
+    );
+    mockProc._stdout.push(userLine([{ tool_use_id: "tu1", content: "data" }]));
+
+    // Cycle 2: 140K tokens (context grew)
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-c2",
+          role: "assistant",
+          content: [{ type: "tool_use", id: "tu2", name: "Grep", input: {} }],
+          usage: { input_tokens: 140_000, output_tokens: 80 },
+        },
+      }) + "\n",
+    );
+    mockProc._stdout.push(userLine([{ tool_use_id: "tu2", content: "matches" }]));
+
+    // Cycle 3: 174K tokens (context grew more)
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-c3",
+          role: "assistant",
+          content: [{ type: "text", text: "Done" }],
+          usage: { input_tokens: 174_000, output_tokens: 120 },
+        },
+      }) + "\n",
+    );
+
+    // Result event: cumulative total across all cycles (434K)
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: { input_tokens: 434_000, output_tokens: 250 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    // Must show the last sub-call (174K), NOT the cumulative 434K
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 174_000,
+      outputTokens: 120,
+    });
+  });
+
+  it("assistant usage with zero input_tokens still counts as defined (blocks result fallback)", async () => {
+    const session = createSession({ sessionId: "tok-zero" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-z",
+          role: "assistant",
+          content: [{ type: "text", text: "Hi" }],
+          usage: { input_tokens: 0, output_tokens: 10 },
+        },
+      }) + "\n",
+    );
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: { input_tokens: 5000, output_tokens: 300 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    // 0 is a defined value — result should NOT override
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 0,
+      outputTokens: 10,
+    });
+  });
+
+  it("result event cache tokens are aggregated correctly when used as fallback", async () => {
+    const session = createSession({ sessionId: "tok-result-cache" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    // Assistant line with NO usage
+    mockProc._stdout.push(assistantLine("Reply"));
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: {
+          input_tokens: 800,
+          output_tokens: 60,
+          cache_creation_input_tokens: 400,
+          cache_read_input_tokens: 200,
+        },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 1400, // 800 + 400 + 200
+      outputTokens: 60,
+    });
+  });
+
+  it("result duration is always captured regardless of token priority", async () => {
+    const session = createSession({ sessionId: "tok-duration" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-d",
+          role: "assistant",
+          content: [{ type: "text", text: "Reply" }],
+          usage: { input_tokens: 5000, output_tokens: 100 },
+        },
+      }) + "\n",
+    );
+    // Result event: tokens should be ignored, but duration should be captured
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        duration_ms: 3500,
+        usage: { input_tokens: 9000, output_tokens: 500 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const doneMsgs = messages.filter((m) => m.type === "done");
+    expect(doneMsgs[0]).toMatchObject({
+      inputTokens: 5000, // from assistant, not result
+      outputTokens: 100,
+      durationMs: 3500, // from result — always captured
+    });
+  });
+
+  it("persists correct tokens in messages.jsonl when result has higher values", async () => {
+    const session = createSession({ sessionId: "tok-persist-priority" });
+
+    session.sendMessage("Hi");
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "assistant",
+        message: {
+          id: "msg-pp",
+          role: "assistant",
+          content: [{ type: "text", text: "Hi back" }],
+          usage: { input_tokens: 80_000, output_tokens: 400 },
+        },
+      }) + "\n",
+    );
+    mockProc._stdout.push(
+      JSON.stringify({
+        type: "result",
+        session_id: "s1",
+        usage: { input_tokens: 250_000, output_tokens: 1200 },
+      }) + "\n",
+    );
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const messagesPath = join(tempDir, "sessions", "tok-persist-priority", "messages.jsonl");
+    const raw = await readFile(messagesPath, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+    const assistantMsg = JSON.parse(lines[1]);
+    // Persisted value should be from assistant event (80K), not result (250K)
+    expect(assistantMsg.inputTokens).toBe(80_000);
+    expect(assistantMsg.outputTokens).toBe(400);
   });
 
   it("persists inputTokens/outputTokens in assistant message", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -492,7 +492,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       if (data.duration_ms != null) {
         resultDurationMs = data.duration_ms;
       }
-      if (data.usage) {
+      // Only use result-level usage as fallback — the last assistant event
+      // carries the actual context-window usage for the final sub-call, while
+      // the result event may report cumulative tokens across all sub-calls
+      // in the turn (which can exceed the context window size).
+      if (data.usage && resultInputTokens === undefined) {
         resultInputTokens =
           data.usage.input_tokens +
           (data.usage.cache_creation_input_tokens ?? 0) +

--- a/frontend/tests/hooks/useContextUsage.test.ts
+++ b/frontend/tests/hooks/useContextUsage.test.ts
@@ -105,4 +105,148 @@ describe("useContextUsage", () => {
     expect(result.current.contextWindow).toBeNull();
     expect(result.current.usageFraction).toBeNull();
   });
+
+  // ── Regression tests: context display accuracy ────────────────────────
+
+  it("shows last turn context, not accumulated total across turns", () => {
+    // Each turn re-sends the full conversation, so each message's inputTokens
+    // represents the context window usage for that turn (growing over time).
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "user", content: "Hello" }),
+      makeMessage({ role: "assistant", content: "Hi", inputTokens: 10_000, outputTokens: 100 }),
+      makeMessage({ role: "user", content: "Tell me more" }),
+      makeMessage({ role: "assistant", content: "Sure", inputTokens: 25_000, outputTokens: 200 }),
+      makeMessage({ role: "user", content: "And more" }),
+      makeMessage({ role: "assistant", content: "Done", inputTokens: 45_000, outputTokens: 300 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    // Must show the LAST turn's context (45K), not cumulative (10+25+45=80K)
+    expect(result.current.inputTokens).toBe(45_000);
+    expect(result.current.usageFraction).toBeCloseTo(0.225); // 45k / 200k
+  });
+
+  it("ignores user messages entirely when scanning for token data", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 30_000, outputTokens: 200 }),
+      makeMessage({ role: "user", content: "Follow-up" }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(30_000);
+  });
+
+  it("handles inputTokens of 0 as valid data", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 0, outputTokens: 0 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(0);
+    expect(result.current.usageFraction).toBe(0);
+  });
+
+  it("returns correct fraction near compaction threshold (~83%)", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 167_000, outputTokens: 500 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.usageFraction).toBeCloseTo(0.835); // 167k / 200k
+  });
+
+  it("handles context dropping after compaction (tokens decrease between turns)", () => {
+    // After compaction the context shrinks — the last turn should show the lower value
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "user", content: "Hello" }),
+      makeMessage({ role: "assistant", content: "Long reply", inputTokens: 170_000, outputTokens: 2000 }),
+      makeMessage({ role: "user", content: "More" }),
+      // After compaction, context is summarized — much smaller
+      makeMessage({ role: "assistant", content: "Compacted reply", inputTokens: 40_000, outputTokens: 500 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(40_000);
+    expect(result.current.usageFraction).toBe(0.2); // 40k / 200k
+  });
+
+  it("skips multiple trailing assistant messages without tokens", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "With tokens", inputTokens: 60_000, outputTokens: 300 }),
+      makeMessage({ role: "assistant", content: "No tokens 1" }),
+      makeMessage({ role: "assistant", content: "No tokens 2" }),
+      makeMessage({ role: "assistant", content: "No tokens 3" }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(60_000);
+  });
+
+  it("handles assistant message with inputTokens but no outputTokens", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 80_000 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(80_000);
+    expect(result.current.outputTokens).toBeNull();
+    expect(result.current.usageFraction).toBe(0.4);
+  });
+
+  it("works with different context window sizes (1M extended)", () => {
+    const extendedModel: ModelCatalogEntry = {
+      ...claudeModel,
+      contextWindow: 1_000_000,
+    };
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 400_000, outputTokens: 1000 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, extendedModel));
+    expect(result.current.inputTokens).toBe(400_000);
+    expect(result.current.contextWindow).toBe(1_000_000);
+    expect(result.current.usageFraction).toBe(0.4); // 400k / 1M
+  });
+
+  it("single-message conversation returns correct usage", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "First reply", inputTokens: 8_000, outputTokens: 200 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBe(8_000);
+    expect(result.current.outputTokens).toBe(200);
+    expect(result.current.usageFraction).toBe(0.04);
+  });
+
+  it("long conversation: always reads the most recent assistant with tokens", () => {
+    const messages: ChatMessage[] = [];
+    // Build a 20-turn conversation where each turn grows context
+    for (let i = 0; i < 20; i++) {
+      messages.push(makeMessage({ role: "user", content: `Turn ${i}` }));
+      messages.push(
+        makeMessage({
+          role: "assistant",
+          content: `Reply ${i}`,
+          inputTokens: (i + 1) * 8_000,
+          outputTokens: (i + 1) * 50,
+        }),
+      );
+    }
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    // Last turn: i=19, inputTokens = 20 * 8000 = 160_000
+    expect(result.current.inputTokens).toBe(160_000);
+    expect(result.current.outputTokens).toBe(1_000);
+    expect(result.current.usageFraction).toBe(0.8);
+  });
+
+  it("only user messages: returns all nulls for tokens", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "user", content: "Hello" }),
+      makeMessage({ role: "user", content: "Anyone?" }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.inputTokens).toBeNull();
+    expect(result.current.outputTokens).toBeNull();
+    expect(result.current.usageFraction).toBeNull();
+  });
+
+  it("exact boundary: inputTokens equals contextWindow gives fraction 1.0", () => {
+    const messages: ChatMessage[] = [
+      makeMessage({ role: "assistant", content: "Reply", inputTokens: 200_000, outputTokens: 500 }),
+    ];
+    const { result } = renderHook(() => useContextUsage(messages, claudeModel));
+    expect(result.current.usageFraction).toBe(1.0);
+  });
 });


### PR DESCRIPTION
…ctual context usage

The result event from Claude CLI reports cumulative tokens across all sub-calls in a turn (tool use loops), which can exceed the context window size. Use it only as fallback when no assistant event provided usage data, since the last assistant event carries the actual context-window usage for the final sub-call.