### PR TITLE
Limit workspace sessions to 4 max (#140)

### DIFF
--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -20,6 +20,8 @@ import {
 import { cn } from "@/lib/utils";
 import type { SessionMetadata } from "@/types";
 
+const MAX_SESSIONS_PER_WORKSPACE = 4;
+
 interface ConversationTabsProps {
   sessions: SessionMetadata[];
   activeSessionId?: string;
@@ -282,9 +284,15 @@ export function ConversationTabs({
 
         <button
           type="button"
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+          className={cn(
+            "flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground",
+            sessions.length >= MAX_SESSIONS_PER_WORKSPACE
+              ? "opacity-40 cursor-not-allowed"
+              : "hover:bg-accent/50 hover:text-foreground",
+          )}
           onClick={onCreateSession}
-          title="New conversation"
+          disabled={sessions.length >= MAX_SESSIONS_PER_WORKSPACE}
+          title={sessions.length >= MAX_SESSIONS_PER_WORKSPACE ? "Session limit reached (4 max)" : "New conversation"}
         >
           <PlusIcon className="size-3.5" />
         </button>

--- a/ios/HiveMobile/Views/Chat/SessionSheet.swift
+++ b/ios/HiveMobile/Views/Chat/SessionSheet.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct SessionSheet: View {
+    private let maxSessions = 4
+
     let sessions: [SessionMetadata]
     let activeSessionId: String?
     let onSelect: (String) -> Void
@@ -37,6 +39,7 @@ struct SessionSheet: View {
                         onCreate()
                         dismiss()
                     }
+                    .disabled(sessions.count >= maxSessions)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Disable the "+" button in the frontend tab bar and the "New" button in the iOS session sheet when a workspace already has 4 conversations
- Frontend shows a tooltip "Session limit reached (4 max)" when the button is disabled
- Hard-coded constant (`4`), frontend + iOS only — no backend changes

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1965 tests)
- [ ] Manual: create 4 sessions in a workspace → verify "+" is greyed out with tooltip (web) and "New" is greyed out (iOS)
- [ ] Manual: delete one session → verify button re-enables