### PR TITLE
fix(frontend): eliminate PR status desync between sidebar and workspace view

### DIFF
--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -9,20 +9,17 @@ import type { BulkPrStatusResponse, PrStatusResponse } from "@/types";
 
 export const prStatusKey = (wsId: string) => ["pr-status", wsId] as const;
 
-const sharedOptions = {
-  refetchInterval: 15_000,
-  staleTime: 10_000,
-  gcTime: 5 * 60_000,
-  placeholderData: keepPreviousData,
-} as const;
-
 export function usePrStatus(wsId: string | undefined) {
   const query = useQuery({
     queryKey: prStatusKey(wsId ?? ""),
     queryFn: (): Promise<PrStatusResponse> =>
       api.get<PrStatusResponse>(`/api/workspaces/${wsId}/pr-status`),
     enabled: !!wsId,
-    ...sharedOptions,
+    staleTime: 10_000,
+    gcTime: 5 * 60_000,
+    placeholderData: keepPreviousData,
+    // No refetchInterval — data is seeded by useBulkPrStatus (Sidebar)
+    // via queryClient.setQueryData, ensuring all consumers update together.
   });
 
   return {
@@ -57,7 +54,10 @@ export function useBulkPrStatus(wsIds: string[]) {
       return data;
     },
     enabled: wsIds.length > 0,
-    ...sharedOptions,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+    gcTime: 5 * 60_000,
+    placeholderData: keepPreviousData,
   });
 
   return {


### PR DESCRIPTION
## Summary

- **Root cause**: `usePrStatus` (WorkspaceView) and `useBulkPrStatus` (Sidebar) each had independent 15s polling timers that inevitably drifted, causing the two UI locations to show different PR status data
- **Fix**: Removed `refetchInterval` from `usePrStatus` so it relies entirely on the cache seeded by `useBulkPrStatus` via `queryClient.setQueryData` — all consumers now update atomically from a single polling source
- Inlined query options and removed the dead `sharedOptions` constant

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (1109 backend + 925 frontend)
- [ ] Manual: open a workspace with a PR, verify sidebar and workspace view update at the exact same moment