### PR TITLE
feat(sidebar): display org/repo with two-tone styling

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -38,11 +38,32 @@ import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useAutomations } from "@/hooks/useAutomations";
 import type { Automation, DiffStatResponse } from "@/types";
 
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/** Extract { owner, repo } from any git URL, or null if unparseable. */
+function parseProjectOwnerRepo(url: string): { owner: string; repo: string } | null {
+  // SCP-style: git@host:owner/repo.git
+  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
+
+  // URL-style: https://host/owner/repo.git or ssh://git@host/owner/repo
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length >= 2)
+      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
+  } catch {
+    // not a valid URL
+  }
+
+  return null;
+}
+
 // ── Shared sidebar group header ──────────────────────────────────────
 
 interface SidebarGroupHeaderProps {
   icon: React.ReactNode;
-  label: string;
+  label: React.ReactNode;
   badge?: React.ReactNode;
   count?: number;
   onAdd?: (e: React.MouseEvent) => void;
@@ -67,7 +88,7 @@ function SidebarGroupHeader({
           className="flex w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md bg-[#1e1e28] px-2.5 py-2 text-left transition-colors hover:bg-[#252532]"
         >
           {icon}
-          <span className="min-w-0 flex-1 truncate text-xs font-semibold uppercase tracking-wider text-sidebar-foreground">
+          <span className="min-w-0 flex-1 truncate text-xs font-semibold lowercase tracking-wider text-sidebar-foreground">
             {label}
           </span>
           {badge}
@@ -206,7 +227,13 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               </div>
             ) : (
               <TooltipProvider delayDuration={400}>
-                {projects.map((project, index) => (
+                {projects.map((project, index) => {
+                  const parsed = parseProjectOwnerRepo(project.url);
+                  const displayLabel = parsed ? (
+                    <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
+                  ) : project.name;
+                  const displayLabelPlain = parsed ? `${parsed.owner}/${parsed.repo}` : project.name;
+                  return (
                   <div
                     key={project.id}
                     className={cn(index > 0 && "mt-2.5")}
@@ -226,10 +253,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                             className="h-5 w-5"
                           />
                         }
-                        label={project.name}
+                        label={displayLabel}
                         count={(project.workspaces ?? []).length}
                         onAdd={() => { void handleAddWorkspace(project.id); }}
-                        addLabel={`Add workspace to ${project.name}`}
+                        addLabel={`Add workspace to ${displayLabelPlain}`}
                         addContent={creatingProjectId === project.id ? "..." : <Plus className="h-4 w-4" />}
                       />
 
@@ -319,7 +346,8 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                       </CollapsibleContent>
                     </Collapsible>
                   </div>
-                ))}
+                  );
+                })}
               </TooltipProvider>
             )}
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -8,6 +8,14 @@ import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { api } from "@/hooks/useApi";
 import type { Project, PullRequestInfo, WsOutgoing } from "@/types";
 
+/** Match elements whose full textContent equals `text` (handles text split across child spans). */
+function withTextContent(text: string) {
+  return (_: string, element: Element | null): boolean => {
+    if (!element || element.textContent !== text) return false;
+    return Array.from(element.children).every((child) => child.textContent !== text);
+  };
+}
+
 vi.mock("@/hooks/useApi", () => ({
   api: {
     get: vi.fn(),
@@ -192,11 +200,11 @@ describe("Sidebar", () => {
     const user = userEvent.setup();
     renderSidebar("/projects", projects);
 
-    expect(await screen.findByText("Alpha")).toBeInTheDocument();
-    expect(screen.getByText("Beta")).toBeInTheDocument();
+    expect(await screen.findByText(withTextContent("acme/alpha"))).toBeInTheDocument();
+    expect(screen.getByText(withTextContent("acme/beta"))).toBeInTheDocument();
     expect(screen.queryByText("workspace/tokyo")).not.toBeInTheDocument();
 
-    await user.click(screen.getByText("Alpha"));
+    await user.click(screen.getByText(withTextContent("acme/alpha")));
     expect(screen.getByText("workspace/tokyo")).toBeInTheDocument();
   });
 
@@ -204,9 +212,9 @@ describe("Sidebar", () => {
     renderSidebar("/projects", projects);
 
     // Project header: button contains name, sibling div contains count
-    const alphaButton = (await screen.findByText("Alpha")).closest("button")!;
+    const alphaButton = (await screen.findByText(withTextContent("acme/alpha"))).closest("button")!;
     const alphaHeader = alphaButton.parentElement!;
-    const betaButton = screen.getByText("Beta").closest("button")!;
+    const betaButton = screen.getByText(withTextContent("acme/beta")).closest("button")!;
     const betaHeader = betaButton.parentElement!;
 
     // Alpha has 1 workspace → count "1" visible in project header
@@ -234,8 +242,8 @@ describe("Sidebar", () => {
     });
     renderSidebar("/projects", projects);
 
-    await screen.findByText("Alpha");
-    await user.click(screen.getByRole("button", { name: "Add workspace to Alpha" }));
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "Add workspace to acme/alpha" }));
 
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith("/api/projects/p1/workspaces");
@@ -255,9 +263,9 @@ describe("Sidebar", () => {
     });
 
     renderSidebar("/projects", projects);
-    await screen.findByText("Alpha");
+    await screen.findByText(withTextContent("acme/alpha"));
 
-    await user.click(screen.getByRole("button", { name: "Add workspace to Alpha" }));
+    await user.click(screen.getByRole("button", { name: "Add workspace to acme/alpha" }));
 
     await waitFor(() => {
       expect(screen.getByTestId("location-path")).toHaveTextContent("/workspaces/w-new");
@@ -268,7 +276,7 @@ describe("Sidebar", () => {
     const { __wsMock } = await getWsMock();
     renderSidebar("/workspaces/w1", projects);
 
-    await screen.findByText("Alpha");
+    await screen.findByText(withTextContent("acme/alpha"));
     expect(screen.queryByRole("img", { name: "Agent thinking" })).not.toBeInTheDocument();
     expect(screen.getByText("workspace/tokyo")).toBeInTheDocument();
 
@@ -277,7 +285,7 @@ describe("Sidebar", () => {
     });
 
     expect(screen.getByRole("img", { name: "Agent thinking" })).toBeInTheDocument();
-    expect(screen.getByText("Alpha")).toBeInTheDocument();
+    expect(screen.getByText(withTextContent("acme/alpha"))).toBeInTheDocument();
 
     act(() => {
       __wsMock.emit("w1", { type: "status", status: "busy", streaming: false });
@@ -344,7 +352,7 @@ describe("Sidebar", () => {
     const { __wsMock } = await getWsMock();
     renderSidebar("/workspaces/w1", multiWsProjects);
 
-    await screen.findByText("Alpha");
+    await screen.findByText(withTextContent("acme/alpha"));
 
     // Stream only w1
     act(() => {


### PR DESCRIPTION
## Summary
- Parse project git URL to display `org/repo` format in sidebar headers instead of plain project name (e.g. `0xlnx/hive`)
- Org name and slash rendered in muted gray, repo name stays white for visual hierarchy
- All sidebar group headers switched from uppercase to lowercase
- Truncation with `…` already handled by existing Tailwind `truncate` class

## Test plan
- [x] Typecheck passes
- [x] All 27 sidebar tests updated and passing
- [x] Full backend (1109) and frontend (912) test suites green