### PR TITLE
Add interactive terminal tab to ScriptPanel

### DIFF
--- a/backend/src/api/scripts.test.ts
+++ b/backend/src/api/scripts.test.ts
@@ -289,6 +289,90 @@ describe("script routes", () => {
     expect(res.json().error).toContain('Script "setup" is already running');
   });
 
+  it("POST /api/workspaces/:wsId/terminal/start returns 404 for unknown workspace", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/workspaces/missing/terminal/start",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Workspace not found" });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/start starts interactive terminal shell", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/start`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ started: true });
+    expect(mocks.startScript).toHaveBeenCalledWith(WS_ID, "terminal", undefined, wsPath);
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(WS_ID, {
+      type: "script_status",
+      scriptType: "terminal",
+      state: "running",
+    });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/start registers exit listener and broadcasts terminal exit state", async () => {
+    const exitListeners = new Map<string, (code: number) => void>();
+    mocks.startScript.mockReturnValue({ exitListeners });
+
+    await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/start`,
+    });
+
+    expect(exitListeners.size).toBe(1);
+    const listener = [...exitListeners.values()][0];
+
+    mocks.broadcastToWorkspace.mockClear();
+    listener(0);
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(WS_ID, {
+      type: "script_status",
+      scriptType: "terminal",
+      state: "done",
+      exitCode: 0,
+    });
+
+    expect(exitListeners.size).toBe(0);
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/start broadcasts terminal error on non-zero exit", async () => {
+    const exitListeners = new Map<string, (code: number) => void>();
+    mocks.startScript.mockReturnValue({ exitListeners });
+
+    await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/start`,
+    });
+
+    const listener = [...exitListeners.values()][0];
+    mocks.broadcastToWorkspace.mockClear();
+    listener(9);
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(WS_ID, {
+      type: "script_status",
+      scriptType: "terminal",
+      state: "error",
+      exitCode: 9,
+    });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/start maps runner errors to 409", async () => {
+    mocks.startScript.mockImplementation(() => {
+      throw new Error("Terminal already running");
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/start`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("Terminal already running");
+  });
+
   it("POST /api/workspaces/:wsId/scripts/:type/stop returns 409 when no script is running", async () => {
     mocks.stopScript.mockReturnValue(false);
 
@@ -326,6 +410,35 @@ describe("script routes", () => {
       scriptType: "backend",
       state: "idle",
     });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/stop stops terminal and broadcasts idle", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/stop`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ stopped: true });
