### PR TITLE
Add Agents management settings page

### DIFF
--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -15,6 +15,8 @@ import {
   getModelCatalog,
   detectAvailableProviders,
   markProviderAvailable,
+  parseVersionFromOutput,
+  getAllProviderInfo,
 } from "./registry.js";
 
 // Cast away the overloaded execFile signature so mockImplementation accepts simpler callbacks.
@@ -315,5 +317,162 @@ describe("contextWindow in catalog", () => {
     for (const model of codexModels) {
       expect(model.contextWindow).toBeUndefined();
     }
+  });
+});
+
+describe("parseVersionFromOutput", () => {
+  it("extracts version from 'v1.0.35'", () => {
+    expect(parseVersionFromOutput("v1.0.35")).toBe("1.0.35");
+  });
+
+  it("extracts version from bare '1.0.35'", () => {
+    expect(parseVersionFromOutput("1.0.35")).toBe("1.0.35");
+  });
+
+  it("extracts version from 'claude v1.0.35'", () => {
+    expect(parseVersionFromOutput("claude v1.0.35")).toBe("1.0.35");
+  });
+
+  it("extracts version from 'codex 0.1.2501.1'", () => {
+    expect(parseVersionFromOutput("codex 0.1.2501.1")).toBe("0.1.2501.1");
+  });
+
+  it("extracts version with pre-release tag", () => {
+    expect(parseVersionFromOutput("1.2.3-beta.1")).toBe("1.2.3-beta.1");
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseVersionFromOutput("")).toBeNull();
+  });
+
+  it("returns null for non-version output", () => {
+    expect(parseVersionFromOutput("some random text")).toBeNull();
+  });
+
+  it("extracts the first semver-like token in multiline output", () => {
+    expect(parseVersionFromOutput("build info\nv2.3.4\nextra")).toBe("2.3.4");
+  });
+});
+
+describe("getAllProviderInfo", () => {
+  it("returns all providers even when none are installed", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        cb(new Error("not found"), { stdout: "", stderr: "" });
+      },
+    );
+    await detectAvailableProviders();
+
+    const info = getAllProviderInfo();
+    expect(info).toHaveLength(3);
+    expect(info.every((p) => !p.installed)).toBe(true);
+    expect(info.every((p) => p.version === null)).toBe(true);
+  });
+
+  it("includes detected version for installed providers", async () => {
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "claude") {
+          cb(null, { stdout: "claude v1.0.35\n", stderr: "" });
+        } else {
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+        }
+      },
+    );
+    await detectAvailableProviders();
+
+    const info = getAllProviderInfo();
+    const claude = info.find((p) => p.id === "claude");
+    expect(claude?.installed).toBe(true);
+    expect(claude?.version).toBe("1.0.35");
+  });
+
+  it("includes correct labels and npm packages", async () => {
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        cb(new Error("not found"), { stdout: "", stderr: "" });
+      },
+    );
+    await detectAvailableProviders();
+
+    const info = getAllProviderInfo();
+    const claude = info.find((p) => p.id === "claude")!;
+    const codex = info.find((p) => p.id === "codex")!;
+    const gemini = info.find((p) => p.id === "gemini")!;
+
+    expect(claude.label).toBe("Claude Code");
+    expect(claude.npmPackage).toBe("@anthropic-ai/claude-code");
+    expect(codex.label).toBe("Codex");
+    expect(codex.npmPackage).toBe("@openai/codex");
+    expect(gemini.label).toBe("Gemini CLI");
+    expect(gemini.npmPackage).toBe("@google/gemini-cli");
+  });
+
+  it("sets version null when CLI output is unparseable", async () => {
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "claude") {
+          cb(null, { stdout: "some weird output\n", stderr: "" });
+        } else {
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+        }
+      },
+    );
+    await detectAvailableProviders();
+
+    const info = getAllProviderInfo();
+    const claude = info.find((p) => p.id === "claude")!;
+    expect(claude.installed).toBe(true);
+    expect(claude.version).toBeNull();
+  });
+
+  it("clears previously detected versions on subsequent detection runs", async () => {
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "claude") {
+          cb(null, { stdout: "claude v1.2.3\n", stderr: "" });
+        } else {
+          cb(new Error("not found"), { stdout: "", stderr: "" });
+        }
+      },
+    );
+    await detectAvailableProviders();
+
+    const firstRun = getAllProviderInfo().find((p) => p.id === "claude")!;
+    expect(firstRun.installed).toBe(true);
+    expect(firstRun.version).toBe("1.2.3");
+
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        cb(new Error("not found"), { stdout: "", stderr: "" });
+      },
+    );
+    await detectAvailableProviders();
+
+    const secondRun = getAllProviderInfo().find((p) => p.id === "claude")!;
+    expect(secondRun.installed).toBe(false);
+    expect(secondRun.version).toBeNull();
+  });
+
+  it("captures versions independently for multiple installed providers", async () => {
+    mockExecFile.mockImplementation(
+      (cmd: string, _args: string[], cb: (...a: unknown[]) => void) => {
+        if (cmd === "claude") {
+          cb(null, { stdout: "v1.0.0\n", stderr: "" });
+          return;
+        }
+        if (cmd === "codex") {
+          cb(null, { stdout: "codex 0.2.5\n", stderr: "" });
+          return;
+        }
+        cb(new Error("not found"), { stdout: "", stderr: "" });
+      },
+    );
+    await detectAvailableProviders();
+
+    const info = getAllProviderInfo();
+    expect(info.find((p) => p.id === "claude")?.version).toBe("1.0.0");
+    expect(info.find((p) => p.id === "codex")?.version).toBe("0.2.5");
+    expect(info.find((p) => p.id === "gemini")?.version).toBeNull();
   });
 });

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -13,6 +13,13 @@ const PROVIDER_LABELS: Record<string, string> = {
   gemini: "Gemini CLI",
 };
 
