### PR TITLE
Fix plan-mode approval

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -921,12 +921,31 @@ describe("ConversationSession", () => {
       "Plan approved. Proceed with implementation.",
       { planMode: false },
       undefined,
-      expect.stringContaining("approved your plan"),
+      expect.stringContaining("ExitPlanMode (unknown)"),
     );
     expect(sendSpy).toHaveBeenNthCalledWith(2, "Not this option");
     expect(sendSpy).toHaveBeenNthCalledWith(
       3,
       "I reject this. Please suggest an alternative approach.",
+    );
+  });
+
+  it("includes the last blocking tool id when approving ExitPlanMode", () => {
+    const session = createSession({ sessionId: "respond-approve-tool-id" });
+
+    session.sendMessage("Plan this");
+    mockProc._stdout.push(
+      assistantToolUseLine({ id: "toolu_plan_42", name: "ExitPlanMode", input: { planFile: "plan.md" } }),
+    );
+
+    const sendSpy = vi.spyOn(session, "sendMessage").mockImplementation(() => {});
+    session.respondToToolInput("ExitPlanMode", { type: "approve" });
+
+    expect(sendSpy).toHaveBeenCalledWith(
+      "Plan approved. Proceed with implementation.",
+      { planMode: false },
+      undefined,
+      expect.stringContaining("ExitPlanMode (toolu_plan_42)"),
     );
   });
 
@@ -1231,6 +1250,29 @@ describe("ConversationSession", () => {
       toolUseId: "toolu_plan",
     });
     expect(session.status).toBe("idle");
