### PR TITLE
fix(frontend): enforce single PR status polling source

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -27,7 +27,7 @@ import {
 import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
 import { useProjects } from "@/hooks/useProjects";
-import { useBulkPrStatus } from "@/hooks/usePrStatus";
+import { useBulkPrStatus, usePrStatusMap } from "@/hooks/usePrStatus";
 import { computePrDisplayCompact } from "@/lib/pr-display";
 import { BranchLabel } from "@/components/BranchLabel";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
@@ -171,7 +171,8 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     () => projects.flatMap((p) => (p.workspaces ?? []).map((ws) => ws.id)),
     [projects],
   );
-  const { results: prStatuses, loading: prLoading } = useBulkPrStatus(allWsIds);
+  const { loading: prLoading } = useBulkPrStatus(allWsIds);
+  const prStatuses = usePrStatusMap(allWsIds);
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];

--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -1,6 +1,8 @@
 import { useMemo } from "react";
 import {
+  useIsFetching,
   useQuery,
+  useQueries,
   useQueryClient,
   keepPreviousData,
 } from "@tanstack/react-query";
@@ -9,27 +11,65 @@ import type { BulkPrStatusResponse, PrStatusResponse } from "@/types";
 
 export const prStatusKey = (wsId: string) => ["pr-status", wsId] as const;
 
+const PR_GC_TIME = 5 * 60_000;
+
+function readPrStatusFromCache(
+  queryClient: ReturnType<typeof useQueryClient>,
+  wsId: string,
+): PrStatusResponse | undefined {
+  return queryClient.getQueryData<PrStatusResponse>(prStatusKey(wsId));
+}
+
 export function usePrStatus(wsId: string | undefined) {
+  const queryClient = useQueryClient();
+  const bulkFetchingCount = useIsFetching({ queryKey: ["pr-status-bulk"] });
+
   const query = useQuery({
     queryKey: prStatusKey(wsId ?? ""),
-    queryFn: (): Promise<PrStatusResponse> =>
-      api.get<PrStatusResponse>(`/api/workspaces/${wsId}/pr-status`),
-    enabled: !!wsId,
-    staleTime: 10_000,
-    gcTime: 5 * 60_000,
+    queryFn: async (): Promise<PrStatusResponse> =>
+      readPrStatusFromCache(queryClient, wsId ?? "") ?? { pr: null },
+    // Cache-only consumer: the sidebar bulk query is the single poller.
+    enabled: false,
+    staleTime: Number.POSITIVE_INFINITY,
+    gcTime: PR_GC_TIME,
     placeholderData: keepPreviousData,
-    // No refetchInterval — data is seeded by useBulkPrStatus (Sidebar)
-    // via queryClient.setQueryData, ensuring all consumers update together.
   });
+
+  const hasData = query.data !== undefined;
+  const loading = !!wsId && !hasData && bulkFetchingCount > 0;
 
   return {
     pr: query.data?.pr ?? null,
     error: query.data?.error ?? null,
-    loading: query.isLoading,
+    loading,
   };
 }
 
 const emptyResults: Record<string, PrStatusResponse> = {};
+
+export function usePrStatusMap(wsIds: string[]) {
+  const queryClient = useQueryClient();
+  const queries = useQueries({
+    queries: wsIds.map((wsId) => ({
+      queryKey: prStatusKey(wsId),
+      queryFn: async (): Promise<PrStatusResponse> =>
+        readPrStatusFromCache(queryClient, wsId) ?? { pr: null },
+      enabled: false,
+      staleTime: Number.POSITIVE_INFINITY,
+      gcTime: PR_GC_TIME,
+      placeholderData: keepPreviousData,
+    })),
+  });
+
+  return useMemo(() => {
+    const results: Record<string, PrStatusResponse> = {};
+    wsIds.forEach((wsId, index) => {
+      const status = queries[index]?.data;
+      if (status) results[wsId] = status;
+    });
+    return results;
+  }, [queries, wsIds]);
+}
 
 export function useBulkPrStatus(wsIds: string[]) {
   const queryClient = useQueryClient();
@@ -56,7 +96,7 @@ export function useBulkPrStatus(wsIds: string[]) {
     enabled: wsIds.length > 0,
     refetchInterval: 15_000,
     staleTime: 10_000,
-    gcTime: 5 * 60_000,
+    gcTime: PR_GC_TIME,
     placeholderData: keepPreviousData,
   });
 

--- a/frontend/tests/hooks/usePrStatus.test.ts
+++ b/frontend/tests/hooks/usePrStatus.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { usePrStatus, useBulkPrStatus, prStatusKey } from "@/hooks/usePrStatus";
+import { usePrStatus, useBulkPrStatus, usePrStatusMap, prStatusKey } from "@/hooks/usePrStatus";
 import { api } from "@/hooks/useApi";
 import type { PrStatusResponse, PullRequestInfo } from "@/types";
 import { createWrapper } from "../test-utils";
@@ -54,28 +54,30 @@ describe("usePrStatus", () => {
     expect(api.get).not.toHaveBeenCalled();
   });
 