+/** npm package name for each provider, used to check for updates. */
+const NPM_PACKAGES: Record<string, string> = {
+  claude: "@anthropic-ai/claude-code",
+  codex: "@openai/codex",
+  gemini: "@google/gemini-cli",
+};
+
 /** All known providers. Availability is checked at runtime via CLI detection. */
 const ALL_PROVIDERS: AgentProvider[] = [
   new ClaudeProvider(),
@@ -27,16 +34,33 @@ const providerMap = new Map<string, AgentProvider>(
 /** Set of provider IDs whose CLI binary was detected on the system. */
 const availableProviderIds = new Set<string>();
 
+/** Detected installed versions. Key = provider ID, value = version string. */
+const detectedVersions = new Map<string, string>();
+
+/**
+ * Extract a semver-like version from CLI --version output.
+ * Handles formats like "1.0.35", "v1.0.35", "claude v1.0.35", "codex 0.1.2501.1".
+ */
+export function parseVersionFromOutput(stdout: string): string | null {
+  const match = stdout.match(/(\d+\.\d+[\w.-]*)/);
+  return match?.[1] ?? null;
+}
+
 /**
  * Probe which provider CLIs are installed.
  * Called once at startup (from preflight or main).
  */
 export async function detectAvailableProviders(): Promise<void> {
   availableProviderIds.clear();
+  detectedVersions.clear();
   for (const provider of ALL_PROVIDERS) {
     try {
-      await execFile(provider.command, ["--version"]);
+      const { stdout } = await execFile(provider.command, ["--version"]);
       availableProviderIds.add(provider.id);
+      const version = parseVersionFromOutput(stdout);
+      if (version) {
+        detectedVersions.set(provider.id, version);
+      }
     } catch {
       // CLI not found — provider won't appear in catalog
     }
@@ -112,4 +136,23 @@ export function getModelCatalog(): ModelCatalogResponse {
   }
 
   return { models, defaultModelId };
+}
+
+export interface AgentProviderInfo {
+  id: string;
+  label: string;
+  npmPackage: string;
+  installed: boolean;
+  version: string | null;
+}
+
+/** Return info about all known providers (installed or not). */
+export function getAllProviderInfo(): AgentProviderInfo[] {
+  return ALL_PROVIDERS.map((p) => ({
+    id: p.id,
+    label: PROVIDER_LABELS[p.id] ?? p.id,
+    npmPackage: NPM_PACKAGES[p.id] ?? "",
+    installed: availableProviderIds.has(p.id),
+    version: detectedVersions.get(p.id) ?? null,
+  }));
 }

--- a/backend/src/api/agents-settings.test.ts
+++ b/backend/src/api/agents-settings.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify from "fastify";
+import type { FastifyInstance } from "fastify";
+
+const mocks = vi.hoisted(() => ({
+  getAllProviderInfo: vi.fn(),
+}));
+
+vi.mock("../agents/providers/registry.js", () => ({
+  getAllProviderInfo: mocks.getAllProviderInfo,
+}));
+
+import { agentSettingsRoutes } from "./agents-settings.js";
+
+let app: ReturnType<typeof Fastify>;
+const originalFetch = globalThis.fetch;
+
+beforeEach(async () => {
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => agentSettingsRoutes(instance));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+function mockFetchNpm(versions: Record<string, string | null>) {
+  globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+    for (const [pkg, version] of Object.entries(versions)) {
+      if (url.includes(encodeURIComponent(pkg)) || url.includes(pkg)) {
+        if (version === null) {
+          return new Response("Not Found", { status: 404 });
+        }
+        return new Response(JSON.stringify({ version }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    }
+    return new Response("Not Found", { status: 404 });
+  }) as typeof fetch;
+}
+
+describe("GET /api/settings/agents", () => {
+  it("returns all providers with correct shape", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.35" },
+      { id: "codex", label: "Codex", npmPackage: "@openai/codex", installed: false, version: null },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.0.35", "@openai/codex": "0.2.0" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.agents).toHaveLength(2);
+    expect(body.agents[0]).toEqual({
+      id: "claude",
+      label: "Claude Code",
+      installed: true,
+      version: "1.0.35",
+      latestVersion: "1.0.35",
+      updateAvailable: false,
+    });
+    expect(body.agents[1]).toEqual({
+      id: "codex",
+      label: "Codex",
+      installed: false,
+      version: null,
+      latestVersion: "0.2.0",
+      updateAvailable: false,
+    });
+  });
+
+  it("sets updateAvailable true when npm version is newer", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.30" },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.0.35" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const body = res.json();
+
+    expect(body.agents[0].updateAvailable).toBe(true);
+    expect(body.agents[0].latestVersion).toBe("1.0.35");
+  });
+
+  it("sets updateAvailable false when versions match", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.35" },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.0.35" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    expect(res.json().agents[0].updateAvailable).toBe(false);
+  });
+
+  it("handles npm registry failure gracefully", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.35" },
+    ]);
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("network error");
+    }) as typeof fetch;
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBeNull();
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("handles npm registry 404 gracefully", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.35" },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": null });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBeNull();
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("handles provider with empty npm package name", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "custom", label: "Custom", npmPackage: "", installed: true, version: "1.0.0" },
+    ]);
+    globalThis.fetch = vi.fn(async () => {
+      throw new Error("fetch should not be called");
+    }) as typeof fetch;
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBeNull();
+    expect(agent.updateAvailable).toBe(false);
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  it("non-installed providers always have updateAvailable false", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "codex", label: "Codex", npmPackage: "@openai/codex", installed: false, version: null },
+    ]);
+    mockFetchNpm({ "@openai/codex": "0.2.0" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    expect(res.json().agents[0].updateAvailable).toBe(false);
+  });
+
+  it("handles installed provider with null version (unparseable --version output)", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: null },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.0.35" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.installed).toBe(true);
+    expect(agent.version).toBeNull();
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("sets updateAvailable false when installed version is newer than npm latest", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "codex", label: "Codex", npmPackage: "@openai/codex", installed: true, version: "0.2.1" },
+    ]);
+    mockFetchNpm({ "@openai/codex": "0.2.0" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBe("0.2.0");
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("marks updateAvailable true when latest has more numeric segments", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.2" },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.2.1" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBe("1.2.1");
+    expect(agent.updateAvailable).toBe(true);
+  });
+
+  it("keeps updateAvailable false when latest version is semver-ambiguous", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.2.0" },
+    ]);
+    mockFetchNpm({ "@anthropic-ai/claude-code": "1.2.0-beta.1" });
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBe("1.2.0-beta.1");
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("keeps provider order stable even when fetch resolves out of order", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.0" },
+      { id: "codex", label: "Codex", npmPackage: "@openai/codex", installed: true, version: "0.1.0" },
+    ]);
+
+    globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+      const url = typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      if (url.includes("@anthropic-ai/claude-code") || url.includes("@anthropic-ai%2Fclaude-code")) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        return new Response(JSON.stringify({ version: "1.0.1" }), { status: 200 });
+      }
+      if (url.includes("@openai/codex") || url.includes("@openai%2Fcodex")) {
+        return new Response(JSON.stringify({ version: "0.2.0" }), { status: 200 });
+      }
+      return new Response("Not Found", { status: 404 });
+    }) as typeof fetch;
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const body = res.json();
+
+    expect(body.agents.map((agent: { id: string }) => agent.id)).toEqual(["claude", "codex"]);
+    expect(body.agents[0].latestVersion).toBe("1.0.1");
+    expect(body.agents[1].latestVersion).toBe("0.2.0");
+  });
+
+  it("returns latestVersion null when npm response JSON is invalid", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.0" },
+    ]);
+    globalThis.fetch = vi.fn(async () => {
+      const response = new Response("not-json", { status: 200 });
+      vi.spyOn(response, "json").mockRejectedValueOnce(new Error("invalid json"));
+      return response;
+    }) as typeof fetch;
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+    const agent = res.json().agents[0];
+
+    expect(agent.latestVersion).toBeNull();
+    expect(agent.updateAvailable).toBe(false);
+  });
+
+  it("queries npm registry using scoped package path", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([
+      { id: "claude", label: "Claude Code", npmPackage: "@anthropic-ai/claude-code", installed: true, version: "1.0.0" },
+    ]);
+    globalThis.fetch = vi.fn(async () => (
+      new Response(JSON.stringify({ version: "1.0.0" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    )) as typeof fetch;
+
+    await app.inject({ method: "GET", url: "/api/settings/agents" });
+
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "https://registry.npmjs.org/@anthropic-ai/claude-code/latest",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});

--- a/backend/src/api/agents-settings.ts
+++ b/backend/src/api/agents-settings.ts
@@ -1,0 +1,86 @@
+import type { FastifyInstance } from "fastify";
+import { getAllProviderInfo } from "../agents/providers/registry.js";
+
+export interface AgentStatusEntry {
+  id: string;
+  label: string;
+  installed: boolean;
+  version: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+}
+
+export interface AgentStatusResponse {
+  agents: AgentStatusEntry[];
+}
+
+const NPM_REGISTRY_TIMEOUT_MS = 5_000;
+
+/**
+ * Fetch the latest published version of an npm package.
+ * Returns null on any error (network timeout, 404, parse failure).
+ */
+async function fetchLatestNpmVersion(packageName: string): Promise<string | null> {
+  if (!packageName) return null;
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), NPM_REGISTRY_TIMEOUT_MS);
+    const res = await fetch(
+      `https://registry.npmjs.org/${packageName}/latest`,
+      { signal: controller.signal },
+    );
+    clearTimeout(timer);
+    if (!res.ok) return null;
+    const data = (await res.json()) as { version?: string };
+    return data.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Compare two semver-ish strings. Returns true if latest > installed.
+ * Only compares numeric segments; returns false on any ambiguity.
+ */
+function isNewerVersion(installed: string, latest: string): boolean {
+  const iParts = installed.split(".").map(Number);
+  const lParts = latest.split(".").map(Number);
+  const len = Math.max(iParts.length, lParts.length);
+  for (let i = 0; i < len; i++) {
+    const a = iParts[i] ?? 0;
+    const b = lParts[i] ?? 0;
+    if (Number.isNaN(a) || Number.isNaN(b)) return false;
+    if (b > a) return true;
+    if (a > b) return false;
+  }
+  return false;
+}
+
+export async function agentSettingsRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/api/settings/agents", async (): Promise<AgentStatusResponse> => {
+    const providers = getAllProviderInfo();
+
+    const latestVersions = await Promise.all(
+      providers.map((p) => fetchLatestNpmVersion(p.npmPackage)),
+    );
+
+    const agents: AgentStatusEntry[] = providers.map((p, i) => {
+      const latestVersion = latestVersions[i];
+      const updateAvailable =
+        p.installed && p.version != null && latestVersion != null
+          ? isNewerVersion(p.version, latestVersion)
+          : false;
+
+      return {
+        id: p.id,
+        label: p.label,
+        installed: p.installed,
+        version: p.version,
+        latestVersion,
+        updateAvailable,
+      };
+    });
+
+    return { agents };
+  });
+}

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -106,6 +106,16 @@ describe("buildApp", () => {
     });
   });
 
