### PR TITLE
Fix queued message leaking to wrong workspace on navigation

### DIFF
--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -252,8 +252,8 @@ export default function WorkspaceView() {
   // ── Message queue: lets users type one follow-up while agent is busy ──
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
 
-  // Clear queue on session switch
-  useEffect(() => { setQueuedMessage(null); }, [sessionId]);
+  // Clear queue on workspace or session switch
+  useEffect(() => { setQueuedMessage(null); }, [wsId, sessionId]);
 
   // Auto-dequeue when the agent finishes and workspace is truly idle
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Queued messages (typed while agent is busy) were sent to the wrong workspace when the user navigated away before the agent finished
- Root cause: the `queuedMessage` state was cleared on session switch but not on workspace switch, so the auto-dequeue effect would fire with the new workspace's `sendMessage` callback
- Fix: add `wsId` to the clear effect's dependency array so the queue is dropped on workspace navigation

## Test plan
- [ ] Open workspace A, send a message, queue a follow-up while agent is streaming
- [ ] Switch to workspace B before the agent finishes
- [ ] Verify the queued message does NOT appear in workspace B
- [ ] Verify normal queue behavior still works (stay in workspace, message auto-sends when agent finishes)