### PR TITLE
fix(frontend): harden tab state persistence and regressions

### DIFF
--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -32,10 +32,10 @@ interface ConversationTabsProps {
   onActivateSession: (sessionId: string) => void;
   onDeleteSession: (sessionId: string) => void;
   openFile?: string | null;
-  isFileActive?: boolean;
-  onFileTabClick?: () => void;
+  isFileTabActive?: boolean;
+  onFileTabActivate?: () => void;
   onFileTabClose?: () => void;
-  onConversationTabClick?: () => void;
+  onConversationActivate?: () => void;
 }
 
 function getTabTitle(session: SessionMetadata): string {
@@ -46,19 +46,19 @@ function getSessionVisualState({
   sessionId,
   activeSessionId,
   isStreaming,
-  isFileActive,
+  isFileTabActive,
   streamingSessions,
   unreadSessions,
 }: {
   sessionId: string;
   activeSessionId?: string;
   isStreaming: boolean;
-  isFileActive?: boolean;
+  isFileTabActive?: boolean;
   streamingSessions?: Record<string, boolean>;
   unreadSessions?: Record<string, boolean>;
 }) {
   const isActive = sessionId === activeSessionId;
-  const isSessionVisible = isActive && !isFileActive;
+  const isSessionVisible = isActive && !isFileTabActive;
   const isSessionStreaming = Boolean(streamingSessions?.[sessionId] ?? (isActive && isStreaming));
   const isSessionUnread = !isSessionVisible && !isSessionStreaming && Boolean(unreadSessions?.[sessionId]);
 
@@ -120,10 +120,10 @@ export function ConversationTabs({
   onActivateSession,
   onDeleteSession,
   openFile,
-  isFileActive,
-  onFileTabClick,
+  isFileTabActive,
+  onFileTabActivate,
   onFileTabClose,
-  onConversationTabClick,
+  onConversationActivate,
 }: ConversationTabsProps) {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
   const [visibleCount, setVisibleCount] = useState(sessions.length);
@@ -178,11 +178,11 @@ export function ConversationTabs({
               type="button"
               className={cn(
                 "group relative flex h-7 max-w-48 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs transition-colors",
-                isFileActive
+                isFileTabActive
                   ? "text-foreground after:absolute after:bottom-0 after:inset-x-2 after:h-0.5 after:rounded-full after:bg-primary"
                   : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
               )}
-              onClick={onFileTabClick}
+              onClick={onFileTabActivate}
             >
               <FileIcon className="size-3 shrink-0" />
               <span className="truncate">{openFile.split("/").pop()}</span>
@@ -194,11 +194,11 @@ export function ConversationTabs({
               type="button"
               className={cn(
                 "relative flex h-7 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs transition-colors",
-                !isFileActive
+                !isFileTabActive
                   ? "text-foreground after:absolute after:bottom-0 after:inset-x-2 after:h-0.5 after:rounded-full after:bg-primary"
                   : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
               )}
-              onClick={onConversationTabClick}
+              onClick={onConversationActivate}
             >
               <MessageSquareIcon className="size-3 shrink-0" />
               <span className="truncate">Untitled</span>
@@ -209,7 +209,7 @@ export function ConversationTabs({
               sessionId: session.sessionId,
               activeSessionId,
               isStreaming,
-              isFileActive,
+              isFileTabActive,
               streamingSessions,
               unreadSessions,
             });
@@ -222,7 +222,7 @@ export function ConversationTabs({
                 type="button"
                 className={cn(
                   "group relative flex h-7 max-w-48 shrink-0 items-center gap-1.5 rounded-md px-2 text-xs transition-colors",
-                  isActive && !isFileActive
+                  isActive && !isFileTabActive
                     ? "text-foreground after:absolute after:bottom-0 after:inset-x-2 after:h-0.5 after:rounded-full after:bg-primary"
                     : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                   !isVisible && "hidden",
@@ -255,7 +255,7 @@ export function ConversationTabs({
                   sessionId: session.sessionId,
                   activeSessionId,
                   isStreaming,
-                  isFileActive,
+                  isFileTabActive,
                   streamingSessions,
                   unreadSessions,
                 });

--- a/frontend/src/hooks/useTabs.ts
+++ b/frontend/src/hooks/useTabs.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import type { TabId } from "../types";
+import { parseTabId, tabId, type TabId } from "../types";
 
 export interface UseTabsReturn {
   activeTabId: TabId | null;
@@ -28,12 +28,14 @@ export function useTabs(
   wsId: string | undefined,
 ): UseTabsReturn {
   const prevWsId = useRef(wsId);
+  const latestSnapshot = useRef<TabSnapshot>({ activeTabId: null, openFile: null });
+  const latestWsId = useRef<string | undefined>(wsId);
 
   // Resolve initial state: restore from cache if available, else default.
   const [activeTabId, setActiveTabId] = useState<TabId | null>(() => {
     const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
     if (cached) return cached.activeTabId;
-    return currentSessionId ? `session:${currentSessionId}` : null;
+    return currentSessionId ? tabId({ type: "session", sessionId: currentSessionId }) : null;
   });
   const [openFile, setOpenFile] = useState<string | null>(() => {
     const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
@@ -67,7 +69,7 @@ export function useTabs(
     if (!currentSessionId) return;
     setActiveTabId((prev) => {
       if (!prev || prev.startsWith("session:")) {
-        return `session:${currentSessionId}`;
+        return tabId({ type: "session", sessionId: currentSessionId });
       }
       return prev;
     });
@@ -79,15 +81,28 @@ export function useTabs(
 
   const openFileTab = useCallback((path: string) => {
     setOpenFile(path);
-    setActiveTabId(`file:${path}`);
+    setActiveTabId(tabId({ type: "file", path }));
   }, []);
 
   const closeFileTab = useCallback(() => {
     setOpenFile(null);
-    setActiveTabId(currentSessionId ? `session:${currentSessionId}` : null);
+    setActiveTabId(currentSessionId ? tabId({ type: "session", sessionId: currentSessionId }) : null);
   }, [currentSessionId]);
 
-  const isFileTabActive = activeTabId?.startsWith("file:") ?? false;
+  useEffect(() => {
+    latestSnapshot.current = { activeTabId, openFile };
+    latestWsId.current = wsId;
+  }, [activeTabId, openFile, wsId]);
+
+  // Preserve current workspace tab state across unmount/remount cycles.
+  useEffect(() => {
+    return () => {
+      if (!latestWsId.current) return;
+      snapshotByWorkspace.set(latestWsId.current, latestSnapshot.current);
+    };
+  }, []);
+
+  const isFileTabActive = activeTabId ? parseTabId(activeTabId).type === "file" : false;
 
   return {
     activeTabId,

--- a/frontend/src/hooks/useTabs.ts
+++ b/frontend/src/hooks/useTabs.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import type { TabId } from "../types";
 
 export interface UseTabsReturn {
@@ -8,14 +8,58 @@ export interface UseTabsReturn {
   activateTab: (id: TabId) => void;
   openFileTab: (path: string) => void;
   closeFileTab: () => void;
-  resetForWorkspace: () => void;
 }
 
-export function useTabs(currentSessionId: string | undefined): UseTabsReturn {
-  const [activeTabId, setActiveTabId] = useState<TabId | null>(
-    currentSessionId ? `session:${currentSessionId}` : null,
-  );
-  const [openFile, setOpenFile] = useState<string | null>(null);
+interface TabSnapshot {
+  activeTabId: TabId | null;
+  openFile: string | null;
+}
+
+/** Module-level cache: survives component remounts, lost on page refresh. */
+const snapshotByWorkspace = new Map<string, TabSnapshot>();
+
+/** Visible for testing only. */
+export function _resetSnapshotCache() {
+  snapshotByWorkspace.clear();
+}
+
+export function useTabs(
+  currentSessionId: string | undefined,
+  wsId: string | undefined,
+): UseTabsReturn {
+  const prevWsId = useRef(wsId);
+
+  // Resolve initial state: restore from cache if available, else default.
+  const [activeTabId, setActiveTabId] = useState<TabId | null>(() => {
+    const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
+    if (cached) return cached.activeTabId;
+    return currentSessionId ? `session:${currentSessionId}` : null;
+  });
+  const [openFile, setOpenFile] = useState<string | null>(() => {
+    const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
+    return cached?.openFile ?? null;
+  });
+
+  // On workspace switch: save outgoing state, restore incoming state.
+  useEffect(() => {
+    if (prevWsId.current === wsId) return;
+
+    // Save outgoing workspace state.
+    if (prevWsId.current) {
+      snapshotByWorkspace.set(prevWsId.current, { activeTabId, openFile });
+    }
+    prevWsId.current = wsId;
+
+    // Restore incoming workspace state (or reset).
+    const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
+    if (cached) {
+      setActiveTabId(cached.activeTabId);
+      setOpenFile(cached.openFile);
+    } else {
+      setActiveTabId(null);
+      setOpenFile(null);
+    }
+  }, [wsId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // When currentSessionId changes and the active tab is a session tab (or null), track it.
   // If the user is on a file tab, don't disturb them.
@@ -43,12 +87,6 @@ export function useTabs(currentSessionId: string | undefined): UseTabsReturn {
     setActiveTabId(currentSessionId ? `session:${currentSessionId}` : null);
   }, [currentSessionId]);
 
-  const resetForWorkspace = useCallback(() => {
-    setOpenFile(null);
-    // Will be set by the currentSessionId sync effect on next render.
-    setActiveTabId(null);
-  }, []);
-
   const isFileTabActive = activeTabId?.startsWith("file:") ?? false;
 
   return {
@@ -58,6 +96,5 @@ export function useTabs(currentSessionId: string | undefined): UseTabsReturn {
     activateTab,
     openFileTab,
     closeFileTab,
-    resetForWorkspace,
   };
 }

--- a/frontend/src/hooks/useTabs.ts
+++ b/frontend/src/hooks/useTabs.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback, useEffect } from "react";
+import type { TabId } from "../types";
+
+export interface UseTabsReturn {
+  activeTabId: TabId | null;
+  openFile: string | null;
+  isFileTabActive: boolean;
+  activateTab: (id: TabId) => void;
+  openFileTab: (path: string) => void;
+  closeFileTab: () => void;
+  resetForWorkspace: () => void;
+}
+
+export function useTabs(currentSessionId: string | undefined): UseTabsReturn {
+  const [activeTabId, setActiveTabId] = useState<TabId | null>(
+    currentSessionId ? `session:${currentSessionId}` : null,
+  );
+  const [openFile, setOpenFile] = useState<string | null>(null);
+
+  // When currentSessionId changes and the active tab is a session tab (or null), track it.
+  // If the user is on a file tab, don't disturb them.
+  useEffect(() => {
+    if (!currentSessionId) return;
+    setActiveTabId((prev) => {
+      if (!prev || prev.startsWith("session:")) {
+        return `session:${currentSessionId}`;
+      }
+      return prev;
+    });
+  }, [currentSessionId]);
+
+  const activateTab = useCallback((id: TabId) => {
+    setActiveTabId(id);
+  }, []);
+
+  const openFileTab = useCallback((path: string) => {
+    setOpenFile(path);
+    setActiveTabId(`file:${path}`);
+  }, []);
+
+  const closeFileTab = useCallback(() => {
+    setOpenFile(null);
+    setActiveTabId(currentSessionId ? `session:${currentSessionId}` : null);
+  }, [currentSessionId]);
+
+  const resetForWorkspace = useCallback(() => {
+    setOpenFile(null);
+    // Will be set by the currentSessionId sync effect on next render.
+    setActiveTabId(null);
+  }, []);
+
+  const isFileTabActive = activeTabId?.startsWith("file:") ?? false;
+
+  return {
+    activeTabId,
+    openFile,
+    isFileTabActive,
+    activateTab,
+    openFileTab,
+    closeFileTab,
+    resetForWorkspace,
+  };
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -243,8 +243,7 @@ export default function WorkspaceView() {
     activateTab,
     openFileTab,
     closeFileTab,
-    resetForWorkspace,
-  } = useTabs(sessionId);
+  } = useTabs(sessionId, wsId);
 
   // Clear unread only when the active conversation is actually visible.
   // If the file tab is open, keep unread state so the tab can show a dot.
@@ -325,11 +324,6 @@ export default function WorkspaceView() {
     },
     [],
   );
-
-  // Reset file viewer when switching workspaces
-  useEffect(() => {
-    resetForWorkspace();
-  }, [wsId, resetForWorkspace]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -47,6 +47,7 @@ import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent } from "@/lib/plan-state";
 import { PlanActionBar } from "@/components/chat/PlanActionBar";
 import { useScripts } from "@/hooks/useScripts";
+import { useTabs } from "@/hooks/useTabs";
 import type { DiffStatResponse, FileMention, ImageAttachment, MessageOptions, QueuedMessage, Workspace, WorkspaceFileTreeNode } from "@/types";
 
 const DEFAULT_EXPANDED = new Set<string>();
@@ -119,10 +120,6 @@ export default function WorkspaceView() {
 
   const [expandedPaths, setExpandedPaths] = useState<Set<string>>(DEFAULT_EXPANDED);
   const [selectedPath, setSelectedPath] = useState("");
-
-  // File viewer state
-  const [openFile, setOpenFile] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState<"conversation" | "file">("conversation");
 
   // Sidebar tab state
   const [sidebarTab, setSidebarTab] = useState<"all" | "modified">("all");
@@ -240,14 +237,23 @@ export default function WorkspaceView() {
     switchCounter,
   } = useConversation(wsId);
 
+  const {
+    openFile,
+    isFileTabActive,
+    activateTab,
+    openFileTab,
+    closeFileTab,
+    resetForWorkspace,
+  } = useTabs(sessionId);
+
   // Clear unread only when the active conversation is actually visible.
   // If the file tab is open, keep unread state so the tab can show a dot.
   useEffect(() => {
-    if (activeTab !== "conversation") return;
+    if (isFileTabActive) return;
     if (wsId && sessionId && liveData[wsId]?.unreadSessions?.[sessionId]) {
       clearUnread(wsId, sessionId);
     }
-  }, [activeTab, wsId, sessionId, liveData, clearUnread]);
+  }, [isFileTabActive, wsId, sessionId, liveData, clearUnread]);
 
   // ── Message queue: lets users type one follow-up while agent is busy ──
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
@@ -322,9 +328,8 @@ export default function WorkspaceView() {
 
   // Reset file viewer when switching workspaces
   useEffect(() => {
-    setOpenFile(null);
-    setActiveTab("conversation");
-  }, [wsId]);
+    resetForWorkspace();
+  }, [wsId, resetForWorkspace]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -334,11 +339,11 @@ export default function WorkspaceView() {
   }, [createSession, switchSession]);
 
   const handleActivateSession = useCallback((targetSessionId: string) => {
-    setActiveTab("conversation");
+    activateTab(`session:${targetSessionId}`);
     if (targetSessionId === sessionId) return;
     switchSession(targetSessionId);
     if (wsId) clearUnread(wsId, targetSessionId);
-  }, [sessionId, switchSession, wsId, clearUnread]);
+  }, [sessionId, switchSession, wsId, clearUnread, activateTab]);
 
   const handleDeleteSession = useCallback(async (targetSessionId: string) => {
     const isActive = targetSessionId === sessionId;
@@ -359,9 +364,8 @@ export default function WorkspaceView() {
 
   const handleFileTreeSelect = useCallback((path: string) => {
     setSelectedPath(path);
-    setOpenFile(path);
-    setActiveTab("file");
-  }, []);
+    openFileTab(path);
+  }, [openFileTab]);
 
   const handleModifiedFileClick = useCallback((filePath: string) => {
     setDiffModalFile(filePath);
@@ -525,15 +529,12 @@ export default function WorkspaceView() {
             onActivateSession={handleActivateSession}
             onDeleteSession={handleDeleteSession}
             openFile={openFile}
-            isFileActive={activeTab === "file"}
-            onFileTabClick={() => setActiveTab("file")}
-            onFileTabClose={() => {
-              setOpenFile(null);
-              setActiveTab("conversation");
-            }}
-            onConversationTabClick={() => setActiveTab("conversation")}
+            isFileTabActive={isFileTabActive}
+            onFileTabActivate={() => openFile && activateTab(`file:${openFile}`)}
+            onFileTabClose={closeFileTab}
+            onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
           />
-          <div className={activeTab === "conversation" ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
+          <div className={!isFileTabActive ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
             <ChatConversation
               messages={messages}
               isStreaming={isStreaming}
@@ -596,7 +597,7 @@ export default function WorkspaceView() {
               </div>
             )}
           </div>
-          {activeTab === "file" && openFile && wsId && (
+          {isFileTabActive && openFile && wsId && (
             <div className="flex min-h-0 flex-1 flex-col">
               <FileViewer wsId={wsId} filePath={openFile} />
             </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -21,6 +21,23 @@ export interface Workspace {
   worktreePath?: string;
 }
 
+// ── Tab types ───────────────────────────────────────────────────────
+
+export type Tab =
+  | { type: "session"; sessionId: string }
+  | { type: "file"; path: string };
+
+export type TabId = `session:${string}` | `file:${string}`;
+
+export function tabId(tab: Tab): TabId {
+  return tab.type === "session" ? `session:${tab.sessionId}` : `file:${tab.path}`;
+}
+
+export function parseTabId(id: TabId): Tab {
+  if (id.startsWith("session:")) return { type: "session", sessionId: id.slice(8) };
+  return { type: "file", path: id.slice(5) };
+}
+
 // ── Completion / autocomplete types ─────────────────────────────────
 
 export type CompletionItemType = "slash_command" | "agent";

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -158,7 +158,7 @@ describe("ConversationTabs", () => {
       sessions: [],
       activeSessionId: undefined,
       openFile: "src/index.ts",
-      isFileActive: true,
+      isFileTabActive: true,
     });
 
     const untitledTab = screen.getByText("Untitled").parentElement as HTMLElement;
@@ -166,19 +166,19 @@ describe("ConversationTabs", () => {
     expect(untitledTab.className).not.toContain("text-accent-foreground");
   });
 
-  it("calls onConversationTabClick when clicking empty Untitled tab", async () => {
+  it("calls onConversationActivate when clicking empty Untitled tab", async () => {
     const user = userEvent.setup();
-    const onConversationTabClick = vi.fn();
+    const onConversationActivate = vi.fn();
     renderTabs({
       sessions: [],
       activeSessionId: undefined,
       openFile: "src/index.ts",
-      isFileActive: true,
-      onConversationTabClick,
+      isFileTabActive: true,
+      onConversationActivate,
     });
 
     await user.click(screen.getByRole("button", { name: "Untitled" }));
-    expect(onConversationTabClick).toHaveBeenCalledTimes(1);
+    expect(onConversationActivate).toHaveBeenCalledTimes(1);
   });
 
   it("renders three or more tabs", () => {
@@ -278,7 +278,7 @@ describe("ConversationTabs", () => {
     renderTabs({
       unreadSessions: { "sess-1": true },
       openFile: "src/index.ts",
-      isFileActive: true,
+      isFileTabActive: true,
     });
 
     const activeButHiddenConversationTab = screen.getByText("First conversation").closest("button")!;
@@ -374,41 +374,41 @@ describe("ConversationTabs — file tab", () => {
     expect(screen.getByText("App.tsx")).toBeInTheDocument();
   });
 
-  it("applies active styling to file tab when isFileActive is true", () => {
-    renderTabs({ openFile: "src/index.ts", isFileActive: true });
+  it("applies active styling to file tab when file tab is active", () => {
+    renderTabs({ openFile: "src/index.ts", isFileTabActive: true });
     const fileTab = screen.getByText("index.ts").closest("button")!;
     expect(fileTab.className).toContain("text-foreground");
     expect(fileTab.className).toContain("after:bg-primary");
   });
 
-  it("applies inactive styling to file tab when isFileActive is false", () => {
-    renderTabs({ openFile: "src/index.ts", isFileActive: false });
+  it("applies inactive styling to file tab when file tab is inactive", () => {
+    renderTabs({ openFile: "src/index.ts", isFileTabActive: false });
     const fileTab = screen.getByText("index.ts").closest("button")!;
     expect(fileTab.className).toContain("text-muted-foreground");
     expect(fileTab.className).not.toContain("text-accent-foreground");
   });
 
   it("dims conversation tab styling when file tab is active", () => {
-    renderTabs({ openFile: "src/index.ts", isFileActive: true });
+    renderTabs({ openFile: "src/index.ts", isFileTabActive: true });
     const convTab = screen.getByText("First conversation").closest("button")!;
     expect(convTab.className).toContain("text-muted-foreground");
     expect(convTab.className).not.toContain("text-accent-foreground");
   });
 
-  it("calls onFileTabClick when clicking the file tab", async () => {
+  it("calls onFileTabActivate callback when clicking the file tab", async () => {
     const user = userEvent.setup();
-    const onFileTabClick = vi.fn();
-    renderTabs({ openFile: "README.md", isFileActive: false, onFileTabClick });
+    const onFileTabActivate = vi.fn();
+    renderTabs({ openFile: "README.md", isFileTabActive: false, onFileTabActivate });
 
     await user.click(screen.getByText("README.md"));
 
-    expect(onFileTabClick).toHaveBeenCalledTimes(1);
+    expect(onFileTabActivate).toHaveBeenCalledTimes(1);
   });
 
   it("calls onFileTabClose when clicking X on the file tab", async () => {
     const user = userEvent.setup();
     const onFileTabClose = vi.fn();
-    renderTabs({ openFile: "README.md", isFileActive: true, onFileTabClose });
+    renderTabs({ openFile: "README.md", isFileTabActive: true, onFileTabClose });
 
     const fileTab = screen.getByText("README.md").closest("button")!;
     await user.hover(fileTab);
@@ -419,7 +419,7 @@ describe("ConversationTabs — file tab", () => {
   });
 
   it("renders file tab to the left of conversation tabs", () => {
-    renderTabs({ openFile: "src/app.ts", isFileActive: true });
+    renderTabs({ openFile: "src/app.ts", isFileTabActive: true });
     const fileTab = screen.getByText("app.ts").closest("button")!;
     const convTab = screen.getByText("First conversation").closest("button")!;
 
@@ -442,7 +442,7 @@ describe("ConversationTabs — file tab", () => {
     const scrollWidthSpy = vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(50);
 
     try {
-      renderTabs({ openFile: "src/app.ts", isFileActive: true });
+      renderTabs({ openFile: "src/app.ts", isFileTabActive: true });
 
       const overflowTrigger = await waitFor(() => {
         const trigger = (

--- a/frontend/tests/hooks/useTabs.test.ts
+++ b/frontend/tests/hooks/useTabs.test.ts
@@ -1,23 +1,25 @@
 import { act, renderHook } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
-import { useTabs } from "@/hooks/useTabs";
+import { afterEach, describe, expect, it } from "vitest";
+import { useTabs, _resetSnapshotCache } from "@/hooks/useTabs";
+
+afterEach(() => _resetSnapshotCache());
 
 describe("useTabs", () => {
   it("defaults active tab to the current session", () => {
-    const { result } = renderHook(() => useTabs("s1"));
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
     expect(result.current.activeTabId).toBe("session:s1");
     expect(result.current.isFileTabActive).toBe(false);
     expect(result.current.openFile).toBeNull();
   });
 
   it("defaults to null when no session ID provided", () => {
-    const { result } = renderHook(() => useTabs(undefined));
+    const { result } = renderHook(() => useTabs(undefined, "ws1"));
     expect(result.current.activeTabId).toBeNull();
     expect(result.current.isFileTabActive).toBe(false);
   });
 
   it("openFileTab activates file and stores path", () => {
-    const { result } = renderHook(() => useTabs("s1"));
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
     act(() => result.current.openFileTab("src/index.ts"));
     expect(result.current.activeTabId).toBe("file:src/index.ts");
     expect(result.current.openFile).toBe("src/index.ts");
@@ -25,7 +27,7 @@ describe("useTabs", () => {
   });
 
   it("openFileTab replaces existing file tab", () => {
-    const { result } = renderHook(() => useTabs("s1"));
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
     act(() => result.current.openFileTab("a.ts"));
     act(() => result.current.openFileTab("b.ts"));
     expect(result.current.openFile).toBe("b.ts");
@@ -33,7 +35,7 @@ describe("useTabs", () => {
   });
 
   it("closeFileTab reverts to current session", () => {
-    const { result } = renderHook(() => useTabs("s1"));
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
     act(() => result.current.openFileTab("a.ts"));
     expect(result.current.isFileTabActive).toBe(true);
     act(() => result.current.closeFileTab());
@@ -43,7 +45,7 @@ describe("useTabs", () => {
   });
 
   it("activateTab switches to any tab", () => {
-    const { result } = renderHook(() => useTabs("s1"));
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
     act(() => result.current.openFileTab("a.ts"));
     // switch back to session
     act(() => result.current.activateTab("session:s1"));
@@ -55,48 +57,86 @@ describe("useTabs", () => {
 
   it("tracks currentSessionId when on a session tab", () => {
     const { result, rerender } = renderHook(
-      ({ sid }) => useTabs(sid),
-      { initialProps: { sid: "s1" } },
+      ({ sid, ws }) => useTabs(sid, ws),
+      { initialProps: { sid: "s1", ws: "ws1" } },
     );
     expect(result.current.activeTabId).toBe("session:s1");
-    rerender({ sid: "s2" });
+    rerender({ sid: "s2", ws: "ws1" });
     expect(result.current.activeTabId).toBe("session:s2");
   });
 
   it("does NOT disturb file tab when currentSessionId changes", () => {
     const { result, rerender } = renderHook(
-      ({ sid }) => useTabs(sid),
-      { initialProps: { sid: "s1" } },
+      ({ sid, ws }) => useTabs(sid, ws),
+      { initialProps: { sid: "s1", ws: "ws1" } },
     );
     act(() => result.current.openFileTab("a.ts"));
     expect(result.current.isFileTabActive).toBe(true);
-    rerender({ sid: "s2" });
+    rerender({ sid: "s2", ws: "ws1" });
     // should still be on the file tab
     expect(result.current.activeTabId).toBe("file:a.ts");
     expect(result.current.isFileTabActive).toBe(true);
   });
 
-  it("resetForWorkspace clears file tab and resets", () => {
-    const { result, rerender } = renderHook(
-      ({ sid }) => useTabs(sid),
-      { initialProps: { sid: "s1" } },
-    );
-    act(() => result.current.openFileTab("a.ts"));
-    act(() => result.current.resetForWorkspace());
-    expect(result.current.openFile).toBeNull();
-    // After reset, activeTabId is null until a new session triggers the sync effect
-    expect(result.current.activeTabId).toBeNull();
-    // Simulate workspace switch: new session ID triggers the effect
-    rerender({ sid: "s2" });
-    expect(result.current.activeTabId).toBe("session:s2");
-    expect(result.current.isFileTabActive).toBe(false);
-  });
-
   it("closeFileTab falls back to null when no session", () => {
-    const { result } = renderHook(() => useTabs(undefined));
+    const { result } = renderHook(() => useTabs(undefined, "ws1"));
     act(() => result.current.openFileTab("a.ts"));
     act(() => result.current.closeFileTab());
     expect(result.current.activeTabId).toBeNull();
     expect(result.current.openFile).toBeNull();
+  });
+
+  // ---- workspace switch persistence ----
+
+  it("restores file tab when switching back to a workspace", () => {
+    const { result, rerender } = renderHook(
+      ({ sid, ws }) => useTabs(sid, ws),
+      { initialProps: { sid: "s1", ws: "ws1" } },
+    );
+    // Open a file in ws1
+    act(() => result.current.openFileTab("a.ts"));
+    expect(result.current.openFile).toBe("a.ts");
+    expect(result.current.isFileTabActive).toBe(true);
+
+    // Switch to ws2 — state should reset
+    rerender({ sid: "s3", ws: "ws2" });
+    expect(result.current.openFile).toBeNull();
+    expect(result.current.activeTabId).toBe("session:s3");
+
+    // Switch back to ws1 — file tab should be restored
+    rerender({ sid: "s1", ws: "ws1" });
+    expect(result.current.openFile).toBe("a.ts");
+    expect(result.current.activeTabId).toBe("file:a.ts");
+    expect(result.current.isFileTabActive).toBe(true);
+  });
+
+  it("restores session tab when switching back with no file open", () => {
+    const { result, rerender } = renderHook(
+      ({ sid, ws }) => useTabs(sid, ws),
+      { initialProps: { sid: "s1", ws: "ws1" } },
+    );
+    // No file opened — just on session tab
+    expect(result.current.activeTabId).toBe("session:s1");
+
+    // Switch to ws2
+    rerender({ sid: "s3", ws: "ws2" });
+    // Switch back to ws1
+    rerender({ sid: "s1", ws: "ws1" });
+    expect(result.current.activeTabId).toBe("session:s1");
+    expect(result.current.openFile).toBeNull();
+  });
+
+  it("resets cleanly for a workspace with no cached state", () => {
+    const { result, rerender } = renderHook(
+      ({ sid, ws }) => useTabs(sid, ws),
+      { initialProps: { sid: "s1", ws: "ws1" } },
+    );
+    act(() => result.current.openFileTab("a.ts"));
+
+    // Switch to ws2 (never visited)
+    rerender({ sid: "s3", ws: "ws2" });
+    expect(result.current.openFile).toBeNull();
+    // session sync effect sets it
+    expect(result.current.activeTabId).toBe("session:s3");
   });
 });

--- a/frontend/tests/hooks/useTabs.test.ts
+++ b/frontend/tests/hooks/useTabs.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useTabs } from "@/hooks/useTabs";
+
+describe("useTabs", () => {
+  it("defaults active tab to the current session", () => {
+    const { result } = renderHook(() => useTabs("s1"));
+    expect(result.current.activeTabId).toBe("session:s1");
+    expect(result.current.isFileTabActive).toBe(false);
+    expect(result.current.openFile).toBeNull();
+  });
+
+  it("defaults to null when no session ID provided", () => {
+    const { result } = renderHook(() => useTabs(undefined));
+    expect(result.current.activeTabId).toBeNull();
+    expect(result.current.isFileTabActive).toBe(false);
+  });
+
+  it("openFileTab activates file and stores path", () => {
+    const { result } = renderHook(() => useTabs("s1"));
+    act(() => result.current.openFileTab("src/index.ts"));
+    expect(result.current.activeTabId).toBe("file:src/index.ts");
+    expect(result.current.openFile).toBe("src/index.ts");
+    expect(result.current.isFileTabActive).toBe(true);
+  });
+
+  it("openFileTab replaces existing file tab", () => {
+    const { result } = renderHook(() => useTabs("s1"));
+    act(() => result.current.openFileTab("a.ts"));
+    act(() => result.current.openFileTab("b.ts"));
+    expect(result.current.openFile).toBe("b.ts");
+    expect(result.current.activeTabId).toBe("file:b.ts");
+  });
+
+  it("closeFileTab reverts to current session", () => {
+    const { result } = renderHook(() => useTabs("s1"));
+    act(() => result.current.openFileTab("a.ts"));
+    expect(result.current.isFileTabActive).toBe(true);
+    act(() => result.current.closeFileTab());
+    expect(result.current.activeTabId).toBe("session:s1");
+    expect(result.current.openFile).toBeNull();
+    expect(result.current.isFileTabActive).toBe(false);
+  });
+
+  it("activateTab switches to any tab", () => {
+    const { result } = renderHook(() => useTabs("s1"));
+    act(() => result.current.openFileTab("a.ts"));
+    // switch back to session
+    act(() => result.current.activateTab("session:s1"));
+    expect(result.current.activeTabId).toBe("session:s1");
+    expect(result.current.isFileTabActive).toBe(false);
+    // file is still open, just not active
+    expect(result.current.openFile).toBe("a.ts");
+  });
+
+  it("tracks currentSessionId when on a session tab", () => {
+    const { result, rerender } = renderHook(
+      ({ sid }) => useTabs(sid),
+      { initialProps: { sid: "s1" } },
+    );
+    expect(result.current.activeTabId).toBe("session:s1");
+    rerender({ sid: "s2" });
+    expect(result.current.activeTabId).toBe("session:s2");
+  });
+
+  it("does NOT disturb file tab when currentSessionId changes", () => {
+    const { result, rerender } = renderHook(
+      ({ sid }) => useTabs(sid),
+      { initialProps: { sid: "s1" } },
+    );
+    act(() => result.current.openFileTab("a.ts"));
+    expect(result.current.isFileTabActive).toBe(true);
+    rerender({ sid: "s2" });
+    // should still be on the file tab
+    expect(result.current.activeTabId).toBe("file:a.ts");
+    expect(result.current.isFileTabActive).toBe(true);
+  });
+
+  it("resetForWorkspace clears file tab and resets", () => {
+    const { result, rerender } = renderHook(
+      ({ sid }) => useTabs(sid),
+      { initialProps: { sid: "s1" } },
+    );
+    act(() => result.current.openFileTab("a.ts"));
+    act(() => result.current.resetForWorkspace());
+    expect(result.current.openFile).toBeNull();
+    // After reset, activeTabId is null until a new session triggers the sync effect
+    expect(result.current.activeTabId).toBeNull();
+    // Simulate workspace switch: new session ID triggers the effect
+    rerender({ sid: "s2" });
+    expect(result.current.activeTabId).toBe("session:s2");
+    expect(result.current.isFileTabActive).toBe(false);
+  });
+
+  it("closeFileTab falls back to null when no session", () => {
+    const { result } = renderHook(() => useTabs(undefined));
+    act(() => result.current.openFileTab("a.ts"));
+    act(() => result.current.closeFileTab());
+    expect(result.current.activeTabId).toBeNull();
+    expect(result.current.openFile).toBeNull();
+  });
+});

--- a/frontend/tests/hooks/useTabs.test.ts
+++ b/frontend/tests/hooks/useTabs.test.ts
@@ -1,8 +1,11 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, cleanup, renderHook } from "@testing-library/react";
 import { afterEach, describe, expect, it } from "vitest";
 import { useTabs, _resetSnapshotCache } from "@/hooks/useTabs";
 
-afterEach(() => _resetSnapshotCache());
+afterEach(() => {
+  cleanup();
+  _resetSnapshotCache();
+});
 
 describe("useTabs", () => {
   it("defaults active tab to the current session", () => {
@@ -138,5 +141,17 @@ describe("useTabs", () => {
     expect(result.current.openFile).toBeNull();
     // session sync effect sets it
     expect(result.current.activeTabId).toBe("session:s3");
+  });
+
+  it("persists latest tab snapshot across unmount/remount in the same workspace", () => {
+    const first = renderHook(() => useTabs("s1", "ws1"));
+    act(() => first.result.current.openFileTab("src/a.ts"));
+    act(() => first.result.current.activateTab("session:s1"));
+    first.unmount();
+
+    const second = renderHook(() => useTabs("s1", "ws1"));
+    expect(second.result.current.openFile).toBe("src/a.ts");
+    expect(second.result.current.activeTabId).toBe("session:s1");
+    expect(second.result.current.isFileTabActive).toBe(false);
   });
 });

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -282,6 +282,7 @@ function TestControls() {
   const navigate = useNavigate();
   return (
     <div>
+      <button type="button" onClick={() => navigate("/workspaces/ws-1")}>go ws-1</button>
       <button type="button" onClick={() => navigate("/workspaces/ws-2")}>go ws-2</button>
     </div>
   );
@@ -767,6 +768,48 @@ describe("WorkspaceView behavior", () => {
           mocks.captureConversationTabsProps.mock.calls.length - 1
         ]?.[0] as { isFileTabActive?: boolean } | undefined;
       expect(lastCall?.isFileTabActive).toBe(false);
+    });
+  });
+
+  it("restores file tab state when navigating away and back to a workspace", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockImplementation((targetWsId?: string) => buildConversationState({
+      sessionId: targetWsId === "ws-2" ? "sess-2" : "sess-1",
+    }));
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    await user.click(screen.getByTestId("select-file-btn"));
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileTabActive?: boolean; openFile?: string | null } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(true);
+      expect(lastCall?.openFile).toBe("src/index.ts");
+    });
+
+    await user.click(screen.getByRole("button", { name: "go ws-2" }));
+    await screen.findByText("kyoto");
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileTabActive?: boolean; openFile?: string | null } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(false);
+      expect(lastCall?.openFile).toBeNull();
+    });
+
+    await user.click(screen.getByRole("button", { name: "go ws-1" }));
+    await screen.findByText("tokyo");
+    await waitFor(() => {
+      const lastCall =
+        mocks.captureConversationTabsProps.mock.calls[
+          mocks.captureConversationTabsProps.mock.calls.length - 1
+        ]?.[0] as { isFileTabActive?: boolean; openFile?: string | null } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(true);
+      expect(lastCall?.openFile).toBe("src/index.ts");
     });
   });
 

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -167,10 +167,10 @@ vi.mock("@/components/ConversationTabs", () => ({
     onDeleteSession: (id: string) => void;
     onCreateSession: () => void;
     onActivateSession: (id: string) => void;
-    onFileTabClick?: () => void;
+    onFileTabActivate?: () => void;
     unreadSessions?: Record<string, boolean>;
   }) => {
-    const { onDeleteSession, onCreateSession, onActivateSession, onFileTabClick } = props;
+    const { onDeleteSession, onCreateSession, onActivateSession, onFileTabActivate } = props;
     mocks.captureConversationTabsProps(props);
     return (
       <div data-testid="conversation-tabs">
@@ -186,7 +186,7 @@ vi.mock("@/components/ConversationTabs", () => ({
         <button type="button" data-testid="activate-session-btn" onClick={() => onActivateSession("sess-2")}>
           activate session
         </button>
-        <button type="button" data-testid="file-tab-btn" onClick={() => onFileTabClick?.()}>
+        <button type="button" data-testid="file-tab-btn" onClick={() => onFileTabActivate?.()}>
           file tab
         </button>
       </div>
@@ -203,7 +203,16 @@ vi.mock("@/components/diff/ModifiedFileList", () => ({
 }));
 
 vi.mock("@/components/ai-elements/file-tree", () => ({
-  FileTree: ({ children }: { children?: ReactNode }) => <div data-testid="file-tree">{children}</div>,
+  FileTree: ({ children, onPathSelect }: { children?: ReactNode; onPathSelect?: (path: string) => void }) => (
+    <div data-testid="file-tree">
+      {children}
+      {onPathSelect && (
+        <button type="button" data-testid="select-file-btn" onClick={() => onPathSelect("src/index.ts")}>
+          select file
+        </button>
+      )}
+    </div>
+  ),
   FileTreeFile: ({ name }: { name: string }) => <div data-testid={`file-${name}`}>{name}</div>,
   FileTreeFolder: ({ name, children }: { name: string; children?: ReactNode }) => (
     <div data-testid={`folder-${name}`}>
@@ -730,18 +739,19 @@ describe("WorkspaceView behavior", () => {
       const lastCall =
         mocks.captureConversationTabsProps.mock.calls[
           mocks.captureConversationTabsProps.mock.calls.length - 1
-        ]?.[0] as { isFileActive?: boolean } | undefined;
-      expect(lastCall?.isFileActive).toBe(false);
+        ]?.[0] as { isFileTabActive?: boolean } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(false);
     });
 
-    await user.click(screen.getByTestId("file-tab-btn"));
+    // Open a file first (via file tree), then the file tab becomes active
+    await user.click(screen.getByTestId("select-file-btn"));
 
     await waitFor(() => {
       const lastCall =
         mocks.captureConversationTabsProps.mock.calls[
           mocks.captureConversationTabsProps.mock.calls.length - 1
-        ]?.[0] as { isFileActive?: boolean } | undefined;
-      expect(lastCall?.isFileActive).toBe(true);
+        ]?.[0] as { isFileTabActive?: boolean } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(true);
     });
 
     await user.click(screen.getByTestId("activate-session-btn"));
@@ -755,8 +765,8 @@ describe("WorkspaceView behavior", () => {
       const lastCall =
         mocks.captureConversationTabsProps.mock.calls[
           mocks.captureConversationTabsProps.mock.calls.length - 1
-        ]?.[0] as { isFileActive?: boolean } | undefined;
-      expect(lastCall?.isFileActive).toBe(false);
+        ]?.[0] as { isFileTabActive?: boolean } | undefined;
+      expect(lastCall?.isFileTabActive).toBe(false);
     });
   });
 

--- a/frontend/tests/types.test.ts
+++ b/frontend/tests/types.test.ts
@@ -3,6 +3,8 @@ import {
   isAskUserQuestion,
   isExitPlanMode,
   parseQuestions,
+  parseTabId,
+  tabId,
   type ToolCall,
 } from "@/types";
 
@@ -53,5 +55,19 @@ describe("tool type helpers", () => {
 
   it("returns empty array for invalid question payload", () => {
     expect(parseQuestions(tool({ input: "oops" }))).toEqual([]);
+  });
+});
+
+describe("tab helpers", () => {
+  it("builds and parses session tab IDs", () => {
+    const id = tabId({ type: "session", sessionId: "sess-1" });
+    expect(id).toBe("session:sess-1");
+    expect(parseTabId(id)).toEqual({ type: "session", sessionId: "sess-1" });
+  });
+
+  it("builds and parses file tab IDs", () => {
+    const id = tabId({ type: "file", path: "src/index.ts" });
+    expect(id).toBe("file:src/index.ts");
+    expect(parseTabId(id)).toEqual({ type: "file", path: "src/index.ts" });
   });
 });


### PR DESCRIPTION
## Summary
- persist latest tab snapshot on unmount in `useTabs` to avoid state loss across remounts
- reuse `tabId` / `parseTabId` helpers in `useTabs` and add coverage for tab helpers
- add regression tests for workspace navigation (`ws-1 -> ws-2 -> ws-1`) and hook unmount/remount behavior

## Validation
- npm run lint --workspace @hive/frontend
- npm run typecheck --workspace @hive/frontend
- npm run test --workspace @hive/frontend
- npm test
