### PR TITLE
fix(frontend): unify PR status cache between sidebar and workspace view

### DIFF
--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -1,7 +1,13 @@
 import { useMemo } from "react";
-import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import {
+  useQuery,
+  useQueryClient,
+  keepPreviousData,
+} from "@tanstack/react-query";
 import { api } from "./useApi";
 import type { BulkPrStatusResponse, PrStatusResponse } from "@/types";
+
+export const prStatusKey = (wsId: string) => ["pr-status", wsId] as const;
 
 const sharedOptions = {
   refetchInterval: 15_000,
@@ -12,7 +18,7 @@ const sharedOptions = {
 
 export function usePrStatus(wsId: string | undefined) {
   const query = useQuery({
-    queryKey: ["pr-status", wsId],
+    queryKey: prStatusKey(wsId ?? ""),
     queryFn: (): Promise<PrStatusResponse> =>
       api.get<PrStatusResponse>(`/api/workspaces/${wsId}/pr-status`),
     enabled: !!wsId,
@@ -29,14 +35,27 @@ export function usePrStatus(wsId: string | undefined) {
 const emptyResults: Record<string, PrStatusResponse> = {};
 
 export function useBulkPrStatus(wsIds: string[]) {
+  const queryClient = useQueryClient();
   const stableKey = useMemo(() => wsIds.slice().sort().join(","), [wsIds]);
 
   const query = useQuery({
     queryKey: ["pr-status-bulk", stableKey],
-    queryFn: (): Promise<BulkPrStatusResponse> =>
-      api.post<BulkPrStatusResponse>("/api/workspaces/pr-status/bulk", {
-        workspaceIds: wsIds,
-      }),
+    queryFn: async (): Promise<BulkPrStatusResponse> => {
+      const data = await api.post<BulkPrStatusResponse>(
+        "/api/workspaces/pr-status/bulk",
+        { workspaceIds: wsIds },
+      );
+
+      // Seed per-workspace cache so usePrStatus consumers see the
+      // same data instantly — no duplicate fetch, no UI desync.
+      if (data.results) {
+        for (const [id, status] of Object.entries(data.results)) {
+          queryClient.setQueryData(prStatusKey(id), status);
+        }
+      }
+
+      return data;
+    },
     enabled: wsIds.length > 0,
     ...sharedOptions,
   });

--- a/frontend/tests/hooks/usePrStatus.test.ts
+++ b/frontend/tests/hooks/usePrStatus.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { usePrStatus, useBulkPrStatus } from "@/hooks/usePrStatus";
+import { usePrStatus, useBulkPrStatus, prStatusKey } from "@/hooks/usePrStatus";
 import { api } from "@/hooks/useApi";
-import type { PullRequestInfo } from "@/types";
+import type { PrStatusResponse, PullRequestInfo } from "@/types";
 import { createWrapper } from "../test-utils";
 
 vi.mock("@/hooks/useApi", () => ({
@@ -253,5 +253,54 @@ describe("useBulkPrStatus", () => {
     await waitFor(() => {
       expect(result.current.results["ws-2"]?.pr?.number).toBe(2);
     });
+  });
+
+  it("seeds per-workspace cache entries after bulk fetch", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce({
+      results: {
+        "ws-1": { pr: makePr({ number: 10 }) },
+        "ws-2": { pr: null, error: "gh not authenticated" },
+      },
+    });
+
+    const { wrapper, queryClient } = createWrapper();
+    renderHook(() => useBulkPrStatus(["ws-1", "ws-2"]), { wrapper });
+
+    await waitFor(() => {
+      const ws1 = queryClient.getQueryData(prStatusKey("ws-1")) as
+        | PrStatusResponse
+        | undefined;
+      expect(ws1?.pr?.number).toBe(10);
+    });
+
+    const ws2 = queryClient.getQueryData(prStatusKey("ws-2")) as
+      | PrStatusResponse
+      | undefined;
+    expect(ws2?.pr).toBeNull();
+    expect(ws2?.error).toBe("gh not authenticated");
+  });
+});
+
+describe("usePrStatus reads bulk-seeded cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns data seeded by bulk without making a standalone request", async () => {
+    const { wrapper, queryClient } = createWrapper();
+
+    // Pre-seed the per-workspace cache as if bulk had populated it
+    queryClient.setQueryData(prStatusKey("ws-1"), {
+      pr: makePr({ number: 77 }),
+    } satisfies PrStatusResponse);
+
+    const { result } = renderHook(() => usePrStatus("ws-1"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.pr?.number).toBe(77);
+    });
+
+    // No standalone GET request should have fired
+    expect(api.get).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- The sidebar (`useBulkPrStatus`) and workspace detail view (`usePrStatus`) were using independent TanStack Query cache entries with separate 15s polling timers, causing visible UI desync — one would update before the other
- Fixed by having the bulk fetch seed per-workspace cache entries via `queryClient.setQueryData`, so both consumers read from the same cache and update simultaneously
- `usePrStatus` retains its own `refetchInterval` for standalone mode (when sidebar isn't mounted), but never fires a redundant request while bulk is active since the cache stays fresh

## Test plan

- [x] Added test: bulk fetch seeds per-workspace cache entries
- [x] Added test: `usePrStatus` reads bulk-seeded cache without standalone HTTP request
- [x] All existing tests pass (2009 tests across backend + frontend)
- [x] Typecheck clean
- [ ] Manual: open app with sidebar visible, navigate to a workspace, confirm sidebar and detail view PR status update at the same time