### PR TITLE
Add file mention support in chat input (#-mentions with autocomplete) 

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -13,6 +13,7 @@ import { buildWorkspaceEnv } from "../utils/env.js";
 import type {
   ChatMessage,
   ContentBlock,
+  FileMention,
   ImageAttachment,
   MessageOptions,
   ServerToolResultType,
@@ -203,7 +204,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   /** Send a user message. Spawns a CLI process for this turn.
    *  When `cliContent` is provided, it is sent to the CLI instead of `content`
    *  while the displayed/persisted message remains `content`. */
-  sendMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[], cliContent?: string): void {
+  sendMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[], cliContent?: string, fileMentions?: FileMention[]): void {
     if (this._status === "streaming") {
       throw new Error("Already streaming — wait for current message to complete or stop it");
     }
@@ -233,7 +234,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           mediaType: images[i].mediaType,
           dataUrl: `/api/workspaces/${this.workspaceId}/sessions/${this.sessionId}/attachments/${s.filename}`,
         }));
-        this.emitUserMessage(content, urlImages);
+        this.emitUserMessage(content, urlImages, fileMentions);
         this.spawnCli(this.buildPromptWithImages(promptContent, saved.map((s) => s.path)), msgOptions);
       }).catch((err) => {
         this._status = "error";
@@ -241,18 +242,19 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         this.emit("error", err instanceof Error ? err : new Error(String(err)));
       });
     } else {
-      this.emitUserMessage(content);
+      this.emitUserMessage(content, undefined, fileMentions);
       this.spawnCli(promptContent, msgOptions);
     }
   }
 
