### PR TITLE
feat(frontend): in-app toast notifications with navigation + regression tests

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,6 +44,7 @@
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.0",
     "shiki": "^3.22.0",
+    "sileo": "^0.1.5",
     "streamdown": "^2.2.0",
     "tailwind-merge": "^3.4.0",
     "use-stick-to-bottom": "^1.1.3"

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
+import { Toaster } from "sileo";
+import "sileo/styles.css";
 import AppLayout from "@/components/AppLayout";
 import WorkspaceView from "@/pages/WorkspaceView";
 import AccountSettings from "@/pages/settings/AccountSettings";
@@ -12,13 +14,20 @@ import AddProjectDialog from "@/components/AddProjectDialog";
 import EmptyStateLogo from "@/components/EmptyStateLogo";
 import AutomationsHome from "@/pages/AutomationsHome";
 import { useProjects } from "@/hooks/useProjects";
+import type { Project } from "@/types";
 import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
+import { useNotificationToasts } from "@/hooks/useNotificationToasts";
 import { wsTransport } from "@/lib/ws-transport";
 
 const AutomationDetail = lazy(() => import("@/pages/AutomationDetail"));
 const PromptTemplatesSettings = lazy(() => import("@/pages/settings/PromptTemplatesSettings"));
 const CreateAutomationDialog = lazy(() => import("@/components/CreateAutomationDialog"));
