### PR TITLE
Add message queue for typing follow-ups while agent is streaming

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -222,8 +222,8 @@ export default function ChatConversation({
 
         {/* Queued follow-up message */}
         {queuedMessage && (
-          <div className="flex w-full items-start justify-end" data-testid="queued-message">
-            <div className="group/queued relative max-w-[85%] rounded-[10px] rounded-br-[2px] border border-primary bg-transparent px-3.5 py-2 text-sm leading-relaxed text-white">
+          <div className="flex w-full flex-col items-end gap-0.5" data-testid="queued-message">
+            <div className="group/queued relative max-w-[85%] rounded-[10px] rounded-br-[2px] border border-dashed border-primary/40 bg-transparent px-3.5 py-2 text-sm leading-relaxed text-white/60">
               <p className="whitespace-pre-wrap">{queuedMessage.content}</p>
               <button
                 type="button"
@@ -234,6 +234,7 @@ export default function ChatConversation({
                 <Trash2Icon className="size-3" />
               </button>
             </div>
+            <span className="pr-1 text-[10px] text-muted-foreground">Queued</span>
           </div>
         )}
       </ConversationContent>

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -13,7 +13,8 @@ import { ToolCallList } from "@/components/chat/ToolCallList";
 import { WorkspaceWelcome } from "@/components/WorkspaceWelcome";
 import { formatElapsed } from "@/lib/time";
 import { getFallbackInteractiveAssistantIndex, hasExitPlanModeTool } from "@/lib/plan-state";
-import type { ChatMessage as ChatMessageType, ToolCall, QuestionAnswer } from "@/types";
+import { Trash2Icon } from "lucide-react";
+import type { ChatMessage as ChatMessageType, QueuedMessage, ToolCall, QuestionAnswer } from "@/types";
 import type { PendingToolInput } from "@/hooks/useConversation";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
 
@@ -35,6 +36,8 @@ interface ChatConversationProps {
   fileCount?: number;
   switchCounter: number;
   error?: string;
+  queuedMessage?: QueuedMessage | null;
+  onClearQueue?: () => void;
 }
 
 export default function ChatConversation({
@@ -55,6 +58,8 @@ export default function ChatConversation({
   fileCount,
   switchCounter,
   error,
+  queuedMessage,
+  onClearQueue,
 }: ChatConversationProps) {
   const [elapsed, setElapsed] = useState(0);
 
@@ -212,6 +217,23 @@ export default function ChatConversation({
           <div className="flex items-center gap-2 text-[11px] text-muted-foreground">
             <AgentActivityPreview size="small" />
             <span>{formatElapsed(elapsed)}</span>
+          </div>
+        )}
+
+        {/* Queued follow-up message */}
+        {queuedMessage && (
+          <div className="flex w-full items-start justify-end" data-testid="queued-message">
+            <div className="group/queued relative max-w-[85%] rounded-[10px] rounded-br-[2px] border border-primary bg-transparent px-3.5 py-2 text-sm leading-relaxed text-white">
+              <p className="whitespace-pre-wrap">{queuedMessage.content}</p>
+              <button
+                type="button"
+                onClick={onClearQueue}
+                className="absolute -top-2 -right-2 flex size-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground opacity-0 transition-opacity hover:text-destructive group-hover/queued:opacity-100"
+                aria-label="Cancel queued message"
+              >
+                <Trash2Icon className="size-3" />
+              </button>
+            </div>
           </div>
         )}
       </ConversationContent>

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -11,9 +11,9 @@ import {
   usePromptInputAttachments,
   type AttachmentsContext,
 } from "@/components/ai-elements/prompt-input";
-import type { ChatMessage, CompletionItem, ImageAttachment, MessageOptions, ThinkingLevel } from "@/types";
+import type { ChatMessage, CompletionItem, ImageAttachment, MessageOptions, QueuedMessage, ThinkingLevel } from "@/types";
 import { cn } from "@/lib/utils";
-import { BrainIcon, BookOpenIcon, PlusIcon } from "lucide-react";
+import { BrainIcon, BookOpenIcon, PlusIcon, SquareIcon } from "lucide-react";
 import { AttachmentPreview } from "@/components/chat/AttachmentPreview";
 import { AutocompletePopup } from "@/components/chat/AutocompletePopup";
 import { ContextRing } from "@/components/chat/ContextRing";
@@ -34,6 +34,8 @@ interface ChatInputProps {
   connectionStatus: "connecting" | "connected" | "disconnected";
   placeholder?: string;
   messages: ChatMessage[];
+  queuedMessage?: QueuedMessage | null;
+  onQueue: (msg: QueuedMessage) => void;
 }
 
 interface AutocompleteState {
@@ -80,6 +82,8 @@ export default function ChatInput({
   connectionStatus,
   placeholder: customPlaceholder,
   messages,
+  queuedMessage,
+  onQueue,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const [thinkingEnabled, setThinkingEnabled] = useState(true);
@@ -90,7 +94,8 @@ export default function ChatInput({
   const [selectedIndex, setSelectedIndex] = useState(0);
   const attachmentsRef = useRef<AttachmentsContext | null>(null);
   const isDisconnected = connectionStatus === "disconnected";
-  const isInputDisabled = disabled || isStreaming || isDisconnected;
+  const hasQueuedMessage = !!queuedMessage;
+  const isInputDisabled = disabled || isDisconnected || hasQueuedMessage;
   const canSubmit = !isInputDisabled && (value.trim().length > 0 || fileCount > 0);
 
   const { models, defaultModelId, selectedModelId, selectedModel, setSelectedModelId, capabilities } = useModels(lockedProvider);
@@ -228,8 +233,12 @@ export default function ChatInput({
       ...(supportsThinkingLevels && { thinkingLevel }),
     };
 
-    const sent = onSend(trimmed, images, options);
-    if (!sent) throw new Error("Message send failed");
+    if (isStreaming) {
+      onQueue({ content: trimmed, images, options });
+    } else {
+      const sent = onSend(trimmed, images, options);
+      if (!sent) throw new Error("Message send failed");
+    }
     setValue("");
     setAutocomplete(null);
   };
@@ -324,12 +333,22 @@ export default function ChatInput({
             >
               <PlusIcon className="size-3" />
             </PromptInputButton>
+            {isStreaming && (
+              <PromptInputButton
+                aria-label="Stop"
+                variant="ghost"
+                size="icon-xs"
+                className="size-5"
+                onClick={(e) => { e.preventDefault(); onStop(); }}
+              >
+                <SquareIcon className="size-3" />
+              </PromptInputButton>
+            )}
             <PromptInputSubmit
-              aria-label={isStreaming ? "Stop" : "Send"}
-              status={isStreaming ? "streaming" : "ready"}
+              aria-label="Send"
+              status="ready"
               variant="ghost"
-              onStop={onStop}
-              disabled={!isStreaming && !canSubmit}
+              disabled={!canSubmit}
               size="icon-xs"
               className={cn(
                 "size-5 border border-border/50",

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -45,7 +45,7 @@ import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput } from "@/lib/plan-state";
 import { useScripts } from "@/hooks/useScripts";
-import type { DiffStatResponse, ImageAttachment, MessageOptions, Workspace, WorkspaceFileTreeNode } from "@/types";
+import type { DiffStatResponse, ImageAttachment, MessageOptions, QueuedMessage, Workspace, WorkspaceFileTreeNode } from "@/types";
 
 const DEFAULT_EXPANDED = new Set<string>();
 
@@ -216,6 +216,7 @@ export default function WorkspaceView() {
     messages,
     isStreaming,
     streamingStartedAt,
+    workspaceStatus,
     currentStreamingText,
     currentThinking,
     activeToolCalls,
@@ -243,6 +244,25 @@ export default function WorkspaceView() {
       clearUnread(wsId, sessionId);
     }
   }, [wsId, sessionId, liveData, clearUnread]);
+
+  // ── Message queue: lets users type one follow-up while agent is busy ──
+  const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
+
+  // Clear queue on session switch
+  useEffect(() => { setQueuedMessage(null); }, [sessionId]);
+
+  // Auto-dequeue when the agent finishes and workspace is truly idle
+  useEffect(() => {
+    if (!queuedMessage) return;
+    if (isStreaming) return;
+    if (workspaceStatus !== "idle") return;
+    if (pendingToolInputs.length > 0) return;
+
+    const { content, images, options } = queuedMessage;
+    const sent = sendMessage(content, images, options);
+    if (sent) setQueuedMessage(null);
+    // If send fails (WS disconnected), keep queue — effect re-fires on reconnect
+  }, [queuedMessage, isStreaming, workspaceStatus, pendingToolInputs, sendMessage]);
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
 
@@ -509,6 +529,8 @@ export default function WorkspaceView() {
               fileCount={fileCount}
               switchCounter={switchCounter}
               error={error}
+              queuedMessage={queuedMessage}
+              onClearQueue={() => setQueuedMessage(null)}
             />
             {tasks.length > 0 && (
               <TaskTracker
@@ -536,6 +558,8 @@ export default function WorkspaceView() {
                 connectionStatus={connectionStatus}
                 placeholder={hasPendingPlan ? "Enter your plan adjustments here..." : undefined}
                 messages={messages}
+                queuedMessage={queuedMessage}
+                onQueue={setQueuedMessage}
               />
             )}
           </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -80,6 +80,14 @@ export interface CreateProjectRequest {
   url: string;
 }
 
+// ── Queued message type ──────────────────────────────────────────────
+
+export interface QueuedMessage {
+  content: string;
+  images?: ImageAttachment[];
+  options?: MessageOptions;
+}
+
 // ── Image attachment type ────────────────────────────────────────────
 
 export interface ImageAttachment {

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -368,6 +368,7 @@ describe("ChatConversation queued message", () => {
     const queued = screen.getByTestId("queued-message");
     expect(queued).toBeInTheDocument();
     expect(queued).toHaveTextContent("my follow-up");
+    expect(queued).toHaveTextContent("Queued");
   });
 
   it("does not render queued message when queuedMessage is null", () => {

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import type { ComponentProps, ReactNode } from "react";
 import { describe, expect, it, vi } from "vitest";
 import ChatConversation from "@/components/ChatConversation";
@@ -347,5 +348,47 @@ describe("ChatConversation hydration on session/workspace switch", () => {
 
     vi.useRealTimers();
     vi.unstubAllGlobals();
+  });
+});
+
+describe("ChatConversation queued message", () => {
+  it("renders queued message at the bottom when queuedMessage is set", () => {
+    renderConversation({
+      messages: [{
+        id: "u1",
+        sessionId: "sess-1",
+        role: "user",
+        content: "first message",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      }],
+      isStreaming: true,
+      queuedMessage: { content: "my follow-up" },
+    });
+
+    const queued = screen.getByTestId("queued-message");
+    expect(queued).toBeInTheDocument();
+    expect(queued).toHaveTextContent("my follow-up");
+  });
+
+  it("does not render queued message when queuedMessage is null", () => {
+    renderConversation({
+      queuedMessage: null,
+    });
+
+    expect(screen.queryByTestId("queued-message")).not.toBeInTheDocument();
+  });
+
+  it("calls onClearQueue when trash button is clicked", async () => {
+    const user = userEvent.setup();
+    const onClearQueue = vi.fn();
+
+    renderConversation({
+      isStreaming: true,
+      queuedMessage: { content: "cancel me" },
+      onClearQueue,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Cancel queued message" }));
+    expect(onClearQueue).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -26,11 +26,13 @@ function renderChatInput(overrides?: Partial<ComponentProps<typeof ChatInput>>) 
   });
   const onSend = overrides?.onSend ?? vi.fn(() => true);
   const onStop = overrides?.onStop ?? vi.fn();
+  const onQueue = overrides?.onQueue ?? vi.fn();
   render(
     <QueryClientProvider client={queryClient}>
       <ChatInput
         onSend={onSend}
         onStop={onStop}
+        onQueue={onQueue}
         disabled={false}
         isStreaming={false}
         connectionStatus="connected"
@@ -39,7 +41,7 @@ function renderChatInput(overrides?: Partial<ComponentProps<typeof ChatInput>>) 
       />
     </QueryClientProvider>,
   );
-  return { onSend, onStop };
+  return { onSend, onStop, onQueue };
 }
 
 describe("ChatInput", () => {
@@ -116,7 +118,6 @@ describe("ChatInput", () => {
     const { onStop } = renderChatInput({ isStreaming: true });
 
     expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
-    expect(screen.getByPlaceholderText("Send a message...")).toBeDisabled();
 
     await user.click(screen.getByRole("button", { name: "Stop" }));
 
@@ -189,5 +190,51 @@ describe("ChatInput", () => {
     renderChatInput({ connectionStatus: "connecting" });
     // "connecting" still uses the default placeholder and doesn't disable input
     expect(screen.getByPlaceholderText("Send a message...")).not.toBeDisabled();
+  });
+
+  // ── Message queue tests ───────────────────────────────────────────
+
+  it("enables textarea during streaming so user can type a follow-up", () => {
+    renderChatInput({ isStreaming: true });
+
+    expect(screen.getByPlaceholderText("Send a message...")).not.toBeDisabled();
+  });
+
+  it("disables textarea when a queued message exists", () => {
+    renderChatInput({
+      isStreaming: true,
+      queuedMessage: { content: "queued follow-up" },
+    });
+
+    expect(screen.getByPlaceholderText("Send a message...")).toBeDisabled();
+  });
+
+  it("calls onQueue instead of onSend when submitting during streaming", async () => {
+    const user = userEvent.setup();
+    const { onSend, onQueue } = renderChatInput({ isStreaming: true });
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "follow up");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onQueue).toHaveBeenCalledWith({
+      content: "follow up",
+      images: undefined,
+      options: { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true },
+    });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  it("shows stop and send buttons separately during streaming", () => {
+    renderChatInput({ isStreaming: true });
+
+    expect(screen.getByRole("button", { name: "Stop" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
+  });
+
+  it("hides stop button when not streaming", () => {
+    renderChatInput({ isStreaming: false });
+
+    expect(screen.queryByRole("button", { name: "Stop" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Send" })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -91,15 +91,18 @@ vi.mock("@/components/ChatConversation", () => ({
     onHandOff,
     isStreaming,
     streamingStartedAt,
+    queuedMessage,
   }: {
     onHandOff: (planContent: string, planPath?: string) => void;
     isStreaming?: boolean;
     streamingStartedAt?: number | null;
+    queuedMessage?: { content: string } | null;
   }) => (
     <div data-testid="chat-conversation">
       chat-conversation
       <div data-testid="chat-is-streaming">{String(Boolean(isStreaming))}</div>
       <div data-testid="chat-streaming-started-at">{streamingStartedAt ?? "none"}</div>
+      <div data-testid="chat-queued-message">{queuedMessage?.content ?? "none"}</div>
       <button type="button" data-testid="handoff-plan-btn" onClick={() => onHandOff("PLAN-CONTENT")}>
         handoff plan
       </button>
@@ -115,9 +118,31 @@ vi.mock("@/components/ChatConversation", () => ({
 }));
 
 vi.mock("@/components/ChatInput", () => ({
-  default: ({ wsId, sessionId }: { wsId?: string; sessionId?: string }) => (
-    <div data-testid="chat-input" data-ws-id={wsId ?? ""} data-session-id={sessionId ?? ""}>
+  default: ({
+    wsId,
+    sessionId,
+    isStreaming,
+    queuedMessage,
+    onQueue,
+  }: {
+    wsId?: string;
+    sessionId?: string;
+    isStreaming?: boolean;
+    queuedMessage?: { content: string } | null;
+    onQueue?: (msg: { content: string }) => void;
+  }) => (
+    <div
+      data-testid="chat-input"
+      data-ws-id={wsId ?? ""}
+      data-session-id={sessionId ?? ""}
+      data-has-queue={queuedMessage ? "true" : "false"}
+    >
       chat-input
+      {isStreaming && onQueue && (
+        <button type="button" data-testid="queue-message-btn" onClick={() => onQueue({ content: "queued msg" })}>
+          queue message
+        </button>
+      )}
     </div>
   ),
 }));
@@ -1807,5 +1832,45 @@ describe("WorkspaceView dropdown terminal interactions", () => {
     await screen.findByText("tokyo");
 
     expect(screen.getByRole("button", { name: "VS Code" })).toBeInTheDocument();
+  });
+
+  it("passes queued message to ChatConversation when queued during streaming", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue({
+      messages: [],
+      isStreaming: true,
+      streamingStartedAt: Date.now(),
+      workspaceStatus: "busy",
+      currentStreamingText: "",
+      currentThinking: "",
+      activeToolCalls: [],
+      pendingToolInputs: [],
+      connectionStatus: "connected",
+      error: null,
+      sessionId: "sess-active",
+      sendMessage: mocks.sendMessage,
+      stopStreaming: mocks.stopStreaming,
+      clearChat: mocks.clearChat,
+      switchSession: mocks.switchSession,
+      answerQuestion: mocks.answerQuestion,
+      batchAnswerQuestions: mocks.batchAnswerQuestions,
+      approvePlan: mocks.approvePlan,
+      rejectToolInput: mocks.rejectToolInput,
+      dismissPlan: mocks.dismissPlan,
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    // Initially no queued message
+    expect(screen.getByTestId("chat-queued-message")).toHaveTextContent("none");
+    expect(screen.getByTestId("chat-input")).toHaveAttribute("data-has-queue", "false");
+
+    // Queue a message via ChatInput's queue button
+    await user.click(screen.getByTestId("queue-message-btn"));
+
+    // Queued message flows to ChatConversation and ChatInput
+    expect(screen.getByTestId("chat-queued-message")).toHaveTextContent("queued msg");
+    expect(screen.getByTestId("chat-input")).toHaveAttribute("data-has-queue", "true");
   });
 });


### PR DESCRIPTION
## Summary
- Users can now type and submit one follow-up message while the agent is still streaming — it queues client-side and auto-dispatches when the current turn completes
- Queued bubble uses a "dashed ghost" treatment (dashed border, reduced opacity, "Queued" label) to clearly distinguish it from sent messages
- Stop and Send are now separate buttons in the input bar; textarea stays enabled during streaming

## Details
- Frontend-only change, zero backend modifications
- Queue state lives in `WorkspaceView` and is passed down to `ChatInput` (routing) and `ChatConversation` (rendering)
- Dequeue guard waits for `workspaceStatus === "idle"` (not just `!isStreaming`) to avoid premature dispatch before `tool_input_required` events
- Queue is cleared on session switch
- Single queued message limit (input disables after queuing)

## Test plan
- [x] 829 frontend tests pass (5 new ChatInput tests, 3 new ChatConversation tests, 1 new WorkspaceView test)
- [x] Typecheck clean
- [ ] Manual: type a message while agent streams → verify dashed bubble appears with "Queued" label
- [ ] Manual: click trash icon on queued bubble → verify it's removed and input re-enables
- [ ] Manual: let agent finish → verify queued message auto-sends
- [ ] Manual: switch sessions while message queued → verify queue clears