### PR TITLE
UI polish: sidebar ellipsis, notification buttons, loading states

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -85,7 +85,10 @@ function SidebarGroupHeader({
       <CollapsibleTrigger asChild>
         <button
           type="button"
-          className="flex w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md bg-[#1e1e28] px-2.5 py-2 text-left transition-colors hover:bg-[#252532]"
+          className={cn(
+            "flex w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md bg-[#1e1e28] px-2.5 py-2 text-left transition-colors hover:bg-[#252532]",
+            count !== undefined && "pr-8",
+          )}
         >
           {icon}
           <span className="min-w-0 flex-1 truncate text-xs font-semibold lowercase tracking-wider text-sidebar-foreground">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -148,6 +148,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
   const [archiveTarget, setArchiveTarget] = useState<string | null>(null);
+  const [archivingWsId, setArchivingWsId] = useState<string | null>(null);
   const liveData = useWorkspaceLiveDataContext();
 
   // Derive active tab from route
@@ -211,9 +212,14 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   };
 
   const doArchive = async (wsId: string) => {
-    const wasActive = activeWsId === wsId;
-    await archiveWorkspace(wsId);
-    if (wasActive) navigate("/projects");
+    setArchivingWsId(wsId);
+    try {
+      const wasActive = activeWsId === wsId;
+      await archiveWorkspace(wsId);
+      if (wasActive) navigate("/projects");
+    } finally {
+      setArchivingWsId(null);
+    }
   };
 
   return (
@@ -278,9 +284,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                             const displayBranch = wsLive?.branch ?? ws.branch;
                             const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
                             const prStatus = prStatuses[ws.id];
+                            const wsArchiving = archivingWsId === ws.id;
 
                             return (
-                              <div key={ws.id} className="group/ws relative">
+                              <div key={ws.id} className={cn("group/ws relative transition-opacity", wsArchiving && "pointer-events-none opacity-40")}>
                                 <Tooltip>
                                   <TooltipTrigger asChild>
                                     <Link
@@ -333,7 +340,11 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                                   </TooltipContent>
                                 </Tooltip>
 
-                                {!wsScriptRunning && (
+                                {wsArchiving ? (
+                                  <div className="absolute right-1.5 top-1.5 p-0.5">
+                                    <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                                  </div>
+                                ) : !wsScriptRunning && (
                                   <button
                                     type="button"
                                     className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -66,9 +66,9 @@ interface SidebarGroupHeaderProps {
   label: React.ReactNode;
   badge?: React.ReactNode;
   count?: number;
+  isLoading?: boolean;
   onAdd?: (e: React.MouseEvent) => void;
   addLabel?: string;
-  addContent?: React.ReactNode;
 }
 
 function SidebarGroupHeader({
@@ -76,9 +76,9 @@ function SidebarGroupHeader({
   label,
   badge,
   count,
+  isLoading,
   onAdd,
   addLabel,
-  addContent,
 }: SidebarGroupHeaderProps) {
   return (
     <div className="group relative flex w-full items-center">
@@ -100,22 +100,28 @@ function SidebarGroupHeader({
       {count !== undefined && (
         <div className="absolute inset-y-0 right-2.5 flex items-center">
           <div className="relative flex h-5 w-5 items-center justify-center">
-            <span className="text-xs tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0">
-              {count}
-            </span>
-            {onAdd && (
-              <button
-                type="button"
-                className="absolute inset-0 flex items-center justify-center text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onAdd(e);
-                }}
-                aria-label={addLabel}
-                title={addLabel}
-              >
-                {addContent ?? <Plus className="h-4 w-4" />}
-              </button>
+            {isLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            ) : (
+              <>
+                <span className="text-xs tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0">
+                  {count}
+                </span>
+                {onAdd && (
+                  <button
+                    type="button"
+                    className="absolute inset-0 flex items-center justify-center text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onAdd(e);
+                    }}
+                    aria-label={addLabel}
+                    title={addLabel}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                )}
+              </>
             )}
           </div>
         </div>
@@ -258,9 +264,9 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                         }
                         label={displayLabel}
                         count={(project.workspaces ?? []).length}
+                        isLoading={creatingProjectId === project.id}
                         onAdd={() => { void handleAddWorkspace(project.id); }}
                         addLabel={`Add workspace to ${displayLabelPlain}`}
-                        addContent={creatingProjectId === project.id ? "..." : <Plus className="h-4 w-4" />}
                       />
 
                       <CollapsibleContent>

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -249,7 +249,7 @@ function TelegramForm({ initial }: { initial: TelegramConfig }) {
       </div>
 
       <div className="mt-4">
-        <FormActions hasCredentials={hasCredentials} {...channel} />
+        <FormActions {...channel} hasCredentials={hasCredentials} />
       </div>
     </NotificationSection>
   );
@@ -374,7 +374,7 @@ function ApnsForm({ initial }: { initial: ApnsConfig }) {
       </div>
 
       <div className="mt-4">
-        <FormActions hasCredentials={hasCredentials} {...channel} />
+        <FormActions {...channel} hasCredentials={hasCredentials} />
       </div>
     </NotificationSection>
   );
@@ -385,24 +385,26 @@ function ApnsForm({ initial }: { initial: ApnsConfig }) {
 // ---------------------------------------------------------------------------
 
 function FormActions({
-  saving, testing, hasCredentials, onTest, onSave, feedback,
+  saving, testing, hasCredentials, enabled, onTest, onSave, feedback,
 }: {
   saving: boolean;
   testing: boolean;
   hasCredentials: boolean;
+  enabled: boolean;
   onTest: () => void;
   onSave: () => void;
   feedback: Feedback;
 }) {
+  const disabled = !enabled;
   return (
     <div className="flex items-center gap-2">
       <button
         type="button"
         onClick={onTest}
-        disabled={testing || !hasCredentials}
+        disabled={disabled || testing || !hasCredentials}
         className={cn(
           "inline-flex cursor-pointer items-center gap-2 rounded-md border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
-          (testing || !hasCredentials) && "pointer-events-none opacity-60",
+          (disabled || testing || !hasCredentials) && "pointer-events-none opacity-60",
         )}
       >
         {testing
@@ -414,10 +416,10 @@ function FormActions({
       <button
         type="button"
         onClick={onSave}
-        disabled={saving}
+        disabled={disabled || saving}
         className={cn(
           "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
-          saving && "pointer-events-none opacity-60",
+          (disabled || saving) && "pointer-events-none opacity-60",
         )}
       >
         {saving

--- a/frontend/tests/pages/NotificationSettings.test.tsx
+++ b/frontend/tests/pages/NotificationSettings.test.tsx
@@ -108,7 +108,7 @@ describe("NotificationSettings", () => {
 
   it("keeps Test button disabled until both credentials are non-empty after trim", async () => {
     const user = userEvent.setup();
-    await renderReady();
+    await renderReady({ enabled: true });
 
     const tg = telegramSection();
     const testButton = tg.getByRole("button", { name: "Test" });
@@ -154,7 +154,7 @@ describe("NotificationSettings", () => {
     const user = userEvent.setup();
     mocks.put.mockRejectedValueOnce(new Error("boom"));
 
-    await renderReady({ botToken: "token", chatId: "chat" });
+    await renderReady({ enabled: true, botToken: "token", chatId: "chat" });
 
     await user.click(telegramSection().getByRole("button", { name: "Save" }));
     expect(await screen.findByText("Failed to save")).toBeInTheDocument();
@@ -167,7 +167,7 @@ describe("NotificationSettings", () => {
     const user = userEvent.setup();
     mocks.post.mockResolvedValueOnce({ ok: true });
 
-    await renderReady({ botToken: "token", chatId: "chat" });
+    await renderReady({ enabled: true, botToken: "token", chatId: "chat" });
 
     await user.click(telegramSection().getByRole("button", { name: "Test" }));
 
@@ -184,7 +184,7 @@ describe("NotificationSettings", () => {
     const user = userEvent.setup();
     mocks.post.mockResolvedValueOnce({ ok: false, error: "chat not found" });
 
-    await renderReady({ botToken: "token", chatId: "chat" });
+    await renderReady({ enabled: true, botToken: "token", chatId: "chat" });
 
     await user.click(telegramSection().getByRole("button", { name: "Test" }));
 
@@ -195,7 +195,7 @@ describe("NotificationSettings", () => {
     const user = userEvent.setup();
     mocks.post.mockRejectedValueOnce(new Error("network"));
 
-    await renderReady({ botToken: "token", chatId: "chat" });
+    await renderReady({ enabled: true, botToken: "token", chatId: "chat" });
 
     await user.click(telegramSection().getByRole("button", { name: "Test" }));
 


### PR DESCRIPTION
## Summary

- **Sidebar header text ellipsis**: add right padding when count badge is present so project names truncate with "…" instead of overlapping the icon
- **Notification settings**: disable Save/Test buttons when the channel toggle is off
- **Workspace creation spinner**: replace the "..." text (only visible on hover) with a Loader2 spinner that's always visible during creation
- **Workspace archive loading state**: fade out the workspace item + show a spinner while the archive API call is in flight

## Test plan

- [ ] Sidebar: verify long project names (e.g. `419labs/starknet-ecosystem.com`) show ellipsis, not overlap
- [ ] Settings > Notifications: toggle Telegram/APNs off → confirm Save and Test buttons are greyed out and non-clickable
- [ ] Sidebar: click "+" to create a workspace → confirm spinner is visible (not just on hover)
- [ ] Sidebar: archive a workspace → confirm it fades out with a spinner until removed