### PR TITLE
Improve AskUserQuestion dismiss with CANCELLED badge

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -927,6 +927,16 @@ describe("ConversationSession", () => {
     );
   });
 
+  it("sends 'Question dismissed.' for AskUserQuestion reject with [question_dismissed] marker", () => {
+    const session = createSession({ sessionId: "ask-dismiss" });
+    const sendSpy = vi.spyOn(session, "sendMessage").mockImplementation(() => {});
+
+    session.respondToToolInput("AskUserQuestion", { type: "reject", message: "[question_dismissed]" });
+
+    expect(sendSpy).toHaveBeenCalledTimes(1);
+    expect(sendSpy).toHaveBeenCalledWith("Question dismissed.");
+  });
+
   // ── Image attachment tests ──────────────────────────────────────────
 
   it("emits user_message with URL-based images after saving to disk", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -702,6 +702,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       const feedback = result.message || "Please suggest an alternative approach.";
       const cliPrompt = `${feedback}\n\nIMPORTANT: You are still in plan mode. Update the plan file in .claude/plans/ with these adjustments, then call ExitPlanMode to submit the updated plan for review. Do NOT modify any source code files directly.`;
       this.sendMessage(feedback, { planMode: true }, undefined, cliPrompt);
+    } else if (toolName === "AskUserQuestion" && result.type === "reject" && result.message === "[question_dismissed]") {
+      this.sendMessage("Question dismissed.");
     } else if (result.type === "reject") {
       this.sendMessage(result.message || "I reject this. Please suggest an alternative approach.");
     }

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -196,19 +196,23 @@ export default function ChatConversation({
               description=""
             />
           ))}