+
+function NotificationToastsBridge({ projects }: { projects: Project[] }) {
+  useNotificationToasts(projects);
+  return null;
+}
 
 export default function App() {
   const { projects, loading, fetchProjects, createProjectWithWorkspace } = useProjects();
@@ -48,6 +57,8 @@ export default function App() {
   return (
     <BrowserRouter>
       <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
+        <Toaster position="top-center" theme="dark" />
+        <NotificationToastsBridge projects={projects} />
         <AddProjectDialog
           open={showAddProject}
           onOpenChange={setShowAddProject}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -57,7 +57,19 @@ export default function App() {
   return (
     <BrowserRouter>
       <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
-        <Toaster position="top-center" theme="dark" />
+        <Toaster
+          position="top-right"
+          theme="dark"
+          options={{
+            fill: "#16161e",
+            styles: {
+              title: "text-[oklch(0.93_0.005_260)]!",
+              description: "text-[oklch(0.707_0.022_261.325)]!",
+              badge: "bg-[#262636]!",
+              button: "bg-[#262636]! text-[oklch(0.93_0.005_260)]! hover:bg-[#2e2e40]!",
+            },
+          }}
+        />
         <NotificationToastsBridge projects={projects} />
         <AddProjectDialog
           open={showAddProject}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -419,6 +419,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 /** Remembers which session was last viewed per workspace (module-level, survives re-mounts). */
 const savedSessionByWorkspace = new Map<string, string>();
 
+/** Pre-seed the session to restore when navigating to a workspace. */
+export function setSavedSession(workspaceId: string, sessionId: string) {
+  savedSessionByWorkspace.set(workspaceId, sessionId);
+}
+
 /** @internal Test-only: clear saved session memory between tests. */
 export function _resetSavedSessions() {
   savedSessionByWorkspace.clear();

--- a/frontend/src/hooks/useNotificationToasts.ts
+++ b/frontend/src/hooks/useNotificationToasts.ts
@@ -1,0 +1,51 @@
+import { useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { sileo } from "sileo";
+import { wsTransport } from "@/lib/ws-transport";
+import { formatElapsed } from "@/lib/time";
+import { getLocalToastsEnabled } from "@/pages/settings/NotificationSettings";
+import type { Project, Workspace } from "@/types";
+
+export function useNotificationToasts(projects: Project[]): void {
+  const location = useLocation();
+  const projectsRef = useRef(projects);
+  projectsRef.current = projects;
+
+  // Keep location in a ref so the WS listener always sees the latest value
+  // without re-subscribing on every navigation.
+  const locationRef = useRef(location.pathname);
+  locationRef.current = location.pathname;
+
+  useEffect(() => {
+    return wsTransport.onGlobalMessage((workspaceId, msg) => {
+      if (!getLocalToastsEnabled()) return;
+
+      // Suppress if user is currently viewing this workspace
+      const match = locationRef.current.match(/^\/workspaces\/([^/]+)/);
+      if (match?.[1] === workspaceId) return;
+
+      // Resolve project name + branch for the toast title
+      let label = workspaceId.slice(0, 8);
+      for (const p of projectsRef.current) {
+        const w = (p.workspaces ?? []).find((w: Workspace) => w.id === workspaceId);
+        if (w) {
+          const branch = w.branch?.replace(/^workspace\//, "") ?? w.name;
+          label = `${p.name} · ${branch}`;
+          break;
+        }
+      }
+
+      if (msg.type === "done" && msg.sessionId) {
+        const duration = msg.durationMs ? ` in ${formatElapsed(msg.durationMs)}` : "";
+        sileo.success({ title: label, description: `Turn complete${duration}` });
+      } else if (msg.type === "cancelled" && !msg.userInitiated && msg.sessionId) {
+        sileo.error({
+          title: label,
+          description: msg.errorDetail ?? "Agent failed",
+        });
+      } else if (msg.type === "error") {
+        sileo.error({ title: label, description: msg.message });
+      }
+    });
+  }, []);
+}

--- a/frontend/src/hooks/useNotificationToasts.ts
+++ b/frontend/src/hooks/useNotificationToasts.ts
@@ -1,20 +1,23 @@
 import { useEffect, useRef } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import { sileo } from "sileo";
 import { wsTransport } from "@/lib/ws-transport";
 import { formatElapsed } from "@/lib/time";
 import { getLocalToastsEnabled } from "@/pages/settings/NotificationSettings";
+import { setSavedSession } from "@/hooks/useConversation";
 import type { Project, Workspace } from "@/types";
 
 export function useNotificationToasts(projects: Project[]): void {
   const location = useLocation();
+  const navigate = useNavigate();
   const projectsRef = useRef(projects);
   projectsRef.current = projects;
 
-  // Keep location in a ref so the WS listener always sees the latest value
-  // without re-subscribing on every navigation.
   const locationRef = useRef(location.pathname);
   locationRef.current = location.pathname;
+
+  const navigateRef = useRef(navigate);
+  navigateRef.current = navigate;
 
   useEffect(() => {
     return wsTransport.onGlobalMessage((workspaceId, msg) => {
@@ -35,16 +38,37 @@ export function useNotificationToasts(projects: Project[]): void {
         }
       }
 
+      const goToWorkspace = (sessionId?: string) => () => {
+        if (sessionId) setSavedSession(workspaceId, sessionId);
+        navigateRef.current(`/workspaces/${workspaceId}`);
+      };
+
       if (msg.type === "done" && msg.sessionId) {
         const duration = msg.durationMs ? ` in ${formatElapsed(msg.durationMs)}` : "";
-        sileo.success({ title: label, description: `Turn complete${duration}` });
+        sileo.success({
+          title: label,
+          description: `Turn complete${duration}`,
+          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
+        });
       } else if (msg.type === "cancelled" && !msg.userInitiated && msg.sessionId) {
         sileo.error({
           title: label,
           description: msg.errorDetail ?? "Agent failed",
+          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
         });
       } else if (msg.type === "error") {
-        sileo.error({ title: label, description: msg.message });
+        sileo.error({
+          title: label,
+          description: msg.message,
+          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
+        });
+      } else if (msg.type === "tool_input_required" && msg.sessionId) {
+        const isPlan = msg.toolName === "ExitPlanMode";
+        sileo.warning({
+          title: label,
+          description: isPlan ? "Plan ready for review" : "Agent needs input",
+          button: { title: isPlan ? "Review" : "Respond", onClick: goToWorkspace(msg.sessionId) },
+        });
       }
     });
   }, []);

--- a/frontend/src/hooks/useNotificationToasts.ts
+++ b/frontend/src/hooks/useNotificationToasts.ts
@@ -38,36 +38,44 @@ export function useNotificationToasts(projects: Project[]): void {
         }
       }
 
-      const goToWorkspace = (sessionId?: string) => () => {
+      // Navigate to the workspace/session and dismiss the toast.
+      // `toastId` is captured by reference — already assigned when onClick fires.
+      let toastId: string;
+      const go = (sessionId?: string) => {
+        sileo.dismiss(toastId);
         if (sessionId) setSavedSession(workspaceId, sessionId);
         navigateRef.current(`/workspaces/${workspaceId}`);
       };
 
       if (msg.type === "done" && msg.sessionId) {
+        const sid = msg.sessionId;
         const duration = msg.durationMs ? ` in ${formatElapsed(msg.durationMs)}` : "";
-        sileo.success({
+        toastId = sileo.success({
           title: label,
           description: `Turn complete${duration}`,
-          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
+          button: { title: "View", onClick: () => go(sid) },
         });
       } else if (msg.type === "cancelled" && !msg.userInitiated && msg.sessionId) {
-        sileo.error({
+        const sid = msg.sessionId;
+        toastId = sileo.error({
           title: label,
           description: msg.errorDetail ?? "Agent failed",
-          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
+          button: { title: "View", onClick: () => go(sid) },
         });
       } else if (msg.type === "error") {
-        sileo.error({
+        const sid = msg.sessionId;
+        toastId = sileo.error({
           title: label,
           description: msg.message,
-          button: { title: "View", onClick: goToWorkspace(msg.sessionId) },
+          button: { title: "View", onClick: () => go(sid) },
         });
       } else if (msg.type === "tool_input_required" && msg.sessionId) {
+        const sid = msg.sessionId;
         const isPlan = msg.toolName === "ExitPlanMode";
-        sileo.warning({
+        toastId = sileo.warning({
           title: label,
           description: isPlan ? "Plan ready for review" : "Agent needs input",
-          button: { title: isPlan ? "Review" : "Respond", onClick: goToWorkspace(msg.sessionId) },
+          button: { title: isPlan ? "Review" : "Respond", onClick: () => go(sid) },
         });
       }
     });

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -4,6 +4,7 @@ import type { WsIncoming, WsOutgoing, HubOutgoing } from "@/types";
 export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
 type MessageHandler = (msg: WsOutgoing) => void;
+type GlobalMessageHandler = (workspaceId: string, msg: WsOutgoing) => void;
 type StatusListener = () => void;
 type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
 export type HistoryMessage = Extract<WsOutgoing, { type: "history" }>;
@@ -45,6 +46,7 @@ class WsTransport {
   };
   private subscriptions = new Map<string, WorkspaceSubscription>();
   private subscribedWorkspaceIds = new Set<string>();
+  private globalListeners = new Set<GlobalMessageHandler>();
 
   /** Connect to a workspace (subscribes it via the hub). */
   connect(workspaceId: string): void {
@@ -168,6 +170,12 @@ class WsTransport {
     };
   };
 
+  /** Register a listener for ALL incoming workspace messages (used by toast notifications). */
+  onGlobalMessage(handler: GlobalMessageHandler): () => void {
+    this.globalListeners.add(handler);
+    return () => { this.globalListeners.delete(handler); };
+  }
+
   /** useSyncExternalStore getSnapshot contract (per workspace). */
   getStatus = (workspaceId: string): ConnectionStatus => {
     const sub = this.subscriptions.get(workspaceId);
@@ -268,6 +276,10 @@ class WsTransport {
 
   private handleIncomingEnvelope(envelope: HubOutgoing): void {
     const { workspaceId, event: msg } = envelope;
+
+    // Notify global listeners (toast notifications, etc.) regardless of subscription state
+    for (const listener of this.globalListeners) listener(workspaceId, msg);
+
     const sub = this.subscriptions.get(workspaceId);
     if (!sub) return;
 

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -1,4 +1,4 @@
-import { useState, type ReactNode } from "react";
+import { useState, useSyncExternalStore, type ReactNode } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Eye, EyeOff, Send, Save, Loader2, Smartphone } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
@@ -53,6 +53,7 @@ export default function NotificationSettings() {
       </SettingsHeader>
 
       <div className="max-w-2xl space-y-6 px-4 py-5">
+        <LocalToastsSection />
         <TelegramForm initial={telegram} />
         <ApnsForm initial={apns} />
       </div>
@@ -126,6 +127,49 @@ function useNotificationChannel(opts: {
     onSave: () => saveMutation.mutate(),
     onTest: () => testMutation.mutate(),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Local toasts — localStorage-backed toggle
+// ---------------------------------------------------------------------------
+
+const LOCAL_TOASTS_KEY = "hive:local-toasts-enabled";
+
+const localToastsListeners = new Set<() => void>();
+
+export function getLocalToastsEnabled(): boolean {
+  try {
+    return localStorage.getItem(LOCAL_TOASTS_KEY) !== "false";
+  } catch {
+    return true;
+  }
+}
+
+function setLocalToastsEnabled(v: boolean) {
+  localStorage.setItem(LOCAL_TOASTS_KEY, String(v));
+  localToastsListeners.forEach((fn) => fn());
+}
+
+export function useLocalToastsEnabled(): boolean {
+  return useSyncExternalStore(
+    (cb) => { localToastsListeners.add(cb); return () => { localToastsListeners.delete(cb); }; },
+    getLocalToastsEnabled,
+  );
+}
+
+function LocalToastsSection() {
+  const enabled = useLocalToastsEnabled();
+  return (
+    <NotificationSection
+      id="local-toasts"
+      title="In-App Toasts"
+      description="Show toast notifications when agents finish in background workspaces."
+      enabled={enabled}
+      onToggle={setLocalToastsEnabled}
+    >
+      <div />
+    </NotificationSection>
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/App";
 
 function renderApp() {

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import App from "@/App";
 
 function renderApp() {
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => ({
   syncWorkspaces: vi.fn(),
   disconnectAll: vi.fn(),
   onMessage: vi.fn(() => ({ unsubscribe: vi.fn(), hadBufferedMessages: false })),
+  onGlobalMessage: vi.fn(() => vi.fn()),
   projects: [] as Array<{
     id: string;
     name: string;
@@ -73,6 +74,7 @@ vi.mock("@/lib/ws-transport", () => ({
     syncWorkspaces: mocks.syncWorkspaces,
     disconnectAll: mocks.disconnectAll,
     onMessage: mocks.onMessage,
+    onGlobalMessage: mocks.onGlobalMessage,
   },
 }));
 

--- a/frontend/tests/hooks/useNotificationToasts.test.tsx
+++ b/frontend/tests/hooks/useNotificationToasts.test.tsx
@@ -1,0 +1,242 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useNotificationToasts } from "@/hooks/useNotificationToasts";
+import type { Project, WsOutgoing } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  onGlobalMessage: vi.fn(),
+  offGlobalMessage: vi.fn(),
+  globalHandler: null as ((workspaceId: string, msg: WsOutgoing) => void) | null,
+  getLocalToastsEnabled: vi.fn(() => true),
+  setSavedSession: vi.fn(),
+  success: vi.fn(() => "toast-success"),
+  error: vi.fn(() => "toast-error"),
+  warning: vi.fn(() => "toast-warning"),
+  dismiss: vi.fn(),
+  navigate: vi.fn(),
+  pathname: "/projects",
+}));
+
+vi.mock("@/lib/ws-transport", () => ({
+  wsTransport: {
+    onGlobalMessage: (handler: (workspaceId: string, msg: WsOutgoing) => void) => {
+      mocks.onGlobalMessage(handler);
+      mocks.globalHandler = handler;
+      return mocks.offGlobalMessage;
+    },
+  },
+}));
+
+vi.mock("@/pages/settings/NotificationSettings", () => ({
+  getLocalToastsEnabled: mocks.getLocalToastsEnabled,
+}));
+
+vi.mock("@/hooks/useConversation", () => ({
+  setSavedSession: mocks.setSavedSession,
+}));
+
+vi.mock("sileo", () => ({
+  sileo: {
+    success: mocks.success,
+    error: mocks.error,
+    warning: mocks.warning,
+    dismiss: mocks.dismiss,
+  },
+}));
+
+vi.mock("react-router-dom", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-router-dom")>();
+  return {
+    ...actual,
+    useLocation: () => ({ pathname: mocks.pathname, search: "", hash: "", state: null, key: "test" }),
+    useNavigate: () => mocks.navigate,
+  };
+});
+
+function makeProjects(): Project[] {
+  return [{
+    id: "p1",
+    name: "Alpha",
+    url: "https://github.com/acme/alpha.git",
+    createdAt: "2026-02-20T00:00:00.000Z",
+    workspaces: [{
+      id: "ws-1",
+      name: "alpha-ws-1",
+      branch: "workspace/feature/toasts",
+      status: "idle",
+      createdAt: "2026-02-20T00:00:00.000Z",
+    }],
+  }];
+}
+
+function emit(workspaceId: string, msg: WsOutgoing) {
+  expect(mocks.globalHandler).not.toBeNull();
+  act(() => {
+    mocks.globalHandler?.(workspaceId, msg);
+  });
+}
+
+describe("useNotificationToasts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.globalHandler = null;
+    mocks.pathname = "/projects";
+    mocks.getLocalToastsEnabled.mockReturnValue(true);
+    mocks.success.mockReturnValue("toast-success");
+    mocks.error.mockReturnValue("toast-error");
+    mocks.warning.mockReturnValue("toast-warning");
+  });
+
+  it("subscribes on mount and unsubscribes on unmount", () => {
+    const { unmount } = renderHook(() => useNotificationToasts(makeProjects()));
+
+    expect(mocks.onGlobalMessage).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(mocks.offGlobalMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not emit toasts when local toasts are disabled", () => {
+    mocks.getLocalToastsEnabled.mockReturnValue(false);
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", { type: "done", sessionId: "sess-1" });
+
+    expect(mocks.success).not.toHaveBeenCalled();
+    expect(mocks.error).not.toHaveBeenCalled();
+    expect(mocks.warning).not.toHaveBeenCalled();
+  });
+
+  it("suppresses toasts for the workspace currently open", () => {
+    mocks.pathname = "/workspaces/ws-1";
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", { type: "done", sessionId: "sess-1" });
+
+    expect(mocks.success).not.toHaveBeenCalled();
+  });
+
+  it("shows a success toast for done events and navigates to the targeted session", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 5000 });
+
+    const payload = mocks.success.mock.calls[0]?.[0];
+    expect(payload).toEqual(expect.objectContaining({
+      title: "Alpha · feature/toasts",
+      description: "Turn complete in 5.0s",
+      button: expect.objectContaining({ title: "View", onClick: expect.any(Function) }),
+    }));
+
+    act(() => {
+      payload.button.onClick();
+    });
+
+    expect(mocks.dismiss).toHaveBeenCalledWith("toast-success");
+    expect(mocks.setSavedSession).toHaveBeenCalledWith("ws-1", "sess-1");
+    expect(mocks.navigate).toHaveBeenCalledWith("/workspaces/ws-1");
+  });
+
+  it("uses workspace id fallback label when project/workspace lookup misses", () => {
+    renderHook(() => useNotificationToasts([]));
+
+    emit("abcdef123456", { type: "done", sessionId: "sess-1" });
+
+    expect(mocks.success).toHaveBeenCalledWith(expect.objectContaining({
+      title: "abcdef12",
+    }));
+  });
+
+  it("ignores user-initiated cancellations", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", { type: "cancelled", sessionId: "sess-1", userInitiated: true });
+
+    expect(mocks.error).not.toHaveBeenCalled();
+  });
+
+  it("shows error toast for agent-side cancellation failures", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", {
+      type: "cancelled",
+      sessionId: "sess-1",
+      userInitiated: false,
+      errorDetail: "Tool crashed",
+    });
+
+    expect(mocks.error).toHaveBeenCalledWith(expect.objectContaining({
+      title: "Alpha · feature/toasts",
+      description: "Tool crashed",
+      button: expect.objectContaining({ title: "View", onClick: expect.any(Function) }),
+    }));
+  });
+
+  it("shows warning toast for plan reviews with a Review CTA", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", {
+      type: "tool_input_required",
+      sessionId: "sess-9",
+      requestId: "req-1",
+      toolName: "ExitPlanMode",
+      toolUseId: "tool-1",
+      input: { questions: [] },
+    });
+
+    expect(mocks.warning).toHaveBeenCalledWith(expect.objectContaining({
+      description: "Plan ready for review",
+      button: expect.objectContaining({ title: "Review" }),
+    }));
+  });
+
+  it("shows warning toast for generic input requests with a Respond CTA", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", {
+      type: "tool_input_required",
+      sessionId: "sess-9",
+      requestId: "req-1",
+      toolName: "AskUser",
+      toolUseId: "tool-1",
+      input: { question: "Continue?" },
+    });
+
+    expect(mocks.warning).toHaveBeenCalledWith(expect.objectContaining({
+      description: "Agent needs input",
+      button: expect.objectContaining({ title: "Respond" }),
+    }));
+  });
+
+  it("navigates on error toasts without seeding session when session id is missing", () => {
+    renderHook(() => useNotificationToasts(makeProjects()));
+
+    emit("ws-1", { type: "error", message: "Backend unreachable" });
+
+    const payload = mocks.error.mock.calls[0]?.[0];
+    act(() => {
+      payload.button.onClick();
+    });
+
+    expect(mocks.dismiss).toHaveBeenCalledWith("toast-error");
+    expect(mocks.setSavedSession).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledWith("/workspaces/ws-1");
+  });
+
+  it("uses latest projects and latest pathname after rerenders", () => {
+    const { rerender } = renderHook(
+      ({ projects }) => useNotificationToasts(projects),
+      { initialProps: { projects: [] as Project[] } },
+    );
+
+    rerender({ projects: makeProjects() });
+    emit("ws-1", { type: "done", sessionId: "sess-1" });
+    expect(mocks.success).toHaveBeenLastCalledWith(expect.objectContaining({
+      title: "Alpha · feature/toasts",
+    }));
+
+    mocks.pathname = "/workspaces/ws-1";
+    rerender({ projects: makeProjects() });
+    emit("ws-1", { type: "done", sessionId: "sess-2" });
+    expect(mocks.success).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -259,6 +259,54 @@ describe("wsTransport", () => {
     expect(received).toEqual([]);
   });
 
+  it("notifies global listeners for messages from any workspace id", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    const global = vi.fn();
+    wsTransport.onGlobalMessage(global);
+
+    socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
+    socket.hubMessage("ws-unsubscribed", { type: "error", message: "boom" });
+
+    expect(global).toHaveBeenCalledTimes(2);
+    expect(global).toHaveBeenNthCalledWith(1, "ws-1", { type: "status", status: "idle", streaming: false });
+    expect(global).toHaveBeenNthCalledWith(2, "ws-unsubscribed", { type: "error", message: "boom" });
+  });
+
+  it("stops notifying a global listener after unsubscribe", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    const global = vi.fn();
+    const unsubscribe = wsTransport.onGlobalMessage(global);
+
+    socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
+    unsubscribe();
+    socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
+
+    expect(global).toHaveBeenCalledTimes(1);
+    expect(global).toHaveBeenLastCalledWith("ws-1", { type: "status", status: "busy", streaming: true });
+  });
+
+  it("notifies all registered global listeners", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    const listenerA = vi.fn();
+    const listenerB = vi.fn();
+    wsTransport.onGlobalMessage(listenerA);
+    wsTransport.onGlobalMessage(listenerB);
+
+    socket.hubMessage("ws-1", { type: "done", sessionId: "sess-1" });
+
+    expect(listenerA).toHaveBeenCalledWith("ws-1", { type: "done", sessionId: "sess-1" });
+    expect(listenerB).toHaveBeenCalledWith("ws-1", { type: "done", sessionId: "sess-1" });
+  });
+
   it("reconnects with backoff after unexpected close while subscribed", () => {
     wsTransport.connect("ws-1");
     const first = MockWebSocket.instances[0]!;

--- a/frontend/tests/pages/NotificationSettings.test.tsx
+++ b/frontend/tests/pages/NotificationSettings.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/hooks/useApi", () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useRealTimers();
+  localStorage.removeItem("hive:local-toasts-enabled");
 });
 
 const defaultApns = {
@@ -32,14 +33,16 @@ async function renderReady(config?: {
   botToken?: string;
   chatId?: string;
 }) {
-  mocks.get.mockResolvedValueOnce({
+  const response = {
     telegram: {
       enabled: config?.enabled ?? false,
       botToken: config?.botToken ?? "",
       chatId: config?.chatId ?? "",
     },
     apns: { ...defaultApns },
-  });
+  };
+  mocks.get.mockResolvedValue(response);
+  mocks.get.mockResolvedValueOnce(response);
 
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -60,6 +63,26 @@ function telegramSection() {
 }
 
 describe("NotificationSettings", () => {
+  it("defaults local in-app toasts toggle to enabled when unset", async () => {
+    await renderReady();
+
+    expect(screen.getByRole("switch", { name: "In-App Toasts" })).toHaveAttribute("aria-checked", "true");
+  });
+
+  it("reads and persists local in-app toasts toggle state in localStorage", async () => {
+    const user = userEvent.setup();
+    localStorage.setItem("hive:local-toasts-enabled", "false");
+
+    await renderReady();
+
+    const toggle = screen.getByRole("switch", { name: "In-App Toasts" });
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(localStorage.getItem("hive:local-toasts-enabled")).toBe("true");
+  });
+
   it("loads and displays Telegram settings from backend", async () => {
     await renderReady({ enabled: true, botToken: "token-1", chatId: "chat-1" });
 

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -8,6 +8,23 @@ class ResizeObserverMock {
 
 vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 
+// jsdom does not implement matchMedia
+if (typeof window !== "undefined" && !window.matchMedia) {
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+}
+
 if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = vi.fn();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,6 +73,7 @@
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.0",
         "shiki": "^3.22.0",
+        "sileo": "^0.1.5",
         "streamdown": "^2.2.0",
         "tailwind-merge": "^3.4.0",
         "use-stick-to-bottom": "^1.1.3"
@@ -10700,6 +10701,33 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.34.3.tgz",
+      "integrity": "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.34.3",
+        "motion-utils": "^12.29.2",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
@@ -13604,6 +13632,47 @@
         "ufo": "^1.6.1"
       }
     },
+    "node_modules/motion": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion/-/motion-12.34.3.tgz",
+      "integrity": "sha512-xZIkBGO7v/Uvm+EyaqYd+9IpXu0sZqLywVlGdCFrrMiaO9JI4Kx51mO9KlHSWwll+gZUVY5OJsWgYI5FywJ/tw==",
+      "license": "MIT",
+      "dependencies": {
+        "framer-motion": "^12.34.3",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.34.3",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.34.3.tgz",
+      "integrity": "sha512-sYgFe+pR9aIM7o4fhs2aXtOI+oqlUd33N9Yoxcgo1Fv7M20sRkHtCmzE/VRNIcq7uNJ+qio+Xubt1FXH3pQ+eQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.29.2"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.29.2",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.29.2.tgz",
+      "integrity": "sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==",
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -15675,6 +15744,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/sileo": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/sileo/-/sileo-0.1.5.tgz",
+      "integrity": "sha512-Fc/3VNFWgQlZttkyvAdnPlzWrLTaii6FIas7nMivlx3uGuKpuNNRZGtSgNRFqTHFn70ZxEjKYxsBIO0nQlDGAg==",
+      "license": "MIT",
+      "dependencies": {
+        "motion": "^12.34.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/sisteransi": {


### PR DESCRIPTION
## Summary
- add in-app toast notifications (Sileo) in `App` with a dedicated `useNotificationToasts` bridge
- add global websocket listeners in `ws-transport` to react to background workspace events
- add a local toggle for in-app toasts in Notification Settings (localStorage-backed)
- support session targeting from toasts via `setSavedSession` in conversation state
- add comprehensive frontend regression tests for toast behavior, global ws listeners, and local-toggle persistence

## Test Plan
- `npm test`
- `npm run typecheck`
- `cd frontend && npx vitest run tests/hooks/useNotificationToasts.test.tsx tests/pages/NotificationSettings.test.tsx tests/lib/ws-transport.test.ts tests/App.test.tsx`

## Notes
- this PR includes the feature commits already present on the branch plus the new test coverage commit.
