### PR TITLE
Inject git context into automation agent system prompts

### DIFF
--- a/backend/src/agents/system-prompt.test.ts
+++ b/backend/src/agents/system-prompt.test.ts
@@ -3,7 +3,8 @@ import { join } from "node:path";
 import { rm, writeFile, mkdir } from "node:fs/promises";
 import { createTempDir } from "../utils/test-helpers.js";
 import { git } from "../utils/git.js";
-import { getGitContext, buildSystemPrompt, loadBasePrompt, DEFAULT_BASE_PROMPT } from "./system-prompt.js";
+import { getGitContext, buildSystemPrompt, loadBasePrompt, formatGitContextBlock, DEFAULT_BASE_PROMPT } from "./system-prompt.js";
+import type { GitContext } from "./system-prompt.js";
 
 let tempDir: string;
 let repoDir: string;
@@ -190,5 +191,80 @@ describe("loadBasePrompt", () => {
     const promptsDir = join(tempDir, "no-such-dir");
     const result = await loadBasePrompt(promptsDir);
     expect(result).toBe(DEFAULT_BASE_PROMPT);
+  });
+});
+
+describe("formatGitContextBlock", () => {
+  const baseCtx: GitContext = {
+    branch: "feat/login",
+    status: "",
+    recentCommits: "abc1234 add login page",
+    defaultBranch: "main",
+  };
+
+  it("includes header, branch, and main branch", () => {
+    const block = formatGitContextBlock(baseCtx);
+    expect(block).toContain("# Git Context (snapshot at session start)");
+    expect(block).toContain("Current branch: feat/login");
+    expect(block).toContain("Main branch: main");
+  });
+
+  it("includes project name when provided", () => {
+    const block = formatGitContextBlock(baseCtx, { projectName: "hive" });
+    expect(block).toContain("Project: hive");
+  });
+
+  it("includes workspace name when provided", () => {
+    const block = formatGitContextBlock(baseCtx, { workspaceName: "geneva" });
+    expect(block).toContain("Workspace: geneva");
+  });
+
+  it("omits project and workspace lines when not provided", () => {
+    const block = formatGitContextBlock(baseCtx);
+    expect(block).not.toContain("Project:");
+    expect(block).not.toContain("Workspace:");
+  });
+
+  it("shows clean status when status is empty", () => {
+    const block = formatGitContextBlock(baseCtx);
+    expect(block).toContain("Status: (clean)");
+  });
+
+  it("shows dirty status when status has content", () => {
+    const ctx = { ...baseCtx, status: "M src/app.ts\n?? new.txt" };
+    const block = formatGitContextBlock(ctx);
+    expect(block).toContain("Status:");
+    expect(block).toContain("M src/app.ts");
+    expect(block).not.toContain("(clean)");
+  });
+
+  it("includes recent commits when present", () => {
+    const block = formatGitContextBlock(baseCtx);
+    expect(block).toContain("Recent commits:");
+    expect(block).toContain("abc1234 add login page");
+  });
+
+  it("omits recent commits section when empty", () => {
+    const ctx = { ...baseCtx, recentCommits: "" };
+    const block = formatGitContextBlock(ctx);
+    expect(block).not.toContain("Recent commits:");
+  });
+
+  it("shows unknown branch when branch is empty", () => {
+    const ctx = { ...baseCtx, branch: "" };
+    const block = formatGitContextBlock(ctx);
+    expect(block).toContain("Current branch: unknown");
+  });
+
+  it("produces identical output to what buildSystemPrompt appends", async () => {
+    // buildSystemPrompt calls formatGitContextBlock internally — verify consistency
+    const prompt = await buildSystemPrompt({
+      cwd: repoDir,
+      projectName: "hive",
+      workspaceName: "geneva",
+    });
+    const ctx = await getGitContext(repoDir);
+    const block = formatGitContextBlock(ctx, { projectName: "hive", workspaceName: "geneva" });
+    expect(prompt).toContain(block);
   });
 });

