### PR TITLE
Add Commit & Push quick action button in chat input

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -457,7 +457,7 @@ export default function ChatInput({
                   onSend(text, undefined, options);
                 }
               }}
-              className="pointer-events-auto rounded border border-dashed border-muted-foreground/40 px-2 py-0.5 text-[11px] text-muted-foreground/40 transition-colors hover:border-muted-foreground/60 hover:text-muted-foreground/60"
+              className="pointer-events-auto rounded border border-dashed border-muted-foreground/30 px-2 py-0.5 text-[11px] text-muted-foreground/40 transition-colors hover:border-muted-foreground/60 hover:text-muted-foreground/60"
             >
               Commit & Push
             </button>

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -439,6 +439,30 @@ export default function ChatInput({
           </PromptInputTools>
         </PromptInputFooter>
         </PromptInput>
+        {!value.trim() && !isInputDisabled && (
+          <div className="pointer-events-none absolute top-2 right-2 z-10 flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => {
+                const text = "Commit and push all changes";
+                const options: MessageOptions = {
+                  model: selectedModelId || undefined,
+                  ...(supportsPlanMode && { planMode: false }),
+                  ...(supportsThinkingToggle && { thinkingEnabled: false }),
+                  ...(supportsThinkingLevels && { thinkingLevel: "low" as ThinkingLevel }),
+                };
+                if (isStreaming) {
+                  onQueue({ content: text, options });
+                } else {
+                  onSend(text, undefined, options);
+                }
+              }}
+              className="pointer-events-auto rounded border border-dashed border-muted-foreground/40 px-2 py-0.5 text-[11px] text-muted-foreground/40 transition-colors hover:border-muted-foreground/60 hover:text-muted-foreground/60"
+            >
+              Commit & Push
+            </button>
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Adds a subtle dashed "Commit & Push" button in the top-right corner of the chat input
- Sends "Commit and push all changes" with thinking disabled for fast/cheap execution
- Disappears when text is entered or input is disabled; supports queue during streaming

## Test plan
- [ ] Verify button appears when input is empty and enabled
- [ ] Verify button disappears when typing text
- [ ] Verify clicking sends the message and button disappears
- [ ] Verify button queues message when agent is streaming
- [ ] Verify button is hidden when input is disabled/disconnected