### PR TITLE
Add unread message badge to sidebar and session tabs

### DIFF
--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -25,6 +25,7 @@ interface ConversationTabsProps {
   activeSessionId?: string;
   isStreaming: boolean;
   streamingSessions?: Record<string, boolean>;
+  unreadSessions?: Record<string, boolean>;
   onCreateSession: () => void;
   onActivateSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
@@ -44,6 +45,7 @@ export function ConversationTabs({
   activeSessionId,
   isStreaming,
   streamingSessions,
+  unreadSessions,
   onCreateSession,
   onActivateSession,
   onDeleteSession,
@@ -155,6 +157,7 @@ export function ConversationTabs({
             const isVisible = i < visibleCount;
             const title = getTabTitle(session);
             const isSessionStreaming = streamingSessions?.[session.sessionId] ?? (isActive && isStreaming);
+            const isSessionUnread = !isActive && !isSessionStreaming && !!unreadSessions?.[session.sessionId];
 
             return (
               <button
@@ -173,6 +176,8 @@ export function ConversationTabs({
                   <div className="flex size-3 shrink-0 items-center justify-center overflow-visible">
                     <AgentActivityPreview size="small" />
                   </div>
+                ) : isSessionUnread ? (
+                  <span className="size-2 shrink-0 rounded-full bg-primary" />
                 ) : (
                   <MessageSquareIcon className="size-3 shrink-0" />
                 )}
@@ -219,6 +224,7 @@ export function ConversationTabs({
                 const isActive = session.sessionId === activeSessionId;
                 const title = getTabTitle(session);
                 const isOverflowStreaming = streamingSessions?.[session.sessionId] ?? (isActive && isStreaming);
+                const isOverflowUnread = !isActive && !isOverflowStreaming && !!unreadSessions?.[session.sessionId];
 
                 return (
                   <DropdownMenuItem
@@ -230,6 +236,8 @@ export function ConversationTabs({
                       <div className="flex size-3 shrink-0 items-center justify-center overflow-visible">
                         <AgentActivityPreview size="small" />
                       </div>
+                    ) : isOverflowUnread ? (
+                      <span className="size-2 shrink-0 rounded-full bg-primary" />
                     ) : (
                       <MessageSquareIcon className="size-3 shrink-0" />
                     )}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -173,6 +173,7 @@ export default function Sidebar({ onAddProject, onCollapse }: SidebarProps) {
                           const wsStreaming = wsLive?.streaming ?? false;
                           const wsScriptRunning = wsLive?.scriptRunning ?? false;
                           const displayBranch = wsLive?.branch ?? ws.branch;
+                          const wsUnread = !wsStreaming && activeWsId !== ws.id && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
                           return (
                             <div key={ws.id} className="group/ws relative">
                               <Link
@@ -183,12 +184,16 @@ export default function Sidebar({ onAddProject, onCollapse }: SidebarProps) {
                                 )}
                               >
                                 <div className="flex items-center gap-1.5">
-                                  {wsStreaming && (
+                                  {wsStreaming ? (
                                     <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
                                       <AgentActivityPreview size="small" />
                                     </div>
-                                  )}
-                                  <BranchLabel branch={displayBranch} showIcon={!wsStreaming} className="min-w-0 flex-1 text-sm" />
+                                  ) : wsUnread ? (
+                                    <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                                      <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                                    </div>
+                                  ) : null}
+                                  <BranchLabel branch={displayBranch} showIcon={!wsStreaming && !wsUnread} className="min-w-0 flex-1 text-sm" />
                                   {wsScriptRunning && (
                                     <WaveIndicator className="shrink-0" />
                                   )}

--- a/frontend/src/contexts/WorkspaceLiveDataContext.tsx
+++ b/frontend/src/contexts/WorkspaceLiveDataContext.tsx
@@ -1,12 +1,23 @@
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useMemo, type ReactNode } from "react";
 import {
   useWorkspaceLiveData,
+  type ClearUnreadFn,
   type WorkspaceLiveData,
 } from "@/hooks/useWorkspaceLiveData";
 
 type LiveDataMap = Record<string, WorkspaceLiveData>;
 
-const WorkspaceLiveDataContext = createContext<LiveDataMap>({});
+interface LiveDataContextValue {
+  liveData: LiveDataMap;
+  clearUnread: ClearUnreadFn;
+}
+
+const noop: ClearUnreadFn = () => {};
+
+const WorkspaceLiveDataContext = createContext<LiveDataContextValue>({
+  liveData: {},
+  clearUnread: noop,
+});
 
 interface Props {
   workspaceIds: string[];
@@ -14,9 +25,10 @@ interface Props {
 }
 
 export function WorkspaceLiveDataProvider({ workspaceIds, children }: Props) {
-  const liveData = useWorkspaceLiveData(workspaceIds);
+  const { liveData, clearUnread } = useWorkspaceLiveData(workspaceIds);
+  const value = useMemo(() => ({ liveData, clearUnread }), [liveData, clearUnread]);
   return (
-    <WorkspaceLiveDataContext.Provider value={liveData}>
+    <WorkspaceLiveDataContext.Provider value={value}>
       {children}
     </WorkspaceLiveDataContext.Provider>
   );
@@ -24,13 +36,18 @@ export function WorkspaceLiveDataProvider({ workspaceIds, children }: Props) {
 
 /** Full live data map keyed by workspace ID. */
 export function useWorkspaceLiveDataContext(): LiveDataMap {
-  return useContext(WorkspaceLiveDataContext);
+  return useContext(WorkspaceLiveDataContext).liveData;
+}
+
+/** Clear unread state for a workspace (and optionally a specific session). */
+export function useClearUnread(): ClearUnreadFn {
+  return useContext(WorkspaceLiveDataContext).clearUnread;
 }
 
 /** Convenience hook for a single workspace's live data. */
 export function useWorkspaceLive(
   wsId: string | undefined,
 ): WorkspaceLiveData {
-  const map = useContext(WorkspaceLiveDataContext);
-  return (wsId ? map[wsId] : undefined) ?? {};
+  const { liveData } = useContext(WorkspaceLiveDataContext);
+  return (wsId ? liveData[wsId] : undefined) ?? {};
 }

--- a/frontend/src/hooks/useWorkspaceLiveData.ts
+++ b/frontend/src/hooks/useWorkspaceLiveData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { wsTransport } from "@/lib/ws-transport";
 import type { BranchInfo, DiffStatResponse, ScriptState } from "@/types";
 
@@ -11,11 +11,14 @@ export interface WorkspaceLiveData {
   diffStats?: DiffStatResponse;
   scriptRunning?: boolean;
   scriptStates?: Record<string, ScriptState>;
+  unreadSessions?: Record<string, boolean>;
 }
+
+export type ClearUnreadFn = (wsId: string, sessionId?: string) => void;
 
 export function useWorkspaceLiveData(
   workspaceIds: string[],
-): Record<string, WorkspaceLiveData> {
+): { liveData: Record<string, WorkspaceLiveData>; clearUnread: ClearUnreadFn } {
   const [liveData, setLiveData] = useState<Record<string, WorkspaceLiveData>>(
     {},
   );
@@ -87,6 +90,16 @@ export function useWorkspaceLiveData(
               diffStats: msg.stats,
             },
           }));
+        } else if ((msg.type === "done" || msg.type === "cancelled") && msg.sessionId) {
+          setLiveData((prev) => {
+            const current = prev[wsId] ?? {};
+            const prevUnread = current.unreadSessions ?? {};
+            if (prevUnread[msg.sessionId!]) return prev;
+            return {
+              ...prev,
+              [wsId]: { ...current, unreadSessions: { ...prevUnread, [msg.sessionId!]: true } },
+            };
+          });
         } else if (msg.type === "script_status") {
           setLiveData((prev) => {
             const current = prev[wsId] ?? {};
@@ -120,5 +133,21 @@ export function useWorkspaceLiveData(
     });
   }, [workspaceIds]);
 
-  return liveData;
+  const clearUnread = useCallback<ClearUnreadFn>((wsId, sessionId) => {
+    setLiveData((prev) => {
+      const current = prev[wsId];
+      if (!current?.unreadSessions) return prev;
+      if (sessionId) {
+        if (!current.unreadSessions[sessionId]) return prev;
+        const { [sessionId]: _, ...rest } = current.unreadSessions;
+        return {
+          ...prev,
+          [wsId]: { ...current, unreadSessions: Object.keys(rest).length > 0 ? rest : undefined },
+        };
+      }
+      return { ...prev, [wsId]: { ...current, unreadSessions: undefined } };
+    });
+  }, []);
+
+  return { liveData, clearUnread };
 }

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -5,7 +5,7 @@ import { CodeXmlIcon, ChevronDownIcon, TerminalIcon } from "lucide-react";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
-import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
+import { useWorkspaceLiveDataContext, useClearUnread } from "@/contexts/WorkspaceLiveDataContext";
 import { useSidebarCollapsed } from "@/hooks/useSidebarCollapsed";
 import {
   FileTree,
@@ -138,7 +138,13 @@ export default function WorkspaceView() {
 
   // Live data via WebSocket (branch + diff stats)
   const liveData = useWorkspaceLiveDataContext();
+  const clearUnread = useClearUnread();
   const { collapsed: sidebarCollapsed } = useSidebarCollapsed();
+
+  // Clear unread state when navigating to a workspace
+  useEffect(() => {
+    if (wsId) clearUnread(wsId);
+  }, [wsId, clearUnread]);
   const displayBranch = (wsId && liveData[wsId]?.branch) || workspace?.branch;
 
   // VS Code Remote SSH
@@ -298,7 +304,8 @@ export default function WorkspaceView() {
     if (targetSessionId === sessionId) return;
     setActiveTab("conversation");
     switchSession(targetSessionId);
-  }, [sessionId, switchSession]);
+    if (wsId) clearUnread(wsId, targetSessionId);
+  }, [sessionId, switchSession, wsId, clearUnread]);
 
   const handleDeleteSession = useCallback(async (targetSessionId: string) => {
     const isActive = targetSessionId === sessionId;
@@ -457,6 +464,7 @@ export default function WorkspaceView() {
             activeSessionId={sessionId}
             isStreaming={isStreaming}
             streamingSessions={wsId ? liveData[wsId]?.streamingSessions : undefined}
+            unreadSessions={wsId ? liveData[wsId]?.unreadSessions : undefined}
             onCreateSession={handleCreateSession}
             onActivateSession={handleActivateSession}
             onDeleteSession={handleDeleteSession}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -145,6 +145,7 @@ export default function WorkspaceView() {
   useEffect(() => {
     if (wsId) clearUnread(wsId);
   }, [wsId, clearUnread]);
+
   const displayBranch = (wsId && liveData[wsId]?.branch) || workspace?.branch;
 
   // VS Code Remote SSH
@@ -236,6 +237,14 @@ export default function WorkspaceView() {
     lockedProvider,
     switchCounter,
   } = useConversation(wsId);
+
+  // Clear unread for the active session reactively (handles done/cancelled
+  // events arriving while the user is already viewing this conversation).
+  useEffect(() => {
+    if (wsId && sessionId && liveData[wsId]?.unreadSessions?.[sessionId]) {
+      clearUnread(wsId, sessionId);
+    }
+  }, [wsId, sessionId, liveData, clearUnread]);
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
 

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { describe, expect, it, vi } from "vitest";
@@ -37,6 +37,10 @@ function renderTabs(props?: Partial<ComponentProps<typeof ConversationTabs>>) {
   );
 
   return { onCreateSession, onActivateSession, onDeleteSession };
+}
+
+function findUnreadDot(container: HTMLElement) {
+  return container.querySelector("span[class*='rounded-full'][class*='bg-primary']");
 }
 
 describe("ConversationTabs", () => {
@@ -251,6 +255,36 @@ describe("ConversationTabs", () => {
     expect(inactiveTab.querySelector("svg")).toBeInTheDocument();
   });
 
+  it("shows unread dot for inactive unread session when not streaming", () => {
+    renderTabs({
+      unreadSessions: { "sess-2": true },
+    });
+
+    const inactiveTab = screen.getByText("Second conversation").closest("button")!;
+    expect(findUnreadDot(inactiveTab)).toBeInTheDocument();
+    expect(inactiveTab.querySelector("svg.lucide-message-square")).toBeNull();
+  });
+
+  it("does not show unread dot for active session even when unreadSessions marks it", () => {
+    renderTabs({
+      unreadSessions: { "sess-1": true },
+    });
+
+    const activeTab = screen.getByText("First conversation").closest("button")!;
+    expect(findUnreadDot(activeTab)).not.toBeInTheDocument();
+  });
+
+  it("prioritizes streaming indicator over unread dot", () => {
+    renderTabs({
+      unreadSessions: { "sess-2": true },
+      streamingSessions: { "sess-2": true },
+    });
+
+    const inactiveTab = screen.getByText("Second conversation").closest("button")!;
+    expect(inactiveTab.querySelector("[aria-label='Agent thinking']")).toBeInTheDocument();
+    expect(findUnreadDot(inactiveTab)).not.toBeInTheDocument();
+  });
+
   it("shows MessageSquare icon on active tab when not streaming", () => {
     renderTabs({ isStreaming: false });
     const activeTab = screen.getByText("First conversation").closest("button")!;
@@ -281,6 +315,40 @@ describe("ConversationTabs", () => {
 
     expect(screen.getByText("Named one")).toBeInTheDocument();
     expect(screen.getByText("Untitled")).toBeInTheDocument();
+  });
+
+  it("shows unread dot in overflow menu for unread overflow sessions", async () => {
+    const user = userEvent.setup();
+    const clientWidthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(50);
+    const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(50);
+
+    try {
+      renderTabs({
+        sessions: [
+          makeSession("s1", "2026-02-12T00:00:03.000Z", "Alpha"),
+          makeSession("s2", "2026-02-12T00:00:02.000Z", "Beta"),
+          makeSession("s3", "2026-02-12T00:00:01.000Z", "Gamma"),
+        ],
+        activeSessionId: "s1",
+        unreadSessions: { s3: true },
+      });
+
+      const overflowTrigger = await waitFor(() => {
+        const trigger = (
+          document.querySelector("svg.lucide-more-horizontal")?.closest("button")
+          ?? document.querySelector("svg.lucide-ellipsis")?.closest("button")
+        ) as HTMLButtonElement | null;
+        expect(trigger).toBeTruthy();
+        return trigger as HTMLButtonElement;
+      });
+
+      await user.click(overflowTrigger);
+      const overflowItem = await screen.findByRole("menuitem", { name: /Gamma/i });
+      expect(findUnreadDot(overflowItem)).toBeInTheDocument();
+    } finally {
+      clientWidthSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+    }
   });
 });
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -120,6 +120,12 @@ function renderSidebar(
   );
 }
 
+function findSidebarUnreadDot(container: HTMLElement) {
+  return container.querySelector(
+    "span[class*='h-1.5'][class*='w-1.5'][class*='rounded-full'][class*='bg-primary']",
+  );
+}
+
 describe("Sidebar", () => {
   const projects: Project[] = [
     {
@@ -313,6 +319,86 @@ describe("Sidebar", () => {
     // Orbit loader should appear only once (for w1)
     const orbitLoaders = screen.getAllByRole("img", { name: "Agent thinking" });
     expect(orbitLoaders).toHaveLength(1);
+  });
+
+  it("shows unread dot for inactive workspace after done event", async () => {
+    const multiWsProjects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [
+          { id: "w1", name: "tokyo", branch: "workspace/tokyo", status: "idle", createdAt: "2026-02-11T00:00:00.000Z" },
+          { id: "w2", name: "paris", branch: "workspace/paris", status: "idle", createdAt: "2026-02-11T00:00:00.000Z" },
+        ],
+      },
+    ];
+
+    const { __wsMock } = await getWsMock();
+    renderSidebar("/workspaces/w1", multiWsProjects);
+
+    await screen.findByText("workspace/paris");
+
+    act(() => {
+      __wsMock.emit("w2", { type: "done", sessionId: "sess-2" });
+    });
+
+    const inactiveLink = screen.getByRole("link", { name: /workspace\/paris/i });
+    expect(findSidebarUnreadDot(inactiveLink)).toBeInTheDocument();
+    expect(inactiveLink.querySelector("svg.lucide-git-branch")).toBeNull();
+  });
+
+  it("does not show unread dot for active workspace", async () => {
+    const { __wsMock } = await getWsMock();
+    renderSidebar("/workspaces/w1", projects);
+
+    await screen.findByText("workspace/tokyo");
+
+    act(() => {
+      __wsMock.emit("w1", { type: "done", sessionId: "sess-1" });
+    });
+
+    const activeLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
+    expect(findSidebarUnreadDot(activeLink)).toBeNull();
+  });
+
+  it("prioritizes streaming indicator over unread dot and restores dot when idle again", async () => {
+    const multiWsProjects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [
+          { id: "w1", name: "tokyo", branch: "workspace/tokyo", status: "idle", createdAt: "2026-02-11T00:00:00.000Z" },
+          { id: "w2", name: "paris", branch: "workspace/paris", status: "idle", createdAt: "2026-02-11T00:00:00.000Z" },
+        ],
+      },
+    ];
+
+    const { __wsMock } = await getWsMock();
+    renderSidebar("/workspaces/w1", multiWsProjects);
+
+    await screen.findByText("workspace/paris");
+    const inactiveLink = screen.getByRole("link", { name: /workspace\/paris/i });
+
+    act(() => {
+      __wsMock.emit("w2", { type: "done", sessionId: "sess-2" });
+    });
+    expect(findSidebarUnreadDot(inactiveLink)).toBeInTheDocument();
+
+    act(() => {
+      __wsMock.emit("w2", { type: "status", status: "busy", sessionId: "sess-2", streaming: true });
+    });
+    expect(inactiveLink.querySelector("[aria-label='Agent thinking']")).toBeInTheDocument();
+    expect(findSidebarUnreadDot(inactiveLink)).toBeNull();
+
+    act(() => {
+      __wsMock.emit("w2", { type: "status", status: "busy", sessionId: "sess-2", streaming: false });
+    });
+    expect(inactiveLink.querySelector("[aria-label='Agent thinking']")).not.toBeInTheDocument();
+    expect(findSidebarUnreadDot(inactiveLink)).toBeInTheDocument();
   });
 
   it("displays live branch name from branch_info WS message", async () => {

--- a/frontend/tests/contexts/WorkspaceLiveDataContext.test.tsx
+++ b/frontend/tests/contexts/WorkspaceLiveDataContext.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   WorkspaceLiveDataProvider,
+  useClearUnread,
   useWorkspaceLive,
   useWorkspaceLiveDataContext,
 } from "@/contexts/WorkspaceLiveDataContext";
@@ -25,6 +27,15 @@ function ContextProbe({ wsId }: { wsId?: string }) {
   );
 }
 
+function ClearUnreadProbe({ wsId = "ws-1", sessionId }: { wsId?: string; sessionId?: string }) {
+  const clearUnread = useClearUnread();
+  return (
+    <button type="button" onClick={() => clearUnread(wsId, sessionId)}>
+      clear unread
+    </button>
+  );
+}
+
 describe("WorkspaceLiveDataContext", () => {
   const clearUnread = vi.fn();
 
@@ -38,6 +49,14 @@ describe("WorkspaceLiveDataContext", () => {
 
     expect(screen.getByTestId("map")).toHaveTextContent("{}");
     expect(screen.getByTestId("single")).toHaveTextContent("{}");
+  });
+
+  it("useClearUnread outside provider is a safe no-op", async () => {
+    const user = userEvent.setup();
+    render(<ClearUnreadProbe wsId="ws-1" sessionId="sess-1" />);
+
+    await user.click(screen.getByRole("button", { name: "clear unread" }));
+    expect(clearUnread).not.toHaveBeenCalled();
   });
 
   it("passes workspace ids to useWorkspaceLiveData and provides full map", () => {
@@ -84,5 +103,17 @@ describe("WorkspaceLiveDataContext", () => {
     );
 
     expect(JSON.parse(screen.getByTestId("single").textContent ?? "{}")).toEqual({});
+  });
+
+  it("useClearUnread forwards calls to the hook implementation from provider", async () => {
+    const user = userEvent.setup();
+    render(
+      <WorkspaceLiveDataProvider workspaceIds={["ws-1"]}>
+        <ClearUnreadProbe wsId="ws-1" sessionId="sess-1" />
+      </WorkspaceLiveDataProvider>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "clear unread" }));
+    expect(clearUnread).toHaveBeenCalledWith("ws-1", "sess-1");
   });
 });

--- a/frontend/tests/contexts/WorkspaceLiveDataContext.test.tsx
+++ b/frontend/tests/contexts/WorkspaceLiveDataContext.test.tsx
@@ -26,9 +26,11 @@ function ContextProbe({ wsId }: { wsId?: string }) {
 }
 
 describe("WorkspaceLiveDataContext", () => {
+  const clearUnread = vi.fn();
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
   });
 
   it("exposes empty defaults outside provider", () => {
@@ -43,7 +45,7 @@ describe("WorkspaceLiveDataContext", () => {
       "ws-1": { status: "busy", streaming: true },
       "ws-2": { status: "idle", scriptRunning: false },
     };
-    mocks.useWorkspaceLiveData.mockReturnValue(liveData);
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData, clearUnread });
 
     render(
       <WorkspaceLiveDataProvider workspaceIds={["ws-1", "ws-2"]}>
@@ -60,7 +62,7 @@ describe("WorkspaceLiveDataContext", () => {
 
   it("returns empty object for undefined workspace id in useWorkspaceLive", () => {
     const liveData = { "ws-1": { status: "busy" } };
-    mocks.useWorkspaceLiveData.mockReturnValue(liveData);
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData, clearUnread });
 
     render(
       <WorkspaceLiveDataProvider workspaceIds={["ws-1"]}>
@@ -73,7 +75,7 @@ describe("WorkspaceLiveDataContext", () => {
 
   it("returns empty object when workspace id is missing from map", () => {
     const liveData = { "ws-1": { status: "idle" } };
-    mocks.useWorkspaceLiveData.mockReturnValue(liveData);
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData, clearUnread });
 
     render(
       <WorkspaceLiveDataProvider workspaceIds={["ws-1"]}>

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -61,6 +61,57 @@ describe("useWorkspaceLiveData", () => {
     expect(result.current.liveData).toEqual({});
   });
 
+  it("marks a session as unread on done events", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-1": true });
+  });
+
+  it("marks a session as unread on cancelled events", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "cancelled", sessionId: "sess-1" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-1": true });
+  });
+
+  it("ignores done/cancelled events without sessionId for unread tracking", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done" });
+      __wsMock.emit("ws-1", { type: "cancelled" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toBeUndefined();
+  });
+
+  it("does not re-render when the same unread session is marked twice", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+    });
+
+    const firstRef = result.current.liveData;
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "cancelled", sessionId: "sess-1" });
+    });
+
+    expect(result.current.liveData).toBe(firstRef);
+  });
+
   it("updates status on WS status message", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
@@ -146,6 +197,24 @@ describe("useWorkspaceLiveData", () => {
       streaming: true,
       streamingSessions: { "sess-b": true },
     });
+  });
+
+  it("keeps unread session data even when that session starts streaming again", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-a",
+        streaming: true,
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-a": true });
+    expect(result.current.liveData["ws-1"]?.streamingSessions).toEqual({ "sess-a": true });
   });
 
   it("updates branch on WS branch_info message", async () => {
@@ -335,5 +404,80 @@ describe("useWorkspaceLiveData", () => {
       branch: "workspace/kyoto",
       branchInfo: { name: "workspace/kyoto", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
     });
+  });
+
+  it("clearUnread removes only the targeted session when sessionId is provided", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-b" });
+    });
+
+    act(() => {
+      result.current.clearUnread("ws-1", "sess-a");
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-b": true });
+  });
+
+  it("clearUnread removes unreadSessions entirely when the last unread session is cleared", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+    });
+
+    act(() => {
+      result.current.clearUnread("ws-1", "sess-a");
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toBeUndefined();
+  });
+
+  it("clearUnread clears all unread sessions for a workspace when no sessionId is provided", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-b" });
+    });
+
+    act(() => {
+      result.current.clearUnread("ws-1");
+    });
+
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toBeUndefined();
+  });
+
+  it("clearUnread is a no-op when no unread state exists for the workspace", () => {
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+    const firstRef = result.current.liveData;
+
+    act(() => {
+      result.current.clearUnread("ws-1");
+    });
+
+    expect(result.current.liveData).toBe(firstRef);
+  });
+
+  it("clearUnread is a no-op when the target session is not unread", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+    });
+
+    const firstRef = result.current.liveData;
+
+    act(() => {
+      result.current.clearUnread("ws-1", "sess-missing");
+    });
+
+    expect(result.current.liveData).toBe(firstRef);
   });
 });

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -58,7 +58,7 @@ describe("useWorkspaceLiveData", () => {
 
   it("returns empty object initially for given workspace IDs", () => {
     const { result } = renderHook(() => useWorkspaceLiveData(["ws-1", "ws-2"]));
-    expect(result.current).toEqual({});
+    expect(result.current.liveData).toEqual({});
   });
 
   it("updates status on WS status message", async () => {
@@ -69,13 +69,13 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true });
     });
 