+  it("registers agent settings routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/settings/agents" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      agents: expect.any(Array),
+    });
+  });
+
   it("registers session routes", async () => {
     app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/api/workspaces/test-ws/session" });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -14,6 +14,7 @@ import { ensureDataDir, getDataDir } from "./state/state.js";
 import { type SessionOptions, rebuildNotifier } from "./agents/agent-manager.js";
 import { GitSyncService } from "./services/git-sync.js";
 import { settingsRoutes } from "./api/settings.js";
+import { agentSettingsRoutes } from "./api/agents-settings.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
@@ -91,6 +92,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     }),
   );
   await app.register((instance: FastifyInstance) => settingsRoutes(instance));
+  await app.register((instance: FastifyInstance) => agentSettingsRoutes(instance));
   await app.register((instance: FastifyInstance) => accountRoutes(instance));
   await app.register((instance: FastifyInstance) => scriptRoutes(instance));
   await app.register((instance: FastifyInstance) =>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import AccountSettings from "@/pages/settings/AccountSettings";
 import AppearanceSettings from "@/pages/settings/AppearanceSettings";
 import ConnectionSettings from "@/pages/settings/ConnectionSettings";
 import NotificationSettings from "@/pages/settings/NotificationSettings";
+import AgentSettings from "@/pages/settings/AgentSettings";
 import ProjectDetail from "@/pages/settings/ProjectDetail";
 import AddProjectDialog from "@/components/AddProjectDialog";
 import EmptyStateLogo from "@/components/EmptyStateLogo";
@@ -64,6 +65,7 @@ export default function App() {
             <Route path="settings/appearance" element={<AppearanceSettings />} />
             <Route path="settings/connection" element={<ConnectionSettings onRefreshConnection={() => { wsTransport.disconnectAll(); fetchProjects(); }} />} />
             <Route path="settings/notifications" element={<NotificationSettings />} />
+            <Route path="settings/agents" element={<AgentSettings />} />
             <Route path="settings/repositories/:projectId" element={<ProjectDetail />} />
           </Route>
         </Routes>

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { ArrowLeft, Bell, CircleUser, Paintbrush, Wifi, GitFork } from "lucide-react";
+import { ArrowLeft, Bell, Bot, CircleUser, Paintbrush, Wifi, GitFork } from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
@@ -58,6 +58,12 @@ export default function SettingsSidebar() {
               label="Notifications"
               icon={<Bell className="h-4 w-4" />}
               active={pathname === "/settings/notifications"}
+            />
+            <NavItem
+              to="/settings/agents"
+              label="Agents"
+              icon={<Bot className="h-4 w-4" />}
+              active={pathname === "/settings/agents"}
             />
           </SidebarSection>
 

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -1,0 +1,115 @@
+import { useQuery } from "@tanstack/react-query";
+import { Loader2, CheckCircle2, ArrowUpCircle, CircleSlash } from "lucide-react";
+import { SettingsHeader } from "@/components/AppLayout";
+import { api } from "@/hooks/useApi";
+import { cn } from "@/lib/utils";
+
+interface AgentStatusEntry {
+  id: string;
+  label: string;
+  installed: boolean;
+  version: string | null;
+  latestVersion: string | null;
+  updateAvailable: boolean;
+}
+
+interface AgentStatusResponse {
+  agents: AgentStatusEntry[];
+}
+
+export default function AgentSettings() {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ["settings", "agents"],
+    queryFn: () => api.get<AgentStatusResponse>("/api/settings/agents"),
+  });
+
+  return (
+    <div className="flex h-full flex-col overflow-auto">
+      <SettingsHeader>
+        <h1 className="text-sm font-medium">Agents</h1>
+      </SettingsHeader>
+
+      <div className="max-w-2xl space-y-4 px-4 py-5">
+        <p className="text-xs text-muted-foreground">
+          Agent CLI tools detected on this server.
+        </p>
+
+        {isLoading && (
+          <div className="flex items-center gap-2 py-8 text-xs text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Checking agent versions…
+          </div>
+        )}
+
+        {isError && (
+          <p className="py-4 text-xs text-red-400">
+            Could not load agent information.
+          </p>
+        )}
+
+        {data?.agents.map((agent) => (
+          <AgentCard key={agent.id} agent={agent} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function AgentCard({ agent }: { agent: AgentStatusEntry }) {
+  return (
+    <section
+      className={cn(
+        "rounded-lg border border-border/50 bg-card/50 p-5",
+        !agent.installed && "opacity-50",
+      )}
+    >
+      <div className="flex items-start justify-between">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">{agent.label}</h2>
+          {agent.installed && agent.version && (
+            <p className="mt-1 font-mono text-xs text-muted-foreground">
+              v{agent.version}
+            </p>
+          )}
+        </div>
+        <StatusBadge agent={agent} />
+      </div>
+    </section>
+  );
+}
+
+function StatusBadge({ agent }: { agent: AgentStatusEntry }) {
+  if (!agent.installed) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+        <CircleSlash className="h-3 w-3" />
+        Not installed
+      </span>
+    );
+  }
+
+  if (agent.updateAvailable) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[11px] font-medium text-amber-400">
+        <ArrowUpCircle className="h-3 w-3" />
+        Update available{agent.latestVersion && ` (${agent.latestVersion})`}
+      </span>
+    );
+  }
+
+  if (agent.latestVersion != null) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-400">
+        <CheckCircle2 className="h-3 w-3" />
+        Up to date
+      </span>
+    );
+  }
+
+  // Installed but couldn't check for updates (registry unreachable)
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-muted/50 px-2.5 py-0.5 text-[11px] font-medium text-muted-foreground">
+      Installed
+    </span>
+  );
+}

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -125,6 +125,10 @@ vi.mock("@/pages/settings/NotificationSettings", () => ({
   default: () => <div>notification settings</div>,
 }));
 
