### PR TITLE
feat(frontend): sub-agent nodes and background agent tracking

### DIFF
--- a/frontend/src/components/TaskTracker.tsx
+++ b/frontend/src/components/TaskTracker.tsx
@@ -2,6 +2,7 @@ import { useState, memo } from "react";
 import { ChevronRightIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import type { TrackedTask, TaskCounts } from "@/hooks/useTasks";
+import type { BackgroundAgent } from "@/hooks/useBackgroundAgents";
 
 const svgProps = {
   className: "size-3",
@@ -35,11 +36,37 @@ function StatusIcon({ status }: { status: TrackedTask["status"] }) {
   }
 }
 
+function AgentStatusIcon({ isRunning }: { isRunning: boolean }) {
+  if (isRunning) {
+    return (
+      <span className="inline-block size-2 animate-pulse rounded-full bg-primary" />
+    );
+  }
+  return (
+    <svg {...svgProps} className="size-3 text-green-500">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}
+
+const botIcon = (
+  <svg {...svgProps} className="size-3 text-muted-foreground/60">
+    <path d="M12 8V4H8" />
+    <rect width="16" height="12" x="4" y="8" rx="2" />
+    <path d="M2 14h2" />
+    <path d="M20 14h2" />
+    <path d="M15 13v2" />
+    <path d="M9 13v2" />
+  </svg>
+);
+
 interface TaskTrackerProps {
   tasks: TrackedTask[];
   currentTask: TrackedTask | undefined;
   counts: TaskCounts;
   isStreaming?: boolean;
+  backgroundAgents?: BackgroundAgent[];
+  backgroundRunningCount?: number;
 }
 
 const TaskTracker = memo(function TaskTracker({
@@ -47,10 +74,16 @@ const TaskTracker = memo(function TaskTracker({
   currentTask,
   counts,
   isStreaming,
+  backgroundAgents = [],
+  backgroundRunningCount = 0,
 }: TaskTrackerProps) {
-  const [expanded, setExpanded] = useState(false);
+  const [tasksExpanded, setTasksExpanded] = useState(false);
+  const [agentsExpanded, setAgentsExpanded] = useState(false);
 
-  if (tasks.length === 0) return null;
+  const hasTasks = tasks.length > 0;
+  const hasAgents = backgroundAgents.length > 0;
+
+  if (!hasTasks && !hasAgents) return null;
 
   const allDone = counts.completed === counts.total;
   const collapsedLabel = currentTask
@@ -59,56 +92,126 @@ const TaskTracker = memo(function TaskTracker({
       ? "All tasks completed"
       : `${counts.pending} task${counts.pending === 1 ? "" : "s"} remaining`;
 
+  const agentLabel = backgroundRunningCount > 0
+    ? `${backgroundRunningCount} background agent${backgroundRunningCount !== 1 ? "s" : ""} running`
+    : "All background agents completed";
+
   return (
     <div className="border-t border-border/50 bg-background px-4 py-1.5">
-      <button
-        type="button"
-        className="inline-flex w-full items-center gap-2 rounded-md py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-        onClick={() => setExpanded(!expanded)}
-      >
-        <ChevronRightIcon
-          className={cn(
-            "size-3.5 shrink-0 transition-transform",
-            expanded && "rotate-90",
-          )}
-        />
-        <span
-          className={cn(
-            "min-w-0 truncate",
-            currentTask && isStreaming && "animate-shimmer",
-          )}
-        >
-          {collapsedLabel}
-        </span>
-        <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/50">
-          {counts.completed}/{counts.total}
-        </span>
-      </button>
-
-      {expanded && (
-        <div className="mt-1 space-y-0.5 pb-0.5">
-          {tasks.map((task) => (
-            <div
-              key={task.id}
-              className="flex items-center gap-2 py-0.5 pl-5 text-xs text-muted-foreground"
+      {/* Tasks section */}
+      {hasTasks && (
+        <>
+          <button
+            type="button"
+            className="inline-flex w-full items-center gap-2 rounded-md py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setTasksExpanded(!tasksExpanded)}
+          >
+            <ChevronRightIcon
+              className={cn(
+                "size-3.5 shrink-0 transition-transform",
+                tasksExpanded && "rotate-90",
+              )}
+            />
+            <span
+              className={cn(
+                "min-w-0 truncate",
+                currentTask && isStreaming && "animate-shimmer",
+              )}
             >
-              <span className="flex shrink-0 items-center justify-center" style={{ width: 12 }}>
-                <StatusIcon status={task.status} />
-              </span>
-              <span
-                className={cn(
-                  "min-w-0 truncate",
-                  task.status === "completed" && "line-through text-muted-foreground/50",
-                  task.status === "in_progress" && "text-foreground",
-                )}
-              >
-                {task.status === "in_progress"
-                  ? (task.activeForm ?? task.subject)
-                  : task.subject}
-              </span>
+              {collapsedLabel}
+            </span>
+            <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/50">
+              {counts.completed}/{counts.total}
+            </span>
+          </button>
+
+          {tasksExpanded && (
+            <div className="mt-1 space-y-0.5 pb-0.5">
+              {tasks.map((task) => (
+                <div
+                  key={task.id}
+                  className="flex items-center gap-2 py-0.5 pl-5 text-xs text-muted-foreground"
+                >
+                  <span className="flex shrink-0 items-center justify-center" style={{ width: 12 }}>
+                    <StatusIcon status={task.status} />
+                  </span>
+                  <span
+                    className={cn(
+                      "min-w-0 truncate",
+                      task.status === "completed" && "line-through text-muted-foreground/50",
+                      task.status === "in_progress" && "text-foreground",
+                    )}
+                  >
+                    {task.status === "in_progress"
+                      ? (task.activeForm ?? task.subject)
+                      : task.subject}
+                  </span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          )}
+        </>
+      )}
+
+      {/* Divider between sections */}
+      {hasTasks && hasAgents && (
+        <div className="my-1 border-t border-border/30" />
+      )}
+
+      {/* Background agents section */}
+      {hasAgents && (
+        <>
+          <button
+            type="button"
+            className="inline-flex w-full items-center gap-2 rounded-md py-0.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+            onClick={() => setAgentsExpanded(!agentsExpanded)}
+          >
+            <ChevronRightIcon
+              className={cn(
+                "size-3.5 shrink-0 transition-transform",
+                agentsExpanded && "rotate-90",
+              )}
+            />
+            <span className="shrink-0">{botIcon}</span>
+            <span
+              className={cn(
+                "min-w-0 truncate",
+                backgroundRunningCount > 0 && isStreaming && "animate-shimmer",
+              )}
+            >
+              {agentLabel}
+            </span>
+            <span className="ml-auto shrink-0 text-[11px] text-muted-foreground/50">
+              {backgroundAgents.length - backgroundRunningCount}/{backgroundAgents.length}
+            </span>
+          </button>
+
+          {agentsExpanded && (
+            <div className="mt-1 space-y-0.5 pb-0.5">
+              {backgroundAgents.map((agent) => (
+                <div
+                  key={agent.toolId}
+                  className="flex items-center gap-2 py-0.5 pl-5 text-xs text-muted-foreground"
+                >
+                  <span className="flex shrink-0 items-center justify-center" style={{ width: 12 }}>
+                    <AgentStatusIcon isRunning={agent.isRunning} />
+                  </span>
+                  <span className="shrink-0 font-medium text-muted-foreground/70">
+                    {agent.subagentType}
+                  </span>
+                  <span
+                    className={cn(
+                      "min-w-0 truncate",
+                      agent.isRunning ? "text-foreground" : "text-muted-foreground/50",
+                    )}
+                  >
+                    {agent.description}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/frontend/src/components/TaskTracker.tsx
+++ b/frontend/src/components/TaskTracker.tsx
@@ -19,8 +19,7 @@ function StatusIcon({ status }: { status: TrackedTask["status"] }) {
     case "completed":
       return (
         <svg {...svgProps} className="size-3 text-green-500">
-          <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
-          <polyline points="22 4 12 14.01 9 11.01" />
+          <polyline points="20 6 9 17 4 12" />
         </svg>
       );
     case "in_progress":
@@ -48,17 +47,6 @@ function AgentStatusIcon({ isRunning }: { isRunning: boolean }) {
     </svg>
   );
 }
-
-const botIcon = (
-  <svg {...svgProps} className="size-3 text-muted-foreground/60">
-    <path d="M12 8V4H8" />
-    <rect width="16" height="12" x="4" y="8" rx="2" />
-    <path d="M2 14h2" />
-    <path d="M20 14h2" />
-    <path d="M15 13v2" />
-    <path d="M9 13v2" />
-  </svg>
-);
 
 interface TaskTrackerProps {
   tasks: TrackedTask[];
@@ -172,7 +160,6 @@ const TaskTracker = memo(function TaskTracker({
                 agentsExpanded && "rotate-90",
               )}
             />
-            <span className="shrink-0">{botIcon}</span>
             <span
               className={cn(
                 "min-w-0 truncate",

--- a/frontend/src/components/chat/SubAgentCard.tsx
+++ b/frontend/src/components/chat/SubAgentCard.tsx
@@ -1,0 +1,222 @@
+import { useState, memo } from "react";
+import type { ToolCall } from "@/types";
+import type { SubAgentInfo } from "@/lib/sub-agent";
+import { cn } from "@/lib/utils";
+import { MessageResponse } from "@/components/ai-elements/message";
+import { ContentPanel, ContentPanelBody, ContentPanelFooter } from "@/components/chat/ContentPanel";
+import ChatToolUse from "@/components/ChatToolUse";
+import { ToolCallTree } from "@/components/chat/ToolCallList";
+
+const svgProps = {
+  className: "size-3.5",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+function AgentIcon({ type }: { type: string }) {
+  switch (type) {
+    case "Explore":
+      return (
+        <svg {...svgProps}>
+          <circle cx="11" cy="11" r="8" />
+          <path d="m21 21-4.3-4.3" />
+        </svg>
+      );
+    case "Plan":
+      return (
+        <svg {...svgProps}>
+          <path d="M12 20h9" />
+          <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+        </svg>
+      );
+    case "Bash":
+      return (
+        <svg {...svgProps}>
+          <polyline points="4 17 10 11 4 5" />
+          <line x1="12" y1="19" x2="20" y2="19" />
+        </svg>
+      );
+    default:
+      return (
+        <svg {...svgProps}>
+          <path d="M12 8V4H8" />
+          <rect width="16" height="12" x="4" y="8" rx="2" />
+          <path d="M2 14h2" />
+          <path d="M20 14h2" />
+          <path d="M15 13v2" />
+          <path d="M9 13v2" />
+        </svg>
+      );
+  }
+}
+
+/** Parse a tool output as a JSON array of content blocks and extract text. */
+function parseContentBlocks(output: string): string | null {
+  try {
+    const parsed = JSON.parse(output);
+    if (!Array.isArray(parsed)) return null;
+    const texts = parsed
+      .filter(
+        (b: unknown): b is { type: "text"; text: string } =>
+          typeof b === "object" &&
+          b !== null &&
+          (b as Record<string, unknown>).type === "text" &&
+          typeof (b as Record<string, unknown>).text === "string",
+      )
+      .map((b) => b.text);
+    return texts.length > 0 ? texts.join("\n\n") : null;
+  } catch {
+    return null;
+  }
+}
+
+interface SubAgentCardProps {
+  tool: ToolCall;
+  info: SubAgentInfo;
+  children: ToolCall[];
+  childrenMap: Map<string, ToolCall[]>;
+  showExecutingState?: boolean;
+}
+
+export const SubAgentCard = memo(function SubAgentCard({
+  tool,
+  info,
+  children,
+  childrenMap,
+  showExecutingState,
+}: SubAgentCardProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [promptOpen, setPromptOpen] = useState(false);
+
+  const isRunning = showExecutingState ? tool.output === undefined : false;
+  const isDone = tool.output !== undefined;
+  const childCount = children.length;
+
+  // Parse output for result footer
+  const resultText = expanded && isDone && tool.output
+    ? parseContentBlocks(tool.output)
+    : null;
+
+  return (
+    <div>
+      {/* Inline button row — same pattern as ChatToolUse */}
+      <div className="my-0.5">
+        <button
+          type="button"
+          className={cn(
+            "inline-flex w-fit max-w-full items-center gap-2 rounded-md py-1 pr-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/80 hover:text-foreground",
+            isRunning && "animate-shimmer",
+          )}
+          onClick={() => setExpanded(!expanded)}
+        >
+          <span
+            className={cn(
+              "shrink-0",
+              isRunning && "text-primary",
+              isDone && "text-green-500/80",
+              !isRunning && !isDone && "text-muted-foreground",
+            )}
+          >
+            <AgentIcon type={info.subagentType} />
+          </span>
+          <span>
+            {info.subagentType}
+          </span>
+          {info.description && (
+            <code className="truncate rounded bg-muted px-1.5 py-0.5 font-mono text-xs text-muted-foreground">
+              {info.description}
+            </code>
+          )}
+          {isDone && childCount > 0 && (
+            <span className="text-muted-foreground/50">
+              · {childCount} tool{childCount !== 1 ? "s" : ""}
+            </span>
+          )}
+          {isRunning && (
+            <span className="flex items-center gap-1.5">
+              <span className="inline-block size-1.5 animate-pulse rounded-full bg-primary" />
+            </span>
+          )}
+          {isDone && (
+            <span className="flex shrink-0 items-center gap-1 text-green-500">
+              <svg className="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+              <span className="text-[10px] font-medium">Done</span>
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* Expanded: children indented with colored left border */}
+      {expanded && (
+        <div
+          className={cn(
+            "ml-4 border-l-2 pl-3",
+            isRunning && "border-primary/40",
+            isDone && "border-green-500/30",
+            !isRunning && !isDone && "border-muted-foreground/20",
+          )}
+        >
+          {/* Prompt toggle */}
+          {info.prompt && (
+            <div className="my-0.5">
+              <button
+                type="button"
+                className="inline-flex w-fit items-center gap-2 rounded-md py-1 pr-2.5 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => setPromptOpen(!promptOpen)}
+              >
+                <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+                </svg>
+                <span>Prompt</span>
+              </button>
+              {promptOpen && (
+                <ContentPanel>
+                  <ContentPanelBody>
+                    <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-muted-foreground">
+                      {info.prompt}
+                    </pre>
+                  </ContentPanelBody>
+                </ContentPanel>
+              )}
+            </div>
+          )}
+
+          {/* Child tools */}
+          <ToolCallTree
+            tools={children}
+            childrenMap={childrenMap}
+            showExecutingState={showExecutingState}
+          />
+
+          {/* Result footer (when expanded and done) */}
+          {isDone && tool.output && (
+            <ContentPanel className="my-1">
+              <ContentPanelFooter>
+                <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/50">
+                  Result
+                </div>
+                {resultText ? (
+                  <div className="prose-sm max-h-96 overflow-auto text-muted-foreground">
+                    <MessageResponse>{resultText}</MessageResponse>
+                  </div>
+                ) : (
+                  <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-muted-foreground">
+                    {typeof tool.output === "string"
+                      ? tool.output
+                      : JSON.stringify(tool.output, null, 2)}
+                  </pre>
+                )}
+              </ContentPanelFooter>
+            </ContentPanel>
+          )}
+        </div>
+      )}
+    </div>
+  );
+});

--- a/frontend/src/components/chat/SubAgentNode.tsx
+++ b/frontend/src/components/chat/SubAgentNode.tsx
@@ -4,7 +4,6 @@ import type { SubAgentInfo } from "@/lib/sub-agent";
 import { cn } from "@/lib/utils";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ContentPanel, ContentPanelBody, ContentPanelFooter } from "@/components/chat/ContentPanel";
-import ChatToolUse from "@/components/ChatToolUse";
 import { ToolCallTree } from "@/components/chat/ToolCallList";
 
 const svgProps = {
@@ -74,7 +73,7 @@ function parseContentBlocks(output: string): string | null {
   }
 }
 
-interface SubAgentCardProps {
+interface SubAgentNodeProps {
   tool: ToolCall;
   info: SubAgentInfo;
   children: ToolCall[];
@@ -82,13 +81,13 @@ interface SubAgentCardProps {
   showExecutingState?: boolean;
 }
 
-export const SubAgentCard = memo(function SubAgentCard({
+export const SubAgentNode = memo(function SubAgentNode({
   tool,
   info,
   children,
   childrenMap,
   showExecutingState,
-}: SubAgentCardProps) {
+}: SubAgentNodeProps) {
   const [expanded, setExpanded] = useState(false);
   const [promptOpen, setPromptOpen] = useState(false);
 

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { findPlanContent } from "@/lib/plan-state";
 import { buildChildrenMap, parseSubAgentInfo } from "@/lib/sub-agent";
 import ChatToolUse, { getToolIcon } from "@/components/ChatToolUse";
-import { SubAgentCard } from "@/components/chat/SubAgentCard";
+import { SubAgentNode } from "@/components/chat/SubAgentNode";
 import { AskUserQuestion } from "@/components/chat/AskUserQuestion";
 import { PlanProposal, type PlanStatus } from "@/components/chat/PlanProposal";
 
@@ -27,12 +27,12 @@ export function ToolCallTree({
       {tools.map((tool) => {
         const children = childrenMap.get(tool.id);
 
-        // Render Task tools as rich SubAgentCard
+        // Render Task tools as rich SubAgentNode
         if (tool.name === "Task") {
           const info = parseSubAgentInfo(tool);
           if (info) {
             return (
-              <SubAgentCard
+              <SubAgentNode
                 key={tool.id}
                 tool={tool}
                 info={info}

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -4,93 +4,16 @@ import type { ToolCall, QuestionAnswer } from "@/types";
 import { isAskUserQuestion, isExitPlanMode } from "@/types";
 import { cn } from "@/lib/utils";
 import { findPlanContent } from "@/lib/plan-state";
+import { buildChildrenMap, parseSubAgentInfo } from "@/lib/sub-agent";
 import ChatToolUse, { getToolIcon } from "@/components/ChatToolUse";
+import { SubAgentCard } from "@/components/chat/SubAgentCard";
 import { AskUserQuestion } from "@/components/chat/AskUserQuestion";
 import { PlanProposal, type PlanStatus } from "@/components/chat/PlanProposal";
-import { ContentPanel, ContentPanelBody } from "@/components/chat/ContentPanel";
 
 const COLLAPSE_THRESHOLD = 3;
 
-/** Build a map of parentToolUseId → children for hierarchical rendering. */
-function buildChildrenMap(tools: ToolCall[]): Map<string, ToolCall[]> {
-  const map = new Map<string, ToolCall[]>();
-  for (const tool of tools) {
-    if (tool.parentToolUseId) {
-      const children = map.get(tool.parentToolUseId) ?? [];
-      children.push(tool);
-      map.set(tool.parentToolUseId, children);
-    }
-  }
-  return map;
-}
-
-/** Extract the prompt text from a Task tool's input JSON. */
-function getTaskPrompt(tool: ToolCall): string | undefined {
-  try {
-    const input = JSON.parse(tool.input);
-    return input.prompt ?? input.description;
-  } catch {
-    return undefined;
-  }
-}
-
-/** A single Task node whose children are collapsed by default. */
-function TaskNode({
-  tool,
-  children,
-  childrenMap,
-  showExecutingState,
-}: {
-  tool: ToolCall;
-  children: ToolCall[];
-  childrenMap: Map<string, ToolCall[]>;
-  showExecutingState?: boolean;
-}) {
-  const [open, setOpen] = useState(false);
-  const [promptOpen, setPromptOpen] = useState(false);
-  const prompt = open ? getTaskPrompt(tool) : undefined;
-
-  return (
-    <div>
-      <ChatToolUse
-        tool={tool}
-        isExecuting={showExecutingState ? tool.output === undefined : undefined}
-        onClick={() => setOpen(!open)}
-      />
-      {open && (
-        <div className="ml-4 border-l-2 border-muted-foreground/20 pl-3">
-          {prompt && (
-            <div className="my-0.5">
-              <button
-                type="button"
-                className="inline-flex w-fit items-center gap-2 rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
-                onClick={() => setPromptOpen(!promptOpen)}
-              >
-                <svg className="size-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-                </svg>
-                <span>Prompt</span>
-              </button>
-              {promptOpen && (
-                <ContentPanel>
-                  <ContentPanelBody>
-                    <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-muted-foreground">
-                      {prompt}
-                    </pre>
-                  </ContentPanelBody>
-                </ContentPanel>
-              )}
-            </div>
-          )}
-          <ToolCallTree tools={children} childrenMap={childrenMap} showExecutingState={showExecutingState} />
-        </div>
-      )}
-    </div>
-  );
-}
-
 /** Recursively render tool calls, nesting children under their parent Task. */
-function ToolCallTree({
+export function ToolCallTree({
   tools,
   childrenMap,
   showExecutingState,
@@ -103,9 +26,28 @@ function ToolCallTree({
     <>
       {tools.map((tool) => {
         const children = childrenMap.get(tool.id);
+
+        // Render Task tools as rich SubAgentCard
+        if (tool.name === "Task") {
+          const info = parseSubAgentInfo(tool);
+          if (info) {
+            return (
+              <SubAgentCard
+                key={tool.id}
+                tool={tool}
+                info={info}
+                children={children ?? []}
+                childrenMap={childrenMap}
+                showExecutingState={showExecutingState}
+              />
+            );
+          }
+        }
+
+        // Non-Task tools with children (defensive fallback)
         if (children && children.length > 0) {
           return (
-            <TaskNode
+            <TaskNodeFallback
               key={tool.id}
               tool={tool}
               children={children}
@@ -114,6 +56,7 @@ function ToolCallTree({
             />
           );
         }
+
         return (
           <ChatToolUse
             key={tool.id}
@@ -123,6 +66,36 @@ function ToolCallTree({
         );
       })}
     </>
+  );
+}
+
+/** Fallback for non-Task tools that have children (shouldn't normally happen). */
+function TaskNodeFallback({
+  tool,
+  children,
+  childrenMap,
+  showExecutingState,
+}: {
+  tool: ToolCall;
+  children: ToolCall[];
+  childrenMap: Map<string, ToolCall[]>;
+  showExecutingState?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <ChatToolUse
+        tool={tool}
+        isExecuting={showExecutingState ? tool.output === undefined : undefined}
+        onClick={() => setOpen(!open)}
+      />
+      {open && (
+        <div className="ml-4 border-l-2 border-muted-foreground/20 pl-3">
+          <ToolCallTree tools={children} childrenMap={childrenMap} showExecutingState={showExecutingState} />
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/frontend/src/hooks/useBackgroundAgents.ts
+++ b/frontend/src/hooks/useBackgroundAgents.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+import type { ChatMessage, ToolCall } from "@/types";
+import { parseSubAgentInfo } from "@/lib/sub-agent";
+
+export interface BackgroundAgent {
+  toolId: string;
+  subagentType: string;
+  description: string;
+  model?: string;
+  isRunning: boolean;
+}
+
+export interface BackgroundAgentsState {
+  agents: BackgroundAgent[];
+  runningCount: number;
+}
+
+const EMPTY: BackgroundAgentsState = {
+  agents: [],
+  runningCount: 0,
+};
+
+export function useBackgroundAgents(
+  messages: ChatMessage[],
+  activeToolCalls: ToolCall[],
+): BackgroundAgentsState {
+  return useMemo(() => {
+    const allTools: ToolCall[] = [];
+    for (const msg of messages) {
+      if (msg.toolCalls) {
+        for (const tc of msg.toolCalls) allTools.push(tc);
+      }
+    }
+    for (const tc of activeToolCalls) allTools.push(tc);
+
+    const agents: BackgroundAgent[] = [];
+
+    for (const tool of allTools) {
+      if (tool.name !== "Task") continue;
+      const info = parseSubAgentInfo(tool);
+      if (!info || !info.runInBackground) continue;
+
+      agents.push({
+        toolId: tool.id,
+        subagentType: info.subagentType,
+        description: info.description,
+        model: info.model,
+        isRunning: tool.output === undefined,
+      });
+    }
+
+    if (agents.length === 0) return EMPTY;
+
+    return {
+      agents,
+      runningCount: agents.filter((a) => a.isRunning).length,
+    };
+  }, [messages, activeToolCalls]);
+}

--- a/frontend/src/lib/sub-agent.ts
+++ b/frontend/src/lib/sub-agent.ts
@@ -37,17 +37,3 @@ export function buildChildrenMap(tools: ToolCall[]): Map<string, ToolCall[]> {
   }
   return map;
 }
-
-/** Recursively count all descendant tools under a given parent. */
-export function getSubAgentChildCount(
-  toolId: string,
-  childrenMap: Map<string, ToolCall[]>,
-): number {
-  const children = childrenMap.get(toolId);
-  if (!children) return 0;
-  let count = children.length;
-  for (const child of children) {
-    count += getSubAgentChildCount(child.id, childrenMap);
-  }
-  return count;
-}

--- a/frontend/src/lib/sub-agent.ts
+++ b/frontend/src/lib/sub-agent.ts
@@ -1,0 +1,53 @@
+import type { ToolCall } from "@/types";
+
+export interface SubAgentInfo {
+  subagentType: string;
+  description: string;
+  prompt?: string;
+  runInBackground: boolean;
+  model?: string;
+}
+
+/** Parse sub-agent metadata from a Task tool's input JSON. */
+export function parseSubAgentInfo(tool: ToolCall): SubAgentInfo | null {
+  if (tool.name !== "Task") return null;
+  try {
+    const input = JSON.parse(tool.input);
+    return {
+      subagentType: input.subagent_type ?? "Agent",
+      description: input.description ?? "",
+      prompt: input.prompt,
+      runInBackground: input.run_in_background === true,
+      model: input.model,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Build a map of parentToolUseId → children for hierarchical rendering. */
+export function buildChildrenMap(tools: ToolCall[]): Map<string, ToolCall[]> {
+  const map = new Map<string, ToolCall[]>();
+  for (const tool of tools) {
+    if (tool.parentToolUseId) {
+      const children = map.get(tool.parentToolUseId) ?? [];
+      children.push(tool);
+      map.set(tool.parentToolUseId, children);
+    }
+  }
+  return map;
+}
+
+/** Recursively count all descendant tools under a given parent. */
+export function getSubAgentChildCount(
+  toolId: string,
+  childrenMap: Map<string, ToolCall[]>,
+): number {
+  const children = childrenMap.get(toolId);
+  if (!children) return 0;
+  let count = children.length;
+  for (const child of children) {
+    count += getSubAgentChildCount(child.id, childrenMap);
+  }
+  return count;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -26,6 +26,7 @@ import { PrStatusSection } from "@/components/PrStatusSection";
 import ScriptPanel from "@/components/ScriptPanel";
 import TaskTracker from "@/components/TaskTracker";
 import { useTasks } from "@/hooks/useTasks";
+import { useBackgroundAgents } from "@/hooks/useBackgroundAgents";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -277,6 +278,7 @@ export default function WorkspaceView() {
   }, [queuedMessage, isStreaming, workspaceStatus, pendingToolInputs, sendMessage]);
 
   const { tasks, currentTask, counts: taskCounts } = useTasks(messages, activeToolCalls);
+  const { agents: backgroundAgents, runningCount: bgRunningCount } = useBackgroundAgents(messages, activeToolCalls);
 
   const { sessions, createSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
 
@@ -587,12 +589,14 @@ export default function WorkspaceView() {
               onClearQueue={() => setQueuedMessage(null)}
               scrollToBottomTrigger={scrollToBottomTrigger}
             />
-            {tasks.length > 0 && !pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") && (
+            {(tasks.length > 0 || backgroundAgents.length > 0) && !pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") && (
               <TaskTracker
                 tasks={tasks}
                 currentTask={currentTask}
                 counts={taskCounts}
                 isStreaming={isStreaming}
+                backgroundAgents={backgroundAgents}
+                backgroundRunningCount={bgRunningCount}
               />
             )}
             {pendingToolInputs.some((p) => p.toolName === "AskUserQuestion") ? (

--- a/frontend/tests/components/TaskTracker.test.tsx
+++ b/frontend/tests/components/TaskTracker.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import TaskTracker from "@/components/TaskTracker";
 import type { TrackedTask, TaskCounts } from "@/hooks/useTasks";
+import type { BackgroundAgent } from "@/hooks/useBackgroundAgents";
 
 function task(overrides: Partial<TrackedTask> & { id: string; subject: string }): TrackedTask {
   return { status: "pending", ...overrides };
@@ -15,6 +16,10 @@ function counts(tasks: TrackedTask[]): TaskCounts {
     inProgress: tasks.filter((t) => t.status === "in_progress").length,
     pending: tasks.filter((t) => t.status === "pending").length,
   };
+}
+
+function agent(overrides: Partial<BackgroundAgent> & { toolId: string; subagentType: string }): BackgroundAgent {
+  return { description: "", isRunning: true, ...overrides };
 }
 
 describe("TaskTracker", () => {
@@ -118,7 +123,7 @@ describe("TaskTracker", () => {
     expect(screen.queryByText("First task")).not.toBeInTheDocument();
     expect(screen.queryByText("Third task")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button"));
+    await user.click(screen.getByText("Working on second"));
 
     // After expand: all tasks visible
     expect(screen.getByText("First task")).toBeInTheDocument();
@@ -137,11 +142,148 @@ describe("TaskTracker", () => {
       <TaskTracker tasks={tasks} currentTask={undefined} counts={counts(tasks)} />,
     );
 
-    const toggle = screen.getByRole("button");
+    const toggle = screen.getByText("1 task remaining");
     await user.click(toggle);
     expect(screen.getByText("First task")).toBeInTheDocument();
 
     await user.click(toggle);
     expect(screen.queryByText("First task")).not.toBeInTheDocument();
+  });
+
+  // ── Background agents ───────────────────────────────────────────────
+
+  it("renders nothing when both tasks and background agents are empty", () => {
+    const { container } = render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={[]}
+        backgroundRunningCount={0}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders background agents section when agents exist without tasks", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Searching codebase", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    expect(screen.getByText("1 background agent running")).toBeInTheDocument();
+  });
+
+  it("shows plural form for multiple running background agents", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Search", isRunning: true }),
+      agent({ toolId: "a2", subagentType: "Plan", description: "Design", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={2}
+      />,
+    );
+
+    expect(screen.getByText("2 background agents running")).toBeInTheDocument();
+  });
+
+  it("shows 'All background agents completed' when none are running", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Done", isRunning: false }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={0}
+      />,
+    );
+
+    expect(screen.getByText("All background agents completed")).toBeInTheDocument();
+  });
+
+  it("expands background agents to show details", async () => {
+    const user = userEvent.setup();
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Searching codebase", isRunning: true }),
+      agent({ toolId: "a2", subagentType: "Plan", description: "Architecture review", isRunning: false }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    // Before expand: details not visible
+    expect(screen.queryByText("Searching codebase")).not.toBeInTheDocument();
+
+    await user.click(screen.getByText("1 background agent running"));
+
+    // After expand: agent details visible
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+    expect(screen.getByText("Searching codebase")).toBeInTheDocument();
+    expect(screen.getByText("Plan")).toBeInTheDocument();
+    expect(screen.getByText("Architecture review")).toBeInTheDocument();
+  });
+
+  it("shows both tasks and agents sections with divider", () => {
+    const tasks = [
+      task({ id: "1", subject: "Fix bug", status: "in_progress" }),
+    ];
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Search", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={tasks}
+        currentTask={tasks[0]}
+        counts={counts(tasks)}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    // Both sections visible
+    expect(screen.getByText("Fix bug")).toBeInTheDocument();
+    expect(screen.getByText("1 background agent running")).toBeInTheDocument();
+  });
+
+  it("shows completed/total badge for background agents", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", isRunning: false }),
+      agent({ toolId: "a2", subagentType: "Plan", isRunning: true }),
+      agent({ toolId: "a3", subagentType: "Bash", isRunning: false }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    // 2 completed out of 3
+    expect(screen.getByText("2/3")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/TaskTracker.test.tsx
+++ b/frontend/tests/components/TaskTracker.test.tsx
@@ -286,4 +286,223 @@ describe("TaskTracker", () => {
     // 2 completed out of 3
     expect(screen.getByText("2/3")).toBeInTheDocument();
   });
+
+  // ── Expanded agent details ────────────────────────────────────────
+
+  it("collapses background agents on second click", async () => {
+    const user = userEvent.setup();
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Searching files", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    const toggle = screen.getByText("1 background agent running");
+    await user.click(toggle);
+    expect(screen.getByText("Searching files")).toBeInTheDocument();
+
+    await user.click(toggle);
+    expect(screen.queryByText("Searching files")).not.toBeInTheDocument();
+  });
+
+  it("tasks and agents sections expand independently", async () => {
+    const user = userEvent.setup();
+    const tasks = [
+      task({ id: "1", subject: "Build feature", status: "in_progress" }),
+    ];
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", description: "Agent work", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={tasks}
+        currentTask={tasks[0]}
+        counts={counts(tasks)}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    // Expand tasks only
+    await user.click(screen.getByText("Build feature"));
+    expect(screen.getAllByText("Build feature")).toHaveLength(2); // label + expanded
+    expect(screen.queryByText("Agent work")).not.toBeInTheDocument();
+
+    // Expand agents too
+    await user.click(screen.getByText("1 background agent running"));
+    expect(screen.getByText("Agent work")).toBeInTheDocument();
+    // Tasks still expanded
+    expect(screen.getAllByText("Build feature")).toHaveLength(2);
+  });
+
+  it("renders only agents section when tasks is empty but agents exist", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Plan", description: "Planning", isRunning: true }),
+    ];
+    const { container } = render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    expect(container.firstChild).not.toBeNull();
+    expect(screen.getByText("1 background agent running")).toBeInTheDocument();
+    // No task count badge since no tasks
+    expect(screen.queryByText("0/0")).not.toBeInTheDocument();
+  });
+
+  it("renders only tasks section when agents is empty but tasks exist", () => {
+    const tasks = [task({ id: "1", subject: "Do thing", status: "pending" })];
+    render(
+      <TaskTracker
+        tasks={tasks}
+        currentTask={undefined}
+        counts={counts(tasks)}
+        backgroundAgents={[]}
+        backgroundRunningCount={0}
+      />,
+    );
+
+    expect(screen.getByText("1 task remaining")).toBeInTheDocument();
+    expect(screen.queryByText(/background agent/)).not.toBeInTheDocument();
+  });
+
+  it("does not show divider when only tasks exist (no agents)", () => {
+    const tasks = [task({ id: "1", subject: "Work", status: "pending" })];
+    const { container } = render(
+      <TaskTracker
+        tasks={tasks}
+        currentTask={undefined}
+        counts={counts(tasks)}
+        backgroundAgents={[]}
+        backgroundRunningCount={0}
+      />,
+    );
+
+    // The divider has border-border/30 class; shouldn't be present with no agents
+    const dividers = container.querySelectorAll(".border-border\\/30");
+    expect(dividers).toHaveLength(0);
+  });
+
+  it("does not show divider when only agents exist (no tasks)", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", isRunning: true }),
+    ];
+    const { container } = render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    const dividers = container.querySelectorAll(".border-border\\/30");
+    expect(dividers).toHaveLength(0);
+  });
+
+  it("shows divider only when both tasks and agents are present", () => {
+    const tasks = [task({ id: "1", subject: "Fix", status: "pending" })];
+    const agents = [agent({ toolId: "a1", subagentType: "Explore", isRunning: true })];
+    const { container } = render(
+      <TaskTracker
+        tasks={tasks}
+        currentTask={undefined}
+        counts={counts(tasks)}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+
+    const dividers = container.querySelectorAll(".border-border\\/30");
+    expect(dividers.length).toBeGreaterThan(0);
+  });
+
+  it("shimmer on agent label requires both running count > 0 and isStreaming", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", isRunning: true }),
+    ];
+
+    // Without isStreaming — no shimmer
+    const { rerender } = render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+      />,
+    );
+    expect(screen.getByText("1 background agent running")).not.toHaveClass("animate-shimmer");
+
+    // With isStreaming — shimmer
+    rerender(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={1}
+        isStreaming
+      />,
+    );
+    expect(screen.getByText("1 background agent running")).toHaveClass("animate-shimmer");
+  });
+
+  it("does not shimmer agent label when backgroundRunningCount is 0 even if streaming", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", isRunning: false }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={0}
+        isStreaming
+      />,
+    );
+    expect(screen.getByText("All background agents completed")).not.toHaveClass("animate-shimmer");
+  });
+
+  it("defaults backgroundAgents prop to empty array", () => {
+    const tasks = [task({ id: "1", subject: "Solo", status: "pending" })];
+    render(
+      <TaskTracker tasks={tasks} currentTask={undefined} counts={counts(tasks)} />,
+    );
+    // Should render tasks section without errors
+    expect(screen.getByText("1 task remaining")).toBeInTheDocument();
+    expect(screen.queryByText(/background agent/)).not.toBeInTheDocument();
+  });
+
+  it("shows correct label for exactly 0/N agents badge", () => {
+    const agents = [
+      agent({ toolId: "a1", subagentType: "Explore", isRunning: true }),
+      agent({ toolId: "a2", subagentType: "Plan", isRunning: true }),
+    ];
+    render(
+      <TaskTracker
+        tasks={[]}
+        currentTask={undefined}
+        counts={{ total: 0, completed: 0, inProgress: 0, pending: 0 }}
+        backgroundAgents={agents}
+        backgroundRunningCount={2}
+      />,
+    );
+    // 0 completed out of 2
+    expect(screen.getByText("0/2")).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/ToolCallList.test.tsx
+++ b/frontend/tests/components/ToolCallList.test.tsx
@@ -311,9 +311,9 @@ describe("ToolCallList", () => {
     expect(screen.queryByText("2 tool calls, 1 subagent")).not.toBeInTheDocument();
   });
 
-  // ── SubAgentCard rendering ──────────────────────────────────────────
+  // ── SubAgentNode rendering ──────────────────────────────────────────
 
-  it("renders Task tools as SubAgentCard with agent type and children collapsed by default", async () => {
+  it("renders Task tools as SubAgentNode with agent type and children collapsed by default", async () => {
     const user = userEvent.setup();
     render(
       <ToolCallList
@@ -337,7 +337,7 @@ describe("ToolCallList", () => {
       />,
     );
 
-    // SubAgentCard header shows agent type
+    // SubAgentNode header shows agent type
     expect(screen.getByText("Explore")).toBeInTheDocument();
     expect(screen.getByText("Scan files")).toBeInTheDocument();
 
@@ -358,7 +358,7 @@ describe("ToolCallList", () => {
     expect(screen.getByText("Look into src/lib and summarize changes.")).toBeInTheDocument();
   });
 
-  it("renders nested SubAgentCards recursively", async () => {
+  it("renders nested SubAgentNodes recursively", async () => {
     const user = userEvent.setup();
     render(
       <ToolCallList
@@ -399,7 +399,7 @@ describe("ToolCallList", () => {
     expect(screen.getByText("Bash")).toBeInTheDocument();
   });
 
-  it("shows completed status badge on SubAgentCard when output exists", () => {
+  it("shows completed status badge on SubAgentNode when output exists", () => {
     render(
       <ToolCallList
         toolCalls={[
@@ -417,7 +417,7 @@ describe("ToolCallList", () => {
     expect(screen.getByText("Done")).toBeInTheDocument();
   });
 
-  it("shows shimmer animation on SubAgentCard during streaming", () => {
+  it("shows shimmer animation on SubAgentNode during streaming", () => {
     render(
       <ToolCallList
         showExecutingState
@@ -437,5 +437,280 @@ describe("ToolCallList", () => {
     // Running state uses shimmer animation on the button (same as other executing tools)
     const btn = screen.getByRole("button", { name: /Explore/i });
     expect(btn).toHaveClass("animate-shimmer");
+  });
+
+  it("does not shimmer SubAgentNode when showExecutingState is false", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-no-output",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Pending" }),
+            output: undefined,
+          }),
+        ]}
+      />,
+    );
+
+    const btn = screen.getByRole("button", { name: /Explore/i });
+    expect(btn).not.toHaveClass("animate-shimmer");
+  });
+
+  it("shows tool count badge on completed SubAgentNode with children", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-parent",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Search" }),
+            output: "Found stuff",
+          }),
+          tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "task-parent", output: "ok" }),
+          tool({ id: "c2", name: "Grep", input: "{}", parentToolUseId: "task-parent", output: "ok" }),
+          tool({ id: "c3", name: "Edit", input: "{}", parentToolUseId: "task-parent", output: "ok" }),
+        ]}
+      />,
+    );
+
+    // 4 regularTools >= 3 triggers collapse; expand summary first
+    await user.click(screen.getByText("1 subagent"));
+
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.getByText(/3 tools/)).toBeInTheDocument();
+  });
+
+  it("shows singular tool count on SubAgentNode with one child", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-one",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Plan", description: "Design" }),
+            output: "Result",
+          }),
+          tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "task-one", output: "ok" }),
+        ]}
+      />,
+    );
+
+    // 2 tools: below collapse threshold, shown directly
+    expect(screen.getByText(/· 1 tool$/)).toBeInTheDocument();
+  });
+
+  it("does not show tool count on running SubAgentNode even with children", () => {
+    render(
+      <ToolCallList
+        showExecutingState
+        toolCalls={[
+          tool({
+            id: "task-running-children",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Working" }),
+            output: undefined,
+          }),
+          tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "task-running-children" }),
+        ]}
+      />,
+    );
+
+    // Running state shows pulse dot, not tool count
+    expect(screen.queryByText(/· \d+ tools?$/)).not.toBeInTheDocument();
+  });
+
+  it("SubAgentNode shows result footer when expanded and done", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-result",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Search" }),
+            output: "The answer is 42",
+          }),
+        ]}
+      />,
+    );
+
+    // Expand the card
+    await user.click(screen.getByText("Explore"));
+
+    // Result footer visible
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    expect(screen.getByText("The answer is 42")).toBeInTheDocument();
+  });
+
+  it("SubAgentNode parses content blocks in output for result footer", async () => {
+    const user = userEvent.setup();
+    const contentBlocks = JSON.stringify([
+      { type: "text", text: "Found the files." },
+      { type: "text", text: "Analysis complete." },
+    ]);
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-blocks",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Analyze" }),
+            output: contentBlocks,
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText("Explore"));
+    expect(screen.getByText("Result")).toBeInTheDocument();
+    // Content blocks parsed and rendered via MessageResponse
+    expect(screen.getByText(/Found the files/)).toBeInTheDocument();
+    expect(screen.getByText(/Analysis complete/)).toBeInTheDocument();
+  });
+
+  it("SubAgentNode falls back to raw output when content blocks parse fails", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-raw",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Scan" }),
+            output: "Just plain text",
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText("Explore"));
+    expect(screen.getByText("Just plain text")).toBeInTheDocument();
+  });
+
+  it("SubAgentNode does not show prompt button when no prompt", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-no-prompt",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "No prompt" }),
+          }),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByText("Explore"));
+    expect(screen.queryByText("Prompt")).not.toBeInTheDocument();
+  });
+
+  it("SubAgentNode defaults to 'Agent' when subagent_type is missing", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-default",
+            name: "Task",
+            input: JSON.stringify({ description: "Generic agent" }),
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Agent")).toBeInTheDocument();
+    expect(screen.getByText("Generic agent")).toBeInTheDocument();
+  });
+
+  it("falls back to generic ChatToolUse when Task has malformed JSON", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-bad",
+            name: "Task",
+            input: "not json at all",
+          }),
+        ]}
+      />,
+    );
+
+    // Should still render something (generic tool use fallback)
+    expect(screen.getByText("Task")).toBeInTheDocument();
+  });
+
+  it("TaskNodeFallback renders for non-Task tools with children", async () => {
+    const user = userEvent.setup();
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({ id: "parent-bash", name: "Bash", input: '{"command":"ls"}', output: "ok" }),
+          tool({ id: "child-read", name: "Read", input: '{"file_path":"/a"}', parentToolUseId: "parent-bash", output: "file content" }),
+        ]}
+      />,
+    );
+
+    // Parent rendered as ChatToolUse
+    expect(screen.getByText("Bash")).toBeInTheDocument();
+    // Child hidden initially
+    expect(screen.queryByText("Read")).not.toBeInTheDocument();
+
+    // Click to expand
+    await user.click(screen.getByText("Bash"));
+    expect(screen.getByText("Read")).toBeInTheDocument();
+  });
+
+  it("filters out TaskUpdate tools from display", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({ name: "Read", input: '{"file_path":"/a"}', output: "ok" }),
+          tool({ name: "TaskUpdate", input: '{"taskId":"1","status":"completed"}', output: "ok" }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Read")).toBeInTheDocument();
+    expect(screen.queryByText("TaskUpdate")).not.toBeInTheDocument();
+  });
+
+  it("SubAgentNode description shown as code element", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-desc",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "My description" }),
+          }),
+        ]}
+      />,
+    );
+
+    const codeEl = screen.getByText("My description");
+    expect(codeEl.tagName).toBe("CODE");
+  });
+
+  it("SubAgentNode hides description when empty", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-no-desc",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "" }),
+          }),
+        ]}
+      />,
+    );
+
+    // No code element should be rendered for empty description
+    const buttons = screen.getAllByRole("button");
+    const agentBtn = buttons.find(b => b.textContent?.includes("Explore"));
+    expect(agentBtn).toBeDefined();
+    const codeEls = agentBtn!.querySelectorAll("code");
+    expect(codeEls).toHaveLength(0);
   });
 });

--- a/frontend/tests/components/ToolCallList.test.tsx
+++ b/frontend/tests/components/ToolCallList.test.tsx
@@ -311,7 +311,9 @@ describe("ToolCallList", () => {
     expect(screen.queryByText("2 tool calls, 1 subagent")).not.toBeInTheDocument();
   });
 
-  it("keeps Task children and prompt collapsed by default, then reveals them on demand", async () => {
+  // ── SubAgentCard rendering ──────────────────────────────────────────
+
+  it("renders Task tools as SubAgentCard with agent type and children collapsed by default", async () => {
     const user = userEvent.setup();
     render(
       <ToolCallList
@@ -335,21 +337,28 @@ describe("ToolCallList", () => {
       />,
     );
 
+    // SubAgentCard header shows agent type
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+    expect(screen.getByText("Scan files")).toBeInTheDocument();
+
+    // Children collapsed by default
     expect(screen.queryByText("Read")).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: "Prompt" })).not.toBeInTheDocument();
+    expect(screen.queryByText("Prompt")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Task \(Explore\)/i }));
+    // Click header to expand
+    await user.click(screen.getByText("Explore"));
 
+    // Children and Prompt now visible
     expect(screen.getByText("Read")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Prompt" })).toBeInTheDocument();
+    expect(screen.getByText("Prompt")).toBeInTheDocument();
     expect(screen.queryByText("Look into src/lib and summarize changes.")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Prompt" }));
-
+    // Toggle prompt
+    await user.click(screen.getByText("Prompt"));
     expect(screen.getByText("Look into src/lib and summarize changes.")).toBeInTheDocument();
   });
 
-  it("renders nested Task trees recursively", async () => {
+  it("renders nested SubAgentCards recursively", async () => {
     const user = userEvent.setup();
     render(
       <ToolCallList
@@ -376,16 +385,57 @@ describe("ToolCallList", () => {
       />,
     );
 
-    expect(screen.getByRole("button", { name: /Task \(Explore\)/i })).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /Task \(Plan\)/i })).not.toBeInTheDocument();
+    // Root card visible with agent type
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+    // Nested card not visible yet
+    expect(screen.queryByText("Plan")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: /Task \(Explore\)/i }));
+    // Expand root card — nested Plan card visible (with Bash in its peek row since Plan is running)
+    await user.click(screen.getByText("Explore"));
+    expect(screen.getByText("Plan")).toBeInTheDocument();
 
-    expect(screen.getByRole("button", { name: /Task \(Plan\)/i })).toBeInTheDocument();
-    expect(screen.queryByText("Bash")).not.toBeInTheDocument();
-
-    await user.click(screen.getByRole("button", { name: /Task \(Plan\)/i }));
-
+    // Expand nested card — Bash is now in the expanded body (may also be in peek row)
+    await user.click(screen.getByText("Plan"));
     expect(screen.getByText("Bash")).toBeInTheDocument();
+  });
+
+  it("shows completed status badge on SubAgentCard when output exists", () => {
+    render(
+      <ToolCallList
+        toolCalls={[
+          tool({
+            id: "task-done",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Search" }),
+            output: "Found 5 files",
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+    expect(screen.getByText("Done")).toBeInTheDocument();
+  });
+
+  it("shows shimmer animation on SubAgentCard during streaming", () => {
+    render(
+      <ToolCallList
+        showExecutingState
+        toolCalls={[
+          tool({
+            id: "task-running",
+            name: "Task",
+            input: JSON.stringify({ subagent_type: "Explore", description: "Searching" }),
+            output: undefined,
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText("Explore")).toBeInTheDocument();
+    expect(screen.getByText("Searching")).toBeInTheDocument();
+    // Running state uses shimmer animation on the button (same as other executing tools)
+    const btn = screen.getByRole("button", { name: /Explore/i });
+    expect(btn).toHaveClass("animate-shimmer");
   });
 });

--- a/frontend/tests/hooks/useBackgroundAgents.test.ts
+++ b/frontend/tests/hooks/useBackgroundAgents.test.ts
@@ -1,0 +1,147 @@
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useBackgroundAgents } from "@/hooks/useBackgroundAgents";
+import type { ChatMessage, ToolCall } from "@/types";
+
+function msg(toolCalls: ToolCall[]): ChatMessage {
+  return {
+    id: "m-" + Math.random().toString(36).slice(2, 6),
+    sessionId: "s1",
+    role: "assistant",
+    content: "",
+    toolCalls,
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function tc(overrides: Partial<ToolCall> & { name: string; input: string }): ToolCall {
+  return { id: "tc-" + Math.random().toString(36).slice(2, 6), ...overrides };
+}
+
+describe("useBackgroundAgents", () => {
+  it("returns empty state when no messages", () => {
+    const { result } = renderHook(() => useBackgroundAgents([], []));
+    expect(result.current.agents).toEqual([]);
+    expect(result.current.runningCount).toBe(0);
+  });
+
+  it("returns empty state when no Task tools exist", () => {
+    const messages = [msg([tc({ name: "Bash", input: '{"command":"ls"}', output: "ok" })])];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toEqual([]);
+  });
+
+  it("returns empty state for foreground Task tools", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "Search", prompt: "find" }),
+          output: "done",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toEqual([]);
+  });
+
+  it("detects background Task tools from messages", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "bg-1",
+          name: "Task",
+          input: JSON.stringify({
+            subagent_type: "Explore",
+            description: "Search codebase",
+            run_in_background: true,
+            model: "haiku",
+          }),
+          output: "found 5 files",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toHaveLength(1);
+    expect(result.current.agents[0]).toMatchObject({
+      toolId: "bg-1",
+      subagentType: "Explore",
+      description: "Search codebase",
+      model: "haiku",
+      isRunning: false,
+    });
+    expect(result.current.runningCount).toBe(0);
+  });
+
+  it("detects running background agents from activeToolCalls", () => {
+    const active: ToolCall[] = [
+      tc({
+        id: "bg-active",
+        name: "Task",
+        input: JSON.stringify({
+          subagent_type: "Plan",
+          description: "Designing architecture",
+          run_in_background: true,
+        }),
+        // no output = still running
+      }),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents([], active));
+    expect(result.current.agents).toHaveLength(1);
+    expect(result.current.agents[0].isRunning).toBe(true);
+    expect(result.current.runningCount).toBe(1);
+  });
+
+  it("counts running and completed agents correctly", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "bg-done",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "Done", run_in_background: true }),
+          output: "result",
+        }),
+      ]),
+    ];
+    const active: ToolCall[] = [
+      tc({
+        id: "bg-running",
+        name: "Task",
+        input: JSON.stringify({ subagent_type: "Plan", description: "Working", run_in_background: true }),
+      }),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, active));
+    expect(result.current.agents).toHaveLength(2);
+    expect(result.current.runningCount).toBe(1);
+  });
+
+  it("ignores Task tools with malformed input JSON", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "Task",
+          input: "not valid json",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toEqual([]);
+  });
+
+  it("ignores Task tools where run_in_background is not true", () => {
+    const messages = [
+      msg([
+        tc({
+          name: "Task",
+          input: JSON.stringify({
+            subagent_type: "Explore",
+            description: "Not bg",
+            run_in_background: false,
+          }),
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toEqual([]);
+  });
+});

--- a/frontend/tests/hooks/useBackgroundAgents.test.ts
+++ b/frontend/tests/hooks/useBackgroundAgents.test.ts
@@ -144,4 +144,160 @@ describe("useBackgroundAgents", () => {
     const { result } = renderHook(() => useBackgroundAgents(messages, []));
     expect(result.current.agents).toEqual([]);
   });
+
+  it("returns same EMPTY reference for repeated empty inputs (memoization)", () => {
+    const { result, rerender } = renderHook(() => useBackgroundAgents([], []));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it("collects background agents from multiple messages", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "bg-1",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "A", run_in_background: true }),
+          output: "done",
+        }),
+      ]),
+      msg([
+        tc({
+          id: "bg-2",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Plan", description: "B", run_in_background: true }),
+          output: "done",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toHaveLength(2);
+    expect(result.current.agents[0].toolId).toBe("bg-1");
+    expect(result.current.agents[1].toolId).toBe("bg-2");
+  });
+
+  it("mixes background agents from messages and activeToolCalls", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "bg-msg",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "From msg", run_in_background: true }),
+          output: "result",
+        }),
+      ]),
+    ];
+    const active: ToolCall[] = [
+      tc({
+        id: "bg-active",
+        name: "Task",
+        input: JSON.stringify({ subagent_type: "Plan", description: "From active", run_in_background: true }),
+      }),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, active));
+    expect(result.current.agents).toHaveLength(2);
+    expect(result.current.agents[0].isRunning).toBe(false);
+    expect(result.current.agents[1].isRunning).toBe(true);
+    expect(result.current.runningCount).toBe(1);
+  });
+
+  it("skips messages without toolCalls", () => {
+    const messages: ChatMessage[] = [
+      {
+        id: "m1",
+        sessionId: "s1",
+        role: "user",
+        content: "Hello",
+        timestamp: new Date().toISOString(),
+      },
+      {
+        id: "m2",
+        sessionId: "s1",
+        role: "assistant",
+        content: "Hi",
+        timestamp: new Date().toISOString(),
+      },
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toEqual([]);
+  });
+
+  it("handles a mix of background and foreground tasks in same message", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "fg",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "FG", run_in_background: false }),
+          output: "done",
+        }),
+        tc({
+          id: "bg",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Plan", description: "BG", run_in_background: true }),
+          output: "done",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toHaveLength(1);
+    expect(result.current.agents[0].toolId).toBe("bg");
+  });
+
+  it("handles output as empty string (still counts as completed)", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "bg-empty",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "Empty", run_in_background: true }),
+          output: "",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents).toHaveLength(1);
+    // empty string is not undefined, so it's completed
+    expect(result.current.agents[0].isRunning).toBe(false);
+    expect(result.current.runningCount).toBe(0);
+  });
+
+  it("handles many background agents", () => {
+    const tools = Array.from({ length: 10 }, (_, i) =>
+      tc({
+        id: `bg-${i}`,
+        name: "Task",
+        input: JSON.stringify({ subagent_type: "Explore", description: `Agent ${i}`, run_in_background: true }),
+        output: i < 5 ? "done" : undefined,
+      }),
+    );
+    const { result } = renderHook(() => useBackgroundAgents([msg(tools)], []));
+    expect(result.current.agents).toHaveLength(10);
+    expect(result.current.runningCount).toBe(5);
+  });
+
+  it("ignores non-Task tools in activeToolCalls", () => {
+    const active: ToolCall[] = [
+      tc({ name: "Bash", input: '{"command":"ls"}' }),
+      tc({ name: "Read", input: '{"file_path":"/a"}' }),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents([], active));
+    expect(result.current.agents).toEqual([]);
+  });
+
+  it("model field is undefined when not provided", () => {
+    const messages = [
+      msg([
+        tc({
+          id: "no-model",
+          name: "Task",
+          input: JSON.stringify({ subagent_type: "Explore", description: "X", run_in_background: true }),
+          output: "done",
+        }),
+      ]),
+    ];
+    const { result } = renderHook(() => useBackgroundAgents(messages, []));
+    expect(result.current.agents[0].model).toBeUndefined();
+  });
 });