--- a/backend/src/agents/system-prompt.ts
+++ b/backend/src/agents/system-prompt.ts
@@ -75,6 +75,40 @@ export async function getGitContext(cwd: string, defaultBranchOverride?: string)
 }
 
 /**
+ * Format a git context block from already-resolved GitContext.
+ * Pure formatting — no async, no git calls.
+ */
+export function formatGitContextBlock(
+  ctx: GitContext,
+  opts?: { projectName?: string; workspaceName?: string },
+): string {
+  const gitLines: string[] = [
+    "# Git Context (snapshot at session start)",
+    "",
+  ];
+
+  if (opts?.projectName) gitLines.push(`Project: ${opts.projectName}`);
+  if (opts?.workspaceName) gitLines.push(`Workspace: ${opts.workspaceName}`);
+
+  gitLines.push(
+    `Current branch: ${ctx.branch || "unknown"}`,
+    `Main branch: ${ctx.defaultBranch}`,
+  );
+
+  if (ctx.status) {
+    gitLines.push("", "Status:", ctx.status);
+  } else {
+    gitLines.push("", "Status: (clean)");
+  }
+
+  if (ctx.recentCommits) {
+    gitLines.push("", "Recent commits:", ctx.recentCommits);
+  }
+
+  return gitLines.join("\n");
+}
+
+/**
  * Build a system prompt by merging a base prompt with dynamic git context.
  */
 export async function buildSystemPrompt(opts: SystemPromptOptions): Promise<string> {
@@ -98,32 +132,7 @@ export async function buildSystemPrompt(opts: SystemPromptOptions): Promise<stri
     .replace(/\{PROJECT}/g, projectName ?? "unknown");
 
   const sections: string[] = [basePrompt];
-
-  // Git context (includes project/workspace info)
-  const gitLines: string[] = [
-    "# Git Context (snapshot at session start)",
-    "",
-  ];
-
-  if (projectName) gitLines.push(`Project: ${projectName}`);
-  if (workspaceName) gitLines.push(`Workspace: ${workspaceName}`);
-
-  gitLines.push(
-    `Current branch: ${ctx.branch || "unknown"}`,
-    `Main branch: ${ctx.defaultBranch}`,
-  );
-
-  if (ctx.status) {
-    gitLines.push("", "Status:", ctx.status);
-  } else {
-    gitLines.push("", "Status: (clean)");
-  }
-
-  if (ctx.recentCommits) {
-    gitLines.push("", "Recent commits:", ctx.recentCommits);
-  }
-
-  sections.push(gitLines.join("\n"));
+  sections.push(formatGitContextBlock(ctx, { projectName, workspaceName }));
 
   return sections.join("\n\n");
 }

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -16,12 +16,22 @@ import type { Automation, AutomationRun, PromptTemplate } from "../types.js";
 // ConversationSession is a complex beast that spawns child processes.
 // We mock it to test scheduler orchestration logic in isolation.
 
