### PR TITLE
Fix folder click triggering file fetch error in file tree

### DIFF
--- a/frontend/src/components/ai-elements/file-tree.tsx
+++ b/frontend/src/components/ai-elements/file-tree.tsx
@@ -118,18 +118,12 @@ export const FileTreeFolder = ({
   children,
   ...props
 }: FileTreeFolderProps) => {
-  const { expandedPaths, togglePath, selectedPath, onPathSelect } =
-    useContext(FileTreeContext);
+  const { expandedPaths, togglePath } = useContext(FileTreeContext);
   const isExpanded = expandedPaths.has(path);
-  const isSelected = selectedPath === path;
 
   const handleOpenChange = useCallback(() => {
     togglePath(path);
   }, [togglePath, path]);
-
-  const handleSelect = useCallback(() => {
-    onPathSelect?.(path);
-  }, [onPathSelect, path]);
 
   const folderContextValue = useMemo(
     () => ({ isExpanded, name, path }),
@@ -147,11 +141,7 @@ export const FileTreeFolder = ({
         >
           <CollapsibleTrigger asChild>
             <button
-              className={cn(
-                "flex w-full items-center gap-1 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50",
-                isSelected && "bg-muted"
-              )}
-              onClick={handleSelect}
+              className="flex w-full items-center gap-1 rounded px-2 py-1 text-left transition-colors hover:bg-muted/50"
               type="button"
             >
               <ChevronRightIcon


### PR DESCRIPTION
## Summary
- Folders in the file tree no longer call `onPathSelect`, which was triggering a file fetch and resulting in a "Not a file" error
- Clicking a folder now only toggles expand/collapse as expected
- Removed dead code: `handleSelect`, `isSelected`, and unused context destructuring from `FileTreeFolder`

## Test plan
- [x] Typecheck passes
- [x] All 1659 tests pass
- [ ] Click a folder in the file tree → should expand/collapse without error
- [ ] Click a file in the file tree → should still open the file viewer