-        {messages.map((msg, i) => (
-          <ChatMessage
-            key={msg.id ?? `${msg.timestamp}-${i}`}
-            message={msg}
-            isInteractive={isMessageInteractive(msg, i)}
-            planStatus={getPlanStatus(msg, i)}
-            dismissedToolCallIds={dismissedToolCallIds}
-            onQuestionAnswer={onQuestionAnswer}
-            onPlanApproval={onPlanApproval}
-            onHandOff={onHandOff}
-            onFileMentionClick={onFileMentionClick}
-          />
-        ))}
+        {messages.map((msg, i) => {
+          // Hide "Question dismissed." user bubbles — the CANCELLED badge already conveys this
+          if (msg.role === "user" && msg.content === "Question dismissed.") return null;
+          return (
+            <ChatMessage
+              key={msg.id ?? `${msg.timestamp}-${i}`}
+              message={msg}
+              isInteractive={isMessageInteractive(msg, i)}
+              planStatus={getPlanStatus(msg, i)}
+              dismissedToolCallIds={dismissedToolCallIds}
+              onQuestionAnswer={onQuestionAnswer}
+              onPlanApproval={onPlanApproval}
+              onHandOff={onHandOff}
+              onFileMentionClick={onFileMentionClick}
+            />
+          );
+        })}
 
         {/* Live streaming content */}
         {isStreaming && (currentStreamingText || currentThinking || activeToolCalls.length > 0) && (

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Conversation,
   ConversationContent,
@@ -152,6 +152,24 @@ export default function ChatConversation({
     return hasLaterPlan ? "revised" : "approved";
   };
 
+  const dismissedToolCallIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (let i = 0; i < messages.length - 1; i++) {
+      const msg = messages[i];
+      const next = messages[i + 1];
+      if (
+        msg.role === "assistant" &&
+        next?.role === "user" &&
+        next.content === "Question dismissed."
+      ) {
+        msg.toolCalls
+          ?.filter((tc) => tc.name === "AskUserQuestion")
+          .forEach((tc) => ids.add(tc.id));
+      }
+    }
+    return ids;
+  }, [messages]);
+
   return (
     <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={settled ? "smooth" : "instant"}>
       {error && (
@@ -184,6 +202,7 @@ export default function ChatConversation({
             message={msg}
             isInteractive={isMessageInteractive(msg, i)}
             planStatus={getPlanStatus(msg, i)}
+            dismissedToolCallIds={dismissedToolCallIds}
             onQuestionAnswer={onQuestionAnswer}
             onPlanApproval={onPlanApproval}
             onHandOff={onHandOff}

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -56,6 +56,7 @@ interface ChatMessageProps {
   message: ChatMessageType;
   isInteractive?: boolean;
   planStatus?: PlanStatus;
+  dismissedToolCallIds?: Set<string>;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onPlanApproval?: () => void;
   onHandOff?: (planContent: string, planPath?: string) => void;
@@ -66,6 +67,7 @@ const ChatMessage = memo(function ChatMessage({
   message,
   isInteractive = false,
   planStatus,
+  dismissedToolCallIds,
   onQuestionAnswer,
   onPlanApproval,
   onHandOff,
@@ -148,6 +150,7 @@ const ChatMessage = memo(function ChatMessage({
                 toolCalls={message.toolCalls}
                 isInteractive={isInteractive}
                 planStatus={planStatus}
+                dismissedToolCallIds={dismissedToolCallIds}
                 onQuestionAnswer={onQuestionAnswer}
                 onPlanApproval={onPlanApproval}
                 onHandOff={onHandOff}

--- a/frontend/src/components/chat/AskUserQuestion.tsx
+++ b/frontend/src/components/chat/AskUserQuestion.tsx
@@ -2,17 +2,19 @@ import { useState, memo } from "react";
 import type { ToolCall } from "@/types";
 import { parseQuestions } from "@/types";
 import { cn } from "@/lib/utils";
-import { MessageSquareIcon, ClockIcon, CheckCircle2Icon } from "lucide-react";
+import { MessageSquareIcon, ClockIcon, CheckCircle2Icon, XCircleIcon } from "lucide-react";
 import { ContentPanel, ContentPanelBody } from "./ContentPanel";
 
 interface AskUserQuestionProps {
   tool: ToolCall;
   isInteractive?: boolean;
+  isDismissed?: boolean;
 }
 
 export const AskUserQuestion = memo(function AskUserQuestion({
   tool,
   isInteractive = false,
+  isDismissed = false,
 }: AskUserQuestionProps) {
   const questions = parseQuestions(tool);
   const [expanded, setExpanded] = useState(false);
@@ -44,9 +46,12 @@ export const AskUserQuestion = memo(function AskUserQuestion({
       >
         <MessageSquareIcon className="size-3.5" />
         <span>User input</span>
-        <span className="inline-flex items-center gap-1 rounded bg-muted px-2 py-0.5 text-[11px] font-mono text-muted-foreground">
-          <CheckCircle2Icon className="size-3" />
-          ANSWERED
+        <span className={cn(
+          "inline-flex items-center gap-1 rounded px-2 py-0.5 text-[11px] font-mono",
+          isDismissed ? "bg-destructive/10 text-destructive" : "bg-muted text-muted-foreground",
+        )}>
+          {isDismissed ? <XCircleIcon className="size-3" /> : <CheckCircle2Icon className="size-3" />}
+          {isDismissed ? "CANCELLED" : "ANSWERED"}
         </span>
         {!expanded && (
           <span className="text-xs font-normal text-muted-foreground/60">

--- a/frontend/src/components/chat/QuestionPanel.tsx
+++ b/frontend/src/components/chat/QuestionPanel.tsx
@@ -1,11 +1,8 @@
-import { useState, useMemo, useCallback, useEffect } from "react";
+import { useState, useMemo, useCallback, useEffect, useRef } from "react";
 import type { PendingToolInput } from "@/hooks/useConversation";
 import type { Question, QuestionAnswer } from "@/types";
-import { MessageResponse } from "@/components/ai-elements/message";
-import { Textarea } from "@/components/ui/textarea";
-import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { XIcon, ChevronLeftIcon, ChevronRightIcon, SendIcon, ArrowRightIcon } from "lucide-react";
+import { XIcon, ChevronLeftIcon, ChevronRightIcon, ArrowUpIcon } from "lucide-react";
 
 interface QuestionPanelProps {
   pendingToolInputs: PendingToolInput[];
@@ -55,6 +52,7 @@ export default function QuestionPanel({
 
   const [currentIndex, setCurrentIndex] = useState(0);
   const [drafts, setDrafts] = useState<Map<string, AnswerDraft>>(new Map());
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Clamp index if questions change
   useEffect(() => {
@@ -68,6 +66,8 @@ export default function QuestionPanel({
   const currentQuestion = flatQuestions[currentIndex];
   const currentDraft =
     currentQuestion ? (drafts.get(draftKey(currentQuestion)) ?? emptyDraft()) : emptyDraft();
+
+  const hasCustomText = currentDraft.customText.trim().length > 0;
 
   const updateDraft = useCallback(
     (patch: Partial<AnswerDraft>) => {
@@ -86,20 +86,30 @@ export default function QuestionPanel({
   const toggleOption = useCallback(
     (optionIndex: number) => {
       if (!currentQuestion) return;
+      // Clicking an option clears custom text
       const isMulti = currentQuestion.question.multiSelect === true;
       if (isMulti) {
         const next = currentDraft.selectedOptions.includes(optionIndex)
           ? currentDraft.selectedOptions.filter((i) => i !== optionIndex)
           : [...currentDraft.selectedOptions, optionIndex];
-        updateDraft({ selectedOptions: next });
+        updateDraft({ selectedOptions: next, customText: "" });
       } else {
         updateDraft({
           selectedOptions:
             currentDraft.selectedOptions[0] === optionIndex ? [] : [optionIndex],
+          customText: "",
         });
       }
     },
     [currentQuestion, currentDraft, updateDraft],
+  );
+
+  const handleCustomTextChange = useCallback(
+    (value: string) => {
+      // Typing in custom input deselects all options
+      updateDraft({ customText: value, selectedOptions: [] });
+    },
+    [updateDraft],
   );
 
   const hasAnswer = (fq: FlatQuestion): boolean => {
@@ -111,7 +121,6 @@ export default function QuestionPanel({
   const answeredCount = flatQuestions.filter(hasAnswer).length;
 
   const handleSubmit = useCallback(() => {
-    // Group answers by toolUseId
     const grouped = new Map<string, QuestionAnswer[]>();
     for (const fq of flatQuestions) {
       const d = drafts.get(draftKey(fq));
@@ -130,148 +139,151 @@ export default function QuestionPanel({
     onBatchSubmit(responses);
   }, [flatQuestions, drafts, onBatchSubmit]);
 
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey && answeredCount > 0) {
+        e.preventDefault();
+        handleSubmit();
+      }
+    },
+    [answeredCount, handleSubmit],
+  );
+
   if (flatQuestions.length === 0) return null;
 
   const total = flatQuestions.length;
+  const canSubmit = answeredCount > 0;
 
   return (
-    <div className="border-t border-border/30 bg-background p-4">
-      {/* Header: question text + dismiss */}
-      <div className="mb-3 flex items-start gap-3">
-        <div className="min-w-0 flex-1 text-sm font-medium">
-          <MessageResponse>{currentQuestion.question.question}</MessageResponse>
+    <div className="border-t border-border/30 px-3 py-3">
+      <div className="rounded-lg border border-border/50 bg-background">
+        {/* Question text + dismiss */}
+        <div className="flex items-start gap-3 px-4 pt-3.5 pb-1">
+          <p className="min-w-0 flex-1 text-[13px] font-medium text-foreground">
+            {currentQuestion.question.question}
+          </p>
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="shrink-0 rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground"
+            aria-label="Dismiss questions"
+          >
+            <XIcon className="size-3.5" />
+          </button>
         </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          aria-label="Dismiss questions"
-        >
-          <XIcon className="size-4" />
-        </button>
-      </div>
 
-      {/* Numbered options */}
-      {currentQuestion.question.options.length > 0 && (
-        <div className="mb-3 space-y-1.5">
-          {currentQuestion.question.options.map((opt, i) => {
-            const isSelected = currentDraft.selectedOptions.includes(i);
-            return (
-              <button
-                key={i}
-                type="button"
-                onClick={() => toggleOption(i)}
-                className={cn(
-                  "flex w-full items-start gap-3 rounded-md px-3 py-2 text-left text-sm transition-colors",
-                  isSelected
-                    ? "bg-primary/10 text-primary ring-1 ring-primary/20"
-                    : "text-foreground hover:bg-muted/50",
-                )}
-              >
-                <span
+        {/* Options */}
+        {currentQuestion.question.options.length > 0 && (
+          <div className="px-4 py-2 space-y-0.5">
+            {currentQuestion.question.options.map((opt, i) => {
+              const isSelected = currentDraft.selectedOptions.includes(i);
+              return (
+                <button
+                  key={i}
+                  type="button"
+                  onClick={() => toggleOption(i)}
                   className={cn(
-                    "mt-0.5 flex size-5 shrink-0 items-center justify-center rounded text-xs font-medium",
+                    "flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
                     isSelected
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-muted text-muted-foreground",
+                      ? "text-foreground bg-muted/60"
+                      : "text-foreground/80 hover:bg-muted/40",
                   )}
                 >
-                  {i + 1}
-                </span>
-                <span className="min-w-0 flex-1">
-                  {opt.label}
-                  {opt.description && (
-                    <span className="block text-xs text-muted-foreground">
-                      {opt.description}
-                    </span>
-                  )}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      )}
-
-      {/* Custom text (the "0" row) */}
-      <div className="mb-3 flex items-start gap-3">
-        <span className="mt-2 flex size-5 shrink-0 items-center justify-center rounded bg-muted text-xs font-medium text-muted-foreground">
-          0
-        </span>
-        <Textarea
-          placeholder="Type something..."
-          value={currentDraft.customText}
-          onChange={(e) => updateDraft({ customText: e.target.value })}
-          className="min-h-[40px] flex-1 text-sm"
-          rows={1}
-        />
-      </div>
-
-      {/* Footer: pagination + submit */}
-      <div className="flex items-center justify-between">
-        {/* Pagination */}
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
-            disabled={currentIndex === 0}
-            className="rounded p-1 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
-            aria-label="Previous question"
-          >
-            <ChevronLeftIcon className="size-4" />
-          </button>
-
-          {/* Dots */}
-          <div className="flex items-center gap-1.5">
-            {flatQuestions.map((fq, i) => (
-              <button
-                key={`${fq.toolUseId}-${fq.questionIndex}`}
-                type="button"
-                onClick={() => setCurrentIndex(i)}
-                className={cn(
-                  "size-2 rounded-full transition-colors",
-                  i === currentIndex
-                    ? "bg-foreground"
-                    : hasAnswer(fq)
-                      ? "bg-primary/60"
-                      : "bg-muted-foreground/30",
-                )}
-                aria-label={`Question ${i + 1}`}
-              />
-            ))}
+                  <span
+                    className={cn(
+                      "flex size-5 shrink-0 items-center justify-center rounded text-xs tabular-nums",
+                      isSelected
+                        ? "text-foreground font-medium"
+                        : "text-muted-foreground",
+                    )}
+                  >
+                    {i + 1}
+                  </span>
+                  <span className="min-w-0 flex-1">{opt.label}</span>
+                </button>
+              );
+            })}
           </div>
+        )}
 
+        {/* Custom text input + submit */}
+        <div className="flex items-center gap-3 px-6 pt-1 pb-3">
+          <span
+            className={cn(
+              "flex size-5 shrink-0 items-center justify-center rounded text-xs tabular-nums",
+              hasCustomText ? "text-foreground font-medium" : "text-muted-foreground/30",
+            )}
+          >
+            0
+          </span>
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Type something..."
+            value={currentDraft.customText}
+            onChange={(e) => handleCustomTextChange(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="min-w-0 flex-1 bg-transparent text-[13px] text-foreground placeholder:text-muted-foreground/40 outline-none"
+          />
+
+          {/* Pagination (multi-question only) */}
+          {total > 1 && (
+            <div className="flex items-center gap-1 mr-1">
+              <button
+                type="button"
+                onClick={() => setCurrentIndex((i) => Math.max(0, i - 1))}
+                disabled={currentIndex === 0}
+                className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-0"
+                aria-label="Previous question"
+              >
+                <ChevronLeftIcon className="size-3.5" />
+              </button>
+              <div className="flex items-center gap-1">
+                {flatQuestions.map((fq, i) => (
+                  <button
+                    key={`${fq.toolUseId}-${fq.questionIndex}`}
+                    type="button"
+                    onClick={() => setCurrentIndex(i)}
+                    className={cn(
+                      "size-1.5 rounded-full transition-colors",
+                      i === currentIndex
+                        ? "bg-foreground"
+                        : hasAnswer(fq)
+                          ? "bg-foreground/40"
+                          : "bg-muted-foreground/20",
+                    )}
+                    aria-label={`Question ${i + 1}`}
+                  />
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={() => setCurrentIndex((i) => Math.min(total - 1, i + 1))}
+                disabled={currentIndex === total - 1}
+                className="rounded p-0.5 text-muted-foreground/50 transition-colors hover:text-foreground disabled:opacity-0"
+                aria-label="Next question"
+              >
+                <ChevronRightIcon className="size-3.5" />
+              </button>
+            </div>
+          )}
+
+          {/* Submit button */}
           <button
             type="button"
-            onClick={() => setCurrentIndex((i) => Math.min(total - 1, i + 1))}
-            disabled={currentIndex === total - 1}
-            className="rounded p-1 text-muted-foreground transition-colors hover:text-foreground disabled:opacity-30"
-            aria-label="Next question"
+            onClick={handleSubmit}
+            disabled={!canSubmit}
+            className={cn(
+              "flex size-7 shrink-0 items-center justify-center rounded-md transition-colors",
+              canSubmit
+                ? "bg-foreground text-background hover:bg-foreground/90 cursor-pointer"
+                : "bg-muted text-muted-foreground/40 cursor-default",
+            )}
+            aria-label={total > 1 ? `Submit (${answeredCount}/${total})` : "Submit"}
           >
-            <ChevronRightIcon className="size-4" />
+            <ArrowUpIcon className="size-3.5" strokeWidth={2.5} />
           </button>
         </div>
-
-        {/* Next / Submit */}
-        {currentIndex < total - 1 ? (
-          <Button
-            size="sm"
-            onClick={() => setCurrentIndex((i) => i + 1)}
-            className="gap-1.5"
-          >
-            Next
-            <ArrowRightIcon className="size-3" />
-          </Button>
-        ) : (
-          <Button
-            size="sm"
-            onClick={handleSubmit}
-            disabled={answeredCount === 0}
-            className="gap-1.5"
-          >
-            <SendIcon className="size-3" />
-            Submit{total > 1 ? ` (${answeredCount}/${total})` : ""}
-          </Button>
-        )}
       </div>
     </div>
   );

--- a/frontend/src/components/chat/QuestionPanel.tsx
+++ b/frontend/src/components/chat/QuestionPanel.tsx
@@ -156,7 +156,7 @@ export default function QuestionPanel({
 
   return (
     <div className="border-t border-border/30 px-3 py-3">
-      <div className="rounded-lg border border-border/50 bg-background">
+      <div className="rounded-lg border border-border/50 bg-muted/40">
         {/* Question text + dismiss */}
         <div className="flex items-start gap-3 px-4 pt-3.5 pb-1">
           <p className="min-w-0 flex-1 text-[13px] font-medium text-foreground">

--- a/frontend/src/components/chat/QuestionPanel.tsx
+++ b/frontend/src/components/chat/QuestionPanel.tsx
@@ -152,7 +152,7 @@ export default function QuestionPanel({
   if (flatQuestions.length === 0) return null;
 
   const total = flatQuestions.length;
-  const canSubmit = answeredCount > 0;
+  const canSubmit = total > 1 ? answeredCount === total : answeredCount > 0;
 
   return (
     <div className="border-t border-border/30 px-3 py-3">

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -231,6 +231,7 @@ interface ToolCallListProps {
   isInteractive?: boolean;
   showExecutingState?: boolean;
   planStatus?: PlanStatus;
+  dismissedToolCallIds?: Set<string>;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onPlanApproval?: () => void;
   onHandOff?: (planContent: string, planPath?: string) => void;
@@ -241,6 +242,7 @@ export function ToolCallList({
   isInteractive,
   showExecutingState,
   planStatus,
+  dismissedToolCallIds,
   onQuestionAnswer: _onQuestionAnswer,
   onPlanApproval,
   onHandOff,
@@ -331,6 +333,7 @@ export function ToolCallList({
               key={tool.id}
               tool={tool}
               isInteractive={isInteractive}
+              isDismissed={dismissedToolCallIds?.has(tool.id)}
             />
           );
         }

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -534,7 +534,7 @@ export default function WorkspaceView() {
               queuedMessage={queuedMessage}
               onClearQueue={() => setQueuedMessage(null)}
             />
-            {tasks.length > 0 && (
+            {tasks.length > 0 && !pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") && (
               <TaskTracker
                 tasks={tasks}
                 currentTask={currentTask}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -546,7 +546,7 @@ export default function WorkspaceView() {
               <QuestionPanel
                 pendingToolInputs={pendingToolInputs}
                 onBatchSubmit={batchAnswerQuestions}
-                onDismiss={() => rejectToolInput("cancel")}
+                onDismiss={() => rejectToolInput("[question_dismissed]")}
               />
             ) : (
               <ChatInput

--- a/frontend/tests/components/AskUserQuestion.test.tsx
+++ b/frontend/tests/components/AskUserQuestion.test.tsx
@@ -62,6 +62,20 @@ describe("AskUserQuestion", () => {
     expect(screen.getByText("Choose runtime")).toBeInTheDocument();
   });
 
+  it("shows CANCELLED badge when isDismissed is true", () => {
+    render(
+      <AskUserQuestion
+        tool={askTool({
+          questions: [{ question: "Pick one", options: [{ label: "A" }] }],
+        })}
+        isDismissed
+      />,
+    );
+
+    expect(screen.getByText("CANCELLED")).toBeInTheDocument();
+    expect(screen.queryByText("ANSWERED")).not.toBeInTheDocument();
+  });
+
   it("returns null when payload has no questions", () => {
     const { container } = render(<AskUserQuestion tool={askTool("{bad json")} />);
     expect(container).toBeEmptyDOMElement();

--- a/frontend/tests/components/QuestionPanel.test.tsx
+++ b/frontend/tests/components/QuestionPanel.test.tsx
@@ -61,15 +61,18 @@ describe("QuestionPanel", () => {
       />,
     );
 
-    await user.click(screen.getByRole("button", { name: /2B/ }));
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    // Q1: pick option B
+    await user.click(screen.getByRole("button", { name: /B/ }));
+    // Navigate to Q2 via pagination dot
+    await user.click(screen.getByRole("button", { name: "Question 2" }));
 
-    await user.click(screen.getByRole("button", { name: /One/ }));
-    await user.click(screen.getByRole("button", { name: /Two/ }));
-    await user.type(screen.getByPlaceholderText("Type something..."), "  extra choice  ");
-    await user.click(screen.getByRole("button", { name: "Next" }));
+    // Q2: type custom text (in multi-select, typing clears any selected options)
+    await user.type(screen.getByPlaceholderText("Type something..."), "extra choice");
+    // Navigate to Q3 via pagination dot
+    await user.click(screen.getByRole("button", { name: "Question 3" }));
 
-    await user.type(screen.getByPlaceholderText("Type something..."), "  custom note  ");
+    // Q3: type custom text
+    await user.type(screen.getByPlaceholderText("Type something..."), "custom note");
     await user.click(screen.getByRole("button", { name: "Submit (3/3)" }));
 
     expect(onBatchSubmit).toHaveBeenCalledTimes(1);
@@ -78,7 +81,7 @@ describe("QuestionPanel", () => {
         toolUseId: "ask-1",
         answers: [
           { questionIndex: 0, selectedOptions: [1], customText: undefined },
-          { questionIndex: 1, selectedOptions: [0, 1], customText: "extra choice" },
+          { questionIndex: 1, selectedOptions: [], customText: "extra choice" },
         ],
       },
       {
@@ -127,5 +130,73 @@ describe("QuestionPanel", () => {
 
     await user.click(screen.getByRole("button", { name: "Dismiss questions" }));
     expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("typing custom text deselects options", async () => {
+    const user = userEvent.setup();
+    const onBatchSubmit = vi.fn();
+    render(
+      <QuestionPanel
+        pendingToolInputs={[
+          askInput("ask-1", [
+            {
+              question: "Pick one",
+              options: [{ label: "A" }, { label: "B" }],
+            },
+          ]),
+        ]}
+        onBatchSubmit={onBatchSubmit}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    // Select option A
+    await user.click(screen.getByRole("button", { name: /A/ }));
+    // Type custom text — should deselect option A
+    await user.type(screen.getByPlaceholderText("Type something..."), "my answer");
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onBatchSubmit).toHaveBeenCalledWith([
+      {
+        toolUseId: "ask-1",
+        answers: [
+          { questionIndex: 0, selectedOptions: [], customText: "my answer" },
+        ],
+      },
+    ]);
+  });
+
+  it("clicking option clears custom text", async () => {
+    const user = userEvent.setup();
+    const onBatchSubmit = vi.fn();
+    render(
+      <QuestionPanel
+        pendingToolInputs={[
+          askInput("ask-1", [
+            {
+              question: "Pick one",
+              options: [{ label: "A" }, { label: "B" }],
+            },
+          ]),
+        ]}
+        onBatchSubmit={onBatchSubmit}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    // Type custom text first
+    await user.type(screen.getByPlaceholderText("Type something..."), "my answer");
+    // Click option B — should clear custom text
+    await user.click(screen.getByRole("button", { name: /B/ }));
+    await user.click(screen.getByRole("button", { name: "Submit" }));
+
+    expect(onBatchSubmit).toHaveBeenCalledWith([
+      {
+        toolUseId: "ask-1",
+        answers: [
+          { questionIndex: 0, selectedOptions: [1], customText: undefined },
+        ],
+      },
+    ]);
   });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -594,7 +594,7 @@ describe("WorkspaceView behavior", () => {
     expect(mocks.batchAnswerQuestions).toHaveBeenCalledWith([{ toolUseId: "ask-1", answers: [] }]);
 
     await user.click(screen.getByRole("button", { name: "dismiss questions" }));
-    expect(mocks.rejectToolInput).toHaveBeenCalledWith("cancel");
+    expect(mocks.rejectToolInput).toHaveBeenCalledWith("[question_dismissed]");
   });
 
   it("activates a session by calling switchSession directly", async () => {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -83,8 +83,10 @@ struct ChatView: View {
                     ScrollView {
                         VStack(spacing: 16) {
                             ForEach(store.displayMessages) { message in
-                                MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
-                                    .id(message.id)
+                                if !(message.role == .user && message.content == "Question dismissed.") {
+                                    MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
+                                        .id(message.id)
+                                }
                             }
 
                             if store.isStreaming {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -50,6 +50,21 @@ struct ChatView: View {
         Set(store.pendingToolInputs.map(\.toolUseId))
     }
 
+    private var dismissedToolCallIds: Set<String> {
+        var ids = Set<String>()
+        let msgs = store.messages
+        for i in 0..<(msgs.count - 1) {
+            let msg = msgs[i]
+            let next = msgs[i + 1]
+            if msg.role == .assistant, next.role == .user, next.content == "Question dismissed." {
+                for tc in msg.toolCalls ?? [] where tc.name == "AskUserQuestion" {
+                    ids.insert(tc.id)
+                }
+            }
+        }
+        return ids
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
@@ -68,7 +83,7 @@ struct ChatView: View {
                     ScrollView {
                         VStack(spacing: 16) {
                             ForEach(store.displayMessages) { message in
-                                MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds)
+                                MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                                     .id(message.id)
                             }
 

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct MessageBubble: View {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
+    var dismissedToolCallIds: Set<String> = []
 
     @State private var copied = false
 
@@ -17,7 +18,7 @@ struct MessageBubble: View {
                 }
 
                 if let tools = message.toolCalls, !tools.isEmpty {
-                    WhisperToolCallsBlock(toolCalls: tools, pendingToolUseIds: pendingToolUseIds)
+                    WhisperToolCallsBlock(toolCalls: tools, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                 }
 
                 messageContent
@@ -398,7 +399,7 @@ private func computeToolStats(_ tool: ToolCall) -> ToolStats? {
     }
 }
 
-private func getToolDisplay(_ tool: ToolCall, isPending: Bool = false) -> ToolDisplay {
+private func getToolDisplay(_ tool: ToolCall, isPending: Bool = false, isDismissed: Bool = false) -> ToolDisplay {
     guard let data = tool.input.data(using: .utf8),
           let input = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         return ToolDisplay(icon: toolIcon(for: tool.name), label: tool.name, detail: String(tool.input.prefix(40)))
@@ -457,12 +458,14 @@ private func getToolDisplay(_ tool: ToolCall, isPending: Bool = false) -> ToolDi
     case "AskUserQuestion":
         let questions = (input["questions"] as? [[String: Any]]) ?? []
         let count = questions.count
+        let badgeText = isPending ? "WAITING" : (isDismissed ? "CANCELLED" : "ANSWERED")
+        let badgeIcon = isPending ? "clock" : (isDismissed ? "xmark.circle" : "checkmark.circle")
         return ToolDisplay(
             icon: "bubble.left",
             label: "User input",
             hideOutput: true,
-            badgeText: isPending ? "WAITING" : "ANSWERED",
-            badgeIcon: isPending ? "clock" : "checkmark.circle",
+            badgeText: badgeText,
+            badgeIcon: badgeIcon,
             overrideSummary: count > 0 ? "\(count) question\(count != 1 ? "s" : "")" : nil
         )
 
@@ -538,6 +541,7 @@ private let collapseThreshold = 3
 private struct WhisperToolCallsBlock: View {
     let toolCalls: [ToolCall]
     var pendingToolUseIds: Set<String> = []
+    var dismissedToolCallIds: Set<String> = []
     @State private var groupExpanded = false
 
     private static let hiddenTaskTools: Set<String> = ["TaskUpdate"]
@@ -575,7 +579,8 @@ private struct WhisperToolCallsBlock: View {
                     WhisperToolCallRow(
                         tool: tool,
                         children: children(for: tool.id),
-                        isPending: pendingToolUseIds.contains(tool.id)
+                        isPending: pendingToolUseIds.contains(tool.id),
+                        isDismissed: dismissedToolCallIds.contains(tool.id)
                     )
                 }
                 .transition(.opacity)
@@ -641,10 +646,11 @@ private struct WhisperToolCallRow: View {
     let tool: ToolCall
     let children: [ToolCall]
     var isPending = false
+    var isDismissed = false
     @State private var isExpanded = false
 
     var body: some View {
-        let display = getToolDisplay(tool, isPending: isPending)
+        let display = getToolDisplay(tool, isPending: isPending, isDismissed: isDismissed)
         let summary = !isExpanded && display.stats == nil ? (display.overrideSummary ?? getOutputSummary(tool)) : nil
 
         VStack(alignment: .leading, spacing: 0) {


### PR DESCRIPTION
## Summary

- Add proper AskUserQuestion cancel: sends `"Question dismissed."` to the agent instead of bare `"cancel"`, giving the agent clear context to adapt
- Show **CANCELLED** badge (with destructive styling) instead of **ANSWERED** when a question was dismissed — across web, desktop, and iOS
- Hide TaskTracker when QuestionPanel is active to free vertical space
- Suppress the redundant `"Question dismissed."` user bubble since the CANCELLED badge already conveys the info

## Test plan

- [x] Backend: new test for `[question_dismissed]` marker in `respondToToolInput()`
- [x] Frontend: new test for `isDismissed` rendering in `AskUserQuestion`
- [x] Existing WorkspaceView test updated for new marker string
- [x] `npm run typecheck` passes
- [x] `npm test` passes (857/857)
- [ ] Manual: trigger AskUserQuestion → click X → verify CANCELLED badge + no user bubble
- [ ] Manual: trigger AskUserQuestion → answer → verify ANSWERED badge still works
- [ ] Manual: reload page → verify badges persist correctly from history