+// Track constructor calls to inspect systemPrompt passed to sessions
+const sessionConstructorCalls: Array<Record<string, unknown>> = [];
+
 vi.mock("../agents/conversation-session.js", async () => {
   const { EventEmitter } = await import("node:events");
   class MockSession extends EventEmitter {
     stopped = false;
     sentMessage: string | undefined;
     sendOptions: Record<string, unknown> | undefined;
+    opts: Record<string, unknown>;
+
+    constructor(opts: Record<string, unknown>) {
+      super();
+      this.opts = opts;
+      sessionConstructorCalls.push(opts);
+    }
 
     sendMessage(msg: string, opts?: Record<string, unknown>) {
       this.sentMessage = msg;
@@ -64,6 +74,19 @@ vi.mock("../utils/paths.js", () => ({
   resolveDefaultBranch: vi.fn(async () => "main"),
 }));
 
+vi.mock("../agents/system-prompt.js", () => ({
+  getGitContext: vi.fn(async () => ({
+    branch: "main",
+    status: "",
+    recentCommits: "abc1234 initial commit",
+    defaultBranch: "main",
+  })),
+  formatGitContextBlock: vi.fn(
+    (_ctx: unknown, opts?: { projectName?: string }) =>
+      `# Git Context (snapshot at session start)\n\nProject: ${opts?.projectName ?? "unknown"}\nCurrent branch: main\nMain branch: main\n\nStatus: (clean)\n\nRecent commits:\nabc1234 initial commit`,
+  ),
+}));
+
 // ── Helpers ─────────────────────────────────────────────────────────
 
 let tmpDir: string;
@@ -97,6 +120,7 @@ function makeRun(overrides: Partial<AutomationRun> = {}): AutomationRun {
 beforeEach(async () => {
   tmpDir = await createTempDir();
   dataDir = join(tmpDir, "data");
+  sessionConstructorCalls.length = 0;
   vi.clearAllMocks();
 });
 
@@ -479,6 +503,113 @@ describe("AutomationScheduler", () => {
 
       const autos = await loadAutomations(dataDir);
       expect(autos[0].workspacePath).toBeDefined();
+
+      scheduler.stop();
+    });
+  });
+
+  describe("git context injection", () => {
+    it("injects git context into system prompt for project-linked automations", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+
+      const auto = makeAutomation({
+        projectId: "proj-1",
+        action: { type: "agent", modelId: "claude:opus-4-6", userPromptInline: "Review code", systemPromptInline: "You are a reviewer." },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      const lastCall = sessionConstructorCalls[sessionConstructorCalls.length - 1];
+      const sysPrompt = lastCall.systemPrompt as string;
+      expect(sysPrompt).toContain("You are a reviewer.");
+      expect(sysPrompt).toContain("# Git Context");
+      expect(sysPrompt).toContain("Project: Test Project");
+      expect(sysPrompt).toContain("## Summary");
+
+      scheduler.stop();
+    });
+
+    it("uses git context as sole system prompt when no system prompt is configured", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+
+      const auto = makeAutomation({
+        projectId: "proj-1",
+        action: { type: "agent", modelId: "claude:opus-4-6", userPromptInline: "Review code" },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      const lastCall = sessionConstructorCalls[sessionConstructorCalls.length - 1];
+      const sysPrompt = lastCall.systemPrompt as string;
+      expect(sysPrompt).toContain("# Git Context");
+      expect(sysPrompt).toContain("## Summary");
+      // Should NOT start with \n\n (no empty prefix from missing base prompt)
+      expect(sysPrompt).not.toMatch(/^\n/);
+
+      scheduler.stop();
+    });
+
+    it("does not inject git context for non-project automations", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue(null as never);
+
+      const auto = makeAutomation({
+        projectId: undefined,
+        action: { type: "agent", modelId: "claude:opus-4-6", userPromptInline: "Do stuff", systemPromptInline: "You are helpful." },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      const lastCall = sessionConstructorCalls[sessionConstructorCalls.length - 1];
+      const sysPrompt = lastCall.systemPrompt as string;
+      expect(sysPrompt).toContain("You are helpful.");
+      expect(sysPrompt).not.toContain("# Git Context");
+
+      scheduler.stop();
+    });
+
+    it("calls getGitContext with workspace path and default branch", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+      const { getGitContext } = await import("../agents/system-prompt.js");
+
+      const auto = makeAutomation({ projectId: "proj-1" });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      expect(getGitContext).toHaveBeenCalledWith(
+        expect.stringContaining("workspace"),
+        "main",
+      );
+
+      scheduler.stop();
+    });
+
+    it("calls formatGitContextBlock with project name", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "My App", repoUrl: "https://github.com/test/repo" } as never);
+      const { formatGitContextBlock } = await import("../agents/system-prompt.js");
+
+      const auto = makeAutomation({ projectId: "proj-1" });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      expect(formatGitContextBlock).toHaveBeenCalledWith(
+        expect.objectContaining({ branch: "main", defaultBranch: "main" }),
+        { projectName: "My App" },
+      );
 
       scheduler.stop();
     });

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -17,6 +17,7 @@ import { getNotifier } from "../agents/agent-manager.js";
 import { loadProject } from "../state/state.js";
 import { git } from "../utils/git.js";
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
+import { getGitContext, formatGitContextBlock } from "../agents/system-prompt.js";
 import type { Automation, AutomationRun, WsOutgoing } from "../types.js";
 
 const SUMMARY_INSTRUCTION =
@@ -154,7 +155,7 @@ export class AutomationScheduler {
     await addRun(autoId, run, this.dataDir);
 
     // Ensure workspace
-    const workspacePath = await this.ensureWorkspace(auto);
+    const { workspacePath, defaultBranch } = await this.ensureWorkspace(auto);
 
     // Update automation with workspace path if needed
     if (!auto.workspacePath) {
@@ -169,13 +170,21 @@ export class AutomationScheduler {
     }
 
     // Resolve prompts
-    const systemPrompt = await this.resolvePrompt(auto.action.systemPromptId, auto.action.systemPromptInline, "system");
+    let systemPrompt = await this.resolvePrompt(auto.action.systemPromptId, auto.action.systemPromptInline, "system");
     const userPrompt = await this.resolvePrompt(auto.action.userPromptId, auto.action.userPromptInline, "user");
 
     if (!userPrompt) {
       const error = "No user prompt resolved";
       await this.completeRun(auto, run.id, "failure", undefined, error, now);
       return { ...run, status: "failure", error };
+    }
+
+    // Inject git context for project-linked automations
+    if (auto.projectId) {
+      const project = await loadProject(auto.projectId, this.dataDir);
+      const ctx = await getGitContext(workspacePath, defaultBranch);
+      const gitBlock = formatGitContextBlock(ctx, { projectName: project?.name });
+      systemPrompt = systemPrompt ? systemPrompt + "\n\n" + gitBlock : gitBlock;
     }
 
     // Create session
@@ -238,7 +247,7 @@ export class AutomationScheduler {
     });
   }
 
-  private async ensureWorkspace(auto: Automation): Promise<string> {
+  private async ensureWorkspace(auto: Automation): Promise<{ workspacePath: string; defaultBranch?: string }> {
     const wsPath = join(this.dataDir, "automations", auto.id, "workspace");
 
     if (auto.projectId) {
@@ -257,18 +266,19 @@ export class AutomationScheduler {
         await git(["fetch", "origin", defaultBranch], wsPath);
         await git(["checkout", defaultBranch], wsPath);
         await git(["reset", "--hard", `origin/${defaultBranch}`], wsPath);
+        return { workspacePath: wsPath, defaultBranch };
       } catch {
         // Does not exist — create worktree
         await mkdir(join(this.dataDir, "automations", auto.id), { recursive: true });
         const defaultBranch = await resolveDefaultBranch(bareRepo);
         await git(["worktree", "add", wsPath, defaultBranch], bareRepo);
+        return { workspacePath: wsPath, defaultBranch };
       }
     } else {
       // Non-project automation: just ensure directory exists
       await mkdir(wsPath, { recursive: true });
+      return { workspacePath: wsPath };
     }
-
-    return wsPath;
   }
 
   private async resolvePrompt(


### PR DESCRIPTION
## Summary
- Extracts `formatGitContextBlock()` from `buildSystemPrompt()` in `system-prompt.ts` as a reusable pure function (no behavior change for workspace agents)
- Updates `ensureWorkspace()` to surface the already-resolved `defaultBranch` in its return value
- Appends a `# Git Context` block (branch, status, recent commits, project name) to the system prompt of project-linked automations, giving agents repo awareness

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — all 1936 tests pass (1080 backend + 856 frontend)
- [x] Existing `system-prompt.test.ts` assertions unchanged (extracted function produces identical output)
- [ ] Manual: trigger a project-linked automation and verify the system prompt includes git context
- [ ] Manual: trigger a non-project automation and verify no git context is injected