--- a/frontend/tests/lib/sub-agent.test.ts
+++ b/frontend/tests/lib/sub-agent.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from "vitest";
+import { parseSubAgentInfo, buildChildrenMap } from "@/lib/sub-agent";
+import type { ToolCall } from "@/types";
+
+function tool(overrides: Partial<ToolCall> & { name: string; input: string }): ToolCall {
+  return { id: "t-" + Math.random().toString(36).slice(2, 6), ...overrides };
+}
+
+describe("parseSubAgentInfo", () => {
+  it("returns null for non-Task tools", () => {
+    expect(parseSubAgentInfo(tool({ name: "Bash", input: '{"command":"ls"}' }))).toBeNull();
+    expect(parseSubAgentInfo(tool({ name: "Read", input: '{"file_path":"/a.ts"}' }))).toBeNull();
+    expect(parseSubAgentInfo(tool({ name: "Edit", input: "{}" }))).toBeNull();
+  });
+
+  it("parses a complete Task input", () => {
+    const result = parseSubAgentInfo(
+      tool({
+        name: "Task",
+        input: JSON.stringify({
+          subagent_type: "Explore",
+          description: "Search codebase",
+          prompt: "Find all test files",
+          run_in_background: true,
+          model: "haiku",
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      subagentType: "Explore",
+      description: "Search codebase",
+      prompt: "Find all test files",
+      runInBackground: true,
+      model: "haiku",
+    });
+  });
+
+  it("defaults subagentType to 'Agent' when missing", () => {
+    const result = parseSubAgentInfo(
+      tool({ name: "Task", input: JSON.stringify({ description: "Do something" }) }),
+    );
+    expect(result?.subagentType).toBe("Agent");
+  });
+
+  it("defaults description to empty string when missing", () => {
+    const result = parseSubAgentInfo(
+      tool({ name: "Task", input: JSON.stringify({ subagent_type: "Plan" }) }),
+    );
+    expect(result?.description).toBe("");
+  });
+
+  it("defaults runInBackground to false when not explicitly true", () => {
+    expect(
+      parseSubAgentInfo(tool({ name: "Task", input: JSON.stringify({}) }))?.runInBackground,
+    ).toBe(false);
+
+    expect(
+      parseSubAgentInfo(
+        tool({ name: "Task", input: JSON.stringify({ run_in_background: false }) }),
+      )?.runInBackground,
+    ).toBe(false);
+
+    expect(
+      parseSubAgentInfo(
+        tool({ name: "Task", input: JSON.stringify({ run_in_background: "true" }) }),
+      )?.runInBackground,
+    ).toBe(false);
+
+    expect(
+      parseSubAgentInfo(
+        tool({ name: "Task", input: JSON.stringify({ run_in_background: 1 }) }),
+      )?.runInBackground,
+    ).toBe(false);
+  });
+
+  it("sets runInBackground to true only for boolean true", () => {
+    const result = parseSubAgentInfo(
+      tool({ name: "Task", input: JSON.stringify({ run_in_background: true }) }),
+    );
+    expect(result?.runInBackground).toBe(true);
+  });
+
+  it("returns null for malformed JSON", () => {
+    expect(parseSubAgentInfo(tool({ name: "Task", input: "not json" }))).toBeNull();
+    expect(parseSubAgentInfo(tool({ name: "Task", input: "{broken" }))).toBeNull();
+    expect(parseSubAgentInfo(tool({ name: "Task", input: "" }))).toBeNull();
+  });
+
+  it("handles prompt being undefined", () => {
+    const result = parseSubAgentInfo(
+      tool({ name: "Task", input: JSON.stringify({ subagent_type: "Explore" }) }),
+    );
+    expect(result?.prompt).toBeUndefined();
+  });
+
+  it("handles model being undefined", () => {
+    const result = parseSubAgentInfo(
+      tool({ name: "Task", input: JSON.stringify({ subagent_type: "Explore" }) }),
+    );
+    expect(result?.model).toBeUndefined();
+  });
+
+  it("preserves various model values", () => {
+    for (const model of ["haiku", "sonnet", "opus"]) {
+      const result = parseSubAgentInfo(
+        tool({ name: "Task", input: JSON.stringify({ subagent_type: "Plan", model }) }),
+      );
+      expect(result?.model).toBe(model);
+    }
+  });
+
+  it("preserves known subagent types", () => {
+    for (const type of ["Explore", "Plan", "Bash", "general-purpose", "web-search", "explore-docs"]) {
+      const result = parseSubAgentInfo(
+        tool({ name: "Task", input: JSON.stringify({ subagent_type: type }) }),
+      );
+      expect(result?.subagentType).toBe(type);
+    }
+  });
+});
+
+describe("buildChildrenMap", () => {
+  it("returns empty map for no tools", () => {
+    expect(buildChildrenMap([]).size).toBe(0);
+  });
+
+  it("returns empty map when no tools have parents", () => {
+    const tools = [
+      tool({ name: "Bash", input: "{}" }),
+      tool({ name: "Read", input: "{}" }),
+    ];
+    expect(buildChildrenMap(tools).size).toBe(0);
+  });
+
+  it("groups children by parentToolUseId", () => {
+    const parent = tool({ id: "parent-1", name: "Task", input: "{}" });
+    const child1 = tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "parent-1" });
+    const child2 = tool({ id: "c2", name: "Grep", input: "{}", parentToolUseId: "parent-1" });
+    const orphan = tool({ id: "o1", name: "Bash", input: "{}" });
+
+    const map = buildChildrenMap([parent, child1, child2, orphan]);
+
+    expect(map.size).toBe(1);
+    expect(map.get("parent-1")).toHaveLength(2);
+    expect(map.get("parent-1")![0].id).toBe("c1");
+    expect(map.get("parent-1")![1].id).toBe("c2");
+  });
+
+  it("handles multiple parents", () => {
+    const child1 = tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "p1" });
+    const child2 = tool({ id: "c2", name: "Grep", input: "{}", parentToolUseId: "p2" });
+    const child3 = tool({ id: "c3", name: "Bash", input: "{}", parentToolUseId: "p1" });
+
+    const map = buildChildrenMap([child1, child2, child3]);
+
+    expect(map.size).toBe(2);
+    expect(map.get("p1")).toHaveLength(2);
+    expect(map.get("p2")).toHaveLength(1);
+  });
+
+  it("preserves insertion order of children", () => {
+    const children = [
+      tool({ id: "c1", name: "Read", input: "{}", parentToolUseId: "p" }),
+      tool({ id: "c2", name: "Grep", input: "{}", parentToolUseId: "p" }),
+      tool({ id: "c3", name: "Edit", input: "{}", parentToolUseId: "p" }),
+    ];
+
+    const map = buildChildrenMap(children);
+    const result = map.get("p")!;
+
+    expect(result[0].id).toBe("c1");
+    expect(result[1].id).toBe("c2");
+    expect(result[2].id).toBe("c3");
+  });
+
+  it("handles nested hierarchies (grandchildren map to their parent, not grandparent)", () => {
+    const parent = tool({ id: "p", name: "Task", input: "{}" });
+    const child = tool({ id: "c", name: "Task", input: "{}", parentToolUseId: "p" });
+    const grandchild = tool({ id: "gc", name: "Bash", input: "{}", parentToolUseId: "c" });
+
+    const map = buildChildrenMap([parent, child, grandchild]);
+
+    expect(map.get("p")).toHaveLength(1);
+    expect(map.get("p")![0].id).toBe("c");
+    expect(map.get("c")).toHaveLength(1);
+    expect(map.get("c")![0].id).toBe("gc");
+    expect(map.has("gc")).toBe(false);
+  });
+
+  it("does not include the parent tool itself in its children", () => {
+    const parent = tool({ id: "p", name: "Task", input: "{}" });
+    const child = tool({ id: "c", name: "Read", input: "{}", parentToolUseId: "p" });
+
+    const map = buildChildrenMap([parent, child]);
+    const children = map.get("p")!;
+
+    expect(children).toHaveLength(1);
+    expect(children[0].id).toBe("c");
+  });
+});


### PR DESCRIPTION
## Summary
- Render Task tool calls as rich inline **SubAgentNode** components with type-specific icons (Explore, Plan, Bash), status indicators (shimmer while running, checkmark when done), expandable children, prompt toggle, and result footer
- Track `run_in_background` Task tools in a new **background agents** section merged into the existing TaskTracker above the chat input
- Extract shared parsing utilities (`parseSubAgentInfo`, `buildChildrenMap`) into `lib/sub-agent.ts`

## Test plan
- [x] 994/994 frontend tests pass
- [x] Typecheck clean
- [x] SubAgentNode rendering: collapsed/expanded, prompt toggle, result footer, content block parsing, malformed JSON fallback, empty description handling
- [x] Background agents hook: detection from messages and activeToolCalls, foreground filtering, running/completed counts
- [x] TaskTracker: background agents section, divider between sections, count badges
- [x] Sub-agent utils: parseSubAgentInfo, buildChildrenMap unit tests
- [ ] Manual test with live agent conversation containing Task tool calls