-  private emitUserMessage(content: string, images?: ImageAttachment[]): void {
+  private emitUserMessage(content: string, images?: ImageAttachment[], fileMentions?: FileMention[]): void {
     const userMsg: ChatMessage = {
       id: nanoid(12),
       sessionId: this.sessionId,
       role: "user",
       content,
       images: images?.length ? images : undefined,
+      fileMentions: fileMentions?.length ? fileMentions : undefined,
       timestamp: new Date().toISOString(),
     };
     if (!this._metadata.title) {

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -11,6 +11,7 @@ import {
   mergeWorkspace,
   archiveWorkspace,
 } from "../workspaces/workspace-manager.js";
+import { git } from "../utils/git.js";
 import { endSession } from "../agents/agent-manager.js";
 import { join } from "node:path";
 import { bareRepoPath, resolveDefaultBranch, workspacesDir } from "../utils/paths.js";
@@ -223,6 +224,21 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       return reply.send(response);
     },
   );
+
+  app.get<{ Params: { wsId: string } }>("/api/workspaces/:wsId/file-completions", async (req, reply) => {
+    try {
+      const result = await getWorkspace(req.params.wsId, dataDir);
+      if (!result) return reply.status(404).send({ error: "Workspace not found" });
+
+      const dir = dataDir ?? getDataDir();
+      const wsPath = join(workspacesDir(dir, result.projectState.id), result.workspace.name);
+      const { stdout } = await git(["ls-files"], wsPath);
+      const files = stdout.split("\n").filter(Boolean);
+      return reply.send({ files });
+    } catch (err: unknown) {
+      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed") });
+    }
+  });
 
   app.get<{ Params: { wsId: string } }>("/api/workspaces/:wsId/files", async (req, reply) => {
     try {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -96,6 +96,13 @@ export interface ImageAttachment {
   dataUrl: string;
 }
 
+// ── File mention type ───────────────────────────────────────────────
+
+export interface FileMention {
+  displayName: string;   // e.g. "git.ts" or "api/index.ts" (disambiguated)
+  relativePath: string;  // e.g. "src/utils/git.ts"
+}
+
 // ── Session / Chat types ────────────────────────────────────────────
 
 export interface SessionMetadata {
@@ -124,6 +131,7 @@ export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
   images?: ImageAttachment[];
+  fileMentions?: FileMention[];
   toolCalls?: ToolCall[];
   thinkingContent?: string;
   timestamp: string;
@@ -280,7 +288,7 @@ export type ThinkingLevel = "low" | "medium" | "high" | "xhigh";
 /** Frontend -> Backend */
 export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
-  | { type: "user_message"; content: string; images?: ImageAttachment[]; options?: MessageOptions; sessionId?: string }
+  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };
 

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -14,6 +14,10 @@ import { errorMessage } from "../utils/errors.js";
 import { isAuthorized } from "../utils/auth.js";
 import type { WsIncoming, WsOutgoing, HubIncoming, HubOutgoing } from "../types.js";
 import { getScriptStatus } from "../services/script-runner.js";
+import { getWorkspace } from "../workspaces/workspace-manager.js";
+import { workspacesDir } from "../utils/paths.js";
+import { getDataDir } from "../state/state.js";
+import { join, resolve, sep } from "node:path";
 
 interface GitSyncSnapshotProvider {
   getCachedBranchInfo: (workspaceId: string) => Extract<WsOutgoing, { type: "branch_info" }>["info"] | undefined;
@@ -47,6 +51,36 @@ const PING_INTERVAL_MS = 30_000;
 const channels = new Map<string, WorkspaceChannel>();
 const hubSockets = new Set<HubSocket>();
 const hubPingTimers = new Map<HubSocket, NodeJS.Timeout>();
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function isWithinWorkspace(workspacePath: string, candidatePath: string): boolean {
+  const root = resolve(workspacePath);
+  const candidate = resolve(candidatePath);
+  return candidate === root || candidate.startsWith(`${root}${sep}`);
+}
+
+function replaceFileMentionsWithAbsolutePaths(
+  content: string,
+  mentions: Array<{ displayName: string; relativePath: string }>,
+  workspacePath: string,
+): string {
+  let resolved = content;
+
+  for (const mention of mentions) {
+    if (!mention.displayName || !mention.relativePath) continue;
+
+    const absPath = resolve(workspacePath, mention.relativePath);
+    if (!isWithinWorkspace(workspacePath, absPath)) continue;
+
+    const pattern = new RegExp(`(^|\\s)#${escapeRegExp(mention.displayName)}(?=\\s|$)`, "g");
+    resolved = resolved.replace(pattern, `$1${absPath}`);
+  }
+
+  return resolved;
+}
 
 // ── Sending helpers ─────────────────────────────────────────────────
 
@@ -354,7 +388,19 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           }
 
           attachSessionListeners(wsId, channel, targetSession);
-          targetSession.sendMessage(incoming.content, incoming.options, incoming.images);
+
+          // Build cliContent by replacing #displayName with absolute paths
+          let cliContent: string | undefined;
+          if (incoming.fileMentions?.length) {
+            const dir = dataDir ?? getDataDir();
+            const wsResult = await getWorkspace(wsId, dir);
+            if (wsResult) {
+              const wsPath = join(workspacesDir(dir, wsResult.projectState.id), wsResult.workspace.name);
+              cliContent = replaceFileMentionsWithAbsolutePaths(incoming.content, incoming.fileMentions, wsPath);
+            }
+          }
+
+          targetSession.sendMessage(incoming.content, incoming.options, incoming.images, cliContent, incoming.fileMentions);
           broadcastToChannel(channel, wsId, {
             type: "status",
             status: "busy",

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -28,6 +28,7 @@ interface ChatConversationProps {
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onPlanApproval?: () => void;
   onHandOff?: (planContent: string, planPath?: string) => void;
+  onFileMentionClick?: (relativePath: string) => void;
   workspaceName?: string;
   projectName?: string;
   branch?: string;
@@ -48,6 +49,7 @@ export default function ChatConversation({
   onQuestionAnswer,
   onPlanApproval,
   onHandOff,
+  onFileMentionClick,
   workspaceName,
   projectName,
   branch,
@@ -180,6 +182,7 @@ export default function ChatConversation({
             onQuestionAnswer={onQuestionAnswer}
             onPlanApproval={onPlanApproval}
             onHandOff={onHandOff}
+            onFileMentionClick={onFileMentionClick}
           />
         ))}
 

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -11,23 +11,27 @@ import {
   usePromptInputAttachments,
   type AttachmentsContext,
 } from "@/components/ai-elements/prompt-input";
-import type { ChatMessage, CompletionItem, ImageAttachment, MessageOptions, ThinkingLevel } from "@/types";
+import type { ChatMessage, CompletionItem, FileMention, ImageAttachment, MessageOptions, ThinkingLevel } from "@/types";
 import { cn } from "@/lib/utils";
 import { BrainIcon, BookOpenIcon, PlusIcon } from "lucide-react";
 import { AttachmentPreview } from "@/components/chat/AttachmentPreview";
 import { AutocompletePopup } from "@/components/chat/AutocompletePopup";
+import { FileAutocompletePopup } from "@/components/chat/FileAutocompletePopup";
+import { MentionHighlightOverlay } from "@/components/chat/MentionHighlightOverlay";
 import { ContextRing } from "@/components/chat/ContextRing";
 import { ModelSelector } from "@/components/chat/ModelSelector";
 import { useCompletions } from "@/hooks/useCompletions";
+import { useFileCompletions } from "@/hooks/useFileCompletions";
 import { useContextUsage } from "@/hooks/useContextUsage";
 import { useModels } from "@/hooks/useModels";
 import { useChatInputDraftPersistence } from "@/hooks/useChatInputDraftPersistence";
+import { fuzzyMatchFiles, disambiguateDisplayName, type FuzzyResult } from "@/lib/fuzzy-match";
 
 interface ChatInputProps {
   wsId?: string;
   sessionId?: string;
   lockedProvider?: string;
-  onSend: (content: string, images?: ImageAttachment[], options?: MessageOptions) => boolean;
+  onSend: (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]) => boolean;
   onStop: () => void;
   disabled: boolean;
   isStreaming: boolean;
@@ -37,7 +41,7 @@ interface ChatInputProps {
 }
 
 interface AutocompleteState {
-  trigger: "/" | "@";
+  trigger: "/" | "@" | "#";
   query: string;
   triggerIndex: number;
 }
@@ -88,7 +92,9 @@ export default function ChatInput({
   const [fileCount, setFileCount] = useState(0);
   const [autocomplete, setAutocomplete] = useState<AutocompleteState | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
+  const [fileMentions, setFileMentions] = useState<FileMention[]>([]);
   const attachmentsRef = useRef<AttachmentsContext | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const isDisconnected = connectionStatus === "disconnected";
   const isInputDisabled = disabled || isStreaming || isDisconnected;
   const canSubmit = !isInputDisabled && (value.trim().length > 0 || fileCount > 0);
@@ -111,12 +117,14 @@ export default function ChatInput({
     defaultModelId,
     thinkingLevel,
     attachmentsRef,
+    fileMentions,
     setValue,
     setThinkingEnabled,
     setPlanMode,
     setSelectedModelId,
     setThinkingLevel,
     setFileCount,
+    setFileMentions,
   });
 
   // Auto-correct model if it conflicts with the session's locked provider
@@ -131,9 +139,10 @@ export default function ChatInput({
   }, [lockedProvider, selectedModelId, models, setSelectedModelId]);
 
   const completionItems = useCompletions(wsId);
+  const filePaths = useFileCompletions(wsId);
 
   const filteredItems = useMemo(() => {
-    if (!autocomplete) return [];
+    if (!autocomplete || autocomplete.trigger === "#") return [];
     const type = autocomplete.trigger === "/" ? "slash_command" : "agent";
     return completionItems
       .filter((item) => item.type === type)
@@ -144,21 +153,35 @@ export default function ChatInput({
       );
   }, [autocomplete, completionItems]);
 
+  const fileResults = useMemo(() => {
+    if (!autocomplete || autocomplete.trigger !== "#") return [];
+    return fuzzyMatchFiles(filePaths, autocomplete.query);
+  }, [autocomplete, filePaths]);
+
   const handleChange = useCallback(
     (e: ChangeEvent<HTMLTextAreaElement>) => {
       const text = e.target.value;
       setValue(text);
 
+      // Prune mentions that no longer appear in the text
+      setFileMentions((prev) =>
+        prev.filter((m) => text.includes(`#${m.displayName}`)),
+      );
+
       const cursor = e.target.selectionStart ?? text.length;
       const beforeCursor = text.slice(0, cursor);
-      const match = beforeCursor.match(/(^|[\s])([/@])(\S*)$/);
+      const match = beforeCursor.match(/(^|[\s])([/@#])(\S*)$/);
 
-      if (match && supportsCompletions) {
-        const trigger = match[2] as "/" | "@";
-        const query = match[3];
-        const triggerIndex = beforeCursor.length - match[2].length - match[3].length;
-        setAutocomplete({ trigger, query, triggerIndex });
-        setSelectedIndex(0);
+      if (match) {
+        const trigger = match[2] as "/" | "@" | "#";
+        if (trigger === "#" || supportsCompletions) {
+          const query = match[3];
+          const triggerIndex = beforeCursor.length - match[2].length - match[3].length;
+          setAutocomplete({ trigger, query, triggerIndex });
+          setSelectedIndex(0);
+        } else {
+          setAutocomplete(null);
+        }
       } else {
         setAutocomplete(null);
       }
@@ -180,25 +203,62 @@ export default function ChatInput({
     [autocomplete, value],
   );
 
+  const selectFileItem = useCallback(
+    (result: FuzzyResult) => {
+      if (!autocomplete) return;
+      const displayName = disambiguateDisplayName(result.path, filePaths);
+      const before = value.slice(0, autocomplete.triggerIndex);
+      const after = value.slice(
+        autocomplete.triggerIndex + 1 + autocomplete.query.length,
+      );
+      const insertion = `#${displayName} `;
+      setValue(before + insertion + after);
+      setFileMentions((prev) => [
+        ...prev.filter((m) => m.relativePath !== result.path),
+        { displayName, relativePath: result.path },
+      ]);
+      setAutocomplete(null);
+    },
+    [autocomplete, value, filePaths],
+  );
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
-      if (!autocomplete || filteredItems.length === 0) return;
+      if (!autocomplete) return;
 
-      if (e.key === "ArrowDown") {
-        e.preventDefault();
-        setSelectedIndex((i) => (i + 1) % filteredItems.length);
-      } else if (e.key === "ArrowUp") {
-        e.preventDefault();
-        setSelectedIndex((i) => (i - 1 + filteredItems.length) % filteredItems.length);
-      } else if (e.key === "Enter" || e.key === "Tab") {
-        e.preventDefault();
-        selectItem(filteredItems[selectedIndex]);
-      } else if (e.key === "Escape") {
-        e.preventDefault();
-        setAutocomplete(null);
+      if (autocomplete.trigger === "#") {
+        if (fileResults.length === 0) return;
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i + 1) % fileResults.length);
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i - 1 + fileResults.length) % fileResults.length);
+        } else if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          selectFileItem(fileResults[selectedIndex]);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          setAutocomplete(null);
+        }
+      } else {
+        if (filteredItems.length === 0) return;
+        if (e.key === "ArrowDown") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i + 1) % filteredItems.length);
+        } else if (e.key === "ArrowUp") {
+          e.preventDefault();
+          setSelectedIndex((i) => (i - 1 + filteredItems.length) % filteredItems.length);
+        } else if (e.key === "Enter" || e.key === "Tab") {
+          e.preventDefault();
+          selectItem(filteredItems[selectedIndex]);
+        } else if (e.key === "Escape") {
+          e.preventDefault();
+          setAutocomplete(null);
+        }
       }
     },
-    [autocomplete, filteredItems, selectedIndex, selectItem],
+    [autocomplete, filteredItems, fileResults, selectedIndex, selectItem, selectFileItem],
   );
 
   const cycleThinkingLevel = useCallback(() => {
@@ -228,13 +288,20 @@ export default function ChatInput({
       ...(supportsThinkingLevels && { thinkingLevel }),
     };
 
-    const sent = onSend(trimmed, images, options);
+    const mentions: FileMention[] | undefined = fileMentions.length > 0
+      ? fileMentions.map((m) => ({ displayName: m.displayName, relativePath: m.relativePath }))
+      : undefined;
+
+    const sent = onSend(trimmed, images, options, mentions);
     if (!sent) throw new Error("Message send failed");
     setValue("");
+    setFileMentions([]);
     setAutocomplete(null);
   };
 
-  const showPopup = autocomplete !== null && filteredItems.length > 0;
+  const showSlashPopup = autocomplete !== null && autocomplete.trigger !== "#" && filteredItems.length > 0;
+  const showFilePopup = autocomplete !== null && autocomplete.trigger === "#" && fileResults.length > 0;
+  const showPopup = showSlashPopup || showFilePopup;
 
   const activeStyle = "bg-primary/10 text-primary ring-1 ring-primary/15 hover:bg-primary/15 hover:text-primary dark:hover:bg-primary/15";
 
@@ -246,7 +313,7 @@ export default function ChatInput({
         planMode && supportsPlanMode && "[&_[data-slot=input-group]]:!border-transparent border-dashed border-primary",
         planMode && supportsPlanMode && showPopup && "rounded-t-none border-t-0",
       )}>
-        {showPopup && (
+        {showSlashPopup && (
           <AutocompletePopup
             items={filteredItems}
             selectedIndex={selectedIndex}
@@ -255,11 +322,26 @@ export default function ChatInput({
             planMode={planMode && supportsPlanMode}
           />
         )}
+        {showFilePopup && (
+          <FileAutocompletePopup
+            items={fileResults}
+            selectedIndex={selectedIndex}
+            onSelect={selectFileItem}
+            onHover={setSelectedIndex}
+            planMode={planMode && supportsPlanMode}
+          />
+        )}
         <PromptInput onSubmit={handleSubmit} accept="image/*" multiple>
         <PromptInputBody>
           <ChatInputAttachments onFileCountChange={setFileCount} attachmentsRef={attachmentsRef} />
+          <MentionHighlightOverlay
+            value={value}
+            fileMentions={fileMentions}
+            textareaRef={textareaRef}
+          />
           <PromptInputTextarea
-            className="min-h-[100px] max-h-40 text-sm placeholder:text-muted-foreground/40"
+            ref={textareaRef}
+            className="min-h-[100px] max-h-40 bg-transparent text-sm placeholder:text-muted-foreground/40"
             placeholder={isDisconnected ? "Reconnecting..." : (customPlaceholder ?? "Send a message...")}
             value={value}
             onChange={handleChange}

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -167,7 +167,6 @@ export default function ChatInput({
       setFileMentions((prev) =>
         prev.filter((m) => text.includes(`#${m.displayName}`)),
       );
-
       const cursor = e.target.selectionStart ?? text.length;
       const beforeCursor = text.slice(0, cursor);
       const match = beforeCursor.match(/(^|[\s])([/@#])(\S*)$/);

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -1,5 +1,5 @@
-import { memo, useState } from "react";
-import type { ChatMessage as ChatMessageType, QuestionAnswer } from "@/types";
+import { memo, useState, type ReactNode } from "react";
+import type { ChatMessage as ChatMessageType, FileMention, QuestionAnswer } from "@/types";
 import { cn } from "@/lib/utils";
 import { formatElapsed } from "@/lib/time";
 import { resolveImageSrc } from "@/lib/image-url";
@@ -8,7 +8,35 @@ import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
 import { ToolCallList } from "@/components/chat/ToolCallList";
 import { CopyButton } from "@/components/chat/CopyButton";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
+import { FileIcon } from "lucide-react";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
+import { splitByFileMentions } from "@/lib/file-mentions";
+
+function renderContentWithMentions(
+  content: string,
+  mentions: FileMention[] | undefined,
+  onFileClick?: (relativePath: string) => void,
+): ReactNode {
+  if (!mentions?.length) return <p className="whitespace-pre-wrap">{content}</p>;
+
+  const segments = splitByFileMentions(content, mentions).map((segment, i) => {
+    const mention = segment.mention;
+    if (!mention) return <span key={i}>{segment.text}</span>;
+    return (
+      <button
+        key={i}
+        type="button"
+        onClick={() => onFileClick?.(mention.relativePath)}
+        className="inline-flex items-center gap-0.5 rounded bg-primary/15 px-1.5 py-0.5 text-xs font-medium text-primary hover:bg-primary/25 transition-colors"
+      >
+        <FileIcon className="size-3" />
+        {mention.displayName}
+      </button>
+    );
+  });
+
+  return <p className="whitespace-pre-wrap">{segments}</p>;
+}
 
 interface ChatMessageProps {
   message: ChatMessageType;
@@ -17,6 +45,7 @@ interface ChatMessageProps {
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onPlanApproval?: () => void;
   onHandOff?: (planContent: string, planPath?: string) => void;
+  onFileMentionClick?: (relativePath: string) => void;
 }
 
 const ChatMessage = memo(function ChatMessage({
@@ -26,6 +55,7 @@ const ChatMessage = memo(function ChatMessage({
   onQuestionAnswer,
   onPlanApproval,
   onHandOff,
+  onFileMentionClick,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
@@ -89,7 +119,7 @@ const ChatMessage = memo(function ChatMessage({
                 </Dialog>
               </>
             )}
-            {message.content && <p className="whitespace-pre-wrap">{message.content}</p>}
+            {message.content && renderContentWithMentions(message.content, message.fileMentions, onFileMentionClick)}
           </>
         ) : (
           <>

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -10,29 +10,43 @@ import { CopyButton } from "@/components/chat/CopyButton";
 import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/components/ui/dialog";
 import { FileIcon } from "lucide-react";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
-import { splitByFileMentions } from "@/lib/file-mentions";
+import { AT_MENTION_RE, splitByAllMentions } from "@/lib/file-mentions";
 
 function renderContentWithMentions(
   content: string,
   mentions: FileMention[] | undefined,
   onFileClick?: (relativePath: string) => void,
 ): ReactNode {
-  if (!mentions?.length) return <p className="whitespace-pre-wrap">{content}</p>;
+  const atMatches = content.match(AT_MENTION_RE);
+  const atMentions = atMatches ? [...new Set(atMatches)] : [];
 
-  const segments = splitByFileMentions(content, mentions).map((segment, i) => {
-    const mention = segment.mention;
-    if (!mention) return <span key={i}>{segment.text}</span>;
-    return (
-      <button
-        key={i}
-        type="button"
-        onClick={() => onFileClick?.(mention.relativePath)}
-        className="inline-flex items-center gap-0.5 rounded bg-primary/15 px-1.5 py-0.5 text-xs font-medium text-primary hover:bg-primary/25 transition-colors"
-      >
-        <FileIcon className="size-3" />
-        {mention.displayName}
-      </button>
-    );
+  if (!mentions?.length && atMentions.length === 0) return <p className="whitespace-pre-wrap">{content}</p>;
+
+  const segments = splitByAllMentions(content, mentions, atMentions).map((segment, i) => {
+    if (segment.mention) {
+      return (
+        <button
+          key={i}
+          type="button"
+          onClick={() => onFileClick?.(segment.mention!.relativePath)}
+          className="inline-flex items-center gap-0.5 rounded bg-primary/15 px-1.5 py-0.5 text-xs font-medium text-primary hover:bg-primary/25 transition-colors"
+        >
+          <FileIcon className="size-3" />
+          {segment.mention!.displayName}
+        </button>
+      );
+    }
+    if (segment.highlight) {
+      return (
+        <span
+          key={i}
+          className="rounded bg-primary/15 px-1 py-0.5 text-xs font-medium text-primary"
+        >
+          {segment.text}
+        </span>
+      );
+    }
+    return <span key={i}>{segment.text}</span>;
   });
 
   return <p className="whitespace-pre-wrap">{segments}</p>;

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -58,6 +58,7 @@ export function ConversationTabs({
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(sessions.length);
   const tabsRef = useRef<HTMLDivElement>(null);
+  const visibleSessionCount = Math.max(0, visibleCount - (openFile ? 1 : 0));
 
   const measureTabs = useCallback(() => {
     const tabsEl = tabsRef.current;
@@ -86,7 +87,7 @@ export function ConversationTabs({
 
   useEffect(() => {
     measureTabs();
-  }, [sessions.length, measureTabs]);
+  }, [sessions, openFile, measureTabs]);
 
   useEffect(() => {
     const el = tabsRef.current;
@@ -96,7 +97,7 @@ export function ConversationTabs({
     return () => observer.disconnect();
   }, [measureTabs]);
 
-  const overflowSessions = sessions.slice(visibleCount);
+  const overflowSessions = sessions.slice(visibleSessionCount);
 
   return (
     <>
@@ -154,7 +155,7 @@ export function ConversationTabs({
           )}
           {sessions.map((session, i) => {
             const isActive = session.sessionId === activeSessionId;
-            const isVisible = i < visibleCount;
+            const isVisible = i < visibleSessionCount;
             const title = getTabTitle(session);
             const isSessionStreaming = streamingSessions?.[session.sessionId] ?? (isActive && isStreaming);
             const isSessionUnread = !isActive && !isSessionStreaming && !!unreadSessions?.[session.sessionId];

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -40,6 +40,74 @@ function getTabTitle(session: SessionMetadata): string {
   return session.title || "Untitled";
 }
 
+function getSessionVisualState({
+  sessionId,
+  activeSessionId,
+  isStreaming,
+  isFileActive,
+  streamingSessions,
+  unreadSessions,
+}: {
+  sessionId: string;
+  activeSessionId?: string;
+  isStreaming: boolean;
+  isFileActive?: boolean;
+  streamingSessions?: Record<string, boolean>;
+  unreadSessions?: Record<string, boolean>;
+}) {
+  const isActive = sessionId === activeSessionId;
+  const isSessionVisible = isActive && !isFileActive;
+  const isSessionStreaming = Boolean(streamingSessions?.[sessionId] ?? (isActive && isStreaming));
+  const isSessionUnread = !isSessionVisible && !isSessionStreaming && Boolean(unreadSessions?.[sessionId]);
+
+  return { isActive, isSessionStreaming, isSessionUnread };
+}
+
+function SessionStatusIndicator({
+  isStreaming,
+  isUnread,
+}: {
+  isStreaming: boolean;
+  isUnread: boolean;
+}) {
+  if (isStreaming) {
+    return (
+      <div className="flex size-3 shrink-0 items-center justify-center overflow-visible">
+        <AgentActivityPreview size="small" />
+      </div>
+    );
+  }
+  if (isUnread) {
+    return <span className="size-2 shrink-0 rounded-full bg-primary" />;
+  }
+  return <MessageSquareIcon className="size-3 shrink-0" />;
+}
+
+function TabCloseAction({ onClose }: { onClose: () => void }) {
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      className={cn(
+        "ml-auto shrink-0 rounded p-0.5 text-muted-foreground/50",
+        "hover:bg-destructive/10 hover:text-destructive",
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        onClose();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.stopPropagation();
+          onClose();
+        }
+      }}
+    >
+      <XIcon className="size-3" />
+    </span>
+  );
+}
+
 export function ConversationTabs({
   sessions,
   activeSessionId,
@@ -116,26 +184,7 @@ export function ConversationTabs({
             >
               <FileIcon className="size-3 shrink-0" />
               <span className="truncate">{openFile.split("/").pop()}</span>
-              <span
-                role="button"
-                tabIndex={0}
-                className={cn(
-                  "ml-auto shrink-0 rounded p-0.5 text-muted-foreground/50",
-                  "hover:bg-destructive/10 hover:text-destructive",
-                )}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onFileTabClose?.();
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter" || e.key === " ") {
-                    e.stopPropagation();
-                    onFileTabClose?.();
-                  }
-                }}
-              >
-                <XIcon className="size-3" />
-              </span>
+              <TabCloseAction onClose={() => onFileTabClose?.()} />
             </button>
           )}
           {sessions.length === 0 && (
@@ -154,11 +203,16 @@ export function ConversationTabs({
             </button>
           )}
           {sessions.map((session, i) => {
-            const isActive = session.sessionId === activeSessionId;
+            const { isActive, isSessionStreaming, isSessionUnread } = getSessionVisualState({
+              sessionId: session.sessionId,
+              activeSessionId,
+              isStreaming,
+              isFileActive,
+              streamingSessions,
+              unreadSessions,
+            });
             const isVisible = i < visibleSessionCount;
             const title = getTabTitle(session);
-            const isSessionStreaming = streamingSessions?.[session.sessionId] ?? (isActive && isStreaming);
-            const isSessionUnread = !isActive && !isSessionStreaming && !!unreadSessions?.[session.sessionId];
 
             return (
               <button
@@ -173,37 +227,10 @@ export function ConversationTabs({
                 )}
                 onClick={() => onActivateSession(session.sessionId)}
               >
-                {isSessionStreaming ? (
-                  <div className="flex size-3 shrink-0 items-center justify-center overflow-visible">
-                    <AgentActivityPreview size="small" />
-                  </div>
-                ) : isSessionUnread ? (
-                  <span className="size-2 shrink-0 rounded-full bg-primary" />
-                ) : (
-                  <MessageSquareIcon className="size-3 shrink-0" />
-                )}
+                <SessionStatusIndicator isStreaming={isSessionStreaming} isUnread={isSessionUnread} />
                 <span className="truncate">{title}</span>
                 {sessions.length > 1 && !isSessionStreaming && (
-                  <span
-                    role="button"
-                    tabIndex={0}
-                    className={cn(
-                      "ml-auto shrink-0 rounded p-0.5 text-muted-foreground/50",
-                      "hover:bg-destructive/10 hover:text-destructive",
-                    )}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setDeleteTarget(session.sessionId);
-                    }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.stopPropagation();
-                        setDeleteTarget(session.sessionId);
-                      }
-                    }}
-                  >
-                    <XIcon className="size-3" />
-                  </span>
+                  <TabCloseAction onClose={() => setDeleteTarget(session.sessionId)} />
                 )}
               </button>
             );
@@ -222,10 +249,15 @@ export function ConversationTabs({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="w-56">
               {overflowSessions.map((session) => {
-                const isActive = session.sessionId === activeSessionId;
+                const { isActive, isSessionStreaming: isOverflowStreaming, isSessionUnread: isOverflowUnread } = getSessionVisualState({
+                  sessionId: session.sessionId,
+                  activeSessionId,
+                  isStreaming,
+                  isFileActive,
+                  streamingSessions,
+                  unreadSessions,
+                });
                 const title = getTabTitle(session);
-                const isOverflowStreaming = streamingSessions?.[session.sessionId] ?? (isActive && isStreaming);
-                const isOverflowUnread = !isActive && !isOverflowStreaming && !!unreadSessions?.[session.sessionId];
 
                 return (
                   <DropdownMenuItem
@@ -233,15 +265,10 @@ export function ConversationTabs({
                     className="flex items-center gap-2"
                     onSelect={() => onActivateSession(session.sessionId)}
                   >
-                    {isOverflowStreaming ? (
-                      <div className="flex size-3 shrink-0 items-center justify-center overflow-visible">
-                        <AgentActivityPreview size="small" />
-                      </div>
-                    ) : isOverflowUnread ? (
-                      <span className="size-2 shrink-0 rounded-full bg-primary" />
-                    ) : (
-                      <MessageSquareIcon className="size-3 shrink-0" />
-                    )}
+                    <SessionStatusIndicator
+                      isStreaming={isOverflowStreaming}
+                      isUnread={isOverflowUnread}
+                    />
                     <span className="flex-1 truncate text-xs">{title}</span>
                     {isActive && (
                       <span className="size-1.5 shrink-0 rounded-full bg-primary" />

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -84,16 +84,17 @@ export function AutocompletePopup({
               {SOURCE_LABELS[source] ?? source}
             </div>
           )}
+          <div className="p-1">
           {groupItems.map(({ item, globalIndex }) => (
             <button
               key={`${item.source}-${item.name}`}
               ref={globalIndex === selectedIndex ? selectedRef : undefined}
               type="button"
               className={cn(
-                "flex w-full items-baseline gap-2 px-3 py-1.5 text-left text-sm transition-colors",
+                "flex w-full items-baseline gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors",
                 globalIndex === selectedIndex
-                  ? "bg-accent text-accent-foreground"
-                  : "text-foreground hover:bg-accent/50",
+                  ? "bg-primary/10 text-primary"
+                  : "text-foreground hover:bg-white/[0.04]",
               )}
               onMouseDown={(e) => {
                 e.preventDefault(); // Prevent textarea blur
@@ -103,12 +104,16 @@ export function AutocompletePopup({
             >
               <span className="shrink-0 font-medium">{item.label}</span>
               {item.description && (
-                <span className="truncate text-xs text-muted-foreground">
+                <span className={cn(
+                  "truncate text-xs",
+                  globalIndex === selectedIndex ? "text-primary/60" : "text-muted-foreground",
+                )}>
                   {item.description}
                 </span>
               )}
             </button>
           ))}
+          </div>
         </div>
       ))}
     </div>

--- a/frontend/src/components/chat/FileAutocompletePopup.tsx
+++ b/frontend/src/components/chat/FileAutocompletePopup.tsx
@@ -39,20 +39,22 @@ export function FileAutocompletePopup({
       <div className="sticky top-0 bg-black/5 dark:bg-[color-mix(in_srgb,var(--background),white_6%)] px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
         Files
       </div>
+      <div className="p-1">
       {items.map((item, i) => {
         const dirPath = item.path.includes("/")
           ? item.path.slice(0, item.path.lastIndexOf("/"))
           : "";
+        const isSelected = i === selectedIndex;
         return (
           <button
             key={item.path}
-            ref={i === selectedIndex ? selectedRef : undefined}
+            ref={isSelected ? selectedRef : undefined}
             type="button"
             className={cn(
-              "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
-              i === selectedIndex
-                ? "bg-accent text-accent-foreground"
-                : "text-foreground hover:bg-accent/50",
+              "flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-left text-sm transition-colors",
+              isSelected
+                ? "bg-primary/10 text-primary"
+                : "text-foreground hover:bg-white/[0.04]",
             )}
             onMouseDown={(e) => {
               e.preventDefault();
@@ -60,16 +62,17 @@ export function FileAutocompletePopup({
             }}
             onMouseEnter={() => onHover(i)}
           >
-            <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <FileIcon className={cn("size-3.5 shrink-0", isSelected ? "text-primary/60" : "text-muted-foreground")} />
             <span className="shrink-0 font-medium">{item.basename}</span>
             {dirPath && (
-              <span className="truncate text-xs text-muted-foreground">
+              <span className={cn("truncate text-xs", isSelected ? "text-primary/60" : "text-muted-foreground")}>
                 {dirPath}
               </span>
             )}
           </button>
         );
       })}
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/FileAutocompletePopup.tsx
+++ b/frontend/src/components/chat/FileAutocompletePopup.tsx
@@ -1,0 +1,75 @@
+import { useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { FileIcon } from "lucide-react";
+import type { FuzzyResult } from "@/lib/fuzzy-match";
+
+interface FileAutocompletePopupProps {
+  items: FuzzyResult[];
+  selectedIndex: number;
+  onSelect: (item: FuzzyResult) => void;
+  onHover: (index: number) => void;
+  planMode?: boolean;
+}
+
+export function FileAutocompletePopup({
+  items,
+  selectedIndex,
+  onSelect,
+  onHover,
+  planMode,
+}: FileAutocompletePopupProps) {
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  if (items.length === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        "absolute bottom-full -left-px -right-px z-50 max-h-[240px] overflow-y-auto rounded-t-md border border-b-0 bg-background dark:bg-[var(--input-group-bg)] shadow-lg",
+        planMode ? "border-dashed border-primary" : "border-border/30",
+      )}
+      style={{
+        "--input-group-bg": "color-mix(in srgb, var(--background), white 3%)",
+      } as React.CSSProperties}
+    >
+      <div className="sticky top-0 bg-black/5 dark:bg-[color-mix(in_srgb,var(--background),white_6%)] px-3 py-1.5 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        Files
+      </div>
+      {items.map((item, i) => {
+        const dirPath = item.path.includes("/")
+          ? item.path.slice(0, item.path.lastIndexOf("/"))
+          : "";
+        return (
+          <button
+            key={item.path}
+            ref={i === selectedIndex ? selectedRef : undefined}
+            type="button"
+            className={cn(
+              "flex w-full items-center gap-2 px-3 py-1.5 text-left text-sm transition-colors",
+              i === selectedIndex
+                ? "bg-accent text-accent-foreground"
+                : "text-foreground hover:bg-accent/50",
+            )}
+            onMouseDown={(e) => {
+              e.preventDefault();
+              onSelect(item);
+            }}
+            onMouseEnter={() => onHover(i)}
+          >
+            <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="shrink-0 font-medium">{item.basename}</span>
+            {dirPath && (
+              <span className="truncate text-xs text-muted-foreground">
+                {dirPath}
+              </span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/chat/MentionHighlightOverlay.tsx
+++ b/frontend/src/components/chat/MentionHighlightOverlay.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, type RefObject } from "react";
+import { useEffect, useMemo, useRef, type RefObject } from "react";
 import type { FileMention } from "@/types";
-import { splitByFileMentions } from "@/lib/file-mentions";
+import { AT_MENTION_RE, splitByAllMentions } from "@/lib/file-mentions";
 
 interface MentionHighlightOverlayProps {
   value: string;
@@ -15,6 +15,14 @@ export function MentionHighlightOverlay({
 }: MentionHighlightOverlayProps) {
   const overlayRef = useRef<HTMLDivElement>(null);
 
+  // Auto-detect @mentions directly from the text
+  const atMentions = useMemo(() => {
+    const matches = value.match(AT_MENTION_RE);
+    return matches ? [...new Set(matches)] : [];
+  }, [value]);
+
+  const totalMentions = fileMentions.length + atMentions.length;
+
   useEffect(() => {
     const textarea = textareaRef.current;
     const overlay = overlayRef.current;
@@ -28,12 +36,12 @@ export function MentionHighlightOverlay({
     syncScroll();
     textarea.addEventListener("scroll", syncScroll);
     return () => textarea.removeEventListener("scroll", syncScroll);
-  }, [textareaRef, fileMentions.length]);
+  }, [textareaRef, totalMentions]);
 
-  if (fileMentions.length === 0) return null;
+  if (totalMentions === 0) return null;
 
-  const segments = splitByFileMentions(value, fileMentions);
-  if (segments.every((s) => !s.mention)) return null;
+  const segments = splitByAllMentions(value, fileMentions, atMentions);
+  if (segments.every((s) => !s.highlight)) return null;
 
   return (
     <div
@@ -43,7 +51,7 @@ export function MentionHighlightOverlay({
       aria-hidden="true"
     >
       {segments.map((seg, i) =>
-        seg.mention ? (
+        seg.highlight ? (
           <mark
             key={i}
             className="rounded-sm bg-primary/15 text-transparent"

--- a/frontend/src/components/chat/MentionHighlightOverlay.tsx
+++ b/frontend/src/components/chat/MentionHighlightOverlay.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, type RefObject } from "react";
+import type { FileMention } from "@/types";
+import { splitByFileMentions } from "@/lib/file-mentions";
+
+interface MentionHighlightOverlayProps {
+  value: string;
+  fileMentions: FileMention[];
+  textareaRef: RefObject<HTMLTextAreaElement | null>;
+}
+
+export function MentionHighlightOverlay({
+  value,
+  fileMentions,
+  textareaRef,
+}: MentionHighlightOverlayProps) {
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const textarea = textareaRef.current;
+    const overlay = overlayRef.current;
+    if (!textarea || !overlay) return;
+
+    const syncScroll = () => {
+      overlay.scrollTop = textarea.scrollTop;
+      overlay.scrollLeft = textarea.scrollLeft;
+    };
+
+    syncScroll();
+    textarea.addEventListener("scroll", syncScroll);
+    return () => textarea.removeEventListener("scroll", syncScroll);
+  }, [textareaRef, fileMentions.length]);
+
+  if (fileMentions.length === 0) return null;
+
+  const segments = splitByFileMentions(value, fileMentions);
+  if (segments.every((s) => !s.mention)) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-3 py-3 text-sm leading-normal"
+      style={{ wordWrap: "break-word" }}
+      aria-hidden="true"
+    >
+      {segments.map((seg, i) =>
+        seg.mention ? (
+          <mark
+            key={i}
+            className="rounded-sm bg-primary/15 text-transparent"
+          >
+            {seg.text}
+          </mark>
+        ) : (
+          <span key={i} className="text-transparent">
+            {seg.text}
+          </span>
+        ),
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useChatInputDraftPersistence.ts
+++ b/frontend/src/hooks/useChatInputDraftPersistence.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, type MutableRefObject } from "react";
+import { useCallback, useEffect, useRef, type MutableRefObject, type Dispatch, type SetStateAction } from "react";
 import type { AttachmentsContext } from "@/components/ai-elements/prompt-input";
-import type { ThinkingLevel } from "@/types";
+import type { FileMention, ThinkingLevel } from "@/types";
 
 interface DraftState {
   value: string;
@@ -9,6 +9,7 @@ interface DraftState {
   selectedModelId: string;
   thinkingLevel: ThinkingLevel;
   files: AttachmentsContext["files"];
+  fileMentions: FileMention[];
 }
 
 interface UseChatInputDraftPersistenceParams {
@@ -21,12 +22,14 @@ interface UseChatInputDraftPersistenceParams {
   defaultModelId: string;
   thinkingLevel: ThinkingLevel;
   attachmentsRef: MutableRefObject<AttachmentsContext | null>;
+  fileMentions: FileMention[];
   setValue: (value: string) => void;
   setThinkingEnabled: (value: boolean) => void;
   setPlanMode: (value: boolean) => void;
   setSelectedModelId: (value: string) => void;
   setThinkingLevel: (value: ThinkingLevel) => void;
   setFileCount: (count: number) => void;
+  setFileMentions: Dispatch<SetStateAction<FileMention[]>>;
 }
 
 const DEFAULT_WORKSPACE_DRAFT_KEY = "__workspace_default__";
@@ -66,6 +69,7 @@ function hasPersistableDraft(draft: DraftState): boolean {
   return (
     draft.value.trim().length > 0 ||
     draft.files.length > 0 ||
+    draft.fileMentions.length > 0 ||
     draft.planMode ||
     !draft.thinkingEnabled
   );
@@ -103,12 +107,14 @@ export function useChatInputDraftPersistence({
   defaultModelId,
   thinkingLevel,
   attachmentsRef,
+  fileMentions,
   setValue,
   setThinkingEnabled,
   setPlanMode,
   setSelectedModelId,
   setThinkingLevel,
   setFileCount,
+  setFileMentions,
 }: UseChatInputDraftPersistenceParams) {
   const prevSessionIdRef = useRef<string | undefined>(sessionId);
   const prevWsIdRef = useRef<string | undefined>(wsId);
@@ -124,6 +130,8 @@ export function useChatInputDraftPersistence({
   thinkingLevelRef.current = thinkingLevel;
   const defaultModelIdRef = useRef(defaultModelId);
   defaultModelIdRef.current = defaultModelId;
+  const fileMentionsRef = useRef(fileMentions);
+  fileMentionsRef.current = fileMentions;
 
   const saveDraftForSession = useCallback((
     targetSessionId: string | undefined,
@@ -138,6 +146,7 @@ export function useChatInputDraftPersistence({
       selectedModelId: selectedModelIdRef.current,
       thinkingLevel: thinkingLevelRef.current,
       files: [...files],
+      fileMentions: [...fileMentionsRef.current],
     }, options?.allowDelete ?? true);
   }, [attachmentsRef, wsId]);
 
@@ -168,6 +177,7 @@ export function useChatInputDraftPersistence({
       setThinkingLevel(draft.thinkingLevel);
       attachmentsRef.current?.restore([...draft.files]);
       setFileCount(draft.files.length);
+      setFileMentions(draft.fileMentions ?? []);
     } else if (sessionId) {
       setValue("");
       setThinkingEnabled(true);
@@ -175,6 +185,7 @@ export function useChatInputDraftPersistence({
       if (defaultModelIdRef.current) setSelectedModelId(defaultModelIdRef.current);
       attachmentsRef.current?.restore([]);
       setFileCount(0);
+      setFileMentions([]);
     }
 
     prevSessionIdRef.current = sessionId;
@@ -189,6 +200,7 @@ export function useChatInputDraftPersistence({
     setSelectedModelId,
     setThinkingLevel,
     setFileCount,
+    setFileMentions,
   ]);
 
   useEffect(() => {

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,5 +1,5 @@
 import { useEffect, useCallback, useReducer, useRef, useSyncExternalStore } from "react";
-import type { ChatMessage, ImageAttachment, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer, QuestionInput } from "@/types";
+import type { ChatMessage, FileMention, ImageAttachment, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer, QuestionInput } from "@/types";
 import { wsTransport } from "@/lib/ws-transport";
 import type { HistoryMessage } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
@@ -549,6 +549,7 @@ export function useConversation(workspaceId: string | undefined) {
     images?: ImageAttachment[],
     options?: MessageOptions,
     sessionId?: string,
+    fileMentions?: FileMention[],
   ): boolean => {
     if (!workspaceId) {
       dispatch({ type: "error", message: "Message not sent: no workspace selected." });
@@ -559,6 +560,7 @@ export function useConversation(workspaceId: string | undefined) {
       type: "user_message",
       content,
       images: images?.length ? images : undefined,
+      fileMentions: fileMentions?.length ? fileMentions : undefined,
       options,
       ...sessionIdField(targetSessionId),
     });

--- a/frontend/src/hooks/useFileCompletions.ts
+++ b/frontend/src/hooks/useFileCompletions.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "./useApi";
+
+interface FileCompletionsResponse {
+  files: string[];
+}
+
+export function useFileCompletions(wsId: string | undefined): string[] {
+  const query = useQuery({
+    queryKey: ["file-completions", wsId],
+    queryFn: () =>
+      api.get<FileCompletionsResponse>(`/api/workspaces/${wsId}/file-completions`),
+    enabled: !!wsId,
+    staleTime: 2 * 60 * 1000,
+    retry: 0,
+  });
+
+  return query.data?.files ?? [];
+}

--- a/frontend/src/hooks/useWsCacheInvalidation.ts
+++ b/frontend/src/hooks/useWsCacheInvalidation.ts
@@ -28,6 +28,7 @@ export function useWsCacheInvalidation(workspaceIds: string[]): void {
             // Files were created/modified/deleted by Claude.
             void queryClient.invalidateQueries({ queryKey: ["files", wsId] });
             void queryClient.invalidateQueries({ queryKey: ["diff-stat", wsId] });
+            void queryClient.invalidateQueries({ queryKey: ["file-completions", wsId] });
             break;
 
           case "status":

--- a/frontend/src/lib/file-mentions.ts
+++ b/frontend/src/lib/file-mentions.ts
@@ -1,0 +1,48 @@
+import type { FileMention } from "@/types";
+
+export interface MentionChunk {
+  text: string;
+  mention?: FileMention;
+}
+
+export function splitByFileMentions(content: string, mentions: FileMention[] | undefined): MentionChunk[] {
+  if (!mentions?.length) return [{ text: content }];
+
+  const chunks: MentionChunk[] = [];
+  let cursor = 0;
+
+  while (cursor < content.length) {
+    let nextIndex = -1;
+    let nextMention: FileMention | undefined;
+
+    for (const mention of mentions) {
+      const needle = `#${mention.displayName}`;
+      const idx = content.indexOf(needle, cursor);
+      if (idx === -1) continue;
+
+      if (
+        nextIndex === -1
+        || idx < nextIndex
+        || (idx === nextIndex && nextMention && needle.length > `#${nextMention.displayName}`.length)
+      ) {
+        nextIndex = idx;
+        nextMention = mention;
+      }
+    }
+
+    if (nextIndex === -1 || !nextMention) {
+      chunks.push({ text: content.slice(cursor) });
+      break;
+    }
+
+    if (nextIndex > cursor) {
+      chunks.push({ text: content.slice(cursor, nextIndex) });
+    }
+
+    const mentionText = `#${nextMention.displayName}`;
+    chunks.push({ text: mentionText, mention: nextMention });
+    cursor = nextIndex + mentionText.length;
+  }
+
+  return chunks.length > 0 ? chunks : [{ text: content }];
+}

--- a/frontend/src/lib/file-mentions.ts
+++ b/frontend/src/lib/file-mentions.ts
@@ -1,48 +1,67 @@
 import type { FileMention } from "@/types";
 
+/** Match @mention tokens: must start after whitespace or beginning of string. */
+export const AT_MENTION_RE = /(?:^|(?<=\s))@[\w][\w-]*/g;
+
 export interface MentionChunk {
   text: string;
   mention?: FileMention;
+  highlight?: boolean;
 }
 
-export function splitByFileMentions(content: string, mentions: FileMention[] | undefined): MentionChunk[] {
-  if (!mentions?.length) return [{ text: content }];
+interface HighlightTarget {
+  needle: string;
+  mention?: FileMention;
+}
+
+function splitByTargets(content: string, targets: HighlightTarget[]): MentionChunk[] {
+  if (targets.length === 0) return [{ text: content }];
 
   const chunks: MentionChunk[] = [];
   let cursor = 0;
 
   while (cursor < content.length) {
-    let nextIndex = -1;
-    let nextMention: FileMention | undefined;
+    let bestIndex = -1;
+    let bestTarget: HighlightTarget | undefined;
 
-    for (const mention of mentions) {
-      const needle = `#${mention.displayName}`;
-      const idx = content.indexOf(needle, cursor);
+    for (const target of targets) {
+      const idx = content.indexOf(target.needle, cursor);
       if (idx === -1) continue;
 
       if (
-        nextIndex === -1
-        || idx < nextIndex
-        || (idx === nextIndex && nextMention && needle.length > `#${nextMention.displayName}`.length)
+        bestIndex === -1
+        || idx < bestIndex
+        || (idx === bestIndex && bestTarget && target.needle.length > bestTarget.needle.length)
       ) {
-        nextIndex = idx;
-        nextMention = mention;
+        bestIndex = idx;
+        bestTarget = target;
       }
     }
 
-    if (nextIndex === -1 || !nextMention) {
+    if (bestIndex === -1 || !bestTarget) {
       chunks.push({ text: content.slice(cursor) });
       break;
     }
 
-    if (nextIndex > cursor) {
-      chunks.push({ text: content.slice(cursor, nextIndex) });
+    if (bestIndex > cursor) {
+      chunks.push({ text: content.slice(cursor, bestIndex) });
     }
 
-    const mentionText = `#${nextMention.displayName}`;
-    chunks.push({ text: mentionText, mention: nextMention });
-    cursor = nextIndex + mentionText.length;
+    chunks.push({ text: bestTarget.needle, mention: bestTarget.mention, highlight: true });
+    cursor = bestIndex + bestTarget.needle.length;
   }
 
   return chunks.length > 0 ? chunks : [{ text: content }];
+}
+
+export function splitByAllMentions(
+  content: string,
+  fileMentions: FileMention[] | undefined,
+  agentMentions: string[] | undefined,
+): MentionChunk[] {
+  const targets: HighlightTarget[] = [
+    ...(fileMentions ?? []).map((m) => ({ needle: `#${m.displayName}`, mention: m })),
+    ...(agentMentions ?? []).map((name) => ({ needle: name })),
+  ];
+  return splitByTargets(content, targets);
 }

--- a/frontend/src/lib/fuzzy-match.ts
+++ b/frontend/src/lib/fuzzy-match.ts
@@ -1,0 +1,77 @@
+export interface FuzzyResult {
+  path: string;
+  basename: string;
+  score: number;
+}
+
+function getBasename(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx >= 0 ? path.slice(idx + 1) : path;
+}
+
+function fuzzyCharMatch(text: string, query: string): number {
+  let qi = 0;
+  for (let ti = 0; ti < text.length && qi < query.length; ti++) {
+    if (text[ti].toLowerCase() === query[qi].toLowerCase()) qi++;
+  }
+  return qi === query.length ? 1 : 0;
+}
+
+export function fuzzyMatchFiles(files: string[], query: string, limit = 15): FuzzyResult[] {
+  if (!query) {
+    return files.slice(0, limit).map((path) => ({
+      path,
+      basename: getBasename(path),
+      score: 0,
+    }));
+  }
+
+  const lowerQuery = query.toLowerCase();
+  const results: FuzzyResult[] = [];
+
+  for (const path of files) {
+    const basename = getBasename(path);
+    const lowerBasename = basename.toLowerCase();
+    const lowerPath = path.toLowerCase();
+
+    let score = 0;
+
+    if (lowerBasename === lowerQuery) {
+      score = 100;
+    } else if (lowerBasename.startsWith(lowerQuery)) {
+      score = 80;
+    } else if (lowerBasename.includes(lowerQuery)) {
+      score = 60;
+    } else if (lowerPath.includes(lowerQuery)) {
+      score = 40;
+    } else if (fuzzyCharMatch(lowerPath, lowerQuery)) {
+      score = 20;
+    }
+
+    if (score > 0) {
+      results.push({ path, basename, score });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score || a.path.length - b.path.length);
+  return results.slice(0, limit);
+}
+
+export function disambiguateDisplayName(selectedPath: string, allFiles: string[]): string {
+  const basename = getBasename(selectedPath);
+  const duplicates = allFiles.filter((f) => getBasename(f) === basename);
+  if (duplicates.length <= 1) return basename;
+
+  const selectedParts = selectedPath.split("/");
+  for (let depth = 2; depth <= selectedParts.length; depth++) {
+    const candidate = selectedParts.slice(-depth).join("/");
+    const others = duplicates.filter((f) => f !== selectedPath);
+    const isUnique = others.every((f) => {
+      const parts = f.split("/");
+      return parts.slice(-depth).join("/") !== candidate;
+    });
+    if (isUnique) return candidate;
+  }
+
+  return selectedPath;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -236,13 +236,14 @@ export default function WorkspaceView() {
     switchCounter,
   } = useConversation(wsId);
 
-  // Clear unread for the active session reactively (handles done/cancelled
-  // events arriving while the user is already viewing this conversation).
+  // Clear unread only when the active conversation is actually visible.
+  // If the file tab is open, keep unread state so the tab can show a dot.
   useEffect(() => {
+    if (activeTab !== "conversation") return;
     if (wsId && sessionId && liveData[wsId]?.unreadSessions?.[sessionId]) {
       clearUnread(wsId, sessionId);
     }
-  }, [wsId, sessionId, liveData, clearUnread]);
+  }, [activeTab, wsId, sessionId, liveData, clearUnread]);
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
 

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -45,7 +45,7 @@ import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput } from "@/lib/plan-state";
 import { useScripts } from "@/hooks/useScripts";
-import type { DiffStatResponse, ImageAttachment, MessageOptions, Workspace, WorkspaceFileTreeNode } from "@/types";
+import type { DiffStatResponse, FileMention, ImageAttachment, MessageOptions, Workspace, WorkspaceFileTreeNode } from "@/types";
 
 const DEFAULT_EXPANDED = new Set<string>();
 
@@ -310,8 +310,8 @@ export default function WorkspaceView() {
   }, [createSession, switchSession]);
 
   const handleActivateSession = useCallback((targetSessionId: string) => {
-    if (targetSessionId === sessionId) return;
     setActiveTab("conversation");
+    if (targetSessionId === sessionId) return;
     switchSession(targetSessionId);
     if (wsId) clearUnread(wsId, targetSessionId);
   }, [sessionId, switchSession, wsId, clearUnread]);
@@ -364,12 +364,12 @@ export default function WorkspaceView() {
   });
 
   const handleSend = useCallback(
-    (content: string, images?: ImageAttachment[], options?: MessageOptions): boolean => {
+    (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]): boolean => {
       if (hasPendingPlan && hasPendingExitPlanInput) {
         rejectToolInput(content);
         return true;
       }
-      return sendMessage(content, images, options);
+      return sendMessage(content, images, options, undefined, fileMentions);
     },
     [hasPendingPlan, hasPendingExitPlanInput, rejectToolInput, sendMessage],
   );
@@ -502,6 +502,7 @@ export default function WorkspaceView() {
               onQuestionAnswer={answerQuestion}
               onPlanApproval={approvePlan}
               onHandOff={handleHandOff}
+              onFileMentionClick={handleFileTreeSelect}
               workspaceName={workspace?.name}
               projectName={workspace?.projectName}
               branch={displayBranch}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -88,6 +88,13 @@ export interface ImageAttachment {
   dataUrl: string;
 }
 
+// ── File mention type ───────────────────────────────────────────────
+
+export interface FileMention {
+  displayName: string;   // e.g. "git.ts" or "api/index.ts" (disambiguated)
+  relativePath: string;  // e.g. "src/utils/git.ts"
+}
+
 // ── Session / Chat types ────────────────────────────────────────────
 
 export interface SessionMetadata {
@@ -115,6 +122,7 @@ export interface ChatMessage {
   role: "user" | "assistant";
   content: string;
   images?: ImageAttachment[];
+  fileMentions?: FileMention[];
   toolCalls?: ToolCall[];
   thinkingContent?: string;
   timestamp: string;
@@ -261,7 +269,7 @@ export interface ModelCatalogResponse {
 /** Frontend -> Backend */
 export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
-  | { type: "user_message"; content: string; images?: ImageAttachment[]; options?: MessageOptions; sessionId?: string }
+  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };
 

--- a/frontend/tests/components/AutocompletePopup.test.tsx
+++ b/frontend/tests/components/AutocompletePopup.test.tsx
@@ -108,8 +108,8 @@ describe("AutocompletePopup", () => {
     const selected = screen.getByRole("button", { name: /\/deploy/i });
     const unselected = screen.getByRole("button", { name: /\/help/i });
 
-    expect(selected.className).toContain("bg-accent");
-    expect(unselected.className).toContain("hover:bg-accent/50");
+    expect(selected.className).toContain("bg-primary/10");
+    expect(unselected.className).toContain("hover:bg-white/[0.04]");
   });
 
   it("calls onSelect on mousedown and prevents default", () => {

--- a/frontend/tests/components/ChatInput.autocomplete.test.tsx
+++ b/frontend/tests/components/ChatInput.autocomplete.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/hooks/useCompletions", () => ({
   useCompletions: vi.fn(),
 }));
 
+vi.mock("@/hooks/useFileCompletions", () => ({
+  useFileCompletions: () => [],
+}));
+
 vi.mock("@/hooks/useModels", () => ({
   useModels: vi.fn(() => ({
     models: [],

--- a/frontend/tests/components/ChatInput.persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.persistence.test.tsx
@@ -8,6 +8,10 @@ vi.mock("@/hooks/useCompletions", () => ({
   useCompletions: () => [],
 }));
 
+vi.mock("@/hooks/useFileCompletions", () => ({
+  useFileCompletions: () => [],
+}));
+
 vi.mock("@/hooks/useApi", () => ({
   api: {
     get: vi.fn(
@@ -206,7 +210,7 @@ describe("ChatInput draft persistence", () => {
     expect(onSend).toHaveBeenLastCalledWith("session b", undefined, {
       planMode: false,
       thinkingEnabled: true,
-    });
+    }, undefined);
 
     rerenderChatInput(rerender, { sessionId: sessionA, onSend });
     await user.type(getInput(), "session a");
@@ -215,7 +219,7 @@ describe("ChatInput draft persistence", () => {
     expect(onSend).toHaveBeenLastCalledWith("session a", undefined, {
       planMode: true,
       thinkingEnabled: false,
-    });
+    }, undefined);
   });
 
   it("removes empty drafts after session switch", () => {

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -64,7 +64,7 @@ describe("ChatInput", () => {
     await user.type(screen.getByPlaceholderText("Send a message..."), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true });
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true }, undefined);
   });
 
   it("sends message on Enter without Shift", async () => {
@@ -73,7 +73,7 @@ describe("ChatInput", () => {
 
     await user.type(screen.getByPlaceholderText("Send a message..."), "hello{enter}");
 
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true });
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true }, undefined);
   });
 
   it("does not send on Shift+Enter", async () => {
@@ -94,7 +94,7 @@ describe("ChatInput", () => {
     await user.type(screen.getByPlaceholderText("Send a message..."), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: true, thinkingEnabled: false });
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: true, thinkingEnabled: false }, undefined);
   });
 
   it("restores default options when toggles are clicked twice", async () => {
@@ -108,7 +108,7 @@ describe("ChatInput", () => {
     await user.type(screen.getByPlaceholderText("Send a message..."), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true });
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true }, undefined);
   });
 
   it("shows stop button and calls onStop while streaming", async () => {
@@ -138,7 +138,7 @@ describe("ChatInput", () => {
     await user.type(input, "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true });
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true }, undefined);
     expect(input).toHaveValue("hello");
   });
 

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -424,4 +424,30 @@ describe("ConversationTabs — file tab", () => {
     const svg = fileTab.querySelector("svg");
     expect(svg).toBeInTheDocument();
   });
+
+  it("keeps all conversation tabs reachable via overflow when file tab consumes visible width", async () => {
+    const user = userEvent.setup();
+    const clientWidthSpy = vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(50);
+    const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(50);
+
+    try {
+      renderTabs({ openFile: "src/app.ts", isFileActive: true });
+
+      const overflowTrigger = await waitFor(() => {
+        const trigger = (
+          document.querySelector("svg.lucide-more-horizontal")?.closest("button")
+          ?? document.querySelector("svg.lucide-ellipsis")?.closest("button")
+        ) as HTMLButtonElement | null;
+        expect(trigger).toBeTruthy();
+        return trigger as HTMLButtonElement;
+      });
+
+      await user.click(overflowTrigger);
+      expect(await screen.findByRole("menuitem", { name: /First conversation/i })).toBeInTheDocument();
+      expect(await screen.findByRole("menuitem", { name: /Second conversation/i })).toBeInTheDocument();
+    } finally {
+      clientWidthSpy.mockRestore();
+      scrollWidthSpy.mockRestore();
+    }
+  });
 });

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -274,6 +274,17 @@ describe("ConversationTabs", () => {
     expect(findUnreadDot(activeTab)).not.toBeInTheDocument();
   });
 
+  it("shows unread dot for active session when file tab is active", () => {
+    renderTabs({
+      unreadSessions: { "sess-1": true },
+      openFile: "src/index.ts",
+      isFileActive: true,
+    });
+
+    const activeButHiddenConversationTab = screen.getByText("First conversation").closest("button")!;
+    expect(findUnreadDot(activeButHiddenConversationTab)).toBeInTheDocument();
+  });
+
   it("prioritizes streaming indicator over unread dot", () => {
     renderTabs({
       unreadSessions: { "sess-2": true },

--- a/frontend/tests/hooks/useChatInputDraftPersistence.test.tsx
+++ b/frontend/tests/hooks/useChatInputDraftPersistence.test.tsx
@@ -3,7 +3,7 @@ import { useRef, useState, type MutableRefObject, type RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileUIPart } from "ai";
 import type { AttachmentsContext } from "@/components/ai-elements/prompt-input";
-import type { ThinkingLevel } from "@/types";
+import type { FileMention, ThinkingLevel } from "@/types";
 import { useChatInputDraftPersistence } from "@/hooks/useChatInputDraftPersistence";
 
 type AttachmentFile = FileUIPart & { id: string };
@@ -49,6 +49,7 @@ function useDraftHarness({ wsId, sessionId }: { wsId?: string; sessionId?: strin
   const [selectedModelId, setSelectedModelId] = useState("");
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("high");
   const [fileCount, setFileCount] = useState(0);
+  const [fileMentions, setFileMentions] = useState<FileMention[]>([]);
   const attachmentsRef = useRef<AttachmentsContext | null>(null);
 
   if (!attachmentsRef.current) {
@@ -71,12 +72,14 @@ function useDraftHarness({ wsId, sessionId }: { wsId?: string; sessionId?: strin
     defaultModelId: "claude:opus-4-6",
     thinkingLevel,
     attachmentsRef: attachmentsRef as MutableRefObject<AttachmentsContext | null>,
+    fileMentions,
     setValue,
     setThinkingEnabled,
     setPlanMode,
     setSelectedModelId,
     setThinkingLevel,
     setFileCount,
+    setFileMentions,
   });
 
   return {
@@ -86,11 +89,13 @@ function useDraftHarness({ wsId, sessionId }: { wsId?: string; sessionId?: strin
     selectedModelId,
     thinkingLevel,
     fileCount,
+    fileMentions,
     setValue,
     setThinkingEnabled,
     setPlanMode,
     setSelectedModelId,
     setThinkingLevel,
+    setFileMentions,
     setFiles,
     attachments: attachmentsRef.current,
   };

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { MemoryRouter, Route, Routes, useNavigate } from "react-router-dom";
@@ -144,9 +144,10 @@ vi.mock("@/components/ConversationTabs", () => ({
     onDeleteSession: (id: string) => void;
     onCreateSession: () => void;
     onActivateSession: (id: string) => void;
+    onFileTabClick?: () => void;
     unreadSessions?: Record<string, boolean>;
   }) => {
-    const { onDeleteSession, onCreateSession, onActivateSession } = props;
+    const { onDeleteSession, onCreateSession, onActivateSession, onFileTabClick } = props;
     mocks.captureConversationTabsProps(props);
     return (
       <div data-testid="conversation-tabs">
@@ -161,6 +162,9 @@ vi.mock("@/components/ConversationTabs", () => ({
         </button>
         <button type="button" data-testid="activate-session-btn" onClick={() => onActivateSession("sess-2")}>
           activate session
+        </button>
+        <button type="button" data-testid="file-tab-btn" onClick={() => onFileTabClick?.()}>
+          file tab
         </button>
       </div>
     );
@@ -660,6 +664,70 @@ describe("WorkspaceView behavior", () => {
     expect(
       clearUnread.mock.calls.some((call) => call[0] === "ws-1" && call[1] === "sess-2"),
     ).toBe(false);
+  });
+
+  it("returns to conversation tab when clicking the already active session", async () => {
+    const user = userEvent.setup();
+    const clearUnread = vi.fn();
+    mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread });
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: false,
+      streamingStartedAt: null,
+      workspaceStatus: "idle",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: "sess-2",
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileActive?: boolean } | undefined;
+      expect(lastCall?.isFileActive).toBe(false);
+    });
+
+    await user.click(screen.getByTestId("file-tab-btn"));
+
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileActive?: boolean } | undefined;
+      expect(lastCall?.isFileActive).toBe(true);
+    });
+
+    await user.click(screen.getByTestId("activate-session-btn"));
+
+    expect(mocks.switchSession).not.toHaveBeenCalled();
+    expect(
+      clearUnread.mock.calls.some((call) => call[0] === "ws-1" && call[1] === "sess-2"),
+    ).toBe(false);
+
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileActive?: boolean } | undefined;
+      expect(lastCall?.isFileActive).toBe(false);
+    });
   });
 
   it("passes unreadSessions from liveData to ConversationTabs", async () => {

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -170,6 +170,11 @@ struct ImageAttachment: Codable, Equatable {
     let dataUrl: String
 }
 
+struct FileMention: Codable, Equatable {
+    let displayName: String
+    let relativePath: String
+}
+
 struct ToolCall: Codable, Identifiable {
     let id: String
     let name: String
@@ -213,6 +218,7 @@ struct ChatMessage: Codable, Identifiable {
     let role: MessageRole
     let content: String
     let images: [ImageAttachment]?
+    let fileMentions: [FileMention]?
     let toolCalls: [ToolCall]?
     let thinkingContent: String?
     let timestamp: String
@@ -222,7 +228,8 @@ struct ChatMessage: Codable, Identifiable {
     let outputTokens: Int?
 
     init(id: String, sessionId: String, role: MessageRole, content: String,
-         images: [ImageAttachment]?, toolCalls: [ToolCall]?, thinkingContent: String?,
+         images: [ImageAttachment]?, fileMentions: [FileMention]? = nil,
+         toolCalls: [ToolCall]?, thinkingContent: String?,
          timestamp: String, cancelled: Bool?, durationMs: Int?,
          inputTokens: Int? = nil, outputTokens: Int? = nil) {
         self.id = id
@@ -230,6 +237,7 @@ struct ChatMessage: Codable, Identifiable {
         self.role = role
         self.content = content
         self.images = images
+        self.fileMentions = fileMentions
         self.toolCalls = toolCalls
         self.thinkingContent = thinkingContent
         self.timestamp = timestamp
@@ -246,6 +254,7 @@ struct ChatMessage: Codable, Identifiable {
         role = try container.decode(MessageRole.self, forKey: .role)
         content = try container.decode(String.self, forKey: .content)
         images = try container.decodeIfPresent([ImageAttachment].self, forKey: .images)
+        fileMentions = try container.decodeIfPresent([FileMention].self, forKey: .fileMentions)
         toolCalls = try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls)
         thinkingContent = try container.decodeIfPresent(String.self, forKey: .thinkingContent)
         timestamp = try container.decode(String.self, forKey: .timestamp)
@@ -275,7 +284,7 @@ struct ChatMessage: Codable, Identifiable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, sessionId, role, content, images, toolCalls
+        case id, sessionId, role, content, images, fileMentions, toolCalls
         case thinkingContent, timestamp, cancelled, durationMs
         case inputTokens, outputTokens
     }

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -70,7 +70,7 @@ enum ToolInputResult: Encodable {
 
 enum WsIncoming: Encodable {
     case switchSession(sessionId: String)
-    case userMessage(content: String, images: [ImageAttachment]?, options: MessageOptions?, sessionId: String?)
+    case userMessage(content: String, images: [ImageAttachment]?, fileMentions: [FileMention]?, options: MessageOptions?, sessionId: String?)
     case stop(sessionId: String?)
     case toolInputResponse(requestId: String, toolName: String, result: ToolInputResult, sessionId: String?)
 
@@ -80,10 +80,11 @@ enum WsIncoming: Encodable {
         case .switchSession(let sessionId):
             try container.encode("switch_session", forKey: .type)
             try container.encode(sessionId, forKey: .sessionId)
-        case .userMessage(let content, let images, let options, let sessionId):
+        case .userMessage(let content, let images, let fileMentions, let options, let sessionId):
             try container.encode("user_message", forKey: .type)
             try container.encode(content, forKey: .content)
             try container.encodeIfPresent(images, forKey: .images)
+            try container.encodeIfPresent(fileMentions, forKey: .fileMentions)
             try container.encodeIfPresent(options, forKey: .options)
             try container.encodeIfPresent(sessionId, forKey: .sessionId)
         case .stop(let sessionId):
@@ -99,7 +100,7 @@ enum WsIncoming: Encodable {
     }
 
     private enum CodingKeys: String, CodingKey {
-        case type, sessionId, content, images, options, requestId, toolName, result
+        case type, sessionId, content, images, fileMentions, options, requestId, toolName, result
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -394,6 +394,7 @@ struct ChatView: View {
             let sent = await store.send?(.userMessage(
                 content: content,
                 images: images.isEmpty ? nil : images,
+                fileMentions: nil,
                 options: options,
                 sessionId: targetSessionId
             )) ?? false

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -55,7 +55,7 @@ struct MessageBubble: View {
         } else if !message.content.isEmpty {
             switch message.role {
             case .user:
-                Text(message.content)
+                Text(highlightedUserContent(message.content, fileMentions: message.fileMentions))
                     .font(.system(size: 14))
                     .foregroundStyle(WhisperColor.text)
                     .lineSpacing(3)
@@ -121,6 +121,51 @@ struct MessageBubble: View {
             urlString += "\(sep)token=\(token)"
         }
         return URL(string: urlString)
+    }
+
+    // MARK: - Mention Highlighting
+
+    @Environment(\.self) private var environment
+
+    private func highlightedUserContent(_ content: String, fileMentions: [FileMention]?) -> AttributedString {
+        var result = AttributedString(content)
+        let accent = Color.accentColor.resolve(in: environment)
+        let accentUI = UIColor(red: CGFloat(accent.red), green: CGFloat(accent.green),
+                               blue: CGFloat(accent.blue), alpha: CGFloat(accent.opacity))
+        let bgColor = accentUI.withAlphaComponent(0.15)
+        let fgColor = accentUI
+
+        // Highlight #fileMentions using metadata
+        if let mentions = fileMentions {
+            for mention in mentions {
+                let needle = "#\(mention.displayName)"
+                var searchStart = result.startIndex
+                while searchStart < result.endIndex,
+                      let range = result[searchStart...].range(of: needle) {
+                    result[range].backgroundColor = bgColor
+                    result[range].foregroundColor = fgColor
+                    searchStart = range.upperBound
+                }
+            }
+        }
+
+        // Highlight @mentions via regex (cursor-based to handle duplicates)
+        if let regex = try? NSRegularExpression(pattern: #"(?:^|(?<=\s))@[\w][\w-]*"#) {
+            let nsContent = content as NSString
+            let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
+            var atCursor = result.startIndex
+            for match in matches {
+                guard let swiftRange = Range(match.range, in: content) else { continue }
+                let needle = String(content[swiftRange])
+                guard atCursor < result.endIndex,
+                      let range = result[atCursor...].range(of: needle) else { continue }
+                result[range].backgroundColor = bgColor
+                result[range].foregroundColor = fgColor
+                atCursor = range.upperBound
+            }
+        }
+
+        return result
     }
 
     private func formatTimestamp(_ ts: String) -> String {
@@ -1062,8 +1107,10 @@ private extension Theme {
         VStack(spacing: 16) {
             MessageBubble(message: ChatMessage(
                 id: "1", sessionId: "s1", role: .user,
-                content: "Can you fix the login bug?",
-                images: nil, toolCalls: nil, thinkingContent: nil,
+                content: "Can you fix the login bug in #auth.ts? Ask @claude-code if needed",
+                images: nil,
+                fileMentions: [FileMention(displayName: "auth.ts", relativePath: "src/utils/auth.ts")],
+                toolCalls: nil, thinkingContent: nil,
                 timestamp: "2026-02-17T12:00:00.000Z", cancelled: nil, durationMs: nil
             ))
             MessageBubble(message: ChatMessage(


### PR DESCRIPTION
## Summary
- Extract `getSessionVisualState`, `SessionStatusIndicator`, and `TabCloseAction` helpers from `ConversationTabs` to eliminate duplicated rendering/logic across visible tabs and overflow menu
- Fix unread dot being incorrectly cleared when the file tab is active — `clearUnread` now only fires when `activeTab === "conversation"`, so the notification persists until the user actually views the conversation
- Add test covering unread dot visibility for the active session when a file tab is open

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (897 backend + 812 frontend)
- [ ] Manual: open a file tab, have the agent finish a turn — verify the session tab shows an unread dot
- [ ] Manual: switch back to the conversation tab — verify the dot clears