### PR TITLE
Inject system prompt for Codex/Gemini and bypass Codex sandbox

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -336,7 +336,15 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       env = undefined;
     } else {
       command = provider!.command;
-      args = provider!.buildArgs(content, { ...msgOptions, model: modelId }, {
+
+      // For providers without a native system-prompt flag (Codex, Gemini),
+      // prepend the system prompt to the first user message content.
+      let cliContent = content;
+      if (isFirstMessage && this.systemPrompt && provider!.id !== "claude") {
+        cliContent = `<context>\n${this.systemPrompt}\n</context>\n\n${content}`;
+      }
+
+      args = provider!.buildArgs(cliContent, { ...msgOptions, model: modelId }, {
         isFirstMessage,
         sessionId: this.cliSessionId,
         systemPrompt: this.systemPrompt,

--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -79,9 +79,9 @@ describe("CodexProvider", () => {
     expect(args).toContain("--json");
   });
 
-  it("includes --full-auto flag", () => {
+  it("includes --dangerously-bypass-approvals-and-sandbox flag", () => {
     const args = provider.buildArgs("Hello", {}, baseSession());
-    expect(args).toContain("--full-auto");
+    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
   });
 
   it("includes --model with cli value when model is specified", () => {

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -42,7 +42,7 @@ export class CodexProvider implements AgentProvider {
     const flags = [
       "--json",
       ...(model ? ["--model", model.cliValue] : []),
-      "--full-auto",
+      "--dangerously-bypass-approvals-and-sandbox",
       "--config", `model_reasoning_effort=${thinkingLevel}`,
     ];
 


### PR DESCRIPTION
## Summary
- **Codex full yolo**: Switch from `--full-auto` to `--dangerously-bypass-approvals-and-sandbox` for unrestricted agent execution (no sandbox, no approval prompts)
- **System prompt for all providers**: Prepend the Hive system prompt (project context, git snapshot) to the first user message for providers that lack a native `--append-system-prompt` flag (Codex, Gemini). Content is wrapped in `<context>` tags and only affects the CLI-bound message — the displayed user message stays unchanged

## Test plan
- [x] Typecheck passes
- [x] All 832 tests pass (backend + frontend)
- [ ] Manual test: send a first message via Codex and verify the system prompt context is prepended
- [ ] Manual test: verify Codex runs without sandbox restrictions
- [ ] Manual test: send a first message via Gemini and verify context injection