### PR TITLE
UI polish: sidebar styling and sub-agent status cleanup

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -86,7 +86,7 @@ function SidebarGroupHeader({
         <button
           type="button"
           className={cn(
-            "flex w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md bg-[#1e1e28] px-2.5 py-2 text-left transition-colors hover:bg-[#252532]",
+            "flex w-full min-w-0 items-center gap-2.5 overflow-hidden rounded-md px-2.5 py-2.5 text-left transition-colors hover:bg-sidebar-accent/40",
             count !== undefined && "pr-8",
           )}
         >
@@ -251,7 +251,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                   return (
                   <div
                     key={project.id}
-                    className={cn(index > 0 && "mt-2.5")}
+                    className={cn(index > 0 && "mt-2.5 border-t border-border pt-2.5")}
                   >
                     <Collapsible
                       open={isProjectExpanded(project.id)}
@@ -293,23 +293,21 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                                     <Link
                                       to={`/workspaces/${ws.id}`}
                                       className={cn(
-                                        "block rounded-md py-1.5 pl-2 pr-2 transition-colors hover:bg-sidebar-accent/60",
+                                        "block rounded-md py-1.5 pl-2 pr-2 transition-colors",
                                         activeWsId === ws.id
-                                          ? "border-2 border-dashed border-primary/50"
-                                          : "border-2 border-transparent",
+                                          ? "bg-primary/10"
+                                          : "hover:bg-sidebar-accent/60",
                                       )}
                                     >
                                       <div className="flex items-center gap-1.5">
-                                        {wsStreaming ? (
-                                          <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
+                                        <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
+                                          {wsStreaming ? (
                                             <AgentActivityPreview size="small" />
-                                          </div>
-                                        ) : wsUnread ? (
-                                          <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center">
+                                          ) : wsUnread ? (
                                             <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                                          </div>
-                                        ) : null}
-                                        <BranchLabel branch={displayBranch} showIcon={!wsStreaming && !wsUnread} className="min-w-0 flex-1 text-sm" />
+                                          ) : null}
+                                        </div>
+                                        <BranchLabel branch={displayBranch} showIcon={false} className="min-w-0 flex-1 text-sm text-muted-foreground" />
                                         {wsScriptRunning && (
                                           <WaveIndicator className="shrink-0" />
                                         )}
@@ -579,10 +577,8 @@ function AutomationRow({ auto, pathname }: { auto: Automation; pathname: string 
     <Link
       to={`/automations/${auto.id}`}
       className={cn(
-        "block rounded-md px-2.5 py-1.5 transition-colors hover:bg-sidebar-accent/60",
-        isActive
-          ? "border-2 border-dashed border-primary/50"
-          : "border-2 border-transparent",
+        "block rounded-md px-2.5 py-1.5 transition-colors",
+        isActive ? "bg-primary/10" : "hover:bg-sidebar-accent/60",
       )}
     >
       <div className="flex items-center gap-2">

--- a/frontend/src/components/chat/SubAgentNode.tsx
+++ b/frontend/src/components/chat/SubAgentNode.tsx
@@ -141,12 +141,9 @@ export const SubAgentNode = memo(function SubAgentNode({
             </span>
           )}
           {isDone && (
-            <span className="flex shrink-0 items-center gap-1 text-green-500">
-              <svg className="size-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-              <span className="text-[10px] font-medium">Done</span>
-            </span>
+            <svg className="size-3 shrink-0 text-green-500" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5} strokeLinecap="round" strokeLinejoin="round">
+              <polyline points="20 6 9 17 4 12" />
+            </svg>
           )}
         </button>
       </div>

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -295,44 +295,36 @@ describe("Sidebar", () => {
     expect(screen.getByText("workspace/tokyo")).toBeInTheDocument();
   });
 
-  it("hides GitBranch icon when streaming and restores it when idle", async () => {
+  it("shows orbit loader when streaming and removes it when idle", async () => {
     const { __wsMock } = await getWsMock();
     renderSidebar("/workspaces/w1", projects);
 
     await screen.findByText("workspace/tokyo");
 
-    // Before streaming: BranchLabel renders its GitBranch SVG icon
+    // Before streaming: no SVG icons (GitBranch icon is always hidden)
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
     const svgsBefore = workspaceLink.querySelectorAll("svg");
-    expect(svgsBefore.length).toBe(1);
-    // The single SVG is the GitBranch icon (class includes "lucide")
-    expect(svgsBefore[0].classList.toString()).toContain("lucide");
+    expect(svgsBefore.length).toBe(0);
 
     act(() => {
       __wsMock.emit("w1", { type: "status", status: "busy", streaming: true });
     });
 
-    // While streaming: orbit loader SVG replaces the GitBranch icon
+    // While streaming: orbit loader SVG appears
     const svgsStreaming = workspaceLink.querySelectorAll("svg");
     const orbitSvg = Array.from(svgsStreaming).find(
       (svg) => svg.getAttribute("aria-label") === "Agent thinking",
     );
     expect(orbitSvg).toBeTruthy();
-    // GitBranch icon should be gone (showIcon=false on BranchLabel)
-    const lucideSvg = Array.from(svgsStreaming).find((svg) =>
-      svg.classList.toString().includes("lucide-git-branch"),
-    );
-    expect(lucideSvg).toBeFalsy();
 
     act(() => {
       __wsMock.emit("w1", { type: "status", status: "busy", streaming: false });
     });
 
-    // After streaming stops: back to GitBranch, no orbit loader
+    // After streaming stops: no SVGs again
     expect(screen.queryByRole("img", { name: "Agent thinking" })).not.toBeInTheDocument();
     const svgsAfter = workspaceLink.querySelectorAll("svg");
-    expect(svgsAfter.length).toBe(1);
-    expect(svgsAfter[0].classList.toString()).toContain("lucide");
+    expect(svgsAfter.length).toBe(0);
   });
 
   it("does not show orbit loader on non-streaming workspaces", async () => {
@@ -475,9 +467,9 @@ describe("Sidebar", () => {
 
     await screen.findByText("workspace/tokyo");
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
-    // No wave indicator initially
+    // No wave indicator initially (no SVGs — GitBranch icon is always hidden)
     const svgsBefore = workspaceLink.querySelectorAll("svg");
-    expect(svgsBefore).toHaveLength(1); // only GitBranch
+    expect(svgsBefore).toHaveLength(0);
 
     act(() => {
       __wsMock.emit("w1", { type: "script_status", scriptType: "run", state: "running" });
@@ -485,7 +477,7 @@ describe("Sidebar", () => {
 
     // Wave indicator SVG should appear (the inline SVG with viewBox="0 0 12 12")
     const svgsAfter = workspaceLink.querySelectorAll("svg");
-    expect(svgsAfter.length).toBeGreaterThan(1);
+    expect(svgsAfter.length).toBeGreaterThan(0);
   });
 
   it("hides wave indicator when script finishes", async () => {
@@ -499,13 +491,13 @@ describe("Sidebar", () => {
     });
 
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
-    expect(workspaceLink.querySelectorAll("svg").length).toBeGreaterThan(1);
+    expect(workspaceLink.querySelectorAll("svg").length).toBeGreaterThan(0);
 
     act(() => {
       __wsMock.emit("w1", { type: "script_status", scriptType: "run", state: "done", exitCode: 0 });
     });
 
-    expect(workspaceLink.querySelectorAll("svg")).toHaveLength(1); // back to GitBranch only
+    expect(workspaceLink.querySelectorAll("svg")).toHaveLength(0); // no SVGs at rest
   });
 
   it("hides archive button when script is running", async () => {

--- a/frontend/tests/components/ToolCallList.test.tsx
+++ b/frontend/tests/components/ToolCallList.test.tsx
@@ -414,7 +414,10 @@ describe("ToolCallList", () => {
     );
 
     expect(screen.getByText("Explore")).toBeInTheDocument();
-    expect(screen.getByText("Done")).toBeInTheDocument();
+    // Completed state shows a checkmark SVG (no "Done" text)
+    const btn = screen.getByRole("button", { name: /Explore/i });
+    const checkmark = btn.querySelector("svg polyline[points='20 6 9 17 4 12']");
+    expect(checkmark).toBeTruthy();
   });
 
   it("shows shimmer animation on SubAgentNode during streaming", () => {
@@ -478,7 +481,10 @@ describe("ToolCallList", () => {
     // 4 regularTools >= 3 triggers collapse; expand summary first
     await user.click(screen.getByText("1 subagent"));
 
-    expect(screen.getByText("Done")).toBeInTheDocument();
+    // Completed state shows checkmark SVG (no "Done" text)
+    const btn = screen.getByRole("button", { name: /Explore/i });
+    const checkmark = btn.querySelector("svg polyline[points='20 6 9 17 4 12']");
+    expect(checkmark).toBeTruthy();
     expect(screen.getByText(/3 tools/)).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary
- Remove "Done" status text from sub-agent nodes, keep only the green checkmark icon
- Sidebar headers: remove static background color, keep hover-only highlight
- Selected workspace/automation: replace dashed border with subtle accent background (`bg-primary/10`)
- Add visible separators (`border-border`) between project groups
- Increase header vertical padding for better spacing
- Workspace titles use muted color, git branch icon hidden (space reserved for streaming/unread indicators)

## Test plan
- [ ] Verify sub-agent nodes show only checkmark icon when done, pulsing dot when running
- [ ] Verify sidebar headers have no background at rest, highlight on hover
- [ ] Verify selected workspace shows accent background, no border
- [ ] Verify selected workspace keeps accent bg on hover (no flicker)
- [ ] Verify separators visible between project groups
- [ ] Verify streaming/unread indicators still appear in workspace rows