### PR TITLE
test(frontend): harden plan-mode regression coverage

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -27,8 +27,6 @@ interface ChatConversationProps {
   activeToolCalls: ToolCall[];
   pendingToolInputs?: PendingToolInput[];
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
-  onPlanApproval?: () => void;
-  onHandOff?: (planContent: string, planPath?: string) => void;
   onFileMentionClick?: (relativePath: string) => void;
   workspaceName?: string;
   projectName?: string;
@@ -50,8 +48,6 @@ export default function ChatConversation({
   activeToolCalls,
   pendingToolInputs = [],
   onQuestionAnswer,
-  onPlanApproval,
-  onHandOff,
   onFileMentionClick,
   workspaceName,
   projectName,
@@ -207,8 +203,6 @@ export default function ChatConversation({
               planStatus={getPlanStatus(msg, i)}
               dismissedToolCallIds={dismissedToolCallIds}
               onQuestionAnswer={onQuestionAnswer}
-              onPlanApproval={onPlanApproval}
-              onHandOff={onHandOff}
               onFileMentionClick={onFileMentionClick}
             />
           );
@@ -231,8 +225,6 @@ export default function ChatConversation({
                 isInteractive
                 showExecutingState
                 onQuestionAnswer={onQuestionAnswer}
-                onPlanApproval={onPlanApproval}
-                onHandOff={onHandOff}
               />
             </div>
           </div>

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -141,11 +141,15 @@ export default function ChatConversation({
   const getPlanStatus = (msg: ChatMessageType, idx: number): PlanStatus | undefined => {
     if (!hasExitPlanModeTool(msg)) return undefined;
     if (isMessageInteractive(msg, idx)) return "interactive";
-    // "Revised" only if a later assistant message also proposes a plan
-    const hasLaterPlan = messages.slice(idx + 1).some(
+    // "Revised" if a later assistant message also proposes a plan,
+    // or if the agent is streaming after the user sent a revision (user message after plan)
+    const after = messages.slice(idx + 1);
+    const hasLaterPlan = after.some(
       (m) => m.role === "assistant" && hasExitPlanModeTool(m),
     );
-    return hasLaterPlan ? "revised" : "approved";
+    if (hasLaterPlan) return "revised";
+    if (isStreaming && after.some((m) => m.role === "user")) return "revised";
+    return "approved";
   };
 
   const dismissedToolCallIds = useMemo(() => {

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -58,8 +58,6 @@ interface ChatMessageProps {
   planStatus?: PlanStatus;
   dismissedToolCallIds?: Set<string>;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
-  onPlanApproval?: () => void;
-  onHandOff?: (planContent: string, planPath?: string) => void;
   onFileMentionClick?: (relativePath: string) => void;
 }
 
@@ -69,8 +67,6 @@ const ChatMessage = memo(function ChatMessage({
   planStatus,
   dismissedToolCallIds,
   onQuestionAnswer,
-  onPlanApproval,
-  onHandOff,
   onFileMentionClick,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
@@ -152,8 +148,6 @@ const ChatMessage = memo(function ChatMessage({
                 planStatus={planStatus}
                 dismissedToolCallIds={dismissedToolCallIds}
                 onQuestionAnswer={onQuestionAnswer}
-                onPlanApproval={onPlanApproval}
-                onHandOff={onHandOff}
               />
             )}
             {message.cancelled && (

--- a/frontend/src/components/chat/PlanActionBar.tsx
+++ b/frontend/src/components/chat/PlanActionBar.tsx
@@ -1,0 +1,53 @@
+import { memo, useState } from "react";
+import { ArrowRightLeftIcon, ClipboardIcon, CheckIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { copyToClipboard } from "@/lib/clipboard";
+
+interface PlanActionBarProps {
+  planContent?: string;
+  planPath?: string;
+  onApprove: () => void;
+  onHandOff: (content: string, planPath?: string) => void;
+}
+
+export const PlanActionBar = memo(function PlanActionBar({
+  planContent,
+  planPath,
+  onApprove,
+  onHandOff,
+}: PlanActionBarProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    if (!planContent) return;
+    await copyToClipboard(planContent);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="absolute right-4 top-0 z-10 flex -translate-y-full items-center gap-1 pb-1">
+      {planContent && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {copied ? <CheckIcon className="size-3 text-green-500" /> : <ClipboardIcon className="size-3" />}
+          Copy
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={() => onHandOff(planContent ?? "", planPath)}
+        className="inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ArrowRightLeftIcon className="size-3" />
+        Hand off
+      </button>
+      <Button size="sm" onClick={onApprove}>
+        Approve
+      </Button>
+    </div>
+  );
+});

--- a/frontend/src/components/chat/PlanProposal.tsx
+++ b/frontend/src/components/chat/PlanProposal.tsx
@@ -17,9 +17,9 @@ export const PlanProposal = memo(function PlanProposal({
 }: PlanProposalProps) {
   const [open, setOpen] = useState(status === "interactive");
 
-  // Auto-collapse when status transitions to "revised" (new refinement arrived)
+  // Auto-collapse when status leaves "interactive" (user revised or approved)
   useEffect(() => {
-    if (status === "revised") setOpen(false);
+    if (status !== "interactive") setOpen(false);
   }, [status]);
 
   const statusBadge =

--- a/frontend/src/components/chat/PlanProposal.tsx
+++ b/frontend/src/components/chat/PlanProposal.tsx
@@ -1,45 +1,26 @@
 import { useState, useEffect, memo } from "react";
-import { FileTextIcon, ChevronDownIcon, ArrowRightLeftIcon } from "lucide-react";
+import { FileTextIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { MessageResponse } from "@/components/ai-elements/message";
-import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { CopyButton } from "@/components/chat/CopyButton";
 
 export type PlanStatus = "interactive" | "approved" | "revised";
 
 interface PlanProposalProps {
   planContent?: string;
-  planPath?: string;
   status: PlanStatus;
-  onApprove?: () => void;
-  onHandOff?: (content: string, planPath?: string) => void;
 }
 
 export const PlanProposal = memo(function PlanProposal({
   planContent,
-  planPath,
   status,
-  onApprove,
-  onHandOff,
 }: PlanProposalProps) {
   const [open, setOpen] = useState(status === "interactive");
-  const [responded, setResponded] = useState(false);
 
   // Auto-collapse when status transitions to "revised" (new refinement arrived)
   useEffect(() => {
     if (status === "revised") setOpen(false);
   }, [status]);
-
-  const handleApprove = () => {
-    setResponded(true);
-    onApprove?.();
-  };
-
-  const handleHandOff = () => {
-    setResponded(true);
-    onHandOff?.(planContent ?? "", planPath);
-  };
 
   const statusBadge =
     status === "approved" ? (
@@ -53,47 +34,23 @@ export const PlanProposal = memo(function PlanProposal({
     ) : null;
 
   return (
-    <div className="my-2 rounded-lg border bg-card">
+    <div className="my-0.5">
       <button
         type="button"
-        className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium hover:bg-muted/50"
+        className={cn(
+          "inline-flex w-fit max-w-full items-center gap-2 rounded-md py-1 pr-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground",
+        )}
         onClick={() => planContent && setOpen(!open)}
       >
-        <FileTextIcon className="size-4 text-muted-foreground" />
+        <span className="shrink-0">
+          <FileTextIcon className="size-3.5" />
+        </span>
         <span>Proposed plan</span>
         {statusBadge}
-        {planContent && (
-          <ChevronDownIcon
-            className={cn(
-              "ml-auto size-4 text-muted-foreground transition-transform",
-              open && "rotate-180",
-            )}
-          />
-        )}
       </button>
-
       {open && planContent && (
-        <div className="border-t px-4 py-3 text-sm">
+        <div className="mt-1 max-h-[70vh] overflow-auto text-sm">
           <MessageResponse>{planContent}</MessageResponse>
-        </div>
-      )}
-
-      {status === "interactive" && !responded && (
-        <div className="flex items-center justify-end gap-2 border-t px-4 py-3">
-          {planContent && <CopyButton content={planContent} />}
-          <Button size="sm" variant="outline" onClick={handleHandOff}>
-            <ArrowRightLeftIcon className="size-3" />
-            Hand off
-          </Button>
-          <Button size="sm" onClick={handleApprove}>
-            Accept
-          </Button>
-        </div>
-      )}
-
-      {status === "interactive" && responded && (
-        <div className="border-t px-4 py-3 text-sm italic text-muted-foreground">
-          Response submitted
         </div>
       )}
     </div>

--- a/frontend/src/components/chat/PlanProposal.tsx
+++ b/frontend/src/components/chat/PlanProposal.tsx
@@ -49,7 +49,7 @@ export const PlanProposal = memo(function PlanProposal({
         {statusBadge}
       </button>
       {open && planContent && (
-        <div className="mt-1 max-h-[70vh] overflow-auto text-sm">
+        <div className="mt-1 [&_h1]:text-2xl [&_h2]:text-xl [&_h3]:text-lg">
           <MessageResponse>{planContent}</MessageResponse>
         </div>
       )}

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -3,6 +3,7 @@ import { ChevronRightIcon } from "lucide-react";
 import type { ToolCall, QuestionAnswer } from "@/types";
 import { isAskUserQuestion, isExitPlanMode } from "@/types";
 import { cn } from "@/lib/utils";
+import { findPlanContent } from "@/lib/plan-state";
 import ChatToolUse, { getToolIcon } from "@/components/ChatToolUse";
 import { AskUserQuestion } from "@/components/chat/AskUserQuestion";
 import { PlanProposal, type PlanStatus } from "@/components/chat/PlanProposal";
@@ -31,129 +32,6 @@ function getTaskPrompt(tool: ToolCall): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-/** Check if a tool targets a .claude/plans/ file. */
-function isPlanFileTool(tool: ToolCall, name: string): boolean {
-  if (tool.name !== name) return false;
-  try {
-    const input = JSON.parse(tool.input);
-    return typeof input.file_path === "string" && input.file_path.includes(".claude/plans/");
-  } catch {
-    return false;
-  }
-}
-
-/** Strip line numbers from Read tool output (handles both tab and → separators). */
-function stripLineNumbers(text: string): string {
-  const lines = text.split("\n");
-  const first = lines.find((l) => l.trim());
-  if (first && /^\s*\d+[\t→]/.test(first)) {
-    return lines.map((l) => l.replace(/^\s*\d+[\t→]/, "")).join("\n");
-  }
-  return text;
-}
-
-/**
- * Extract plan content from tool calls, handling both Write (initial) and
- * Read+Edit (refinement) flows. Returns content + the Write tool id to
- * filter from regular tools when present.
- */
-function findPlanContent(
-  toolCalls: ToolCall[],
-): { content: string; writeToolId?: string; planPath?: string } | undefined {
-  // 1. Write tool → full content available directly
-  const writeTool = toolCalls.filter((t) => isPlanFileTool(t, "Write")).pop();
-  if (writeTool) {
-    try {
-      const input = JSON.parse(writeTool.input) as { content?: string; file_path?: string };
-      const content = input.content ?? "";
-      return { content, writeToolId: writeTool.id, planPath: input.file_path };
-    } catch {
-      /* fall through */
-    }
-  }
-
-  // 2. Edit tool → reconstruct from Read output + Edit diffs
-  const editTools = toolCalls.filter((t) => isPlanFileTool(t, "Edit"));
-  if (editTools.length > 0) {
-    let planPath: string | undefined;
-    try {
-      planPath = JSON.parse(editTools[0].input).file_path;
-    } catch {
-      /* fall through */
-    }
-
-    if (planPath) {
-      const readTool = [...toolCalls].reverse().find((t) => {
-        if (t.name !== "Read" || !t.output) return false;
-        try {
-          return JSON.parse(t.input).file_path === planPath;
-        } catch {
-          return false;
-        }
-      });
-
-      if (readTool?.output) {
-        let content = stripLineNumbers(readTool.output);
-        for (const edit of editTools) {
-          try {
-            const inp = JSON.parse(edit.input);
-            if (
-              inp.file_path === planPath &&
-              typeof inp.old_string === "string" &&
-              typeof inp.new_string === "string"
-            ) {
-              content = inp.replace_all
-                ? content.replaceAll(inp.old_string, inp.new_string)
-                : content.replace(inp.old_string, inp.new_string);
-            }
-          } catch {
-            /* skip */
-          }
-        }
-        return { content, planPath };
-      }
-    }
-  }
-
-  // 3. ExitPlanMode input → Claude passes the full plan content directly
-  const exitTool = toolCalls.find((t) => t.name === "ExitPlanMode");
-  if (exitTool) {
-    try {
-      const input = JSON.parse(exitTool.input);
-      if (typeof input.plan === "string" && input.plan.trim()) {
-        const planPath = typeof input.file_path === "string" ? input.file_path : undefined;
-        return { content: input.plan, planPath };
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-
-  // 4. Fallback: last Write tool to any .md file (plan may not live in .claude/plans/)
-  const mdWriteTool = toolCalls.filter((t) => {
-    if (t.name !== "Write") return false;
-    try {
-      const input = JSON.parse(t.input);
-      return typeof input.file_path === "string" && input.file_path.endsWith(".md");
-    } catch {
-      return false;
-    }
-  }).pop();
-  if (mdWriteTool) {
-    try {
-      const input = JSON.parse(mdWriteTool.input) as { content?: string; file_path?: string };
-      const content = input.content ?? "";
-      if (content.trim()) {
-        return { content, writeToolId: mdWriteTool.id, planPath: input.file_path };
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-
-  return undefined;
 }
 
 /** A single Task node whose children are collapsed by default. */
@@ -255,8 +133,6 @@ interface ToolCallListProps {
   planStatus?: PlanStatus;
   dismissedToolCallIds?: Set<string>;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
-  onPlanApproval?: () => void;
-  onHandOff?: (planContent: string, planPath?: string) => void;
 }
 
 export function ToolCallList({
@@ -266,8 +142,6 @@ export function ToolCallList({
   planStatus,
   dismissedToolCallIds,
   onQuestionAnswer: _onQuestionAnswer,
-  onPlanApproval,
-  onHandOff,
 }: ToolCallListProps) {
   const [expanded, setExpanded] = useState(false);
 
@@ -365,10 +239,7 @@ export function ToolCallList({
             <PlanProposal
               key={tool.id}
               planContent={planContent}
-              planPath={planData?.planPath}
               status={effectiveStatus}
-              onApprove={onPlanApproval}
-              onHandOff={onHandOff}
             />
           );
         }

--- a/frontend/src/lib/plan-state.ts
+++ b/frontend/src/lib/plan-state.ts
@@ -92,14 +92,20 @@ export function findPlanContent(
   // 2. Edit tool → reconstruct from Read output + Edit diffs
   const editTools = toolCalls.filter((t) => isPlanFileTool(t, "Edit"));
   if (editTools.length > 0) {
-    let planPath: string | undefined;
-    try {
-      planPath = JSON.parse(editTools[0].input).file_path;
-    } catch {
-      /* fall through */
-    }
+    const candidatePaths = [...new Set(
+      editTools
+        .map((edit) => {
+          try {
+            const parsed = JSON.parse(edit.input) as { file_path?: unknown };
+            return typeof parsed.file_path === "string" ? parsed.file_path : undefined;
+          } catch {
+            return undefined;
+          }
+        })
+        .filter((path): path is string => typeof path === "string"),
+    )].reverse();
 
-    if (planPath) {
+    for (const planPath of candidatePaths) {
       const readTool = [...toolCalls].reverse().find((t) => {
         if (t.name !== "Read" || !t.output) return false;
         try {

--- a/frontend/src/lib/plan-state.ts
+++ b/frontend/src/lib/plan-state.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "@/types";
+import type { ChatMessage, ToolCall } from "@/types";
 
 interface PendingToolLike {
   toolName: string;
@@ -44,4 +44,129 @@ export function isPlanAwaitingUserInput(params: {
   const fallbackInteractiveIdx = getFallbackInteractiveAssistantIndex(messages, isStreaming);
   if (fallbackInteractiveIdx < 0) return false;
   return hasExitPlanModeTool(messages[fallbackInteractiveIdx]);
+}
+
+// -- Plan content extraction (moved from ToolCallList) --
+
+/** Check if a tool targets a .claude/plans/ file. */
+export function isPlanFileTool(tool: ToolCall, name: string): boolean {
+  if (tool.name !== name) return false;
+  try {
+    const input = JSON.parse(tool.input);
+    return typeof input.file_path === "string" && input.file_path.includes(".claude/plans/");
+  } catch {
+    return false;
+  }
+}
+
+/** Strip line numbers from Read tool output (handles both tab and → separators). */
+export function stripLineNumbers(text: string): string {
+  const lines = text.split("\n");
+  const first = lines.find((l) => l.trim());
+  if (first && /^\s*\d+[\t→]/.test(first)) {
+    return lines.map((l) => l.replace(/^\s*\d+[\t→]/, "")).join("\n");
+  }
+  return text;
+}
+
+/**
+ * Extract plan content from tool calls, handling both Write (initial) and
+ * Read+Edit (refinement) flows. Returns content + the Write tool id to
+ * filter from regular tools when present.
+ */
+export function findPlanContent(
+  toolCalls: ToolCall[],
+): { content: string; writeToolId?: string; planPath?: string } | undefined {
+  // 1. Write tool → full content available directly
+  const writeTool = toolCalls.filter((t) => isPlanFileTool(t, "Write")).pop();
+  if (writeTool) {
+    try {
+      const input = JSON.parse(writeTool.input) as { content?: string; file_path?: string };
+      const content = input.content ?? "";
+      return { content, writeToolId: writeTool.id, planPath: input.file_path };
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // 2. Edit tool → reconstruct from Read output + Edit diffs
+  const editTools = toolCalls.filter((t) => isPlanFileTool(t, "Edit"));
+  if (editTools.length > 0) {
+    let planPath: string | undefined;
+    try {
+      planPath = JSON.parse(editTools[0].input).file_path;
+    } catch {
+      /* fall through */
+    }
+
+    if (planPath) {
+      const readTool = [...toolCalls].reverse().find((t) => {
+        if (t.name !== "Read" || !t.output) return false;
+        try {
+          return JSON.parse(t.input).file_path === planPath;
+        } catch {
+          return false;
+        }
+      });
+
+      if (readTool?.output) {
+        let content = stripLineNumbers(readTool.output);
+        for (const edit of editTools) {
+          try {
+            const inp = JSON.parse(edit.input);
+            if (
+              inp.file_path === planPath &&
+              typeof inp.old_string === "string" &&
+              typeof inp.new_string === "string"
+            ) {
+              content = inp.replace_all
+                ? content.replaceAll(inp.old_string, inp.new_string)
+                : content.replace(inp.old_string, inp.new_string);
+            }
+          } catch {
+            /* skip */
+          }
+        }
+        return { content, planPath };
+      }
+    }
+  }
+
+  // 3. ExitPlanMode input → Claude passes the full plan content directly
+  const exitTool = toolCalls.find((t) => t.name === "ExitPlanMode");
+  if (exitTool) {
+    try {
+      const input = JSON.parse(exitTool.input);
+      if (typeof input.plan === "string" && input.plan.trim()) {
+        const planPath = typeof input.file_path === "string" ? input.file_path : undefined;
+        return { content: input.plan, planPath };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  // 4. Fallback: last Write tool to any .md file (plan may not live in .claude/plans/)
+  const mdWriteTool = toolCalls.filter((t) => {
+    if (t.name !== "Write") return false;
+    try {
+      const input = JSON.parse(t.input);
+      return typeof input.file_path === "string" && input.file_path.endsWith(".md");
+    } catch {
+      return false;
+    }
+  }).pop();
+  if (mdWriteTool) {
+    try {
+      const input = JSON.parse(mdWriteTool.input) as { content?: string; file_path?: string };
+      const content = input.content ?? "";
+      if (content.trim()) {
+        return { content, writeToolId: mdWriteTool.id, planPath: input.file_path };
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  return undefined;
 }

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -44,7 +44,8 @@ import { openTerminalSsh } from "@/lib/terminal";
 import { useLayoutContext } from "@/components/AppLayout";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
-import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput } from "@/lib/plan-state";
+import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent } from "@/lib/plan-state";
+import { PlanActionBar } from "@/components/chat/PlanActionBar";
 import { useScripts } from "@/hooks/useScripts";
 import type { DiffStatResponse, FileMention, ImageAttachment, MessageOptions, QueuedMessage, Workspace, WorkspaceFileTreeNode } from "@/types";
 
@@ -386,6 +387,22 @@ export default function WorkspaceView() {
     pendingToolInputs,
   });
 
+  const pendingPlanData = useMemo(() => {
+    if (!hasPendingPlan) return undefined;
+    // Check active streaming tool calls first
+    if (activeToolCalls.some((t) => t.name === "ExitPlanMode")) {
+      return findPlanContent(activeToolCalls);
+    }
+    // Fall back to committed messages
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const msg = messages[i];
+      if (msg.role === "assistant" && msg.toolCalls?.some((t) => t.name === "ExitPlanMode")) {
+        return findPlanContent(msg.toolCalls);
+      }
+    }
+    return undefined;
+  }, [hasPendingPlan, messages, activeToolCalls]);
+
   const handleSend = useCallback(
     (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]): boolean => {
       if (hasPendingPlan && hasPendingExitPlanInput) {
@@ -526,8 +543,6 @@ export default function WorkspaceView() {
               activeToolCalls={activeToolCalls}
               pendingToolInputs={pendingToolInputs}
               onQuestionAnswer={answerQuestion}
-              onPlanApproval={approvePlan}
-              onHandOff={handleHandOff}
               onFileMentionClick={handleFileTreeSelect}
               workspaceName={workspace?.name}
               projectName={workspace?.projectName}
@@ -554,21 +569,31 @@ export default function WorkspaceView() {
                 onDismiss={() => rejectToolInput("[question_dismissed]")}
               />
             ) : (
-              <ChatInput
-                wsId={wsId}
-                sessionId={sessionId}
-                lockedProvider={effectiveLockedProvider}
-                onSend={handleSend}
-                onStop={stopStreaming}
-                disabled={false}
-                isStreaming={isStreaming}
-                connectionStatus={connectionStatus}
-                placeholder={hasPendingPlan ? "Enter your plan adjustments here..." : undefined}
-                messages={messages}
-                queuedMessage={queuedMessage}
-                onQueue={setQueuedMessage}
-                agentPlanMode={agentPlanMode}
-              />
+              <div className="relative">
+                {hasPendingPlan && pendingPlanData && (
+                  <PlanActionBar
+                    planContent={pendingPlanData.content}
+                    planPath={pendingPlanData.planPath}
+                    onApprove={approvePlan}
+                    onHandOff={handleHandOff}
+                  />
+                )}
+                <ChatInput
+                  wsId={wsId}
+                  sessionId={sessionId}
+                  lockedProvider={effectiveLockedProvider}
+                  onSend={handleSend}
+                  onStop={stopStreaming}
+                  disabled={false}
+                  isStreaming={isStreaming}
+                  connectionStatus={connectionStatus}
+                  placeholder={hasPendingPlan ? "Enter your plan adjustments here..." : undefined}
+                  messages={messages}
+                  queuedMessage={queuedMessage}
+                  onQueue={setQueuedMessage}
+                  agentPlanMode={agentPlanMode}
+                />
+              </div>
             )}
           </div>
           {activeTab === "file" && openFile && wsId && (

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -33,7 +33,23 @@ vi.mock("@/components/ai-elements/conversation", () => ({
 }));
 
 vi.mock("@/components/ChatMessage", () => ({
-  default: ({ message }: { message: ChatMessage }) => <div data-testid={`msg-${message.id}`}>{message.content}</div>,
+  default: ({
+    message,
+    planStatus,
+    isInteractive,
+  }: {
+    message: ChatMessage;
+    planStatus?: string;
+    isInteractive?: boolean;
+  }) => (
+    <div
+      data-testid={`msg-${message.id}`}
+      data-plan-status={planStatus ?? "none"}
+      data-interactive={String(Boolean(isInteractive))}
+    >
+      {message.content}
+    </div>
+  ),
 }));
 
 vi.mock("@/components/chat/AgentActivityPreview", () => ({
@@ -391,5 +407,99 @@ describe("ChatConversation queued message", () => {
 
     await user.click(screen.getByRole("button", { name: "Cancel queued message" }));
     expect(onClearQueue).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ChatConversation plan status behavior", () => {
+  function assistantWithPlan(id: string, content: string): ChatMessage {
+    return {
+      id,
+      sessionId: "sess-1",
+      role: "assistant",
+      content,
+      timestamp: "2026-02-20T00:00:00.000Z",
+      toolCalls: [
+        {
+          id: `${id}-tool`,
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: content }),
+        },
+      ],
+    };
+  }
+
+  it("marks a plan message as interactive when pending tool input matches tool call id", () => {
+    const message = assistantWithPlan("a1", "Plan A");
+    renderConversation({
+      messages: [message],
+      pendingToolInputs: [
+        {
+          requestId: "req-1",
+          toolName: "ExitPlanMode",
+          toolUseId: "a1-tool",
+          input: {},
+        },
+      ],
+    });
+
+    const node = screen.getByTestId("msg-a1");
+    expect(node).toHaveAttribute("data-interactive", "true");
+    expect(node).toHaveAttribute("data-plan-status", "interactive");
+  });
+
+  it("marks a standalone latest plan as interactive in fallback mode", () => {
+    renderConversation({
+      messages: [assistantWithPlan("a1", "Plan A")],
+    });
+
+    expect(screen.getByTestId("msg-a1")).toHaveAttribute("data-plan-status", "interactive");
+  });
+
+  it("marks an earlier plan as revised while latest plan remains interactive", () => {
+    renderConversation({
+      messages: [
+        assistantWithPlan("a1", "Plan A"),
+        assistantWithPlan("a2", "Plan B"),
+      ],
+    });
+
+    expect(screen.getByTestId("msg-a1")).toHaveAttribute("data-plan-status", "revised");
+    expect(screen.getByTestId("msg-a2")).toHaveAttribute("data-plan-status", "interactive");
+  });
+
+  it("marks a plan as revised while streaming after user feedback", () => {
+    renderConversation({
+      isStreaming: true,
+      messages: [
+        assistantWithPlan("a1", "Plan A"),
+        {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "Please change step 2",
+          timestamp: "2026-02-20T00:00:01.000Z",
+        },
+      ],
+    });
+
+    expect(screen.getByTestId("msg-a1")).toHaveAttribute("data-plan-status", "revised");
+  });
+});
+
+describe("ChatConversation question-dismissed rendering", () => {
+  it("hides synthetic 'Question dismissed.' user messages", () => {
+    renderConversation({
+      messages: [
+        {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "Question dismissed.",
+          timestamp: "2026-02-20T00:00:00.000Z",
+        },
+      ],
+    });
+
+    expect(screen.queryByTestId("msg-u1")).not.toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/PlanActionBar.test.tsx
+++ b/frontend/tests/components/PlanActionBar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PlanActionBar } from "@/components/chat/PlanActionBar";
+
+const mocks = vi.hoisted(() => ({
+  copyToClipboard: vi.fn(),
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: mocks.copyToClipboard,
+}));
+
+describe("PlanActionBar", () => {
+  it("calls approve and handoff callbacks with plan payload", async () => {
+    const user = userEvent.setup();
+    const onApprove = vi.fn();
+    const onHandOff = vi.fn();
+
+    render(
+      <PlanActionBar
+        planContent="Implementation steps"
+        planPath=".claude/plans/feature.md"
+        onApprove={onApprove}
+        onHandOff={onHandOff}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onApprove).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole("button", { name: /Hand off/i }));
+    expect(onHandOff).toHaveBeenCalledWith("Implementation steps", ".claude/plans/feature.md");
+  });
+
+  it("passes empty content to handoff when plan content is unavailable", async () => {
+    const user = userEvent.setup();
+    const onHandOff = vi.fn();
+
+    render(<PlanActionBar onApprove={vi.fn()} onHandOff={onHandOff} />);
+
+    expect(screen.queryByRole("button", { name: "Copy" })).not.toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Hand off/i }));
+    expect(onHandOff).toHaveBeenCalledWith("", undefined);
+  });
+
+  it("copies plan content and shows transient success state", async () => {
+    vi.useFakeTimers();
+    mocks.copyToClipboard.mockResolvedValue(undefined);
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout");
+
+    render(
+      <PlanActionBar
+        planContent="copy me"
+        onApprove={vi.fn()}
+        onHandOff={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+    });
+    await vi.waitFor(() => {
+      expect(mocks.copyToClipboard).toHaveBeenCalledWith("copy me");
+    });
+    expect(timeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
+
+    act(() => {
+      vi.advanceTimersByTime(2000);
+    });
+    timeoutSpy.mockRestore();
+    vi.useRealTimers();
+  });
+});

--- a/frontend/tests/components/PlanProposal.test.tsx
+++ b/frontend/tests/components/PlanProposal.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { PlanProposal } from "@/components/chat/PlanProposal";
+
+vi.mock("@/components/ai-elements/message", () => ({
+  MessageResponse: ({ children }: { children: string }) => <div data-testid="plan-content">{children}</div>,
+}));
+
+describe("PlanProposal", () => {
+  it("starts expanded in interactive mode and toggles on click", async () => {
+    const user = userEvent.setup();
+    render(<PlanProposal status="interactive" planContent="## Plan body" />);
+
+    expect(screen.getByTestId("plan-content")).toHaveTextContent("## Plan body");
+    await user.click(screen.getByRole("button", { name: /Proposed plan/i }));
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+  });
+
+  it("starts collapsed for approved and revised states with matching badge", () => {
+    const { rerender } = render(<PlanProposal status="approved" planContent="Approved plan" />);
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
+
+    rerender(<PlanProposal status="revised" planContent="Revised plan" />);
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+    expect(screen.getByText("Revised")).toBeInTheDocument();
+  });
+
+  it("auto-collapses when status leaves interactive", async () => {
+    const user = userEvent.setup();
+    const { rerender } = render(<PlanProposal status="interactive" planContent="Plan V1" />);
+
+    expect(screen.getByTestId("plan-content")).toHaveTextContent("Plan V1");
+    await user.click(screen.getByRole("button", { name: /Proposed plan/i }));
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /Proposed plan/i }));
+    expect(screen.getByTestId("plan-content")).toHaveTextContent("Plan V1");
+
+    rerender(<PlanProposal status="approved" planContent="Plan V1" />);
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+  });
+
+  it("does not toggle open when plan content is missing", async () => {
+    const user = userEvent.setup();
+    render(<PlanProposal status="interactive" />);
+
+    await user.click(screen.getByRole("button", { name: /Proposed plan/i }));
+    expect(screen.queryByTestId("plan-content")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/ToolCallList.test.tsx
+++ b/frontend/tests/components/ToolCallList.test.tsx
@@ -31,45 +31,41 @@ describe("ToolCallList", () => {
     expect(screen.getByText("Bash")).toBeInTheDocument();
   });
 
-  it("renders ExitPlanMode as PlanProposal and calls approval callback", async () => {
+  it("renders ExitPlanMode as PlanProposal with inline tool-style header", async () => {
     const user = userEvent.setup();
-    const onPlanApproval = vi.fn();
 
     render(
       <ToolCallList
         toolCalls={[tool({ name: "ExitPlanMode", input: JSON.stringify({ plan: "Test plan content" }) })]}
         isInteractive
-        onPlanApproval={onPlanApproval}
       />,
     );
 
     expect(screen.getByText("Proposed plan")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Accept" }));
+    // Action buttons are no longer inside PlanProposal (moved to PlanActionBar above ChatInput)
+    expect(screen.queryByRole("button", { name: "Accept" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Hand off" })).not.toBeInTheDocument();
 
-    expect(onPlanApproval).toHaveBeenCalledTimes(1);
+    // Interactive plan starts expanded — content visible immediately
+    expect(screen.getByText("Test plan content")).toBeInTheDocument();
+
+    // Click to collapse
+    await user.click(screen.getByText("Proposed plan"));
+    expect(screen.queryByText("Test plan content")).not.toBeInTheDocument();
   });
 
-  it("renders interactive plan actions even when ExitPlanMode has no plan content", async () => {
-    const user = userEvent.setup();
-    const onHandOff = vi.fn();
-
+  it("renders PlanProposal header even when ExitPlanMode has no plan content", () => {
     render(
       <ToolCallList
         toolCalls={[tool({ name: "ExitPlanMode", input: "{}" })]}
         isInteractive
-        onHandOff={onHandOff}
       />,
     );
 
     expect(screen.getByText("Proposed plan")).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Copy message" })).not.toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Hand off" })).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Accept" })).toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: "Hand off" }));
-
-    expect(onHandOff).toHaveBeenCalledWith("", undefined);
-    expect(screen.getByText("Response submitted")).toBeInTheDocument();
+    // No action buttons in inline view
+    expect(screen.queryByRole("button", { name: "Accept" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Hand off" })).not.toBeInTheDocument();
   });
 
   it("falls back to the last markdown Write tool when plan content is not in .claude/plans", () => {
@@ -251,7 +247,6 @@ describe("ToolCallList", () => {
   });
 
   it("always shows interactive tools even when collapsed", () => {
-    const onPlanApproval = vi.fn();
     render(
       <ToolCallList
         toolCalls={[
@@ -261,7 +256,6 @@ describe("ToolCallList", () => {
           tool({ name: "ExitPlanMode", input: JSON.stringify({ plan: "Test plan" }) }),
         ]}
         isInteractive
-        onPlanApproval={onPlanApproval}
       />,
     );
 
@@ -269,9 +263,8 @@ describe("ToolCallList", () => {
     expect(screen.getByText("3 tool calls")).toBeInTheDocument();
     expect(screen.queryByText("Read")).not.toBeInTheDocument();
 
-    // PlanProposal always visible with Accept button
+    // PlanProposal always visible (inline tool header)
     expect(screen.getByText("Proposed plan")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Accept" })).toBeInTheDocument();
   });
 
   it("handles singular tool call label", () => {

--- a/frontend/tests/lib/plan-state.test.ts
+++ b/frontend/tests/lib/plan-state.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  findPlanContent,
   getFallbackInteractiveAssistantIndex,
   hasExitPlanModeTool,
   hasPendingExitPlanModeInput,
+  isPlanFileTool,
   isPlanAwaitingUserInput,
+  stripLineNumbers,
 } from "@/lib/plan-state";
-import type { ChatMessage } from "@/types";
+import type { ChatMessage, ToolCall } from "@/types";
 
 function userMessage(id: string): ChatMessage {
   return {
@@ -27,6 +30,15 @@ function assistantMessage(id: string, withPlanTool = false): ChatMessage {
     toolCalls: withPlanTool
       ? [{ id: "tool-plan", name: "ExitPlanMode", input: "{}" }]
       : undefined,
+  };
+}
+
+function toolCall(overrides: Partial<ToolCall> = {}): ToolCall {
+  return {
+    id: "tool-1",
+    name: "Read",
+    input: "{}",
+    ...overrides,
   };
 }
 
@@ -84,5 +96,186 @@ describe("plan-state helpers", () => {
       pendingToolInputs: [],
     });
     expect(pending).toBe(false);
+  });
+});
+
+describe("plan-state plan content extraction", () => {
+  it("detects plan file tools by name and path", () => {
+    expect(
+      isPlanFileTool(
+        toolCall({
+          name: "Write",
+          input: JSON.stringify({ file_path: ".claude/plans/feature.md" }),
+        }),
+        "Write",
+      ),
+    ).toBe(true);
+    expect(
+      isPlanFileTool(
+        toolCall({
+          name: "Write",
+          input: JSON.stringify({ file_path: ".claude/plans/feature.md" }),
+        }),
+        "Read",
+      ),
+    ).toBe(false);
+    expect(isPlanFileTool(toolCall({ name: "Write", input: "{bad" }), "Write")).toBe(false);
+  });
+
+  it("strips line numbers when Read output is prefixed with tab or arrow separators", () => {
+    expect(stripLineNumbers("1\t# Plan\n2\t- A")).toBe("# Plan\n- A");
+    expect(stripLineNumbers("  10→alpha\n11→beta")).toBe("alpha\nbeta");
+    expect(stripLineNumbers("# Title\n2\t- Keep")).toBe("# Title\n2\t- Keep");
+  });
+
+  it("prefers the latest .claude/plans Write tool and returns write tool id", () => {
+    const result = findPlanContent([
+      toolCall({
+        id: "write-old",
+        name: "Write",
+        input: JSON.stringify({
+          file_path: ".claude/plans/old.md",
+          content: "old content",
+        }),
+      }),
+      toolCall({
+        id: "write-new",
+        name: "Write",
+        input: JSON.stringify({
+          file_path: ".claude/plans/new.md",
+          content: "new content",
+        }),
+      }),
+    ]);
+
+    expect(result).toEqual({
+      content: "new content",
+      writeToolId: "write-new",
+      planPath: ".claude/plans/new.md",
+    });
+  });
+
+  it("reconstructs plan content from Read + Edit flow", () => {
+    const result = findPlanContent([
+      toolCall({
+        id: "read-1",
+        name: "Read",
+        input: JSON.stringify({ file_path: ".claude/plans/feature.md" }),
+        output: "1\t# Plan\n2\t- step alpha\n3\t- step alpha\n",
+      }),
+      toolCall({
+        id: "edit-1",
+        name: "Edit",
+        input: JSON.stringify({
+          file_path: ".claude/plans/feature.md",
+          old_string: "alpha",
+          new_string: "beta",
+          replace_all: true,
+        }),
+      }),
+    ]);
+
+    expect(result).toEqual({
+      content: "# Plan\n- step beta\n- step beta\n",
+      planPath: ".claude/plans/feature.md",
+    });
+  });
+
+  it("uses latest matching Read output and applies only same-path edits", () => {
+    const result = findPlanContent([
+      toolCall({
+        id: "read-old",
+        name: "Read",
+        input: JSON.stringify({ file_path: ".claude/plans/feature.md" }),
+        output: "1\t- old",
+      }),
+      toolCall({
+        id: "read-new",
+        name: "Read",
+        input: JSON.stringify({ file_path: ".claude/plans/feature.md" }),
+        output: "1\t- original",
+      }),
+      toolCall({
+        id: "edit-other-file",
+        name: "Edit",
+        input: JSON.stringify({
+          file_path: ".claude/plans/other.md",
+          old_string: "original",
+          new_string: "wrong",
+        }),
+      }),
+      toolCall({
+        id: "edit-plan",
+        name: "Edit",
+        input: JSON.stringify({
+          file_path: ".claude/plans/feature.md",
+          old_string: "original",
+          new_string: "updated",
+        }),
+      }),
+    ]);
+
+    expect(result).toEqual({
+      content: "- updated",
+      planPath: ".claude/plans/feature.md",
+    });
+  });
+
+  it("falls back to ExitPlanMode input when no write/edit content is available", () => {
+    const result = findPlanContent([
+      toolCall({
+        id: "exit-1",
+        name: "ExitPlanMode",
+        input: JSON.stringify({
+          plan: "finalized plan",
+          file_path: ".claude/plans/final.md",
+        }),
+      }),
+    ]);
+
+    expect(result).toEqual({
+      content: "finalized plan",
+      planPath: ".claude/plans/final.md",
+    });
+  });
+
+  it("falls back to the latest markdown Write when ExitPlanMode plan is blank", () => {
+    const result = findPlanContent([
+      toolCall({
+        id: "write-doc",
+        name: "Write",
+        input: JSON.stringify({
+          file_path: "docs/implementation-plan.md",
+          content: "doc plan",
+        }),
+      }),
+      toolCall({
+        id: "exit-blank",
+        name: "ExitPlanMode",
+        input: JSON.stringify({ plan: "  " }),
+      }),
+    ]);
+
+    expect(result).toEqual({
+      content: "doc plan",
+      writeToolId: "write-doc",
+      planPath: "docs/implementation-plan.md",
+    });
+  });
+
+  it("returns undefined when no extraction strategy yields plan content", () => {
+    expect(findPlanContent([])).toBeUndefined();
+    expect(
+      findPlanContent([
+        toolCall({
+          id: "write-empty",
+          name: "Write",
+          input: JSON.stringify({
+            file_path: "docs/implementation-plan.md",
+            content: "   ",
+          }),
+        }),
+      ]),
+    ).toBeUndefined();
   });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -88,12 +88,10 @@ vi.mock("@/components/ScriptPanel", () => ({
 
 vi.mock("@/components/ChatConversation", () => ({
   default: ({
-    onHandOff,
     isStreaming,
     streamingStartedAt,
     queuedMessage,
   }: {
-    onHandOff: (planContent: string, planPath?: string) => void;
     isStreaming?: boolean;
     streamingStartedAt?: number | null;
     queuedMessage?: { content: string } | null;
@@ -103,16 +101,6 @@ vi.mock("@/components/ChatConversation", () => ({
       <div data-testid="chat-is-streaming">{String(Boolean(isStreaming))}</div>
       <div data-testid="chat-streaming-started-at">{streamingStartedAt ?? "none"}</div>
       <div data-testid="chat-queued-message">{queuedMessage?.content ?? "none"}</div>
-      <button type="button" data-testid="handoff-plan-btn" onClick={() => onHandOff("PLAN-CONTENT")}>
-        handoff plan
-      </button>
-      <button
-        type="button"
-        data-testid="handoff-plan-path-btn"
-        onClick={() => onHandOff("PLAN-CONTENT", ".claude/plans/background.md")}
-      >
-        handoff plan path
-      </button>
     </div>
   ),
 }));
@@ -971,10 +959,33 @@ describe("WorkspaceView behavior", () => {
     mocks.switchSession.mockResolvedValue(undefined);
     mocks.refreshSessions.mockResolvedValue(undefined);
 
+    // Set up plan state so PlanActionBar renders
+    mocks.useConversation.mockReturnValue({
+      ...mocks.useConversation(),
+      messages: [{
+        id: "msg-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "PLAN-CONTENT" }),
+        }],
+      }],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-exit",
+        requestId: "req-1",
+        sessionId: "sess-1",
+        input: {},
+      }],
+    });
+
     renderWorkspace();
     await screen.findByText("tokyo");
 
-    await user.click(screen.getByTestId("handoff-plan-btn"));
+    await user.click(screen.getByRole("button", { name: /hand off/i }));
 
     await waitFor(() => {
       expect(mocks.dismissPlan).toHaveBeenCalledWith("Plan handed off to a new session.");
@@ -1002,10 +1013,33 @@ describe("WorkspaceView behavior", () => {
     mocks.switchSession.mockResolvedValue(undefined);
     mocks.refreshSessions.mockResolvedValue(undefined);
 
+    // Set up plan state with file path so PlanActionBar renders
+    mocks.useConversation.mockReturnValue({
+      ...mocks.useConversation(),
+      messages: [{
+        id: "msg-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "PLAN-CONTENT", file_path: ".claude/plans/background.md" }),
+        }],
+      }],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-exit",
+        requestId: "req-1",
+        sessionId: "sess-1",
+        input: {},
+      }],
+    });
+
     renderWorkspace();
     await screen.findByText("tokyo");
 
-    await user.click(screen.getByTestId("handoff-plan-path-btn"));
+    await user.click(screen.getByRole("button", { name: /hand off/i }));
 
     await waitFor(() => {
       expect(mocks.sendMessage).toHaveBeenCalledWith(

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -110,13 +110,17 @@ vi.mock("@/components/ChatInput", () => ({
     wsId,
     sessionId,
     isStreaming,
+    placeholder,
     queuedMessage,
+    onSend,
     onQueue,
   }: {
     wsId?: string;
     sessionId?: string;
     isStreaming?: boolean;
+    placeholder?: string;
     queuedMessage?: { content: string } | null;
+    onSend?: (content: string) => boolean;
     onQueue?: (msg: { content: string }) => void;
   }) => (
     <div
@@ -124,8 +128,14 @@ vi.mock("@/components/ChatInput", () => ({
       data-ws-id={wsId ?? ""}
       data-session-id={sessionId ?? ""}
       data-has-queue={queuedMessage ? "true" : "false"}
+      data-placeholder={placeholder ?? ""}
     >
       chat-input
+      {onSend && (
+        <button type="button" data-testid="chat-send-btn" onClick={() => onSend("queued revision")}>
+          send message
+        </button>
+      )}
       {isStreaming && onQueue && (
         <button type="button" data-testid="queue-message-btn" onClick={() => onQueue({ content: "queued msg" })}>
           queue message
@@ -231,6 +241,34 @@ const FILE_TREE: WorkspaceFileTreeNode[] = [
 
 const DIFF_STATS = { committed: [], uncommitted: [] };
 
+function buildConversationState(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    messages: [],
+    isStreaming: false,
+    streamingStartedAt: null,
+    workspaceStatus: "idle",
+    currentStreamingText: "",
+    currentThinking: "",
+    activeToolCalls: [],
+    pendingToolInputs: [],
+    connectionStatus: "connected",
+    error: null,
+    sessionId: undefined,
+    sendMessage: mocks.sendMessage,
+    stopStreaming: mocks.stopStreaming,
+    clearChat: mocks.clearChat,
+    switchSession: mocks.switchSession,
+    answerQuestion: mocks.answerQuestion,
+    batchAnswerQuestions: mocks.batchAnswerQuestions,
+    approvePlan: mocks.approvePlan,
+    rejectToolInput: mocks.rejectToolInput,
+    dismissPlan: mocks.dismissPlan,
+    ...overrides,
+  };
+}
+
 function TestControls() {
   const navigate = useNavigate();
   return (
@@ -318,28 +356,7 @@ describe("WorkspaceView behavior", () => {
       throw new Error(`Unexpected URL: ${url}`);
     });
 
-    mocks.useConversation.mockReturnValue({
-      messages: [],
-      isStreaming: false,
-      streamingStartedAt: null,
-      workspaceStatus: "idle",
-      currentStreamingText: "",
-      currentThinking: "",
-      activeToolCalls: [],
-      pendingToolInputs: [],
-      connectionStatus: "connected",
-      error: null,
-      sessionId: undefined,
-      sendMessage: mocks.sendMessage,
-      stopStreaming: mocks.stopStreaming,
-      clearChat: mocks.clearChat,
-      switchSession: mocks.switchSession,
-      answerQuestion: mocks.answerQuestion,
-      batchAnswerQuestions: mocks.batchAnswerQuestions,
-      approvePlan: mocks.approvePlan,
-      rejectToolInput: mocks.rejectToolInput,
-      dismissPlan: mocks.dismissPlan,
-    });
+    mocks.useConversation.mockReturnValue(buildConversationState());
 
     mocks.useSessions.mockReturnValue({
       sessions: [],
@@ -960,8 +977,7 @@ describe("WorkspaceView behavior", () => {
     mocks.refreshSessions.mockResolvedValue(undefined);
 
     // Set up plan state so PlanActionBar renders
-    mocks.useConversation.mockReturnValue({
-      ...mocks.useConversation(),
+    mocks.useConversation.mockReturnValue(buildConversationState({
       messages: [{
         id: "msg-plan",
         role: "assistant",
@@ -980,7 +996,7 @@ describe("WorkspaceView behavior", () => {
         sessionId: "sess-1",
         input: {},
       }],
-    });
+    }));
 
     renderWorkspace();
     await screen.findByText("tokyo");
@@ -1014,8 +1030,7 @@ describe("WorkspaceView behavior", () => {
     mocks.refreshSessions.mockResolvedValue(undefined);
 
     // Set up plan state with file path so PlanActionBar renders
-    mocks.useConversation.mockReturnValue({
-      ...mocks.useConversation(),
+    mocks.useConversation.mockReturnValue(buildConversationState({
       messages: [{
         id: "msg-plan",
         role: "assistant",
@@ -1034,7 +1049,7 @@ describe("WorkspaceView behavior", () => {
         sessionId: "sess-1",
         input: {},
       }],
-    });
+    }));
 
     renderWorkspace();
     await screen.findByText("tokyo");
@@ -1049,6 +1064,175 @@ describe("WorkspaceView behavior", () => {
         "sess-new",
       );
     });
+  });
+
+  it("approves plan from floating action bar", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue(buildConversationState({
+      messages: [{
+        id: "msg-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "PLAN-CONTENT" }),
+        }],
+      }],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-exit",
+        requestId: "req-1",
+        input: {},
+      }],
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.getByRole("button", { name: "Approve" })).toBeInTheDocument();
+    expect(screen.getByTestId("chat-input")).toHaveAttribute(
+      "data-placeholder",
+      "Enter your plan adjustments here...",
+    );
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(mocks.approvePlan).toHaveBeenCalledTimes(1);
+  });
+
+  it("prioritizes active tool-call plan content over older message plan during handoff", async () => {
+    const user = userEvent.setup();
+    mocks.createSession.mockResolvedValue({
+      sessionId: "sess-new",
+      workspaceId: "ws-1",
+      createdAt: "2026-02-12T00:00:00.000Z",
+      updatedAt: "2026-02-12T00:00:00.000Z",
+      messageCount: 0,
+    });
+    mocks.switchSession.mockResolvedValue(undefined);
+    mocks.refreshSessions.mockResolvedValue(undefined);
+    mocks.useConversation.mockReturnValue(buildConversationState({
+      messages: [{
+        id: "msg-old-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-old-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "OLD-PLAN-CONTENT" }),
+        }],
+      }],
+      activeToolCalls: [{
+        id: "tool-active-exit",
+        name: "ExitPlanMode",
+        input: JSON.stringify({ plan: "ACTIVE-PLAN-CONTENT" }),
+      }],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-active-exit",
+        requestId: "req-active",
+        input: {},
+      }],
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: /Hand off/i }));
+
+    await waitFor(() => {
+      expect(mocks.sendMessage).toHaveBeenCalledWith(
+        "Here is the implementation plan to execute:\n\nACTIVE-PLAN-CONTENT",
+        undefined,
+        undefined,
+        "sess-new",
+      );
+    });
+  });
+
+  it("routes send action to rejectToolInput while ExitPlanMode input is pending", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue(buildConversationState({
+      messages: [{
+        id: "msg-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "PLAN-CONTENT" }),
+        }],
+      }],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-exit",
+        requestId: "req-1",
+        input: {},
+      }],
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByTestId("chat-send-btn"));
+
+    expect(mocks.rejectToolInput).toHaveBeenCalledWith("queued revision");
+    expect(mocks.sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("uses normal sendMessage flow when pending plan is from fallback history only", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue(buildConversationState({
+      messages: [{
+        id: "msg-plan",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:00.000Z",
+        toolCalls: [{
+          id: "tool-exit",
+          name: "ExitPlanMode",
+          input: JSON.stringify({ plan: "PLAN-CONTENT" }),
+        }],
+      }],
+      pendingToolInputs: [],
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+    await user.click(screen.getByTestId("chat-send-btn"));
+
+    expect(mocks.rejectToolInput).not.toHaveBeenCalled();
+    expect(mocks.sendMessage).toHaveBeenCalledWith(
+      "queued revision",
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it("does not render plan action bar when plan is pending but content is unavailable", async () => {
+    mocks.useConversation.mockReturnValue(buildConversationState({
+      messages: [],
+      activeToolCalls: [],
+      pendingToolInputs: [{
+        toolName: "ExitPlanMode",
+        toolUseId: "tool-exit",
+        requestId: "req-1",
+        input: {},
+      }],
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.queryByRole("button", { name: "Approve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Hand off/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId("chat-input")).toHaveAttribute(
+      "data-placeholder",
+      "Enter your plan adjustments here...",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add comprehensive regression coverage for plan-mode state extraction and UI flows
- add dedicated tests for `PlanProposal` and `PlanActionBar` components
- strengthen `ChatConversation` and `WorkspaceView` plan-mode interaction tests
- fix `findPlanContent` edge case when multiple `Edit` tool calls target different plan paths

## Validation
- `npx vitest run tests/lib/plan-state.test.ts tests/components/ChatConversation.test.tsx tests/components/PlanActionBar.test.tsx tests/components/PlanProposal.test.tsx tests/components/ToolCallList.test.tsx tests/pages/WorkspaceView.test.tsx`
- `npm run typecheck --workspace @hive/frontend`
