### PR TITLE
fix(notifications): include agent output preview in Telegram

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -7,7 +7,7 @@ import { saveProject, getDataDir, loadProject, withProjectStateLock } from "../s
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
 import { runNamingTask } from "./naming.js";
 import { NotFoundError } from "../utils/errors.js";
-import { extractSummary } from "../utils/summary-extractor.js";
+import { extractSummary, extractPreview } from "../utils/summary-extractor.js";
 import type { ChatMessage, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
 import { TelegramChannel } from "../notifications/telegram.js";
@@ -445,7 +445,7 @@ function attachNotificationListener(
           let summary: string | undefined;
           try {
             const messages = await session.getMessages();
-            summary = extractSummary(messages);
+            summary = extractSummary(messages) ?? extractPreview(messages);
           } catch { /* non-fatal */ }
           n.notify({
             type: "agent_turn_complete",

--- a/backend/src/utils/summary-extractor.test.ts
+++ b/backend/src/utils/summary-extractor.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { extractSummary, extractSummaryFromText } from "./summary-extractor.js";
+import { extractSummary, extractSummaryFromText, extractPreview } from "./summary-extractor.js";
 import type { ChatMessage } from "../types.js";
 
 function msg(role: "user" | "assistant", content: string): ChatMessage {
@@ -69,5 +69,51 @@ describe("extractSummary", () => {
   it("returns undefined when assistant has no summary", () => {
     const messages = [msg("assistant", "Just text, no summary")];
     expect(extractSummary(messages)).toBeUndefined();
+  });
+});
+
+describe("extractPreview", () => {
+  it("returns content of last assistant message", () => {
+    const messages = [
+      msg("user", "Do something"),
+      msg("assistant", "Here is what I did."),
+    ];
+    expect(extractPreview(messages)).toBe("Here is what I did.");
+  });
+
+  it("truncates at maxLen and appends ellipsis", () => {
+    const long = "A".repeat(600);
+    const messages = [msg("assistant", long)];
+    const result = extractPreview(messages, 500);
+    expect(result).toHaveLength(501); // 500 chars + "…"
+    expect(result!.endsWith("…")).toBe(true);
+  });
+
+  it("returns full text when under maxLen", () => {
+    const messages = [msg("assistant", "Short text")];
+    expect(extractPreview(messages, 500)).toBe("Short text");
+  });
+
+  it("skips empty/whitespace-only assistant messages", () => {
+    const messages = [
+      msg("assistant", "First answer"),
+      msg("user", "Continue"),
+      msg("assistant", "   "),
+    ];
+    expect(extractPreview(messages)).toBe("First answer");
+  });
+
+  it("returns undefined when no assistant messages", () => {
+    expect(extractPreview([msg("user", "Hello")])).toBeUndefined();
+  });
+
+  it("returns undefined for empty list", () => {
+    expect(extractPreview([])).toBeUndefined();
+  });
+
+  it("respects custom maxLen", () => {
+    const messages = [msg("assistant", "Hello world, this is a test")];
+    const result = extractPreview(messages, 10);
+    expect(result).toBe("Hello worl…");
   });
 });

--- a/backend/src/utils/summary-extractor.ts
+++ b/backend/src/utils/summary-extractor.ts
@@ -20,3 +20,23 @@ export function extractSummaryFromText(text: string): string | undefined {
   const trimmed = match[1].trim();
   return trimmed || undefined;
 }
+
+/**
+ * Fallback preview: return the first `maxLen` characters of the last
+ * assistant message content (trimmed). Used when no structured
+ * "## Summary" section is present.
+ */
+export function extractPreview(
+  messages: ChatMessage[],
+  maxLen = 500,
+): string | undefined {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "assistant") {
+      const text = messages[i].content.trim();
+      if (!text) continue;
+      if (text.length <= maxLen) return text;
+      return text.slice(0, maxLen) + "…";
+    }
+  }
+  return undefined;
+}


### PR DESCRIPTION
## Summary
- Telegram notifications for completed agent turns were empty when the agent didn't produce a `## Summary` markdown section (only automations instruct that via system prompt — normal workspace conversations never do)
- Added `extractPreview()` fallback in `summary-extractor.ts`: takes the first 500 chars of the last assistant message content when no `## Summary` heading is found
- Wired the fallback in `agent-manager.ts` with `extractSummary(messages) ?? extractPreview(messages)`
- APNS (iOS) not touched — push notifications have limited payload size

## Test plan
- [x] All 1014 existing tests pass
- [x] Typecheck passes
- [x] 7 new tests for `extractPreview` (truncation, empty messages, custom maxLen, etc.)