-    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
+    expect(result.current.liveData["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", streaming: false });
     });
 
-    expect(result.current["ws-1"]).toEqual({ status: "idle", streaming: false, streamingSessions: {} });
+    expect(result.current.liveData["ws-1"]).toEqual({ status: "idle", streaming: false, streamingSessions: {} });
   });
 
   it("tracks multiple streaming sessions even when workspace status stays busy", async () => {
@@ -91,7 +91,7 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    expect(result.current["ws-1"]).toEqual({
+    expect(result.current.liveData["ws-1"]).toEqual({
       status: "busy",
       streaming: true,
       streamingSessions: { "sess-a": true },
@@ -106,7 +106,7 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    expect(result.current["ws-1"]).toEqual({
+    expect(result.current.liveData["ws-1"]).toEqual({
       status: "busy",
       streaming: true,
       streamingSessions: { "sess-a": true, "sess-b": true },
@@ -141,7 +141,7 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    expect(result.current["ws-1"]).toEqual({
+    expect(result.current.liveData["ws-1"]).toEqual({
       status: "busy",
       streaming: true,
       streamingSessions: { "sess-b": true },
@@ -158,7 +158,7 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "branch_info", info: branchInfo });
     });
 
-    expect(result.current["ws-1"]).toEqual({
+    expect(result.current.liveData["ws-1"]).toEqual({
       branch: "workspace/tokyo",
       branchInfo,
     });
@@ -175,7 +175,7 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    const firstReference = result.current;
+    const firstReference = result.current.liveData;
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -184,7 +184,7 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    expect(result.current).toBe(firstReference);
+    expect(result.current.liveData).toBe(firstReference);
   });
 
   it("cleans up stale entries when workspace IDs change", async () => {
@@ -199,13 +199,13 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-2", { type: "status", status: "idle", streaming: false });
     });
 
-    expect(result.current["ws-1"]).toBeDefined();
-    expect(result.current["ws-2"]).toBeDefined();
+    expect(result.current.liveData["ws-1"]).toBeDefined();
+    expect(result.current.liveData["ws-2"]).toBeDefined();
 
     rerender(["ws-1"]);
 
-    expect(result.current["ws-1"]).toBeDefined();
-    expect(result.current["ws-2"]).toBeUndefined();
+    expect(result.current.liveData["ws-1"]).toBeDefined();
+    expect(result.current.liveData["ws-2"]).toBeUndefined();
   });
 
   it("unsubscribes handlers on unmount", async () => {
@@ -227,8 +227,8 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "running" });
     });
 
-    expect(result.current["ws-1"]?.scriptRunning).toBe(true);
-    expect(result.current["ws-1"]?.scriptStates).toEqual({ run: "running" });
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(true);
+    expect(result.current.liveData["ws-1"]?.scriptStates).toEqual({ run: "running" });
   });
 
   it("clears scriptRunning when script finishes", async () => {
@@ -238,13 +238,13 @@ describe("useWorkspaceLiveData", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "running" });
     });
-    expect(result.current["ws-1"]?.scriptRunning).toBe(true);
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(true);
 
     act(() => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "done", exitCode: 0 });
     });
