### PR TITLE
Fix chat auto-scroll re-engagement on manual scroll and send

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -4,6 +4,8 @@ import {
   ConversationContent,
   ConversationEmptyState,
   ConversationScrollButton,
+  ConversationScrollLockReEngager,
+  ConversationScrollTrigger,
 } from "@/components/ai-elements/conversation";
 import ChatMessage from "@/components/ChatMessage";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
@@ -38,6 +40,7 @@ interface ChatConversationProps {
   agentPlanMode?: boolean;
   queuedMessage?: QueuedMessage | null;
   onClearQueue?: () => void;
+  scrollToBottomTrigger?: number;
 }
 
 export default function ChatConversation({
@@ -60,6 +63,7 @@ export default function ChatConversation({
   error,
   queuedMessage,
   onClearQueue,
+  scrollToBottomTrigger = 0,
 }: ChatConversationProps) {
   const [elapsed, setElapsed] = useState(0);
 
@@ -265,6 +269,8 @@ export default function ChatConversation({
         )}
       </ConversationContent>
       <ConversationScrollButton />
+      <ConversationScrollLockReEngager />
+      <ConversationScrollTrigger trigger={scrollToBottomTrigger} />
     </Conversation>
   );
 }

--- a/frontend/src/components/ai-elements/conversation.tsx
+++ b/frontend/src/components/ai-elements/conversation.tsx
@@ -5,7 +5,7 @@ import type { ComponentProps } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
-import { useCallback } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -98,6 +98,57 @@ export const ConversationScrollButton = ({
       </Button>
     )
   );
+};
+
+/**
+ * Workaround for a race condition in use-stick-to-bottom: when new content
+ * streams in (ResizeObserver fires), the library's handleScroll bails early
+ * because resizeDifference is non-zero, so it never re-engages the sticky
+ * lock even though the user has manually scrolled back to the bottom.
+ *
+ * This component listens for scroll events and calls scrollToBottom() when
+ * the user is within the threshold but the library hasn't re-locked.
+ */
+const SCROLL_LOCK_THRESHOLD_PX = 70;
+
+export const ConversationScrollLockReEngager = () => {
+  const { scrollRef, isAtBottom, scrollToBottom } = useStickToBottomContext();
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const handleScroll = () => {
+      if (isAtBottom) return;
+      const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+      if (distanceFromBottom <= SCROLL_LOCK_THRESHOLD_PX) {
+        scrollToBottom();
+      }
+    };
+
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => el.removeEventListener("scroll", handleScroll);
+  }, [scrollRef, isAtBottom, scrollToBottom]);
+
+  return null;
+};
+
+/**
+ * Scrolls to bottom whenever the trigger counter increments.
+ * Used to force scroll-to-bottom on user send / queue actions.
+ */
+export const ConversationScrollTrigger = ({ trigger }: { trigger: number }) => {
+  const { scrollToBottom } = useStickToBottomContext();
+  const prev = useRef(trigger);
+
+  useEffect(() => {
+    if (trigger !== prev.current) {
+      prev.current = trigger;
+      scrollToBottom();
+    }
+  }, [trigger, scrollToBottom]);
+
+  return null;
 };
 
 export interface ConversationMessage {

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -254,6 +254,9 @@ export default function WorkspaceView() {
     }
   }, [isFileTabActive, wsId, sessionId, liveData, clearUnread]);
 
+  // ── Scroll-to-bottom trigger: incremented on send/queue to force scroll ──
+  const [scrollToBottomTrigger, setScrollToBottomTrigger] = useState(0);
+
   // ── Message queue: lets users type one follow-up while agent is busy ──
   const [queuedMessage, setQueuedMessage] = useState<QueuedMessage | null>(null);
 
@@ -405,9 +408,12 @@ export default function WorkspaceView() {
     (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]): boolean => {
       if (hasPendingPlan && hasPendingExitPlanInput) {
         rejectToolInput(content);
+        setScrollToBottomTrigger((c) => c + 1);
         return true;
       }
-      return sendMessage(content, images, options, undefined, fileMentions);
+      const sent = sendMessage(content, images, options, undefined, fileMentions);
+      if (sent) setScrollToBottomTrigger((c) => c + 1);
+      return sent;
     },
     [hasPendingPlan, hasPendingExitPlanInput, rejectToolInput, sendMessage],
   );
@@ -549,6 +555,7 @@ export default function WorkspaceView() {
               error={error}
               queuedMessage={queuedMessage}
               onClearQueue={() => setQueuedMessage(null)}
+              scrollToBottomTrigger={scrollToBottomTrigger}
             />
             {tasks.length > 0 && !pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") && (
               <TaskTracker
@@ -586,7 +593,7 @@ export default function WorkspaceView() {
                   placeholder={hasPendingPlan ? "Enter your plan adjustments here..." : undefined}
                   messages={messages}
                   queuedMessage={queuedMessage}
-                  onQueue={setQueuedMessage}
+                  onQueue={(msg) => { setQueuedMessage(msg); setScrollToBottomTrigger((c) => c + 1); }}
                   agentPlanMode={agentPlanMode}
                 />
               </div>

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -30,6 +30,8 @@ vi.mock("@/components/ai-elements/conversation", () => ({
     title?: string;
   }) => <div data-testid="conversation-empty-state">{children ?? title}</div>,
   ConversationScrollButton: () => <button type="button" data-testid="conversation-scroll-btn">scroll</button>,
+  ConversationScrollLockReEngager: () => null,
+  ConversationScrollTrigger: () => null,
 }));
 
 vi.mock("@/components/ChatMessage", () => ({


### PR DESCRIPTION
## Summary

- **Manual scroll to bottom now re-engages sticky mode**: `use-stick-to-bottom` has a race condition where `ResizeObserver` events (from streaming content) cause `handleScroll` to bail early, preventing the sticky lock from re-engaging. Added `ConversationScrollLockReEngager` that detects when the user is within 70px of the bottom and forces re-lock via `scrollToBottom()`.
- **Send/queue actions scroll to bottom**: Added `ConversationScrollTrigger` driven by a counter prop, incremented on message send, plan rejection, and queue — so the chat always jumps to bottom when the user submits input.

## Test plan

- [x] Typecheck passes
- [x] All 910 tests pass
- [ ] Manual: scroll up during streaming, then manually scroll back to bottom — verify sticky mode re-engages and chat follows new content
- [ ] Manual: scroll up, send a message — verify chat scrolls to bottom
- [ ] Manual: queue a message while agent is busy — verify chat scrolls to bottom