### PR TITLE
Fix keyboard dismissal in iOS settings

### DIFF
--- a/ios/HiveMobile/Views/Settings/SettingsView.swift
+++ b/ios/HiveMobile/Views/Settings/SettingsView.swift
@@ -6,8 +6,13 @@ struct SettingsView: View {
     @AppStorage("authToken") private var token = ""
     @AppStorage("hiveAccent") private var accentId = "violet"
 
+    @FocusState private var focusedField: Field?
     @State private var healthStatus: HealthStatus = .unknown
     @State private var isChecking = false
+
+    private enum Field: Hashable {
+        case host, port, token
+    }
 
     var body: some View {
         Form {
@@ -15,7 +20,15 @@ struct SettingsView: View {
             connectionSection
             healthSection
         }
+        .scrollDismissesKeyboard(.interactively)
+        .onTapGesture { focusedField = nil }
         .toolbar(.hidden, for: .navigationBar)
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { focusedField = nil }
+            }
+        }
     }
 
     // MARK: - Accent Color Picker
@@ -76,6 +89,7 @@ struct SettingsView: View {
         Section("Connection") {
             LabeledContent("Host") {
                 TextField("hostname or IP", text: $host)
+                    .focused($focusedField, equals: .host)
                     .textContentType(.URL)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
@@ -83,11 +97,13 @@ struct SettingsView: View {
             }
             LabeledContent("Port") {
                 TextField("port", text: $port)
+                    .focused($focusedField, equals: .port)
                     .keyboardType(.numberPad)
                     .multilineTextAlignment(.trailing)
             }
             LabeledContent("Token") {
                 SecureField("auth token", text: $token)
+                    .focused($focusedField, equals: .token)
                     .multilineTextAlignment(.trailing)
             }
         }


### PR DESCRIPTION
## Summary
- Add `scrollDismissesKeyboard(.interactively)` so swiping down dismisses the keyboard
- Add tap-to-dismiss via `@FocusState` — tapping outside a field clears focus
- Add a "Done" toolbar button above the keyboard (essential for the Port field which uses `.numberPad` with no Return key)

## Test plan
- [ ] Open Settings, tap Host/Port/Token fields — keyboard appears
- [ ] Tap outside the active field — keyboard dismisses
- [ ] Scroll down while keyboard is open — keyboard follows the finger interactively
- [ ] Tap Port field (numberPad) — verify "Done" button appears above keyboard and dismisses it