-    expect(result.current["ws-1"]?.scriptRunning).toBe(false);
-    expect(result.current["ws-1"]?.scriptStates).toEqual({ run: "done" });
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(false);
+    expect(result.current.liveData["ws-1"]?.scriptStates).toEqual({ run: "done" });
   });
 
   it("stays scriptRunning while at least one script type is running", async () => {
@@ -255,18 +255,18 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "setup", state: "running" });
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "running" });
     });
-    expect(result.current["ws-1"]?.scriptRunning).toBe(true);
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(true);
 
     act(() => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "setup", state: "done", exitCode: 0 });
     });
     // run is still running
-    expect(result.current["ws-1"]?.scriptRunning).toBe(true);
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(true);
 
     act(() => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "error", exitCode: 1 });
     });
-    expect(result.current["ws-1"]?.scriptRunning).toBe(false);
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(false);
   });
 
   it("computes scriptRunning for arbitrary named scripts", async () => {
@@ -278,8 +278,8 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "frontend", state: "done", exitCode: 0 });
     });
 
-    expect(result.current["ws-1"]?.scriptRunning).toBe(true);
-    expect(result.current["ws-1"]?.scriptStates).toEqual({
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(true);
+    expect(result.current.liveData["ws-1"]?.scriptStates).toEqual({
       backend: "running",
       frontend: "done",
     });
@@ -288,8 +288,8 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "backend", state: "error", exitCode: 1 });
     });
 