-  it("fetches PR status for the workspace", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({ pr: makePr({ number: 7 }) });
+  it("reads a seeded cache entry without standalone fetch", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(prStatusKey("ws-1"), {
+      pr: makePr({ number: 7 }),
+    } satisfies PrStatusResponse);
 
-    const { wrapper } = createWrapper();
     const { result } = renderHook(() => usePrStatus("ws-1"), { wrapper });
 
     await waitFor(() => {
       expect(result.current.pr?.number).toBe(7);
     });
 
-    expect(api.get).toHaveBeenCalledWith("/api/workspaces/ws-1/pr-status");
     expect(result.current.error).toBeNull();
     expect(result.current.loading).toBe(false);
+    expect(api.get).not.toHaveBeenCalled();
   });
 
-  it("exposes backend error messages", async () => {
-    vi.mocked(api.get).mockResolvedValueOnce({
+  it("exposes seeded error payloads", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(prStatusKey("ws-1"), {
       pr: null,
       error: "gh not authenticated — run `gh auth login`",
-    });
+    } satisfies PrStatusResponse);
 
-    const { wrapper } = createWrapper();
     const { result } = renderHook(() => usePrStatus("ws-1"), { wrapper });
 
     await waitFor(() => {
@@ -83,34 +85,42 @@ describe("usePrStatus", () => {
     });
 
     expect(result.current.pr).toBeNull();
+    expect(api.get).not.toHaveBeenCalled();
   });
 
-  it("reports loading=true while the request is in flight", async () => {
-    const pending = deferred<{ pr: PullRequestInfo | null; error?: string }>();
-    vi.mocked(api.get).mockReturnValueOnce(pending.promise);
+  it("reports loading=true while the shared bulk poll is in flight", async () => {
+    const pending = deferred<{ results: Record<string, PrStatusResponse> }>();
+    vi.mocked(api.post).mockReturnValueOnce(pending.promise);
 
     const { wrapper } = createWrapper();
+    renderHook(() => useBulkPrStatus(["ws-1"]), { wrapper });
     const { result } = renderHook(() => usePrStatus("ws-1"), { wrapper });
 
-    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
 
     await act(async () => {
-      pending.resolve({ pr: makePr({ number: 99 }) });
+      pending.resolve({ results: { "ws-1": { pr: makePr({ number: 99 }) } } });
       await Promise.resolve();
     });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
+      expect(result.current.pr?.number).toBe(99);
     });
-    expect(result.current.pr?.number).toBe(99);
+    expect(api.get).not.toHaveBeenCalled();
   });
 
-  it("refetches when workspace id changes", async () => {
-    vi.mocked(api.get)
-      .mockResolvedValueOnce({ pr: makePr({ number: 1 }) })
-      .mockResolvedValueOnce({ pr: makePr({ number: 2 }) });
+  it("updates when workspace id changes and cache is already seeded", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(prStatusKey("ws-1"), {
+      pr: makePr({ number: 1 }),
+    } satisfies PrStatusResponse);
+    queryClient.setQueryData(prStatusKey("ws-2"), {
+      pr: makePr({ number: 2 }),
+    } satisfies PrStatusResponse);
 
-    const { wrapper } = createWrapper();
     const { result, rerender } = renderHook(
       ({ wsId }: { wsId: string | undefined }) => usePrStatus(wsId),
       {
@@ -128,9 +138,31 @@ describe("usePrStatus", () => {
     await waitFor(() => {
       expect(result.current.pr?.number).toBe(2);
     });
+    expect(api.get).not.toHaveBeenCalled();
+  });
+});
 
-    expect(api.get).toHaveBeenNthCalledWith(1, "/api/workspaces/ws-1/pr-status");
-    expect(api.get).toHaveBeenNthCalledWith(2, "/api/workspaces/ws-2/pr-status");
+describe("usePrStatusMap", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns statuses from shared per-workspace cache", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(prStatusKey("ws-1"), {
+      pr: makePr({ number: 11 }),
+    } satisfies PrStatusResponse);
+    queryClient.setQueryData(prStatusKey("ws-2"), {
+      pr: null,
+      error: "Failed to fetch PR status",
+    } satisfies PrStatusResponse);
+
+    const { result } = renderHook(() => usePrStatusMap(["ws-1", "ws-2"]), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current["ws-1"]?.pr?.number).toBe(11);
+    });
+    expect(result.current["ws-2"]?.error).toBe("Failed to fetch PR status");
   });
 });
 


### PR DESCRIPTION
## Summary
- remove standalone PR-status fetching from `usePrStatus` and make it cache-only
- keep `useBulkPrStatus` as the only network poller and source of seeded query-cache data
- make Sidebar read PR status from the same per-workspace cache map used by other consumers
- update hook tests to lock single-poller behavior and shared-cache reads

## Problem fixed
The frontend could run concurrent PR status fetch paths (bulk + per-workspace), causing status drift between Sidebar and WorkspaceView.

## Validation
- npm run test -- tests/hooks/usePrStatus.test.ts tests/components/Sidebar.test.tsx
- npm run typecheck
- npm run lint -- src/hooks/usePrStatus.ts src/components/Sidebar.tsx
