### PR TITLE
Fix iOS pull-to-refresh not re-syncing workspace live data

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -72,6 +72,9 @@ struct HiveApp: App {
                 case .active:
                     if let bg = backgroundedAt, Date().timeIntervalSince(bg) > 2 {
                         projectStore.statusMonitor.appDidBecomeActive()
+                        // Also refresh project/workspace list from REST so newly
+                        // created or archived workspaces appear immediately.
+                        Task { await projectStore.refresh() }
                     }
                     backgroundedAt = nil
                 default:

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -213,13 +213,20 @@ final class HubStatusMonitor {
 
     // MARK: - App lifecycle
 
+    /// Force a full WS reconnect to get fresh bootstrap data for all workspaces.
+    /// Used by pull-to-refresh so the backend re-sends status, history, branch_info,
+    /// diff_stats, and script_status for every subscribed workspace.
+    func forceRefresh() {
+        storeCache.clearAllStreamingState()
+        hubConnection?.forceReconnect()
+    }
+
     /// Called when the app returns to foreground after a non-trivial background period.
     /// Clears stale streaming state and forces an immediate hub reconnect so the
     /// backend bootstrap (status + history) writes into a clean slate.
     func appDidBecomeActive() {
         streamingBeforeBackground = streamingWorkspaces
-        storeCache.clearAllStreamingState()
-        hubConnection?.forceReconnect()
+        forceRefresh()
     }
 }
 

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -32,6 +32,9 @@ struct HubView: View {
             // Unstructured Task shields refresh from SwiftUI prematurely
             // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
             await Task { @MainActor in
+                // Force WS reconnect so the backend re-sends full bootstrap
+                // (status, history, branch_info, diff_stats) for all workspaces.
+                store.statusMonitor.forceRefresh()
                 await store.refresh()
             }.value
         }


### PR DESCRIPTION
## Summary
- Pull-to-refresh was reusing the existing WebSocket connection, causing the backend to skip bootstrap (status, history, branch_info, diff_stats, script_status) for already-subscribed workspaces. Now forces a WS reconnect on pull-to-refresh so all data is re-sent fresh.
- Return from background now also triggers a REST project/workspace list refresh, so newly created or archived workspaces appear immediately.
- Extracted `forceRefresh()` on `HubStatusMonitor` to DRY up the reconnect logic shared between pull-to-refresh and `appDidBecomeActive()`.

## Test plan
- [ ] Launch the app → verify initial sync works as before
- [ ] Pull-to-refresh on HubView → verify streaming status, branch info, diff stats, and conversation history all update
- [ ] Background the app for >2s, create/archive a workspace from another client, return to app → verify the workspace list updates and WS data refreshes