-    expect(result.current["ws-1"]?.scriptRunning).toBe(false);
-    expect(result.current["ws-1"]?.scriptStates).toEqual({
+    expect(result.current.liveData["ws-1"]?.scriptRunning).toBe(false);
+    expect(result.current.liveData["ws-1"]?.scriptStates).toEqual({
       backend: "error",
       frontend: "done",
     });
@@ -303,13 +303,13 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "running" });
     });
 
-    const firstRef = result.current;
+    const firstRef = result.current.liveData;
 
     act(() => {
       __wsMock.emit("ws-1", { type: "script_status", scriptType: "run", state: "running" });
     });
 
-    expect(result.current).toBe(firstRef);
+    expect(result.current.liveData).toBe(firstRef);
   });
 
   it("handles multiple workspaces independently", async () => {
@@ -320,8 +320,8 @@ describe("useWorkspaceLiveData", () => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true });
     });
 
-    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
-    expect(result.current["ws-2"]).toBeUndefined();
+    expect(result.current.liveData["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
+    expect(result.current.liveData["ws-2"]).toBeUndefined();
 
     act(() => {
       __wsMock.emit("ws-2", {
@@ -330,8 +330,8 @@ describe("useWorkspaceLiveData", () => {
       });
     });
 
-    expect(result.current["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
-    expect(result.current["ws-2"]).toEqual({
+    expect(result.current.liveData["ws-1"]).toEqual({ status: "busy", streaming: true, streamingSessions: {} });
+    expect(result.current.liveData["ws-2"]).toEqual({
       branch: "workspace/kyoto",
       branchInfo: { name: "workspace/kyoto", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
     });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -12,7 +12,7 @@ const mocks = vi.hoisted(() => ({
   apiGet: vi.fn(),
   useConversation: vi.fn(),
   useSessions: vi.fn(),
-  useWorkspaceLiveData: vi.fn().mockReturnValue({}),
+  useWorkspaceLiveData: vi.fn().mockReturnValue({ liveData: {}, clearUnread: vi.fn() }),
   sendMessage: vi.fn(),
   stopStreaming: vi.fn(),
   clearChat: vi.fn(),
@@ -276,7 +276,7 @@ describe("WorkspaceView behavior", () => {
     mocks.refreshSessions.mockReset();
     mocks.clearCachedData.mockReset();
     mocks.useWorkspaceLiveData.mockReset();
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
     mocks.openExternal.mockReset();
 
     mocks.useScripts.mockReturnValue({
@@ -577,7 +577,10 @@ describe("WorkspaceView behavior", () => {
 
   it("displays live branch name from useWorkspaceLiveData when available", async () => {
     mocks.useWorkspaceLiveData.mockReturnValue({
-      "ws-1": { branch: "feature/live-branch", branchInfo: { name: "feature/live-branch", lastSyncedAt: "2026-02-13T00:00:00.000Z" } },
+      liveData: {
+        "ws-1": { branch: "feature/live-branch", branchInfo: { name: "feature/live-branch", lastSyncedAt: "2026-02-13T00:00:00.000Z" } },
+      },
+      clearUnread: vi.fn(),
     });
 
     renderWorkspace();
@@ -833,7 +836,7 @@ describe("WorkspaceView session delete behavior", () => {
     mocks.refreshSessions.mockReset();
     mocks.clearCachedData.mockReset();
     mocks.useWorkspaceLiveData.mockReset();
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
 
     mocks.useScripts.mockReturnValue({
       config: null,
@@ -1045,7 +1048,7 @@ describe("WorkspaceView sidebar split resize", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
     localStorage.removeItem("sidebar-split");
   });
 
@@ -1294,7 +1297,7 @@ describe("WorkspaceView VS Code SSH host resolution", () => {
       disconnectOutput: mocks.disconnectScriptOutput,
     });
 
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
   }
 
   beforeEach(() => {
@@ -1547,7 +1550,7 @@ describe("WorkspaceView dropdown terminal interactions", () => {
       disconnectOutput: mocks.disconnectScriptOutput,
     });
 
-    mocks.useWorkspaceLiveData.mockReturnValue({});
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
   }
 
   beforeEach(() => {

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => ({
   openExternal: vi.fn(),
   useTerminalApps: vi.fn().mockReturnValue([]),
   openTerminalSsh: vi.fn(),
+  captureConversationTabsProps: vi.fn(),
 }));
 
 vi.mock("@/hooks/useApi", () => ({
@@ -139,30 +140,31 @@ vi.mock("@/components/chat/QuestionPanel", () => ({
 }));
 
 vi.mock("@/components/ConversationTabs", () => ({
-  ConversationTabs: ({
-    onDeleteSession,
-    onCreateSession,
-    onActivateSession,
-  }: {
+  ConversationTabs: (props: {
     onDeleteSession: (id: string) => void;
     onCreateSession: () => void;
     onActivateSession: (id: string) => void;
-  }) => (
-    <div data-testid="conversation-tabs">
-      <button type="button" data-testid="delete-active-btn" onClick={() => onDeleteSession("sess-active")}>
-        delete active
-      </button>
-      <button type="button" data-testid="delete-inactive-btn" onClick={() => onDeleteSession("sess-inactive")}>
-        delete inactive
-      </button>
-      <button type="button" data-testid="create-session-btn" onClick={onCreateSession}>
-        create session
-      </button>
-      <button type="button" data-testid="activate-session-btn" onClick={() => onActivateSession("sess-2")}>
-        activate session
-      </button>
-    </div>
-  ),
+    unreadSessions?: Record<string, boolean>;
+  }) => {
+    const { onDeleteSession, onCreateSession, onActivateSession } = props;
+    mocks.captureConversationTabsProps(props);
+    return (
+      <div data-testid="conversation-tabs">
+        <button type="button" data-testid="delete-active-btn" onClick={() => onDeleteSession("sess-active")}>
+          delete active
+        </button>
+        <button type="button" data-testid="delete-inactive-btn" onClick={() => onDeleteSession("sess-inactive")}>
+          delete inactive
+        </button>
+        <button type="button" data-testid="create-session-btn" onClick={onCreateSession}>
+          create session
+        </button>
+        <button type="button" data-testid="activate-session-btn" onClick={() => onActivateSession("sess-2")}>
+          activate session
+        </button>
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/diff/GitDiffModal", () => ({
@@ -277,6 +279,7 @@ describe("WorkspaceView behavior", () => {
     mocks.clearCachedData.mockReset();
     mocks.useWorkspaceLiveData.mockReset();
     mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
+    mocks.captureConversationTabsProps.mockReset();
     mocks.openExternal.mockReset();
 
     mocks.useScripts.mockReturnValue({
@@ -573,6 +576,90 @@ describe("WorkspaceView behavior", () => {
     await user.click(screen.getByTestId("activate-session-btn"));
 
     expect(mocks.switchSession).toHaveBeenCalledWith("sess-2");
+  });
+
+  it("clears workspace unread state on mount and when switching workspace route", async () => {
+    const user = userEvent.setup();
+    const clearUnread = vi.fn();
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    expect(clearUnread).toHaveBeenCalledWith("ws-1");
+
+    await user.click(screen.getByRole("button", { name: "go ws-2" }));
+    await screen.findByText("kyoto");
+    expect(clearUnread).toHaveBeenCalledWith("ws-2");
+  });
+
+  it("clears unread state for target session when activating a different session", async () => {
+    const user = userEvent.setup();
+    const clearUnread = vi.fn();
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByTestId("activate-session-btn"));
+    expect(clearUnread).toHaveBeenCalledWith("ws-1", "sess-2");
+  });
+
+  it("does not clear target session unread when clicking the already active session", async () => {
+    const user = userEvent.setup();
+    const clearUnread = vi.fn();
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      streamingStartedAt: null,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: "sess-2",
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByTestId("activate-session-btn"));
+    expect(mocks.switchSession).not.toHaveBeenCalled();
+    expect(
+      clearUnread.mock.calls.some((call) => call[0] === "ws-1" && call[1] === "sess-2"),
+    ).toBe(false);
+  });
+
+  it("passes unreadSessions from liveData to ConversationTabs", async () => {
+    const unreadSessions = { "sess-2": true, "sess-3": true };
+    mocks.useWorkspaceLiveData.mockReturnValue({
+      liveData: {
+        "ws-1": { unreadSessions },
+      },
+      clearUnread: vi.fn(),
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { unreadSessions?: Record<string, boolean> } | undefined;
+      expect(lastCall?.unreadSessions).toEqual(unreadSessions);
+    });
   });
 
   it("displays live branch name from useWorkspaceLiveData when available", async () => {

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -17,6 +17,9 @@ final class HubStatusMonitor {
         didSet { persistCompleted() }
     }
 
+    /// Workspace currently visible in ChatView (suppresses unread badge).
+    var viewingWorkspaceId: String?
+
     /// Called whenever the streaming workspace set changes.
     var onStreamingChange: ((Set<String>) -> Void)?
 
@@ -184,6 +187,7 @@ final class HubStatusMonitor {
     }
 
     fileprivate func didReceiveDone(for workspaceId: String) {
+        guard workspaceId != viewingWorkspaceId else { return }
         completedWorkspaces.insert(workspaceId)
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -195,6 +195,7 @@ struct ChatView: View {
         .onDisappear {
             saveCurrentDraft()
             store.onTurnCompleted = nil
+            projectStore.statusMonitor.viewingWorkspaceId = nil
         }
     }
 
@@ -217,6 +218,7 @@ struct ChatView: View {
     // MARK: - Setup
 
     private func setup() async {
+        projectStore.statusMonitor.viewingWorkspaceId = workspace.id
         projectStore.statusMonitor.clearCompleted(workspace.id)
 
         // Wire post-turn re-sync: after done/cancelled, re-fetch messages from REST


### PR DESCRIPTION
Track completed turns (done/cancelled events) per workspace in useWorkspaceLiveData. Show a primary-colored dot on sidebar workspace items and replace the session tab icon when a background session finishes. Badges clear automatically on workspace navigation or session tab switch.