### PR TITLE
Fix iOS history missing during streaming + duplicate messages

### DIFF
--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -219,12 +219,17 @@ final class ConversationStore {
             // Only update messages for the active session
             guard historySessionId == nil || sessionId == nil || historySessionId == sessionId else { return }
 
+            // Always apply history — it contains finalized turns only.
+            // Streaming content lives in sessionStreams and is appended
+            // separately by displayMessages.
+            messages = msgs
+            bumpHistoryToken(for: historySessionId)
+            sessionId = historySessionId ?? sessionId
+
+            // Derive pending tool inputs from history only when not actively
+            // streaming (during streaming, live WS tool inputs take precedence).
             let activeStream = historySessionId.flatMap { sessionStreams[$0] }
             if activeStream?.isStreaming != true {
-                messages = msgs
-                bumpHistoryToken(for: historySessionId)
-                sessionId = historySessionId ?? sessionId
-                // Derive pending tool inputs from history
                 let derived = derivePendingToolInputsFromHistory(msgs)
                 if let sid = historySessionId {
                     if activeStream != nil || !derived.isEmpty {
@@ -311,6 +316,12 @@ final class ConversationStore {
         let isActive = sid == sessionId
         let hasContent = !stream.currentText.isEmpty || !stream.activeToolCalls.isEmpty || !stream.currentThinking.isEmpty
 
+        // Remove stream slot FIRST so displayMessages never shows both the
+        // finalized message (in `messages`) and the streaming ghost (from
+        // `streamingMessage`). The local `stream` is a value-type copy
+        // captured above, so it survives this removal.
+        sessionStreams.removeValue(forKey: sid)
+
         if isActive {
             if hasContent {
                 let msg = ChatMessage(
@@ -342,8 +353,6 @@ final class ConversationStore {
                 messages.append(msg)
             }
         }
-        // Clean up the slot — REST fetch on switch-back will include the completed message.
-        sessionStreams.removeValue(forKey: sid)
     }
 
     /// Derive pending tool inputs from history — mirrors frontend's derivePendingToolInputsFromHistory.

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -237,9 +237,7 @@ struct ChatView: View {
                     )
                     guard store.sessionId == sessionId else { return }
                     guard store.historyToken(for: sessionId) == requestToken else { return }
-                    if store.sessionStreams[sessionId]?.isStreaming != true {
-                        store.messages = msgs
-                    }
+                    store.messages = msgs
                 } catch {
                     // Best-effort — streamed messages remain as fallback
                 }
@@ -314,11 +312,9 @@ struct ChatView: View {
                 isLoading = false
                 return
             }
-            // Don't overwrite messages while streaming — the active stream state
-            // would be lost (matches the guard in ConversationStore's .history handler).
-            if store.sessionStreams[sessionId]?.isStreaming != true {
-                store.messages = msgs
-            }
+            // History contains only finalized turns; streaming content lives
+            // in sessionStreams and is appended by displayMessages.
+            store.messages = msgs
         } catch is CancellationError {
             // View disappeared
         } catch {


### PR DESCRIPTION
## Summary

- Remove `isStreaming` guards that blocked REST/WS history from loading when a conversation was actively streaming — history contains only finalized turns while streaming content lives separately in `sessionStreams`, so they don't overlap
- Reorder `finalizeMessage()` to clear the stream slot before appending the finalized message, eliminating the observation window where `displayMessages` could show both the streaming ghost and the finalized message simultaneously

## Test plan

- [ ] Kill app, reopen, navigate to a conversation mid-stream → previous history should be visible alongside the live streaming message
- [ ] Normal turn completion → finalized message appears exactly once, no duplicate/flash
- [ ] Session switching during streaming → history loads correctly for the target session
- [ ] WS reconnect during streaming → bootstrap history applies without clobbering stream