### PR TITLE
Fix unread badge clearing per-session instead of per-workspace

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -158,7 +158,7 @@ export default function Sidebar({ onAddProject }: SidebarProps) {
                           const wsStreaming = wsLive?.streaming ?? false;
                           const wsScriptRunning = wsLive?.scriptRunning ?? false;
                           const displayBranch = wsLive?.branch ?? ws.branch;
-                          const wsUnread = !wsStreaming && activeWsId !== ws.id && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
+                          const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
                           return (
                             <div key={ws.id} className="group/ws relative">
                               <Link

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -142,10 +142,6 @@ export default function WorkspaceView() {
   const liveData = useWorkspaceLiveDataContext();
   const clearUnread = useClearUnread();
 
-  // Clear unread state when navigating to a workspace
-  useEffect(() => {
-    if (wsId) clearUnread(wsId);
-  }, [wsId, clearUnread]);
 
 
   const displayBranch = (wsId && liveData[wsId]?.branch) || workspace?.branch;

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -349,7 +349,7 @@ describe("Sidebar", () => {
     expect(inactiveLink.querySelector("svg.lucide-git-branch")).toBeNull();
   });
 
-  it("does not show unread dot for active workspace", async () => {
+  it("shows unread dot even for the active workspace when a session completes", async () => {
     const { __wsMock } = await getWsMock();
     renderSidebar("/workspaces/w1", projects);
 
@@ -360,7 +360,7 @@ describe("Sidebar", () => {
     });
 
     const activeLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
-    expect(findSidebarUnreadDot(activeLink)).toBeNull();
+    expect(findSidebarUnreadDot(activeLink)).not.toBeNull();
   });
 
   it("prioritizes streaming indicator over unread dot and restores dot when idle again", async () => {

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -578,18 +578,39 @@ describe("WorkspaceView behavior", () => {
     expect(mocks.switchSession).toHaveBeenCalledWith("sess-2");
   });
 
-  it("clears workspace unread state on mount and when switching workspace route", async () => {
+  it("clears only the active session unread on mount (not entire workspace)", async () => {
     const user = userEvent.setup();
     const clearUnread = vi.fn();
-    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
+    const liveData = { "ws-1": { unreadSessions: { "sess-1": true } } };
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData, clearUnread });
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      streamingStartedAt: null,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: "sess-1",
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
 
     renderWorkspace();
     await screen.findByText("tokyo");
-    expect(clearUnread).toHaveBeenCalledWith("ws-1");
-
-    await user.click(screen.getByRole("button", { name: "go ws-2" }));
-    await screen.findByText("kyoto");
-    expect(clearUnread).toHaveBeenCalledWith("ws-2");
+    // Should clear only the active session, not the entire workspace
+    expect(clearUnread).toHaveBeenCalledWith("ws-1", "sess-1");
+    expect(clearUnread).not.toHaveBeenCalledWith("ws-1");
   });
 
   it("clears unread state for target session when activating a different session", async () => {


### PR DESCRIPTION
## Summary
- Removed the blanket `clearUnread(wsId)` on workspace navigation that wiped all session badges at once — now only the active session is marked as read via the existing reactive `useEffect`
- Removed `activeWsId !== ws.id` guard from sidebar badge so the unread dot shows even on the selected workspace (other sessions may still be unread)

## Test plan
- [x] Typecheck passes
- [x] All 781 tests pass (updated 2 tests to match new per-session behavior)
- [ ] Manual: stream on workspace B while on A → badge appears on B → click B → only active session badge clears → switch to unread session tab → that badge clears