### PR TITLE
Fix chat draft lost when switching between workspaces

### DIFF
--- a/frontend/src/hooks/useChatInputDraftPersistence.ts
+++ b/frontend/src/hooks/useChatInputDraftPersistence.ts
@@ -116,8 +116,8 @@ export function useChatInputDraftPersistence({
   setFileCount,
   setFileMentions,
 }: UseChatInputDraftPersistenceParams) {
-  const prevSessionIdRef = useRef<string | undefined>(sessionId);
-  const prevWsIdRef = useRef<string | undefined>(wsId);
+  const prevSessionIdRef = useRef<string | undefined>(undefined);
+  const prevWsIdRef = useRef<string | undefined>(undefined);
   const valueRef = useRef(value);
   valueRef.current = value;
   const thinkingRef = useRef(thinkingEnabled);
@@ -132,6 +132,8 @@ export function useChatInputDraftPersistence({
   defaultModelIdRef.current = defaultModelId;
   const fileMentionsRef = useRef(fileMentions);
   fileMentionsRef.current = fileMentions;
+  const wsIdRef = useRef(wsId);
+  wsIdRef.current = wsId;
 
   const saveDraftForSession = useCallback((
     targetSessionId: string | undefined,
@@ -139,7 +141,7 @@ export function useChatInputDraftPersistence({
   ) => {
     if (!targetSessionId) return;
     const files = attachmentsRef.current?.files ?? [];
-    upsertDraft(options?.targetWsId ?? wsId, targetSessionId, {
+    upsertDraft(options?.targetWsId ?? wsIdRef.current, targetSessionId, {
       value: valueRef.current,
       thinkingEnabled: thinkingRef.current,
       planMode: planModeRef.current,
@@ -148,46 +150,49 @@ export function useChatInputDraftPersistence({
       files: [...files],
       fileMentions: [...fileMentionsRef.current],
     }, options?.allowDelete ?? true);
-  }, [attachmentsRef, wsId]);
+  }, [attachmentsRef]);
 
+  // Merged save/restore effect — handles both workspace and session transitions
+  // in a single pass, using the PREVIOUS wsId for saves to avoid the race where
+  // wsId updates before sessionId in separate render cycles.
   useEffect(() => {
     const prevWsId = prevWsIdRef.current;
-    if (prevWsId !== wsId) {
-      saveDraftForSession(prevSessionIdRef.current, { targetWsId: prevWsId });
-      prevSessionIdRef.current = sessionId;
-      prevWsIdRef.current = wsId;
-    }
-  }, [wsId, sessionId, saveDraftForSession]);
+    const prevSessionId = prevSessionIdRef.current;
+    const wsChanged = prevWsId !== wsId;
+    const sessionChanged = prevSessionId !== sessionId;
 
-  useEffect(() => {
-    const prevId = prevSessionIdRef.current;
-    if (prevId && prevId !== sessionId) {
-      saveDraftForSession(prevId);
+    if (!wsChanged && !sessionChanged) return;
+
+    // Save outgoing session's draft under its ORIGINAL workspace.
+    if (prevSessionId) {
+      saveDraftForSession(prevSessionId, { targetWsId: prevWsId });
     }
 
-    const draft = sessionId
-      ? getWorkspaceDrafts(wsId).get(sessionId)
-      : undefined;
-
-    if (draft) {
-      setValue(draft.value);
-      setThinkingEnabled(draft.thinkingEnabled);
-      setPlanMode(draft.planMode);
-      setSelectedModelId(draft.selectedModelId);
-      setThinkingLevel(draft.thinkingLevel);
-      attachmentsRef.current?.restore([...draft.files]);
-      setFileCount(draft.files.length);
-      setFileMentions(draft.fileMentions ?? []);
-    } else if (sessionId) {
-      setValue("");
-      setThinkingEnabled(true);
-      setPlanMode(false);
-      if (defaultModelIdRef.current) setSelectedModelId(defaultModelIdRef.current);
-      attachmentsRef.current?.restore([]);
-      setFileCount(0);
-      setFileMentions([]);
+    // Restore incoming session's draft from the CURRENT workspace.
+    // Skip when sessionId is undefined (transient workspace-switch state).
+    if (sessionId && (wsChanged || sessionChanged)) {
+      const draft = getWorkspaceDrafts(wsId).get(sessionId);
+      if (draft) {
+        setValue(draft.value);
+        setThinkingEnabled(draft.thinkingEnabled);
+        setPlanMode(draft.planMode);
+        setSelectedModelId(draft.selectedModelId);
+        setThinkingLevel(draft.thinkingLevel);
+        attachmentsRef.current?.restore([...draft.files]);
+        setFileCount(draft.files.length);
+        setFileMentions(draft.fileMentions ?? []);
+      } else {
+        setValue("");
+        setThinkingEnabled(true);
+        setPlanMode(false);
+        if (defaultModelIdRef.current) setSelectedModelId(defaultModelIdRef.current);
+        attachmentsRef.current?.restore([]);
+        setFileCount(0);
+        setFileMentions([]);
+      }
     }
 
+    prevWsIdRef.current = wsId;
     prevSessionIdRef.current = sessionId;
   }, [
     wsId,
@@ -203,9 +208,13 @@ export function useChatInputDraftPersistence({
     setFileMentions,
   ]);
 
+  // Unmount cleanup: persist current draft without deleting.
   useEffect(() => {
     return () => {
-      saveDraftForSession(prevSessionIdRef.current, { allowDelete: false });
+      saveDraftForSession(prevSessionIdRef.current, {
+        allowDelete: false,
+        targetWsId: prevWsIdRef.current,
+      });
     };
   }, [saveDraftForSession]);
 }

--- a/frontend/tests/components/ChatInput.persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.persistence.test.tsx
@@ -237,6 +237,29 @@ describe("ChatInput draft persistence", () => {
     expect(inputValue()).toBe("");
   });
 
+  it("keeps draft when wsId changes before sessionId (multi-render-cycle)", () => {
+    const sessA = nextId("sess-a");
+    const sessB = nextId("sess-b");
+    const { a: wsA, b: wsB } = makeWorkspaceIds();
+    const { rerender } = renderChatInput(sessA, wsA);
+
+    setInputValue("important draft");
+
+    // Simulate real-world navigation: wsId changes first, sessionId is stale
+    rerenderChatInput(rerender, { wsId: wsB, sessionId: sessA });
+    // Then sessionId becomes undefined (prepare_workspace_switch)
+    rerenderChatInput(rerender, { wsId: wsB, sessionId: undefined });
+    // Then sessionId settles to the new workspace's session
+    rerenderChatInput(rerender, { wsId: wsB, sessionId: sessB });
+    expect(inputValue()).toBe("");
+
+    // Navigate back — same multi-step transition
+    rerenderChatInput(rerender, { wsId: wsA, sessionId: sessB });
+    rerenderChatInput(rerender, { wsId: wsA, sessionId: undefined });
+    rerenderChatInput(rerender, { wsId: wsA, sessionId: sessA });
+    expect(inputValue()).toBe("important draft");
+  });
+
   it("persists attachment previews per session across switches", async () => {
     const user = userEvent.setup();
     const { a: sessionA, b: sessionB } = makeSessionIds();


### PR DESCRIPTION
## Summary

- Merged two separate `useEffect`s in `useChatInputDraftPersistence` into one that handles both workspace and session transitions atomically, always saving the outgoing draft under the **previous** workspace key
- Stabilized `saveDraftForSession` callback by reading `wsId` from a ref instead of closing over it (eliminates the unmount cleanup reinstalling on every workspace change)
- Added regression test simulating the real-world multi-render-cycle transition (wsId changes before sessionId settles)

Fixes the bug where typing text in a workspace's chat input, navigating to another workspace, and coming back would lose the draft.

## Root cause

`wsId` (from URL params) and `sessionId` (from `useConversation` reducer) change in **separate render cycles** during workspace navigation. The old Effect 2's save defaulted to the current `wsId` from its closure — which was already the **new** workspace — so the outgoing draft was saved under the wrong key.

## Test plan

- [x] All 893 existing tests pass
- [x] New test: `keeps draft when wsId changes before sessionId (multi-render-cycle)` — simulates the real transition sequence (wsId changes → sessionId stale → sessionId undefined → sessionId settles)
- [ ] Manual: type in workspace A input → navigate to workspace B → navigate back to A → verify draft is preserved