+  });
+
+  it("emits plan_mode_changed for EnterPlanMode and ExitPlanMode tool use blocks", async () => {
+    const session = createSession({ sessionId: "plan-mode-events" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Plan this");
+    mockProc._stdout.push(
+      assistantToolUseLine({ id: "toolu_enter", name: "EnterPlanMode", input: {} }),
+    );
+    mockProc._stdout.push(
+      assistantToolUseLine({ id: "toolu_exit", name: "ExitPlanMode", input: { plan: "Step 1" } }),
+    );
+
+    mockProc._emitClose(137);
+    await new Promise((r) => setTimeout(r, 50));
+
+    const planModeEvents = messages.filter((m) => m.type === "plan_mode_changed");
+    expect(planModeEvents).toMatchObject([
+      { type: "plan_mode_changed", sessionId: "plan-mode-events", active: true },
+      { type: "plan_mode_changed", sessionId: "plan-mode-events", active: false },
+    ]);
   });
 
   // ── Conversation title tests ──────────────────────────────────────

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -918,7 +918,10 @@ describe("ConversationSession", () => {
 
     expect(sendSpy).toHaveBeenNthCalledWith(
       1,
-      "approved",
+      "Plan approved. Proceed with implementation.",
+      { planMode: false },
+      undefined,
+      expect.stringContaining("approved your plan"),
     );
     expect(sendSpy).toHaveBeenNthCalledWith(2, "Not this option");
     expect(sendSpy).toHaveBeenNthCalledWith(

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -132,6 +132,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private _lastPlanMode = false;
   private _metadata: SessionMetadata;
   private stopReason: StopReason | null = null;
+  private _lastBlockingToolUseId: string | undefined;
 
   constructor(config: ConversationSessionConfig) {
     super();
@@ -430,9 +431,19 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
               pendingTaskStack.push(block.id);
             }
 
+            // Emit plan mode state changes for UI auto-toggle
+            if (block.name === "EnterPlanMode" || block.name === "ExitPlanMode") {
+              this.emit("message", {
+                type: "plan_mode_changed",
+                sessionId: this.sessionId,
+                active: block.name === "EnterPlanMode",
+              } as WsOutgoing);
+            }
+
             // Only intercept blocking tools for providers that support them
             if (supportsBlockingTools && blockingToolNames.has(block.name) && this.process) {
               killedForBlockingTool = true;
+              this._lastBlockingToolUseId = block.id;
               this.process.kill("SIGKILL");
             }
             break;
@@ -688,7 +699,13 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         this.sendMessage(msg);
       }
     } else if (toolName === "ExitPlanMode" && result.type === "approve") {
-      this.sendMessage("approved");
+      const toolUseId = this._lastBlockingToolUseId ?? "unknown";
+      this.sendMessage(
+        "Plan approved. Proceed with implementation.",
+        { planMode: false },
+        undefined,
+        `[Tool result for ExitPlanMode (${toolUseId}): Plan approved by user.]\n\nThe user has reviewed and approved your plan. You are no longer in plan mode. Execute the implementation step by step. Do NOT call ExitPlanMode again or re-propose the plan.`,
+      );
     } else if (toolName === "ExitPlanMode" && result.type === "dismiss") {
       const userMsg: ChatMessage = {
         id: nanoid(12),

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -307,7 +307,8 @@ export type WsOutgoing =
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
-  | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number };
+  | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }
+  | { type: "plan_mode_changed"; sessionId: string; active: boolean };
 
 // ── Automation types ─────────────────────────────────────────────────
 

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -40,6 +40,7 @@ interface ChatInputProps {
   messages: ChatMessage[];
   queuedMessage?: QueuedMessage | null;
   onQueue: (msg: QueuedMessage) => void;
+  agentPlanMode?: boolean;
 }
 
 interface AutocompleteState {
@@ -88,6 +89,7 @@ export default function ChatInput({
   messages,
   queuedMessage,
   onQueue,
+  agentPlanMode,
 }: ChatInputProps) {
   const [value, setValue] = useState("");
   const [thinkingEnabled, setThinkingEnabled] = useState(true);
@@ -142,6 +144,12 @@ export default function ChatInput({
       if (fallback) setSelectedModelId(fallback.id);
     }
   }, [lockedProvider, selectedModelId, models, setSelectedModelId]);
+
+  // Auto-enable plan mode when the agent enters plan mode on its own
+  useEffect(() => {
+    if (agentPlanMode === true) setPlanMode(true);
+    if (agentPlanMode === false) setPlanMode(false);
+  }, [agentPlanMode]);
 
   const completionItems = useCompletions(wsId);
   const filePaths = useFileCompletions(wsId);

--- a/frontend/src/components/chat/PlanProposal.tsx
+++ b/frontend/src/components/chat/PlanProposal.tsx
@@ -31,8 +31,6 @@ export const PlanProposal = memo(function PlanProposal({
     if (status === "revised") setOpen(false);
   }, [status]);
 
-  if (!planContent) return null;
-
   const handleApprove = () => {
     setResponded(true);
     onApprove?.();
@@ -40,7 +38,7 @@ export const PlanProposal = memo(function PlanProposal({
 
   const handleHandOff = () => {
     setResponded(true);
-    onHandOff?.(planContent, planPath);
+    onHandOff?.(planContent ?? "", planPath);
   };
 
   const statusBadge =
@@ -59,20 +57,22 @@ export const PlanProposal = memo(function PlanProposal({
       <button
         type="button"
         className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium hover:bg-muted/50"
-        onClick={() => setOpen(!open)}
+        onClick={() => planContent && setOpen(!open)}
       >
         <FileTextIcon className="size-4 text-muted-foreground" />
         <span>Proposed plan</span>
         {statusBadge}
-        <ChevronDownIcon
-          className={cn(
-            "ml-auto size-4 text-muted-foreground transition-transform",
-            open && "rotate-180",
-          )}
-        />
+        {planContent && (
+          <ChevronDownIcon
+            className={cn(
+              "ml-auto size-4 text-muted-foreground transition-transform",
+              open && "rotate-180",
+            )}
+          />
+        )}
       </button>
 
-      {open && (
+      {open && planContent && (
         <div className="border-t px-4 py-3 text-sm">
           <MessageResponse>{planContent}</MessageResponse>
         </div>
@@ -80,7 +80,7 @@ export const PlanProposal = memo(function PlanProposal({
 
       {status === "interactive" && !responded && (
         <div className="flex items-center justify-end gap-2 border-t px-4 py-3">
-          <CopyButton content={planContent} />
+          {planContent && <CopyButton content={planContent} />}
           <Button size="sm" variant="outline" onClick={handleHandOff}>
             <ArrowRightLeftIcon className="size-3" />
             Hand off

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -131,6 +131,28 @@ function findPlanContent(
     }
   }
 
+  // 4. Fallback: last Write tool to any .md file (plan may not live in .claude/plans/)
+  const mdWriteTool = toolCalls.filter((t) => {
+    if (t.name !== "Write") return false;
+    try {
+      const input = JSON.parse(t.input);
+      return typeof input.file_path === "string" && input.file_path.endsWith(".md");
+    } catch {
+      return false;
+    }
+  }).pop();
+  if (mdWriteTool) {
+    try {
+      const input = JSON.parse(mdWriteTool.input) as { content?: string; file_path?: string };
+      const content = input.content ?? "";
+      if (content.trim()) {
+        return { content, writeToolId: mdWriteTool.id, planPath: input.file_path };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
   return undefined;
 }
 

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -18,6 +18,7 @@ interface SessionStreamState {
   isStreaming: boolean;
   streamingStartedAt: number | null;
   pendingToolInputs: PendingToolInput[];
+  agentPlanMode?: boolean;
 }
 
 const emptyStreamState: SessionStreamState = {
@@ -361,6 +362,12 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       });
     }
 
+    case "plan_mode_changed": {
+      const sid = action.sessionId || state.sessionId;
+      if (!sid) return state;
+      return updateStream(state, sid, { agentPlanMode: action.active });
+    }
+
     case "clear_pending_tool_inputs": {
       const sid = state.sessionId;
       if (!sid || !state.sessionStreams[sid]) return state;
@@ -646,6 +653,7 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(state.sessionId),
     });
     dispatch({ type: "clear_pending_tool_inputs" });
+    dispatch({ type: "plan_mode_changed", sessionId: state.sessionId ?? "", active: false });
     historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
@@ -693,6 +701,7 @@ export function useConversation(workspaceId: string | undefined) {
     connectionStatus,
     error: state.error,
     sessionId: state.sessionId,
+    agentPlanMode: activeStream?.agentPlanMode,
     lockedProvider: state.lockedProvider,
     switchCounter: state.switchCounter,
     sendMessage,

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -234,6 +234,7 @@ export default function WorkspaceView() {
     approvePlan,
     rejectToolInput,
     dismissPlan,
+    agentPlanMode,
     lockedProvider,
     switchCounter,
   } = useConversation(wsId);
@@ -566,6 +567,7 @@ export default function WorkspaceView() {
                 messages={messages}
                 queuedMessage={queuedMessage}
                 onQueue={setQueuedMessage}
+                agentPlanMode={agentPlanMode}
               />
             )}
           </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -297,7 +297,8 @@ export type WsOutgoing =
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
-  | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number };
+  | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }
+  | { type: "plan_mode_changed"; sessionId: string; active: boolean };
 
 // ── Automation types ─────────────────────────────────────────────────
 

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -27,7 +27,7 @@ function renderChatInput(overrides?: Partial<ComponentProps<typeof ChatInput>>) 
   const onSend = overrides?.onSend ?? vi.fn(() => true);
   const onStop = overrides?.onStop ?? vi.fn();
   const onQueue = overrides?.onQueue ?? vi.fn();
-  render(
+  const view = render(
     <QueryClientProvider client={queryClient}>
       <ChatInput
         onSend={onSend}
@@ -41,7 +41,24 @@ function renderChatInput(overrides?: Partial<ComponentProps<typeof ChatInput>>) 
       />
     </QueryClientProvider>,
   );
-  return { onSend, onStop, onQueue };
+  const rerender = (nextOverrides?: Partial<ComponentProps<typeof ChatInput>>) => {
+    view.rerender(
+      <QueryClientProvider client={queryClient}>
+        <ChatInput
+          onSend={onSend}
+          onStop={onStop}
+          onQueue={onQueue}
+          disabled={false}
+          isStreaming={false}
+          connectionStatus="connected"
+          messages={[]}
+          {...overrides}
+          {...nextOverrides}
+        />
+      </QueryClientProvider>,
+    );
+  };
+  return { onSend, onStop, onQueue, rerender };
 }
 
 describe("ChatInput", () => {
@@ -111,6 +128,35 @@ describe("ChatInput", () => {
     await user.click(screen.getByRole("button", { name: "Send" }));
 
     expect(onSend).toHaveBeenCalledWith("hello", undefined, { model: "claude:opus-4-6", planMode: false, thinkingEnabled: true }, undefined);
+  });
+
+  it("enables plan mode automatically when agentPlanMode is true", async () => {
+    const user = userEvent.setup();
+    const { onSend } = renderChatInput({ agentPlanMode: true });
+
+    await user.type(screen.getByPlaceholderText("Send a message..."), "hello");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, {
+      model: "claude:opus-4-6",
+      planMode: true,
+      thinkingEnabled: true,
+    }, undefined);
+  });
+
+  it("updates plan mode when agentPlanMode changes", async () => {
+    const user = userEvent.setup();
+    const { onSend, rerender } = renderChatInput({ agentPlanMode: true });
+
+    rerender({ agentPlanMode: false });
+    await user.type(screen.getByPlaceholderText("Send a message..."), "hello");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSend).toHaveBeenCalledWith("hello", undefined, {
+      model: "claude:opus-4-6",
+      planMode: false,
+      thinkingEnabled: true,
+    }, undefined);
   });
 
   it("shows stop button and calls onStop while streaming", async () => {

--- a/frontend/tests/components/ToolCallList.test.tsx
+++ b/frontend/tests/components/ToolCallList.test.tsx
@@ -49,6 +49,81 @@ describe("ToolCallList", () => {
     expect(onPlanApproval).toHaveBeenCalledTimes(1);
   });
 
+  it("renders interactive plan actions even when ExitPlanMode has no plan content", async () => {
+    const user = userEvent.setup();
+    const onHandOff = vi.fn();
+
+    render(
+      <ToolCallList
+        toolCalls={[tool({ name: "ExitPlanMode", input: "{}" })]}
+        isInteractive
+        onHandOff={onHandOff}
+      />,
+    );
+
+    expect(screen.getByText("Proposed plan")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Copy message" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Hand off" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Accept" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Hand off" }));
+
+    expect(onHandOff).toHaveBeenCalledWith("", undefined);
+    expect(screen.getByText("Response submitted")).toBeInTheDocument();
+  });
+
+  it("falls back to the last markdown Write tool when plan content is not in .claude/plans", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "write-plan-md",
+            name: "Write",
+            input: JSON.stringify({
+              file_path: "docs/plan.md",
+              content: "## Plan from markdown file",
+            }),
+          }),
+          tool({ name: "ExitPlanMode", input: "{}" }),
+        ]}
+        isInteractive
+      />,
+    );
+
+    expect(screen.getByText("Plan from markdown file")).toBeInTheDocument();
+    expect(screen.queryByText("Write")).not.toBeInTheDocument();
+  });
+
+  it("uses the last markdown Write tool when multiple markdown writes exist", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "write-old",
+            name: "Write",
+            input: JSON.stringify({
+              file_path: "docs/plan.md",
+              content: "Old plan",
+            }),
+          }),
+          tool({
+            id: "write-new",
+            name: "Write",
+            input: JSON.stringify({
+              file_path: "docs/plan.md",
+              content: "New plan",
+            }),
+          }),
+          tool({ name: "ExitPlanMode", input: "{}" }),
+        ]}
+        isInteractive
+      />,
+    );
+
+    expect(screen.getByText("New plan")).toBeInTheDocument();
+    expect(screen.queryByText("Old plan")).not.toBeInTheDocument();
+  });
+
   it("renders AskUserQuestion as awaiting-response indicator in interactive mode", () => {
     const askTool = tool({
       id: "ask-1",

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -620,6 +620,105 @@ describe("useConversation", () => {
     });
   });
 
+  it("tracks agentPlanMode from plan_mode_changed events for the active session", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-active",
+        streaming: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "plan_mode_changed",
+        sessionId: "sess-active",
+        active: true,
+      });
+    });
+
+    expect(result.current.agentPlanMode).toBe(true);
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "plan_mode_changed",
+        sessionId: "sess-active",
+        active: false,
+      });
+    });
+
+    expect(result.current.agentPlanMode).toBe(false);
+  });
+
+  it("does not change active agentPlanMode when plan_mode_changed is for another session", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-active",
+        streaming: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "plan_mode_changed",
+        sessionId: "sess-active",
+        active: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "plan_mode_changed",
+        sessionId: "sess-other",
+        active: false,
+      });
+    });
+
+    expect(result.current.agentPlanMode).toBe(true);
+  });
+
+  it("clears local agentPlanMode after approvePlan", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-approve",
+        streaming: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "plan_mode_changed",
+        sessionId: "sess-approve",
+        active: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "tool_input_required",
+        sessionId: "sess-approve",
+        requestId: "req-approve",
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-approve",
+        input: {},
+      });
+    });
+
+    expect(result.current.agentPlanMode).toBe(true);
+
+    act(() => {
+      result.current.approvePlan();
+    });
+
+    expect(result.current.agentPlanMode).toBe(false);
+    expect(__wsMock.sendMock).toHaveBeenLastCalledWith("ws-1", {
+      type: "tool_input_response",
+      requestId: "req-approve",
+      toolName: "ExitPlanMode",
+      result: { type: "approve" },
+      sessionId: "sess-approve",
+    });
+  });
+
   it("includes current sessionId in tool input responses when available", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -121,6 +121,7 @@ enum WsOutgoing: Decodable {
     case branchInfo(info: BranchInfo)
     case diffStats(stats: DiffStatResponse)
     case scriptStatus(scriptType: String, state: String, exitCode: Int?)
+    case planModeChanged(sessionId: String, active: Bool)
 
     private enum CodingKeys: String, CodingKey {
         case type, sessionId, text, id, name, input, output
@@ -129,6 +130,7 @@ enum WsOutgoing: Decodable {
         case message, status, streaming, streamingStartedAt, lockedProvider
         case messages, info, stats
         case scriptType, state, exitCode
+        case active
     }
 
     init(from decoder: Decoder) throws {
@@ -237,6 +239,11 @@ enum WsOutgoing: Decodable {
                 scriptType: try container.decode(String.self, forKey: .scriptType),
                 state: try container.decode(String.self, forKey: .state),
                 exitCode: try container.decodeIfPresent(Int.self, forKey: .exitCode)
+            )
+        case "plan_mode_changed":
+            self = .planModeChanged(
+                sessionId: try container.decode(String.self, forKey: .sessionId),
+                active: try container.decode(Bool.self, forKey: .active)
             )
         default:
             // Silently ignore unknown types instead of throwing — the backend

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -10,6 +10,7 @@ struct SessionStreamState {
     var isStreaming = false
     var streamingStartedAt: Date?
     var pendingToolInputs: [PendingToolInput] = []
+    var agentPlanMode: Bool?
 }
 
 @MainActor
@@ -56,15 +57,15 @@ final class ConversationStore {
     /// Provider locked for this session (pushed via WS status events).
     var lockedProvider: String?
 
-    /// Whether the agent has entered plan mode on its own (via EnterPlanMode tool).
-    var agentPlanMode: Bool?
-
     // MARK: - Computed
 
     /// The active session's stream state (convenience accessor).
     var activeStream: SessionStreamState? {
         sessionId.flatMap { sessionStreams[$0] }
     }
+
+    /// Whether the active session's agent entered plan mode on its own (via EnterPlanMode).
+    var agentPlanMode: Bool? { activeStream?.agentPlanMode }
 
     /// Busy state for the currently focused session only.
     var isBusy: Bool { activeStream?.isStreaming ?? false }
@@ -252,15 +253,21 @@ final class ConversationStore {
             break // Handled by sidebar, not relevant to chat
 
         case .planModeChanged(let sid, let active):
-            if sid == sessionId {
-                agentPlanMode = active
-            }
+            ensureStream(for: sid, streaming: false)
+            sessionStreams[sid]?.agentPlanMode = active
         }
     }
 
     func clearPendingToolInputs() {
         guard let sid = sessionId else { return }
         sessionStreams[sid]?.pendingToolInputs = []
+    }
+
+    /// Set plan-mode state for a specific session.
+    func setAgentPlanMode(_ active: Bool?, for sessionId: String?) {
+        guard let sessionId else { return }
+        ensureStream(for: sessionId, streaming: false)
+        sessionStreams[sessionId]?.agentPlanMode = active
     }
 
     /// Current history token for a given session.

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -56,6 +56,9 @@ final class ConversationStore {
     /// Provider locked for this session (pushed via WS status events).
     var lockedProvider: String?
 
+    /// Whether the agent has entered plan mode on its own (via EnterPlanMode tool).
+    var agentPlanMode: Bool?
+
     // MARK: - Computed
 
     /// The active session's stream state (convenience accessor).
@@ -247,6 +250,11 @@ final class ConversationStore {
 
         case .scriptStatus:
             break // Handled by sidebar, not relevant to chat
+
+        case .planModeChanged(let sid, let active):
+            if sid == sessionId {
+                agentPlanMode = active
+            }
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -464,7 +464,7 @@ struct ChatView: View {
                 // Auto-disable plan mode toggle on approve
                 if pending.toolName == "ExitPlanMode", case .approve = result {
                     planModeEnabled = false
-                    store.agentPlanMode = false
+                    store.setAgentPlanMode(false, for: pending.sessionId)
                 }
             } else if pending.sessionId == activeSessionId {
                 store.messages.append(ChatMessage(

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -200,6 +200,11 @@ struct ChatView: View {
                 selectedModelId = modelCatalog.defaultModelId
             }
         }
+        .onChange(of: store.agentPlanMode) { _, active in
+            if let active {
+                planModeEnabled = active
+            }
+        }
         .onChange(of: lockedProvider) { _, newProvider in
             guard let newProvider, !selectedModelId.isEmpty else { return }
             let currentProvider = selectedModelId.split(separator: ":").first.map(String.init) ?? ""
@@ -456,6 +461,11 @@ struct ChatView: View {
             if sent {
                 store.clearPendingToolInputs()
                 store.bumpHistoryToken(for: pending.sessionId)
+                // Auto-disable plan mode toggle on approve
+                if pending.toolName == "ExitPlanMode", case .approve = result {
+                    planModeEnabled = false
+                    store.agentPlanMode = false
+                }
             } else if pending.sessionId == activeSessionId {
                 store.messages.append(ChatMessage(
                     id: UUID().uuidString, sessionId: "", role: .assistant,


### PR DESCRIPTION
## Summary
- strengthen backend and frontend plan-mode regression coverage
- add tests for plan mode change propagation, ExitPlanMode approval behavior, and markdown plan fallbacks
- refactor iOS ConversationStore to keep agent plan mode per session instead of global state
- update iOS ChatView approval flow to write plan mode on the target session

## Validation
- npm run test --workspace @hive/backend -- src/agents/conversation-session.test.ts
- npm run test --workspace @hive/frontend -- tests/components/ToolCallList.test.tsx tests/components/ChatInput.test.tsx tests/hooks/useConversation.test.tsx
- iOS build and tests could not be executed in this environment (swift and xcodebuild unavailable)