+vi.mock("@/pages/settings/AgentSettings", () => ({
+  default: () => <div>agent settings</div>,
+}));
+
 vi.mock("@/pages/settings/ProjectDetail", () => ({
   default: () => <div>project detail</div>,
 }));
@@ -245,6 +249,14 @@ describe("App", () => {
     renderApp();
 
     expect(screen.getByText("notification settings")).toBeInTheDocument();
+  });
+
+  it("renders agent settings route", () => {
+    window.history.pushState({}, "", "/settings/agents");
+
+    renderApp();
+
+    expect(screen.getByText("agent settings")).toBeInTheDocument();
   });
 
   it("redirects /projects/:id to /projects", () => {

--- a/frontend/tests/components/SettingsSidebar.test.tsx
+++ b/frontend/tests/components/SettingsSidebar.test.tsx
@@ -51,6 +51,7 @@ describe("SettingsSidebar", () => {
           <Route path="/settings" element={<SettingsShell />}>
             <Route path="appearance" element={<div>Appearance settings</div>} />
             <Route path="notifications" element={<div>Notification settings</div>} />
+            <Route path="agents" element={<div>Agents settings</div>} />
             <Route path="repositories/:projectId" element={<div>Repository settings</div>} />
           </Route>
           <Route path="/workspaces/:wsId" element={<div>Workspace w1</div>} />
@@ -77,6 +78,7 @@ describe("SettingsSidebar", () => {
           <Route path="/settings" element={<SettingsShell />}>
             <Route path="appearance" element={<div>Appearance settings</div>} />
             <Route path="notifications" element={<div>Notification settings</div>} />
+            <Route path="agents" element={<div>Agents settings</div>} />
           </Route>
           <Route path="/projects" element={<div>Projects list</div>} />
         </Routes>
@@ -97,6 +99,7 @@ describe("SettingsSidebar", () => {
           <Route path="/settings" element={<SettingsShell />}>
             <Route path="appearance" element={<div>Appearance settings</div>} />
             <Route path="notifications" element={<div>Notification settings</div>} />
+            <Route path="agents" element={<div>Agents settings</div>} />
           </Route>
         </Routes>
       </MemoryRouter>,
@@ -106,5 +109,39 @@ describe("SettingsSidebar", () => {
     await waitFor(() => {
       expect(screen.getByText("Notification settings")).toBeInTheDocument();
     });
+  });
+
+  it("navigates to agents settings", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="appearance" element={<div>Appearance settings</div>} />
+            <Route path="agents" element={<div>Agents settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("link", { name: /Agents/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Agents settings")).toBeInTheDocument();
+    });
+  });
+
+  it("highlights the agents link when agents route is active", async () => {
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/settings/agents"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="agents" element={<div>Agents settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await screen.findByText("Agents settings");
+    expect(screen.getByRole("link", { name: /Agents/i })).toHaveClass("bg-primary/10");
   });
 });

--- a/frontend/tests/pages/AgentSettings.test.tsx
+++ b/frontend/tests/pages/AgentSettings.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import AgentSettings from "@/pages/settings/AgentSettings";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: { get: mocks.get },
+}));
+
+vi.mock("@/components/AppLayout", () => ({
+  SettingsHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-tauri-drag-region>{children}</div>
+  ),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AgentSettings />
+    </QueryClientProvider>,
+  );
+}
+
+describe("AgentSettings", () => {
+  it("renders heading with drag region", async () => {
+    mocks.get.mockResolvedValueOnce({ agents: [] });
+    renderPage();
+    const heading = await screen.findByRole("heading", { name: "Agents" });
+    expect(heading.closest("div")).toHaveAttribute("data-tauri-drag-region");
+  });
+
+  it("shows loading state", () => {
+    mocks.get.mockReturnValue(new Promise(() => {}));
+    renderPage();
+    expect(screen.getByText(/Checking agent versions/)).toBeInTheDocument();
+  });
+
+  it("requests agent settings from the expected API endpoint", async () => {
+    mocks.get.mockResolvedValueOnce({ agents: [] });
+    renderPage();
+
+    await screen.findByRole("heading", { name: "Agents" });
+    expect(mocks.get).toHaveBeenCalledWith("/api/settings/agents");
+  });
+
+  it("renders installed agent with 'Up to date' badge", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "claude", label: "Claude Code", installed: true, version: "1.0.35", latestVersion: "1.0.35", updateAvailable: false },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("v1.0.35")).toBeInTheDocument();
+    expect(screen.getByText("Up to date")).toBeInTheDocument();
+  });
+
+  it("renders 'Update available' badge when newer version exists", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "codex", label: "Codex", installed: true, version: "0.1.2", latestVersion: "0.2.0", updateAvailable: true },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText(/Update available/)).toBeInTheDocument();
+    expect(screen.getByText(/0\.2\.0/)).toBeInTheDocument();
+  });
+
+  it("renders 'Not installed' badge for missing agents", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "gemini", label: "Gemini CLI", installed: false, version: null, latestVersion: null, updateAvailable: false },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("Gemini CLI")).toBeInTheDocument();
+    expect(screen.getByText("Not installed")).toBeInTheDocument();
+  });
+
+  it("renders neutral 'Installed' badge when registry is unreachable", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "claude", label: "Claude Code", installed: true, version: "1.0.35", latestVersion: null, updateAvailable: false },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("Installed")).toBeInTheDocument();
+  });
+
+  it("hides version text for installed agents when version is null", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "claude", label: "Claude Code", installed: true, version: null, latestVersion: "1.0.35", updateAvailable: false },
+      ],
+    });
+    renderPage();
+
+    await screen.findByText("Claude Code");
+    expect(screen.queryByText(/^v/)).not.toBeInTheDocument();
+  });
+
+  it("shows error state when API call fails", async () => {
+    mocks.get.mockRejectedValueOnce(new Error("offline"));
+    renderPage();
+    expect(await screen.findByText(/Could not load agent information/)).toBeInTheDocument();
+  });
+
+  it("does not show version for non-installed agents", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "codex", label: "Codex", installed: false, version: null, latestVersion: "0.2.0", updateAvailable: false },
+      ],
+    });
+    renderPage();
+    await screen.findByText("Codex");
+    expect(screen.queryByText(/^v/)).not.toBeInTheDocument();
+  });
+
+  it("renders multiple agents", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "claude", label: "Claude Code", installed: true, version: "1.0.35", latestVersion: "1.0.35", updateAvailable: false },
+        { id: "codex", label: "Codex", installed: true, version: "0.1.2", latestVersion: "0.2.0", updateAvailable: true },
+        { id: "gemini", label: "Gemini CLI", installed: false, version: null, latestVersion: null, updateAvailable: false },
+      ],
+    });
+    renderPage();
+    expect(await screen.findByText("Claude Code")).toBeInTheDocument();
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(screen.getByText("Gemini CLI")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- New **Settings > Agents** page displaying all known providers (Claude Code, Codex, Gemini CLI) with installation status, detected version, and npm update availability
- Backend captures CLI version strings during startup detection (previously discarded) and exposes `GET /api/settings/agents` with parallel npm registry lookups
- Four badge states: **Not installed** (gray/dimmed), **Installed** (neutral, registry unreachable), **Up to date** (green), **Update available** (amber with latest version)
- Non-installed agents shown at 50% opacity with "Not installed" badge

## Test plan

- [x] Backend: `parseVersionFromOutput` handles various CLI output formats
- [x] Backend: `getAllProviderInfo` returns all 3 providers regardless of availability
- [x] Backend: `GET /api/settings/agents` returns correct shape with version comparison
- [x] Backend: npm registry timeout/404 handled gracefully (latestVersion null, updateAvailable false)
- [x] Backend: route registered in index.ts integration test
- [x] Frontend: loading, error, and all 4 badge states rendered correctly
- [x] Frontend: route navigable from sidebar
- [x] Frontend: sidebar highlights active agents link
- [x] `npm run typecheck` and `npm test` pass (901 backend + 809 frontend tests)