+    expect(mocks.stopScript).toHaveBeenCalledWith(WS_ID, "terminal");
+    expect(mocks.broadcastToWorkspace).toHaveBeenCalledWith(WS_ID, {
+      type: "script_status",
+      scriptType: "terminal",
+      state: "idle",
+    });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal/stop returns 409 when terminal is not running", async () => {
+    mocks.stopScript.mockReturnValue(false);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal/stop`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: "No running terminal to stop" });
+    expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
   });
 
   it("broadcasts script_status idle on stop", async () => {

--- a/backend/src/api/scripts.ts
+++ b/backend/src/api/scripts.ts
@@ -25,6 +25,31 @@ export async function scriptRoutes(app: FastifyInstance, dataDir?: string) {
     };
   }
 
+  function startAndBroadcast(
+    wsId: string,
+    scriptType: string,
+    command: string | undefined,
+    wsPath: string,
+  ) {
+    const proc = startScript(wsId, scriptType, command, wsPath);
+    broadcastToWorkspace(wsId, {
+      type: "script_status",
+      scriptType,
+      state: "running",
+    });
+
+    const listenerId = `broadcast-${Date.now()}`;
+    proc.exitListeners.set(listenerId, (code) => {
+      broadcastToWorkspace(wsId, {
+        type: "script_status",
+        scriptType,
+        state: code === 0 ? "done" : "error",
+        exitCode: code,
+      });
+      proc.exitListeners.delete(listenerId);
+    });
+  }
+
   // GET /api/workspaces/:wsId/scripts — config + status
   app.get<{ Params: { wsId: string } }>(
     "/api/workspaces/:wsId/scripts",
@@ -60,23 +85,7 @@ export async function scriptRoutes(app: FastifyInstance, dataDir?: string) {
       }
 
       try {
-        const proc = startScript(req.params.wsId, scriptType, command, resolved.wsPath);
-        broadcastToWorkspace(req.params.wsId, {
-          type: "script_status",
-          scriptType,
-          state: "running",
-        });
-        // Broadcast exit status when the process finishes
-        const listenerId = `broadcast-${Date.now()}`;
-        proc.exitListeners.set(listenerId, (code) => {
-          broadcastToWorkspace(req.params.wsId, {
-            type: "script_status",
-            scriptType,
-            state: code === 0 ? "done" : "error",
-            exitCode: code,
-          });
-          proc.exitListeners.delete(listenerId);
-        });
+        startAndBroadcast(req.params.wsId, scriptType, command, resolved.wsPath);
         return reply.send({ started: true });
       } catch (err: unknown) {
         return reply.status(409).send({ error: errorMessage(err, "Failed to start script") });
@@ -98,6 +107,43 @@ export async function scriptRoutes(app: FastifyInstance, dataDir?: string) {
       broadcastToWorkspace(req.params.wsId, {
         type: "script_status",
         scriptType,
+        state: "idle",
+      });
+
+      return reply.send({ stopped: true });
+    },
+  );
+
+  // POST /api/workspaces/:wsId/terminal/start — interactive shell
+  app.post<{ Params: { wsId: string } }>(
+    "/api/workspaces/:wsId/terminal/start",
+    async (req, reply) => {
+      const { wsId } = req.params;
+      const resolved = await resolveWsPath(wsId);
+      if (!resolved) return reply.status(404).send({ error: "Workspace not found" });
+
+      try {
+        startAndBroadcast(wsId, "terminal", undefined, resolved.wsPath);
+        return reply.send({ started: true });
+      } catch (err: unknown) {
+        return reply.status(409).send({ error: errorMessage(err, "Failed to start terminal") });
+      }
+    },
+  );
+
+  // POST /api/workspaces/:wsId/terminal/stop
+  app.post<{ Params: { wsId: string } }>(
+    "/api/workspaces/:wsId/terminal/stop",
+    async (req, reply) => {
+      const { wsId } = req.params;
+      const stopped = stopScript(wsId, "terminal");
+      if (!stopped) {
+        return reply.status(409).send({ error: "No running terminal to stop" });
+      }
+
+      broadcastToWorkspace(wsId, {
+        type: "script_status",
+        scriptType: "terminal",
         state: "idle",
       });
 

--- a/backend/src/services/script-runner.test.ts
+++ b/backend/src/services/script-runner.test.ts
@@ -111,6 +111,22 @@ describe("script-runner", () => {
     expect(getScriptStatus("ws-1").setup?.state).toBe("running");
   });
 
+  it("starts an interactive shell when command is undefined", () => {
+    process.env.SHELL = "/bin/bash";
+
+    const proc = startScript("ws-1", "terminal", undefined, "/tmp/workspace");
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "/bin/bash",
+      [],
+      expect.objectContaining({
+        cwd: "/tmp/workspace",
+      }),
+    );
+    expect(proc.state).toBe("running");
+    expect(getScriptStatus("ws-1").terminal?.state).toBe("running");
+  });
+
   it("throws when trying to start the same script while it is already running", () => {
     startScript("ws-1", "setup", "npm ci", "/tmp/workspace");
     expect(() => startScript("ws-1", "setup", "npm ci", "/tmp/workspace")).toThrow(

--- a/backend/src/services/script-runner.ts
+++ b/backend/src/services/script-runner.ts
@@ -28,7 +28,7 @@ function key(wsId: string, type: ScriptType): string {
 export function startScript(
   wsId: string,
   type: ScriptType,
-  command: string,
+  command: string | undefined,
   cwd: string,
 ): ScriptProcess {
   const k = key(wsId, type);
@@ -43,7 +43,8 @@ export function startScript(
   }
 
   const shell = process.env.SHELL || "/bin/sh";
-  const ptyProcess = pty.spawn(shell, ["-c", command], {
+  const args = command ? ["-c", command] : [];
+  const ptyProcess = pty.spawn(shell, args, {
     cwd,
     env: buildWorkspaceEnv({ TERM: "xterm-256color" }),
     cols: 80,

--- a/frontend/src/components/ScriptPanel.tsx
+++ b/frontend/src/components/ScriptPanel.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
-import { PlayIcon, SquareIcon, RotateCcwIcon, CheckCircle2Icon } from "lucide-react";
+import { PlayIcon, SquareIcon, RotateCcwIcon, CheckCircle2Icon, TerminalSquareIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { WaveIndicator } from "@/components/WaveIndicator";
@@ -14,6 +14,8 @@ interface ScriptPanelProps {
   status: Record<string, ScriptStatusInfo>;
   onStart: (type: string) => Promise<void> | void;
   onStop: (type: string) => Promise<void> | void;
+  onStartTerminal: () => void;
+  onStopTerminal: () => void;
   onConnectOutput: (type: string, term: XTerm) => void;
   onDisconnectOutput: () => void;
 }
@@ -22,6 +24,7 @@ interface TabInfo {
   key: string;
   label: string;
   isSetup: boolean;
+  isTerminal: boolean;
 }
 
 function StatusIndicator({ status, isSetup }: { status: ScriptStatusInfo; isSetup: boolean }) {
@@ -37,13 +40,15 @@ function StatusIndicator({ status, isSetup }: { status: ScriptStatusInfo; isSetu
 function buildTabs(config: HiveConfig | null): TabInfo[] {
   const tabs: TabInfo[] = [];
   if (config?.scripts?.setup) {
-    tabs.push({ key: "setup", label: "Setup", isSetup: true });
+    tabs.push({ key: "setup", label: "Setup", isSetup: true, isTerminal: false });
   }
   if (config?.scripts?.run) {
     for (const name of Object.keys(config.scripts.run)) {
-      tabs.push({ key: name, label: name.charAt(0).toUpperCase() + name.slice(1), isSetup: false });
+      tabs.push({ key: name, label: name.charAt(0).toUpperCase() + name.slice(1), isSetup: false, isTerminal: false });
     }
   }
+  // Always add terminal tab
+  tabs.push({ key: "terminal", label: "Terminal", isSetup: false, isTerminal: true });
   return tabs;
 }
 
@@ -52,17 +57,20 @@ export default function ScriptPanel({
   status,
   onStart,
   onStop,
+  onStartTerminal,
+  onStopTerminal,
   onConnectOutput,
   onDisconnectOutput,
 }: ScriptPanelProps) {
   const tabs = buildTabs(config);
-  const hasScripts = tabs.length > 0;
 
-  const [activeTab, setActiveTab] = useState<string>(tabs[0]?.key ?? "");
+  const [activeTab, setActiveTab] = useState<string>(tabs[0]?.key ?? "terminal");
 
   // If the active tab no longer exists in config, fall back to first
-  const effectiveTab = tabs.find((t) => t.key === activeTab)?.key ?? tabs[0]?.key ?? "";
-  const isSetupTab = tabs.find((t) => t.key === effectiveTab)?.isSetup ?? false;
+  const effectiveTab = tabs.find((t) => t.key === activeTab)?.key ?? tabs[0]?.key ?? "terminal";
+  const tabInfo = tabs.find((t) => t.key === effectiveTab);
+  const isSetupTab = tabInfo?.isSetup ?? false;
+  const isTerminalTab = tabInfo?.isTerminal ?? false;
   const currentStatus: ScriptStatusInfo = status[effectiveTab] ?? { state: "idle" };
 
   const containerRef = useRef<HTMLDivElement>(null);
@@ -74,6 +82,12 @@ export default function ScriptPanel({
   const [runGeneration, setRunGeneration] = useState(0);
 
   const shouldShowTerminal = currentStatus.state !== "idle";
+  const actionLabel = isSetupTab ? "Run setup" : isTerminalTab ? "Start terminal" : "Run";
+  const idleDescription = isSetupTab
+    ? "Install dependencies"
+    : isTerminalTab
+      ? "Open an interactive shell"
+      : "Start this script";
 
   const initTerminal = useCallback(() => {
     const el = containerRef.current;
@@ -152,34 +166,21 @@ export default function ScriptPanel({
 
   const handleAction = async () => {
     if (currentStatus.state === "running") {
-      onStop(effectiveTab);
+      if (isTerminalTab) {
+        onStopTerminal();
+      } else {
+        onStop(effectiveTab);
+      }
     } else {
       destroyTerminal();
-      await onStart(effectiveTab);
+      if (isTerminalTab) {
+        onStartTerminal();
+      } else {
+        await onStart(effectiveTab);
+      }
       setRunGeneration((g) => g + 1);
     }
   };
-
-  if (!hasScripts) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col">
-        <div className="flex h-9 items-center border-t border-border/50 px-3">
-          <span className="text-xs uppercase tracking-wide text-muted-foreground">Scripts</span>
-        </div>
-        <div className="flex flex-1 flex-col items-center justify-center gap-2 px-4 text-center text-muted-foreground">
-          <p className="text-xs">
-            Add a <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">hive.json</code> to your repo to define setup &amp; run scripts.
-          </p>
-          <pre className="mt-1 rounded-md bg-muted/50 px-3 py-2 text-left text-[11px] leading-relaxed">{`{
-  "scripts": {
-    "setup": "npm install",
-    "run": { "dev": "npm run dev" }
-  }
-}`}</pre>
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -191,6 +192,7 @@ export default function ScriptPanel({
             <button
               key={tab.key}
               type="button"
+              aria-label={tab.label}
               className={cn(
                 "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
                 effectiveTab === tab.key
@@ -199,8 +201,17 @@ export default function ScriptPanel({
               )}
               onClick={() => setActiveTab(tab.key)}
             >
-              <StatusIndicator status={tabStatus} isSetup={tab.isSetup} />
-              {tab.label}
+              {tab.isTerminal ? (
+                <>
+                  {tabStatus.state === "running" && <WaveIndicator />}
+                  <TerminalSquareIcon className="size-3" />
+                </>
+              ) : (
+                <>
+                  <StatusIndicator status={tabStatus} isSetup={tab.isSetup} />
+                  {tab.label}
+                </>
+              )}
             </button>
           );
         })}
@@ -216,7 +227,7 @@ export default function ScriptPanel({
               <RotateCcwIcon className="size-3" />
             </Button>
           ) : (
-            <Button variant="ghost" size="icon-xs" onClick={handleAction} title={isSetupTab ? "Run setup" : "Run"}>
+            <Button variant="ghost" size="icon-xs" onClick={handleAction} title={actionLabel}>
               <PlayIcon className="size-3" />
             </Button>
           )}
@@ -227,9 +238,9 @@ export default function ScriptPanel({
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {shouldShowTerminal ? (
           <>
-            <div ref={containerRef} className="h-full w-full bg-background" />
+            <div ref={containerRef} className="h-full w-full px-3" style={{ backgroundColor: "#09090f" }} />
             {/* Port badge */}
-            {!isSetupTab && config?.port && currentStatus.state === "running" && (
+            {!isSetupTab && !isTerminalTab && config?.port && currentStatus.state === "running" && (
               <div className="absolute bottom-2 right-2">
                 <Badge variant="secondary" className="text-[10px]">
                   Port {config.port}
@@ -239,17 +250,25 @@ export default function ScriptPanel({
           </>
         ) : (
           <div className="flex h-full flex-col items-center justify-center gap-3">
-            <PlayIcon className="size-8 text-muted-foreground/30" />
+            {isTerminalTab ? (
+              <TerminalSquareIcon className="size-8 text-muted-foreground/30" />
+            ) : (
+              <PlayIcon className="size-8 text-muted-foreground/30" />
+            )}
             <Button
               variant="outline"
               size="sm"
               onClick={handleAction}
             >
-              <PlayIcon className="size-3" />
-              {isSetupTab ? "Run setup" : "Run"}
+              {isTerminalTab ? (
+                <TerminalSquareIcon className="size-3" />
+              ) : (
+                <PlayIcon className="size-3" />
+              )}
+              {actionLabel}
             </Button>
             <p className="text-xs text-muted-foreground/60">
-              {isSetupTab ? "Install dependencies" : "Start this script"}
+              {idleDescription}
             </p>
           </div>
         )}

--- a/frontend/src/hooks/useScripts.ts
+++ b/frontend/src/hooks/useScripts.ts
@@ -48,15 +48,26 @@ export function useScripts(wsId: string | undefined) {
   const invalidate = () =>
     queryClient.invalidateQueries({ queryKey: ["scripts", wsId] });
 
+  const setOptimisticStatus = (type: string, next: ScriptStatusInfo) => {
+    queryClient.setQueryData<WorkspaceScriptsResponse>(["scripts", wsId], (prev) =>
+      prev
+        ? { ...prev, status: { ...prev.status, [type]: next } }
+        : prev,
+    );
+  };
+
+  const closeConnectionIfType = (type: string) => {
+    if (connectedTypeRef.current !== type) return;
+    wsRef.current?.close();
+    wsRef.current = null;
+    connectedTypeRef.current = null;
+  };
+
   const startScript = useMutation({
     mutationFn: (type: string) =>
       api.post(`/api/workspaces/${wsId}/scripts/${type}/start`),
     onMutate: (type) => {
-      queryClient.setQueryData<WorkspaceScriptsResponse>(["scripts", wsId], (prev) =>
-        prev
-          ? { ...prev, status: { ...prev.status, [type]: { state: "running" as const } } }
-          : prev,
-      );
+      setOptimisticStatus(type, { state: "running" });
     },
     onError: invalidate,
   });
@@ -64,19 +75,30 @@ export function useScripts(wsId: string | undefined) {
   const stopScript = useMutation({
     mutationFn: (type: string) => {
       // Close WS first so the PTY exit message doesn't override the idle status
-      if (connectedTypeRef.current === type) {
-        wsRef.current?.close();
-        wsRef.current = null;
-        connectedTypeRef.current = null;
-      }
+      closeConnectionIfType(type);
       return api.post(`/api/workspaces/${wsId}/scripts/${type}/stop`);
     },
     onMutate: (type) => {
-      queryClient.setQueryData<WorkspaceScriptsResponse>(["scripts", wsId], (prev) =>
-        prev
-          ? { ...prev, status: { ...prev.status, [type]: { state: "idle" as const } } }
-          : prev,
-      );
+      setOptimisticStatus(type, { state: "idle" });
+    },
+    onError: invalidate,
+  });
+
+  const startTerminal = useMutation({
+    mutationFn: () => api.post(`/api/workspaces/${wsId}/terminal/start`),
+    onMutate: () => {
+      setOptimisticStatus("terminal", { state: "running" });
+    },
+    onError: invalidate,
+  });
+
+  const stopTerminal = useMutation({
+    mutationFn: () => {
+      closeConnectionIfType("terminal");
+      return api.post(`/api/workspaces/${wsId}/terminal/stop`);
+    },
+    onMutate: () => {
+      setOptimisticStatus("terminal", { state: "idle" });
     },
     onError: invalidate,
   });
@@ -161,8 +183,22 @@ export function useScripts(wsId: string | undefined) {
     config: query.data?.config ?? null,
     status: query.data?.status ?? EMPTY_STATUS,
     loading: query.isLoading,
-    startScript: (type: string) => startScript.mutate(type),
-    stopScript: (type: string) => stopScript.mutate(type),
+    startScript: (type: string) => {
+      if (!wsId) return;
+      startScript.mutate(type);
+    },
+    stopScript: (type: string) => {
+      if (!wsId) return;
+      stopScript.mutate(type);
+    },
+    startTerminal: () => {
+      if (!wsId) return;
+      startTerminal.mutate();
+    },
+    stopTerminal: () => {
+      if (!wsId) return;
+      stopTerminal.mutate();
+    },
     connectOutput,
     disconnectOutput,
     refresh: invalidate,

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -258,6 +258,8 @@ export default function WorkspaceView() {
     status: scriptsStatus,
     startScript,
     stopScript,
+    startTerminal,
+    stopTerminal,
     connectOutput: connectScriptOutput,
     disconnectOutput: disconnectScriptOutput,
   } = useScripts(wsId);
@@ -630,6 +632,8 @@ export default function WorkspaceView() {
               status={scriptsStatus}
               onStart={startScript}
               onStop={stopScript}
+              onStartTerminal={startTerminal}
+              onStopTerminal={stopTerminal}
               onConnectOutput={connectScriptOutput}
               onDisconnectOutput={disconnectScriptOutput}
             />

--- a/frontend/tests/components/ScriptPanel.test.tsx
+++ b/frontend/tests/components/ScriptPanel.test.tsx
@@ -40,6 +40,8 @@ function renderPanel(
 ) {
   const onStart = overrides?.onStart ?? vi.fn();
   const onStop = overrides?.onStop ?? vi.fn();
+  const onStartTerminal = overrides?.onStartTerminal ?? vi.fn();
+  const onStopTerminal = overrides?.onStopTerminal ?? vi.fn();
   const onConnectOutput = overrides?.onConnectOutput ?? vi.fn();
   const onDisconnectOutput = overrides?.onDisconnectOutput ?? vi.fn();
 
@@ -58,12 +60,14 @@ function renderPanel(
     },
     onStart,
     onStop,
+    onStartTerminal,
+    onStopTerminal,
     onConnectOutput,
     onDisconnectOutput,
   };
 
   const utils = render(<ScriptPanel {...defaultProps} {...overrides} />);
-  return { ...utils, onStart, onStop, onConnectOutput, onDisconnectOutput };
+  return { ...utils, onStart, onStop, onStartTerminal, onStopTerminal, onConnectOutput, onDisconnectOutput };
 }
 
 describe("ScriptPanel", () => {
@@ -77,17 +81,17 @@ describe("ScriptPanel", () => {
     vi.useRealTimers();
   });
 
-  it("renders placeholder when no scripts are defined", () => {
+  it("renders terminal tab when no scripts are defined", () => {
     renderPanel({ config: {} });
 
-    expect(screen.getByText("hive.json")).toBeInTheDocument();
-    expect(screen.getByText(/setup & run scripts/i)).toBeInTheDocument();
+    // Terminal tab is always present even without hive.json scripts
+    expect(screen.getByText("Start terminal")).toBeInTheDocument();
   });
 
-  it("renders placeholder when config is null", () => {
+  it("renders terminal tab when config is null", () => {
     renderPanel({ config: null });
 
-    expect(screen.getByText("hive.json")).toBeInTheDocument();
+    expect(screen.getByText("Start terminal")).toBeInTheDocument();
   });
 
   it("starts setup script from idle state", async () => {
@@ -99,6 +103,18 @@ describe("ScriptPanel", () => {
     });
 
     expect(onStart).toHaveBeenCalledWith("setup");
+  });
+
+  it("starts terminal from idle state when terminal tab is selected", async () => {
+    const { onStart, onStartTerminal } = renderPanel({ config: null, status: {} });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Start terminal"));
+      await Promise.resolve();
+    });
+
+    expect(onStartTerminal).toHaveBeenCalledTimes(1);
+    expect(onStart).not.toHaveBeenCalled();
   });
 
   it("shows wave indicator when script is running", () => {
@@ -122,6 +138,8 @@ describe("ScriptPanel", () => {
         status={{ setup: { state: "done", exitCode: 0 }, run: { state: "idle" } }}
         onStart={vi.fn()}
         onStop={vi.fn()}
+        onStartTerminal={vi.fn()}
+        onStopTerminal={vi.fn()}
         onConnectOutput={vi.fn()}
         onDisconnectOutput={vi.fn()}
       />,
@@ -136,6 +154,8 @@ describe("ScriptPanel", () => {
         status={{ setup: { state: "error", exitCode: 1 }, run: { state: "idle" } }}
         onStart={vi.fn()}
         onStop={vi.fn()}
+        onStartTerminal={vi.fn()}
+        onStopTerminal={vi.fn()}
         onConnectOutput={vi.fn()}
         onDisconnectOutput={vi.fn()}
       />,
@@ -152,6 +172,8 @@ describe("ScriptPanel", () => {
         status={{ setup: { state: "done", exitCode: 0 }, run: { state: "done", exitCode: 0 } }}
         onStart={vi.fn()}
         onStop={vi.fn()}
+        onStartTerminal={vi.fn()}
+        onStopTerminal={vi.fn()}
         onConnectOutput={vi.fn()}
         onDisconnectOutput={vi.fn()}
       />,
@@ -183,6 +205,34 @@ describe("ScriptPanel", () => {
       fireEvent.click(screen.getByTitle("Stop"));
     });
     expect(onStop).toHaveBeenCalledWith("setup");
+  });
+
+  it("shows running terminal for terminal tab and stops via terminal callbacks", () => {
+    const { onStop, onStopTerminal, onConnectOutput } = renderPanel({
+      config: { scripts: { setup: "npm ci" }, port: 3000 },
+      status: {
+        setup: { state: "idle" },
+        terminal: { state: "running" },
+      },
+    });
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Terminal" }));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(60);
+    });
+
+    expect(onConnectOutput).toHaveBeenCalledWith("terminal", expect.anything());
+    expect(screen.queryByText("Port 3000")).not.toBeInTheDocument();
+
+    act(() => {
+      fireEvent.click(screen.getByTitle("Stop"));
+    });
+
+    expect(onStopTerminal).toHaveBeenCalledTimes(1);
+    expect(onStop).not.toHaveBeenCalled();
   });
 
   it("re-runs finished script and disconnects old terminal first", async () => {
@@ -279,6 +329,7 @@ describe("ScriptPanel", () => {
     expect(screen.getByRole("button", { name: "Setup" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Backend" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Frontend" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Terminal" })).toBeInTheDocument();
   });
 
   it("starts a named run script when selected", async () => {

--- a/frontend/tests/hooks/useScripts.test.tsx
+++ b/frontend/tests/hooks/useScripts.test.tsx
@@ -225,6 +225,46 @@ describe("useScripts", () => {
     expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/scripts/backend/start");
   });
 
+  it("starts terminal and sets terminal status to running optimistically", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useScripts("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.startTerminal();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status.terminal).toEqual({ state: "running" });
+    });
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/terminal/start");
+  });
+
+  it("reverts terminal state to server data when terminal start fails", async () => {
+    mocks.apiGet
+      .mockResolvedValueOnce(scriptsResponse())
+      .mockResolvedValueOnce({
+        ...scriptsResponse(),
+        status: {
+          ...scriptsResponse().status,
+          terminal: { state: "done", exitCode: 0 },
+        },
+      });
+    mocks.apiPost.mockRejectedValueOnce(new Error("already running"));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useScripts("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.startTerminal();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status.terminal).toEqual({ state: "done", exitCode: 0 });
+    });
+  });
+
   it("reverts to server state when start fails", async () => {
     mocks.apiGet
       .mockResolvedValueOnce(scriptsResponse())
@@ -274,6 +314,33 @@ describe("useScripts", () => {
     });
 
     expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/scripts/run/stop");
+
+    const closeCallOrder = ws.close.mock.invocationCallOrder[0];
+    const postCallOrder = mocks.apiPost.mock.invocationCallOrder[0];
+    expect(closeCallOrder).toBeLessThan(postCallOrder);
+  });
+
+  it("closes active websocket before stopping terminal", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useScripts("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const term = createTerminal();
+    act(() => {
+      result.current.connectOutput("terminal", term as unknown as { cols: number; rows: number });
+    });
+
+    const ws = MockWebSocket.instances[0];
+    if (!ws) throw new Error("expected websocket instance");
+
+    act(() => {
+      result.current.stopTerminal();
+    });
+
+    await waitFor(() => {
+      expect(ws.close).toHaveBeenCalledTimes(1);
+    });
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/terminal/stop");
 
     const closeCallOrder = ws.close.mock.invocationCallOrder[0];
     const postCallOrder = mocks.apiPost.mock.invocationCallOrder[0];
@@ -483,6 +550,29 @@ describe("useScripts", () => {
     });
   });
 
+  it("does not close websocket when stopping terminal from a non-terminal connection", async () => {
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useScripts("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const term = createTerminal();
+    act(() => {
+      result.current.connectOutput("run", term as unknown as { cols: number; rows: number });
+    });
+
+    const ws = MockWebSocket.instances[0];
+    if (!ws) throw new Error("expected websocket instance");
+
+    act(() => {
+      result.current.stopTerminal();
+    });
+
+    expect(ws.close).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/terminal/stop");
+    });
+  });
+
   it("replaces existing websocket when reconnecting to another script type", async () => {
     const { wrapper } = createWrapper();
     const { result } = renderHook(() => useScripts("ws-1"), { wrapper });
@@ -514,6 +604,8 @@ describe("useScripts", () => {
     act(() => {
       result.current.startScript("setup");
       result.current.stopScript("setup");
+      result.current.startTerminal();
+      result.current.stopTerminal();
       result.current.connectOutput(
         "setup" as ScriptType,
         term as unknown as { cols: number; rows: number },


### PR DESCRIPTION
Always-present Terminal tab in the script panel that spawns an interactive PTY shell (no command needed). Backend routes for terminal start/stop, script-runner support for command-less shell mode, and frontend wiring with dedicated start/stop terminal callbacks. Terminal padding and dark background for the xterm container.