### PR TITLE
Add copy-to-clipboard button on iOS agent messages

### DIFF
--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -5,6 +5,8 @@ struct MessageBubble: View {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
 
+    @State private var copied = false
+
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
             if message.role == .user { Spacer(minLength: 60) }
@@ -103,6 +105,27 @@ struct MessageBubble: View {
                     Text(formatDuration(ms))
                         .font(WhisperFont.mono(10))
                         .foregroundStyle(WhisperColor.textMuted)
+                }
+
+                if message.role == .assistant, !message.content.isEmpty {
+                    Text("·")
+                        .font(WhisperFont.mono(10))
+                        .foregroundStyle(WhisperColor.textMuted)
+                    Button {
+                        UIPasteboard.general.string = message.content
+                        copied = true
+                        Task {
+                            try? await Task.sleep(for: .seconds(2))
+                            copied = false
+                        }
+                    } label: {
+                        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 10))
+                            .foregroundStyle(copied ? .green : WhisperColor.textMuted)
+                            .contentTransition(.symbolEffect(.replace))
+                            .frame(width: 14, height: 14)
+                    }
+                    .buttonStyle(.plain)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Adds a copy button (clipboard icon) in the message footer of assistant messages on iOS, matching the existing frontend behavior
- Button appears next to the duration indicator with a `·` separator
- Copies the full message content to the system clipboard via `UIPasteboard`
- Visual feedback: icon toggles to a green checkmark for 2 seconds after tap

## Test plan
- [ ] Open a chat with agent messages on iOS
- [ ] Verify the clipboard icon appears in the footer next to the duration
- [ ] Tap the icon and confirm the message content is copied to clipboard
- [ ] Verify the icon changes to a green checkmark and reverts after ~2s
- [ ] Verify no button appears on user messages or streaming messages