### PR TITLE
UI polish: red stop button, setup tab default, plan status fix

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -7,6 +7,7 @@ import { saveProject, getDataDir, loadProject, withProjectStateLock } from "../s
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
 import { runNamingTask } from "./naming.js";
 import { NotFoundError } from "../utils/errors.js";
+import { extractSummary } from "../utils/summary-extractor.js";
 import type { ChatMessage, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
 import { TelegramChannel } from "../notifications/telegram.js";
@@ -426,16 +427,42 @@ function attachNotificationListener(
 ): void {
   if (!notifier) return;
   const n = notifier;
+  const baseCtx = {
+    workspaceId: ctx.workspace.id,
+    workspaceName: ctx.workspace.name,
+    projectName: ctx.projectState.name,
+    sessionId: session.sessionId,
+  };
+
   session.on("message", (msg) => {
-    if (msg.type !== "done") return;
-    n.notify({
-      type: "agent_turn_complete",
-      workspaceId: ctx.workspace.id,
-      workspaceName: ctx.workspace.name,
-      projectName: ctx.projectState.name,
-      sessionId: session.sessionId,
-      durationMs: msg.durationMs,
-    }).catch(() => {});
+    if (msg.type === "done") {
+      if (msg.pendingToolName === "AskUserQuestion") {
+        n.notify({ type: "agent_needs_input", ...baseCtx }).catch(() => {});
+      } else if (msg.pendingToolName === "ExitPlanMode") {
+        n.notify({ type: "agent_proposed_plan", ...baseCtx }).catch(() => {});
+      } else {
+        void (async () => {
+          let summary: string | undefined;
+          try {
+            const messages = await session.getMessages();
+            summary = extractSummary(messages);
+          } catch { /* non-fatal */ }
+          n.notify({
+            type: "agent_turn_complete",
+            ...baseCtx,
+            durationMs: msg.durationMs,
+            summary,
+          }).catch(() => {});
+        })();
+      }
+    } else if (msg.type === "cancelled" && !msg.userInitiated) {
+      n.notify({
+        type: "agent_failed",
+        ...baseCtx,
+        durationMs: msg.durationMs,
+        errorDetail: msg.errorDetail,
+      }).catch(() => {});
+    }
   });
 }
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -581,7 +581,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
       const exitCode = code ?? 1;
       const wasCancelled = exitCode !== 0 && this._status === "streaming" && !killedForBlockingTool;
-      const cancelledByPark = wasCancelled && this.stopReason === "park";
+      const capturedStopReason = this.stopReason;
+      const capturedStreamingStart = this._streamingStartedAt;
+      const cancelledByPark = wasCancelled && capturedStopReason === "park";
       const shouldSurfaceCancelled = wasCancelled && !cancelledByPark;
       const cancellationErrorDetail = shouldSurfaceCancelled
         ? buildCancellationErrorDetail(exitCode, lastStderr)
@@ -621,10 +623,22 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         ? toolCalls.filter((tc) => blockingToolNames.has(tc.name))
         : [];
 
+      const pendingToolName = unansweredBlockingTools.length > 0
+        ? unansweredBlockingTools[0]!.name
+        : undefined;
+
       void (async () => {
         await this.persistQueue;
         if (shouldSurfaceCancelled) {
-          this.emit("message", { type: "cancelled", sessionId: this.sessionId });
+          const cancelDurationMs = resultDurationMs
+            ?? (capturedStreamingStart ? Date.now() - capturedStreamingStart : undefined);
+          this.emit("message", {
+            type: "cancelled",
+            sessionId: this.sessionId,
+            errorDetail: cancellationErrorDetail,
+            userInitiated: capturedStopReason === "user",
+            durationMs: cancelDurationMs,
+          });
         } else if (!cancelledByPark) {
           this.emit("message", {
             type: "done",
@@ -632,6 +646,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
             durationMs: resultDurationMs,
             inputTokens: resultInputTokens,
             outputTokens: resultOutputTokens,
+            pendingToolName,
           });
         }
 

--- a/backend/src/notifications/apns.ts
+++ b/backend/src/notifications/apns.ts
@@ -2,6 +2,7 @@ import { connect, type ClientHttp2Session } from "node:http2";
 import { createSign } from "node:crypto";
 import type { NotificationChannel, NotificationEvent } from "./types.js";
 import type { ApnsConfig } from "../state/config.js";
+import { formatDuration } from "../utils/format.js";
 
 const PRODUCTION_HOST = "https://api.push.apple.com";
 const SANDBOX_HOST = "https://api.sandbox.push.apple.com";
@@ -181,15 +182,40 @@ export class ApnsChannel implements NotificationChannel {
     let body: string;
     let extraData: Record<string, string> = {};
 
-    if (event.type === "agent_turn_complete") {
-      title = "Agent finished";
-      body = `${event.projectName} / ${event.workspaceName}`;
-      extraData = { workspaceId: event.workspaceId };
-    } else {
-      const statusLabel = event.status === "success" ? "Success" : "Failed";
-      title = `Automation: ${event.automationName}`;
-      body = `Status: ${statusLabel}${event.projectName ? ` | ${event.projectName}` : ""}`;
-      extraData = { automationId: event.automationId };
+    switch (event.type) {
+      case "agent_turn_complete": {
+        const dur = event.durationMs != null ? ` (${formatDuration(event.durationMs)})` : "";
+        title = "Agent finished";
+        body = `${event.projectName} / ${event.workspaceName}${dur}`;
+        extraData = { workspaceId: event.workspaceId };
+        break;
+      }
+      case "agent_needs_input": {
+        title = "Agent needs input";
+        body = `${event.projectName} / ${event.workspaceName}`;
+        extraData = { workspaceId: event.workspaceId };
+        break;
+      }
+      case "agent_proposed_plan": {
+        title = "Agent proposed a plan";
+        body = `${event.projectName} / ${event.workspaceName}`;
+        extraData = { workspaceId: event.workspaceId };
+        break;
+      }
+      case "agent_failed": {
+        const dur = event.durationMs != null ? ` (${formatDuration(event.durationMs)})` : "";
+        title = "Agent failed";
+        body = `${event.projectName} / ${event.workspaceName}${dur}`;
+        extraData = { workspaceId: event.workspaceId };
+        break;
+      }
+      case "automation_run_complete": {
+        const statusLabel = event.status === "success" ? "Success" : "Failed";
+        title = `Automation: ${event.automationName}`;
+        body = `Status: ${statusLabel}${event.projectName ? ` | ${event.projectName}` : ""}`;
+        extraData = { automationId: event.automationId };
+        break;
+      }
     }
 
     const payload = JSON.stringify({

--- a/backend/src/notifications/telegram-formatting.test.ts
+++ b/backend/src/notifications/telegram-formatting.test.ts
@@ -1,13 +1,17 @@
 /**
- * Tests for Telegram message formatting of automation_run_complete events.
- * The original telegram.test.ts covers agent_turn_complete; this file focuses
- * on the new automation notification variant.
+ * Tests for Telegram message formatting of notification event types.
+ * The original telegram.test.ts covers agent_turn_complete basics; this file
+ * covers automation events and the newer notification variants.
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { TelegramChannel } from "./telegram.js";
 import type { NotificationEvent } from "./types.js";
 
 type AutomationRunEvent = Extract<NotificationEvent, { type: "automation_run_complete" }>;
+type NeedsInputEvent = Extract<NotificationEvent, { type: "agent_needs_input" }>;
+type ProposedPlanEvent = Extract<NotificationEvent, { type: "agent_proposed_plan" }>;
+type FailedEvent = Extract<NotificationEvent, { type: "agent_failed" }>;
+type TurnCompleteEvent = Extract<NotificationEvent, { type: "agent_turn_complete" }>;
 
 function automationEvent(overrides: Partial<AutomationRunEvent> = {}): AutomationRunEvent {
   return {
@@ -60,7 +64,7 @@ describe("automation_run_complete formatting", () => {
     const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
     expect(body.text).toContain("Automation: Daily Code Review");
     expect(body.text).toContain("✅ Success");
-    expect(body.text).toContain("Duration: 121s");
+    expect(body.text).toContain("Duration: 2m 1s");
     expect(body.text).toContain("Reviewed 12 files, found 3 issues.");
   });
 
@@ -186,5 +190,114 @@ describe("automation_run_complete formatting", () => {
 
     body = JSON.parse(String(fetchMock.mock.calls[1]![1]?.body));
     expect(body.text).toContain("real error");
+  });
+});
+
+const wsCtx = {
+  workspaceId: "ws-1",
+  workspaceName: "tokyo",
+  projectName: "hive",
+  sessionId: "s-1",
+};
+
+describe("agent_needs_input formatting", () => {
+  it("formats with question mark emoji", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: NeedsInputEvent = { type: "agent_needs_input", ...wsCtx };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("❓");
+    expect(body.text).toContain("Agent needs input");
+    expect(body.text).toContain("Project: hive");
+    expect(body.text).toContain("Workspace: tokyo");
+  });
+});
+
+describe("agent_proposed_plan formatting", () => {
+  it("formats with clipboard emoji", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: ProposedPlanEvent = { type: "agent_proposed_plan", ...wsCtx };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("📋");
+    expect(body.text).toContain("Agent proposed a plan");
+    expect(body.text).toContain("Workspace: tokyo");
+  });
+});
+
+describe("agent_failed formatting", () => {
+  it("formats with error detail and duration", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: FailedEvent = {
+      type: "agent_failed",
+      ...wsCtx,
+      durationMs: 92000,
+      errorDetail: "exit code 1 | stderr: out of memory",
+    };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("❌");
+    expect(body.text).toContain("Agent failed");
+    expect(body.text).toContain("Duration: 1m 32s");
+    expect(body.text).toContain("out of memory");
+  });
+
+  it("omits error detail when not provided", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: FailedEvent = { type: "agent_failed", ...wsCtx };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("Agent failed");
+    expect(body.text).not.toContain("Duration:");
+  });
+});
+
+describe("agent_turn_complete with summary", () => {
+  it("includes summary when provided", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: TurnCompleteEvent = {
+      type: "agent_turn_complete",
+      ...wsCtx,
+      durationMs: 92000,
+      summary: "Refactored 5 files and added tests.",
+    };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("Agent finished");
+    expect(body.text).toContain("Duration: 1m 32s");
+    expect(body.text).toContain("Refactored 5 files and added tests.");
+  });
+
+  it("omits summary when not provided", async () => {
+    const fetchMock = mockFetch();
+    const channel = withEnv("token", "chat");
+    const event: TurnCompleteEvent = {
+      type: "agent_turn_complete",
+      ...wsCtx,
+      durationMs: 5000,
+    };
+
+    await channel.send(event);
+
+    const body = JSON.parse(String(fetchMock.mock.calls[0]![1]?.body));
+    expect(body.text).toContain("Agent finished");
+    expect(body.text).toContain("Duration: 5s");
+    // No trailing content after duration
+    expect(body.text).not.toContain("\n\n");
   });
 });

--- a/backend/src/notifications/telegram.ts
+++ b/backend/src/notifications/telegram.ts
@@ -1,4 +1,5 @@
 import type { NotificationChannel, NotificationEvent } from "./types.js";
+import { formatDuration } from "../utils/format.js";
 
 function escapeHtml(text: string): string {
   return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
@@ -12,19 +13,49 @@ function formatMessage(event: NotificationEvent): string {
   switch (event.type) {
     case "agent_turn_complete": {
       const duration =
-        event.durationMs != null ? `\nDuration: ${Math.round(event.durationMs / 1000)}s` : "";
+        event.durationMs != null ? `\nDuration: ${formatDuration(event.durationMs)}` : "";
+      const summary =
+        event.summary ? `\n\n${escapeHtml(truncate(event.summary, 4000))}` : "";
       return (
         `🤖 <b>Agent finished</b>\n` +
         `Project: ${escapeHtml(event.projectName)}\n` +
         `Workspace: ${escapeHtml(event.workspaceName)}` +
-        duration
+        duration +
+        summary
+      );
+    }
+    case "agent_needs_input": {
+      return (
+        `❓ <b>Agent needs input</b>\n` +
+        `Project: ${escapeHtml(event.projectName)}\n` +
+        `Workspace: ${escapeHtml(event.workspaceName)}`
+      );
+    }
+    case "agent_proposed_plan": {
+      return (
+        `📋 <b>Agent proposed a plan</b>\n` +
+        `Project: ${escapeHtml(event.projectName)}\n` +
+        `Workspace: ${escapeHtml(event.workspaceName)}`
+      );
+    }
+    case "agent_failed": {
+      const duration =
+        event.durationMs != null ? `\nDuration: ${formatDuration(event.durationMs)}` : "";
+      const detail =
+        event.errorDetail ? `\n\n${escapeHtml(truncate(event.errorDetail, 4000))}` : "";
+      return (
+        `❌ <b>Agent failed</b>\n` +
+        `Project: ${escapeHtml(event.projectName)}\n` +
+        `Workspace: ${escapeHtml(event.workspaceName)}` +
+        duration +
+        detail
       );
     }
     case "automation_run_complete": {
       const statusIcon = event.status === "success" ? "✅" : "❌";
       const statusLabel = event.status === "success" ? "Success" : "Failed";
       const duration =
-        event.durationMs != null ? `\nDuration: ${Math.round(event.durationMs / 1000)}s` : "";
+        event.durationMs != null ? `\nDuration: ${formatDuration(event.durationMs)}` : "";
       const project = event.projectName ? `\nProject: ${escapeHtml(event.projectName)}` : "";
 
       let body = "";

--- a/backend/src/notifications/types.ts
+++ b/backend/src/notifications/types.ts
@@ -10,6 +10,30 @@ export type NotificationEvent =
       projectName: string;
       sessionId: string;
       durationMs?: number;
+      summary?: string;
+    }
+  | {
+      type: "agent_needs_input";
+      workspaceId: string;
+      workspaceName: string;
+      projectName: string;
+      sessionId: string;
+    }
+  | {
+      type: "agent_proposed_plan";
+      workspaceId: string;
+      workspaceName: string;
+      projectName: string;
+      sessionId: string;
+    }
+  | {
+      type: "agent_failed";
+      workspaceId: string;
+      workspaceName: string;
+      projectName: string;
+      sessionId: string;
+      durationMs?: number;
+      errorDetail?: string;
     }
   | {
       type: "automation_run_complete";

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -299,9 +299,9 @@ export type WsOutgoing =
   | { type: "tool_use"; sessionId: string; id: string; name: string; input: string; parentToolUseId?: string }
   | { type: "tool_result"; sessionId: string; toolUseId: string; output: string }
   | { type: "tool_input_required"; sessionId: string; requestId: string; toolName: string; toolUseId: string; input: unknown }
-  | { type: "done"; sessionId: string; durationMs?: number; inputTokens?: number; outputTokens?: number }
+  | { type: "done"; sessionId: string; durationMs?: number; inputTokens?: number; outputTokens?: number; pendingToolName?: string }
   | { type: "error"; message: string; sessionId?: string }
-  | { type: "cancelled"; sessionId: string }
+  | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: WorkspaceStatus; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
   | { type: "user_message"; message: ChatMessage }
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }

--- a/backend/src/utils/format.test.ts
+++ b/backend/src/utils/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { formatDuration } from "./format.js";
+
+describe("formatDuration", () => {
+  it("formats zero", () => {
+    expect(formatDuration(0)).toBe("0s");
+  });
+
+  it("formats sub-second durations", () => {
+    expect(formatDuration(500)).toBe("1s");
+    expect(formatDuration(499)).toBe("0s");
+  });
+
+  it("formats seconds only", () => {
+    expect(formatDuration(45000)).toBe("45s");
+    expect(formatDuration(59499)).toBe("59s");
+  });
+
+  it("formats minutes and seconds", () => {
+    expect(formatDuration(60000)).toBe("1m 0s");
+    expect(formatDuration(92000)).toBe("1m 32s");
+    expect(formatDuration(125400)).toBe("2m 5s");
+  });
+
+  it("rounds to nearest second", () => {
+    expect(formatDuration(1499)).toBe("1s");
+    expect(formatDuration(1500)).toBe("2s");
+  });
+});

--- a/backend/src/utils/format.ts
+++ b/backend/src/utils/format.ts
@@ -1,0 +1,11 @@
+/**
+ * Format a duration in milliseconds to a human-friendly string.
+ * Uses whole seconds: "1m 32s", "45s", "0s".
+ */
+export function formatDuration(ms: number): string {
+  const totalSec = Math.round(ms / 1000);
+  const min = Math.floor(totalSec / 60);
+  const sec = totalSec % 60;
+  if (min > 0) return `${min}m ${sec}s`;
+  return `${sec}s`;
+}

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -35,6 +35,7 @@ interface ChatConversationProps {
   fileCount?: number;
   switchCounter: number;
   error?: string;
+  agentPlanMode?: boolean;
   queuedMessage?: QueuedMessage | null;
   onClearQueue?: () => void;
 }
@@ -55,6 +56,7 @@ export default function ChatConversation({
   defaultBranch,
   fileCount,
   switchCounter,
+  agentPlanMode,
   error,
   queuedMessage,
   onClearQueue,
@@ -148,7 +150,9 @@ export default function ChatConversation({
       (m) => m.role === "assistant" && hasExitPlanModeTool(m),
     );
     if (hasLaterPlan) return "revised";
-    if (isStreaming && after.some((m) => m.role === "user")) return "revised";
+    // While streaming after a rejection, agentPlanMode stays true — mark as revised
+    // even before the new plan arrives. After approval, agentPlanMode is false.
+    if (isStreaming && agentPlanMode && after.some((m) => m.role === "user")) return "revised";
     return "approved";
   };
 

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -430,7 +430,7 @@ export default function ChatInput({
                 className="size-5"
                 onClick={(e) => { e.preventDefault(); onStop(); }}
               >
-                <SquareIcon className="size-3" />
+                <SquareIcon className="size-3 text-red-500" />
               </PromptInputButton>
             )}
             <PromptInputSubmit

--- a/frontend/src/components/ScriptPanel.tsx
+++ b/frontend/src/components/ScriptPanel.tsx
@@ -66,6 +66,14 @@ export default function ScriptPanel({
 
   const [activeTab, setActiveTab] = useState<string>(tabs[0]?.key ?? "terminal");
 
+  // When config loads and tabs change, reset to first tab (e.g. "setup") if current tab is just the default "terminal"
+  const firstTabKey = tabs[0]?.key ?? "terminal";
+  useEffect(() => {
+    if (firstTabKey !== "terminal") {
+      setActiveTab((prev) => prev === "terminal" ? firstTabKey : prev);
+    }
+  }, [firstTabKey]);
+
   // If the active tab no longer exists in config, fall back to first
   const effectiveTab = tabs.find((t) => t.key === activeTab)?.key ?? tabs[0]?.key ?? "terminal";
   const tabInfo = tabs.find((t) => t.key === effectiveTab);

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -550,6 +550,7 @@ export default function WorkspaceView() {
               defaultBranch={workspace?.defaultBranch}
               fileCount={fileCount}
               switchCounter={switchCounter}
+              agentPlanMode={agentPlanMode}
               error={error}
               queuedMessage={queuedMessage}
               onClearQueue={() => setQueuedMessage(null)}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -289,9 +289,9 @@ export type WsOutgoing =
   | { type: "tool_use"; sessionId: string; id: string; name: string; input: string; parentToolUseId?: string }
   | { type: "tool_result"; sessionId: string; toolUseId: string; output: string }
   | { type: "tool_input_required"; sessionId: string; requestId: string; toolName: string; toolUseId: string; input: unknown }
-  | { type: "done"; sessionId: string; durationMs?: number; inputTokens?: number; outputTokens?: number }
+  | { type: "done"; sessionId: string; durationMs?: number; inputTokens?: number; outputTokens?: number; pendingToolName?: string }
   | { type: "error"; message: string; sessionId?: string }
-  | { type: "cancelled"; sessionId: string }
+  | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: "idle" | "busy"; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
   | { type: "user_message"; message: ChatMessage }
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -467,9 +467,10 @@ describe("ChatConversation plan status behavior", () => {
     expect(screen.getByTestId("msg-a2")).toHaveAttribute("data-plan-status", "interactive");
   });
 
-  it("marks a plan as revised while streaming after user feedback", () => {
+  it("marks plan as revised while streaming after rejection (agentPlanMode=true)", () => {
     renderConversation({
       isStreaming: true,
+      agentPlanMode: true,
       messages: [
         assistantWithPlan("a1", "Plan A"),
         {
@@ -483,6 +484,25 @@ describe("ChatConversation plan status behavior", () => {
     });
 
     expect(screen.getByTestId("msg-a1")).toHaveAttribute("data-plan-status", "revised");
+  });
+
+  it("keeps plan as approved while streaming after approval (agentPlanMode=false)", () => {
+    renderConversation({
+      isStreaming: true,
+      agentPlanMode: false,
+      messages: [
+        assistantWithPlan("a1", "Plan A"),
+        {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "Plan approved. Proceed with implementation.",
+          timestamp: "2026-02-20T00:00:01.000Z",
+        },
+      ],
+    });
+
+    expect(screen.getByTestId("msg-a1")).toHaveAttribute("data-plan-status", "approved");
   });
 });
 

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -112,9 +112,9 @@ enum WsOutgoing: Decodable {
     case toolUse(sessionId: String, id: String, name: String, input: String, parentToolUseId: String?)
     case toolResult(sessionId: String, toolUseId: String, output: String)
     case toolInputRequired(sessionId: String, requestId: String, toolName: String, toolUseId: String, input: String)
-    case done(sessionId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?)
+    case done(sessionId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, pendingToolName: String?)
     case error(message: String, sessionId: String?)
-    case cancelled(sessionId: String)
+    case cancelled(sessionId: String, errorDetail: String?, userInitiated: Bool?, durationMs: Int?)
     case status(status: WorkspaceStatus, sessionId: String?, streaming: Bool?, streamingStartedAt: Double?, lockedProvider: String?)
     case userMessage(message: ChatMessage)
     case history(messages: [ChatMessage], sessionId: String?)
@@ -126,7 +126,8 @@ enum WsOutgoing: Decodable {
     private enum CodingKeys: String, CodingKey {
         case type, sessionId, text, id, name, input, output
         case parentToolUseId, toolUseId, requestId, toolName
-        case durationMs, inputTokens, outputTokens
+        case durationMs, inputTokens, outputTokens, pendingToolName
+        case errorDetail, userInitiated
         case message, status, streaming, streamingStartedAt, lockedProvider
         case messages, info, stats
         case scriptType, state, exitCode
@@ -206,15 +207,28 @@ enum WsOutgoing: Decodable {
             } else {
                 doneOutputTokens = nil
             }
+            let donePendingToolName = try container.decodeIfPresent(String.self, forKey: .pendingToolName)
             self = .done(sessionId: doneSessionId, durationMs: doneDuration,
-                         inputTokens: doneInputTokens, outputTokens: doneOutputTokens)
+                         inputTokens: doneInputTokens, outputTokens: doneOutputTokens,
+                         pendingToolName: donePendingToolName)
         case "error":
             self = .error(
                 message: try container.decode(String.self, forKey: .message),
                 sessionId: try container.decodeIfPresent(String.self, forKey: .sessionId)
             )
         case "cancelled":
-            self = .cancelled(sessionId: try container.decode(String.self, forKey: .sessionId))
+            let cancelledSid = try container.decode(String.self, forKey: .sessionId)
+            let cancelledErrorDetail = try container.decodeIfPresent(String.self, forKey: .errorDetail)
+            let cancelledUserInitiated = try container.decodeIfPresent(Bool.self, forKey: .userInitiated)
+            let cancelledDuration: Int?
+            if let intVal = try? container.decodeIfPresent(Int.self, forKey: .durationMs) {
+                cancelledDuration = intVal
+            } else if let doubleVal = try? container.decodeIfPresent(Double.self, forKey: .durationMs) {
+                cancelledDuration = Int(doubleVal)
+            } else {
+                cancelledDuration = nil
+            }
+            self = .cancelled(sessionId: cancelledSid, errorDetail: cancelledErrorDetail, userInitiated: cancelledUserInitiated, durationMs: cancelledDuration)
         case "status":
             self = .status(
                 status: try container.decode(WorkspaceStatus.self, forKey: .status),

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -145,12 +145,12 @@ final class ConversationStore {
                 toolName: toolName, toolUseId: toolUseId, input: input
             ))
 
-        case .done(let sid, let durationMs, let inputTokens, let outputTokens):
+        case .done(let sid, let durationMs, let inputTokens, let outputTokens, _):
             finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: false,
                             inputTokens: inputTokens, outputTokens: outputTokens)
             onTurnCompleted?(sid)
 
-        case .cancelled(let sid):
+        case .cancelled(let sid, _, _, _):
             finalizeMessage(sessionId: sid, durationMs: nil, cancelled: true)
             onTurnCompleted?(sid)
 


### PR DESCRIPTION
## Summary
- Make the stop button icon red for better visibility (consistent with iOS)
- Auto-select "Setup" tab in ScriptPanel when config loads instead of defaulting to "Terminal"
- Fix plan status badge incorrectly showing "Revised" after approval — now uses `agentPlanMode` to distinguish approve (planMode=false → "Approved") from reject (planMode=true → "Revised")

## Test plan
- [x] All 893 tests pass
- [x] Typecheck passes