### PR TITLE
fix: audit review — reliability, observability, and graceful shutdown

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -732,6 +732,15 @@ export function getStreamingSessionIds(wsId: string): string[] {
     .map((s) => s.sessionId);
 }
 
+/** Park all in-memory sessions (for graceful shutdown). */
+export function stopAllSessions(): void {
+  for (const sessions of loadedSessionsByWorkspace.values()) {
+    for (const session of sessions.values()) {
+      session.stop("park");
+    }
+  }
+}
+
 // ── Test helpers ────────────────────────────────────────────────────
 
 /** For testing: clear all active sessions. */

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -617,7 +617,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       this._metadata.updatedAt = new Date().toISOString();
       this.persistQueue = this.persistQueue
         .then(() => this.saveMetadata())
-        .catch(() => {});
+        .catch((err) => console.error("[session] Persist metadata failed:", err));
 
       const unansweredBlockingTools = killedForBlockingTool
         ? toolCalls.filter((tc) => blockingToolNames.has(tc.name))
@@ -746,7 +746,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this._metadata.updatedAt = new Date().toISOString();
     this.persistQueue = this.persistQueue
       .then(() => this.saveMetadata())
-      .catch(() => {});
+      .catch((err) => console.error("[session] Persist metadata failed:", err));
   }
 
   private async appendMessage(msg: ChatMessage): Promise<void> {
@@ -754,15 +754,15 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       await mkdir(this.sessionDir, { recursive: true });
       const messagesPath = join(this.sessionDir, "messages.jsonl");
       await appendFile(messagesPath, JSON.stringify(msg) + "\n", "utf-8");
-    } catch {
-      // Non-fatal
+    } catch (err) {
+      console.error("[session] appendMessage failed:", err);
     }
   }
 
   private enqueuePersist(msg: ChatMessage): Promise<void> {
     this.persistQueue = this.persistQueue
       .then(() => this.appendMessage(msg))
-      .catch(() => {});
+      .catch((err) => console.error("[session] Persist message failed:", err));
     return this.persistQueue;
   }
 
@@ -775,8 +775,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       await mkdir(this.sessionDir, { recursive: true });
       const metaPath = join(this.sessionDir, "metadata.json");
       await writeFile(metaPath, JSON.stringify(this._metadata, null, 2), "utf-8");
-    } catch {
-      // Non-fatal
+    } catch (err) {
+      console.error("[session] saveMetadata failed:", err);
     }
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -10,8 +10,8 @@ import { sessionRoutes } from "./api/agents.js";
 import { streamRoutes } from "./ws/stream.js";
 import { createAuthHook } from "./utils/auth.js";
 import { createRateLimitHook } from "./utils/rate-limit.js";
-import { ensureDataDir, getDataDir } from "./state/state.js";
-import { type SessionOptions, rebuildNotifier } from "./agents/agent-manager.js";
+import { ensureDataDir, getDataDir, loadAllProjects, saveProject } from "./state/state.js";
+import { type SessionOptions, rebuildNotifier, stopAllSessions } from "./agents/agent-manager.js";
 import { GitSyncService } from "./services/git-sync.js";
 import { settingsRoutes } from "./api/settings.js";
 import { agentSettingsRoutes } from "./api/agents-settings.js";
@@ -27,6 +27,7 @@ import { broadcastToWorkspace } from "./ws/stream.js";
 import type { StreamRoutesOptions } from "./ws/stream.js";
 import { preflight } from "./utils/preflight.js";
 import { detectAvailableProviders } from "./agents/providers/registry.js";
+import { stopAllScripts } from "./services/script-runner.js";
 
 const HOST = process.env.HOST ?? "127.0.0.1";
 const PORT = Number(process.env.PORT ?? 3000);
@@ -114,12 +115,35 @@ export async function buildApp(opts: BuildAppOptions = {}) {
 
 const BRANCH_SYNC_INTERVAL_MS = 10_000;
 
+/** Reset workspaces left in "busy" state from a previous unclean shutdown. */
+async function reconcileStaleWorkspaces(dataDir: string): Promise<void> {
+  const projects = await loadAllProjects(dataDir);
+  let fixed = 0;
+  for (const project of projects) {
+    let dirty = false;
+    for (const ws of project.workspaces) {
+      if (ws.status === "busy") {
+        ws.status = "idle";
+        dirty = true;
+        fixed++;
+      }
+    }
+    if (dirty) {
+      await saveProject(project, dataDir);
+    }
+  }
+  if (fixed > 0) {
+    console.log(`[server] Reconciled ${fixed} stale busy workspace(s) to idle`);
+  }
+}
+
 async function main() {
   await preflight();
   await detectAvailableProviders();
 
   const dataDir = getDataDir();
   await ensureDataDir(dataDir);
+  await reconcileStaleWorkspaces(dataDir);
 
   const config = await loadConfig(dataDir);
   rebuildNotifier(config);
@@ -150,6 +174,26 @@ async function main() {
   await scheduler.start();
 
   await app.listen({ host: HOST, port: PORT });
+
+  // Graceful shutdown on SIGTERM/SIGINT
+  let shuttingDown = false;
+  const shutdown = async (signal: string) => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    console.log(`[server] ${signal} received, shutting down...`);
+
+    stopAllSessions();
+    stopAllScripts();
+
+    await app.close();
+
+    // Give persist queues a moment to flush
+    await new Promise((r) => setTimeout(r, 1000));
+    process.exit(0);
+  };
+
+  process.on("SIGTERM", () => void shutdown("SIGTERM"));
+  process.on("SIGINT", () => void shutdown("SIGINT"));
 }
 
 main().catch((err) => {

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -182,8 +182,13 @@ export class AutomationScheduler {
     // Inject git context for project-linked automations
     if (auto.projectId) {
       const project = await loadProject(auto.projectId, this.dataDir);
+      if (!project) {
+        const error = `Project ${auto.projectId} not found (deleted?)`;
+        await this.completeRun(auto, run.id, "failure", undefined, error, now);
+        return { ...run, status: "failure", error };
+      }
       const ctx = await getGitContext(workspacePath, defaultBranch);
-      const gitBlock = formatGitContextBlock(ctx, { projectName: project?.name });
+      const gitBlock = formatGitContextBlock(ctx, { projectName: project.name });
       systemPrompt = systemPrompt ? systemPrompt + "\n\n" + gitBlock : gitBlock;
     }
 
@@ -204,7 +209,8 @@ export class AutomationScheduler {
     if (systemPrompt) {
       const sessDir = join(autoDir, "sessions", run.sessionId);
       await mkdir(sessDir, { recursive: true });
-      await writeFile(join(sessDir, "system-prompt.txt"), systemPrompt, "utf-8").catch(() => {});
+      await writeFile(join(sessDir, "system-prompt.txt"), systemPrompt, "utf-8")
+        .catch((err) => console.error("[scheduler] Persist system prompt failed:", err));
     }
 
     // Listen for completion
@@ -274,8 +280,13 @@ export class AutomationScheduler {
         await git(["checkout", defaultBranch], wsPath);
         await git(["reset", "--hard", `origin/${defaultBranch}`], wsPath);
         return { workspacePath: wsPath, defaultBranch };
-      } catch {
-        // Does not exist — create worktree
+      } catch (err) {
+        // Only treat "not a git repo" / missing directory as "needs worktree creation"
+        const msg = err instanceof Error ? err.message : "";
+        const isNotExists =
+          /not a git repository/i.test(msg) || /no such file or directory/i.test(msg);
+        if (!isNotExists) throw err;
+
         await mkdir(join(this.dataDir, "automations", auto.id), { recursive: true });
         const defaultBranch = await resolveDefaultBranch(bareRepo);
         await git(["worktree", "add", wsPath, defaultBranch], bareRepo);

--- a/backend/src/services/script-runner.ts
+++ b/backend/src/services/script-runner.ts
@@ -154,6 +154,15 @@ export function getScriptProcess(wsId: string, type: ScriptType): ScriptProcess 
   return activeScripts.get(key(wsId, type));
 }
 
+/** Stop all running scripts across all workspaces (for graceful shutdown). */
+export function stopAllScripts(): void {
+  for (const k of [...activeScripts.keys()]) {
+    const [wsId, ...rest] = k.split(":");
+    const type = rest.join(":");
+    if (wsId && type) stopScript(wsId, type);
+  }
+}
+
 /** For test cleanup. */
 export function _clearAll(): void {
   for (const proc of activeScripts.values()) {

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -255,8 +255,10 @@ class WsTransport {
       try {
         const envelope = JSON.parse(event.data as string) as HubOutgoing;
         this.handleIncomingEnvelope(envelope);
-      } catch {
-        // Ignore malformed messages
+      } catch (err) {
+        if (import.meta.env.DEV) {
+          console.warn("[ws] Failed to parse message:", err);
+        }
       }
     };
 

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -128,6 +128,10 @@ export default function WorkspaceView() {
 
   // Sidebar split: fraction of height given to file tree (vs ScriptPanel)
   const splitContainerRef = useRef<HTMLDivElement>(null);
+  const pointerHandlersRef = useRef<{
+    move: (e: PointerEvent) => void;
+    up: (e: PointerEvent) => void;
+  } | null>(null);
   const [sidebarSplit, setSidebarSplit] = useState<number>(() => {
     const stored = localStorage.getItem("sidebar-split");
     const parsed = stored ? parseFloat(stored) : NaN;
@@ -322,13 +326,27 @@ export default function WorkspaceView() {
         setIsDraggingSplit(false);
         document.removeEventListener("pointermove", onPointerMove);
         document.removeEventListener("pointerup", onPointerUp);
+        pointerHandlersRef.current = null;
       };
 
+      pointerHandlersRef.current = { move: onPointerMove, up: onPointerUp };
       document.addEventListener("pointermove", onPointerMove);
       document.addEventListener("pointerup", onPointerUp);
     },
     [],
   );
+
+  // Clean up leaked pointer listeners on unmount (e.g. navigate mid-drag)
+  useEffect(() => {
+    return () => {
+      const handlers = pointerHandlersRef.current;
+      if (handlers) {
+        document.removeEventListener("pointermove", handlers.move);
+        document.removeEventListener("pointerup", handlers.up);
+        pointerHandlersRef.current = null;
+      }
+    };
+  }, []);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -737,6 +755,7 @@ export default function WorkspaceView() {
             <div
               role="separator"
               aria-orientation="horizontal"
+              aria-label="Resize panel"
               className="group relative h-1.5 shrink-0 cursor-row-resize select-none"
               onPointerDown={handleDividerPointerDown}
             >


### PR DESCRIPTION
## Summary

Addresses findings from the codebase audit — focused on reliability, observability, and crash recovery.

- **Silent error logging**: Replace 6 silent `catch(() => {})` / `catch { // Non-fatal }` blocks with `console.error` logging in `conversation-session.ts` and `automation-scheduler.ts`. Disk-full or permission-denied conditions are now visible in server logs instead of silently dropping data.
- **Divider pointer listener leak**: `WorkspaceView` drag handlers now track refs and clean up on unmount, preventing leaked `pointermove`/`pointerup` listeners when navigating mid-drag. Also adds `aria-label="Resize panel"` on the separator.
- **Automation error handling**: Bare `catch` in workspace setup now distinguishes "not a git repo / missing directory" from permission errors, corrupt git state, etc. — re-throws the latter instead of silently attempting a `worktree add`. Null project guard fails the run early with a clear error message instead of injecting `undefined` into the agent's system prompt.
- **WS dev logging**: Malformed WebSocket message parsing now logs `console.warn` in development mode (`import.meta.env.DEV`) — zero production impact, surfaces protocol bugs during dev.
- **Graceful SIGTERM/SIGINT shutdown**: New `stopAllSessions()` and `stopAllScripts()` functions park all agent sessions and kill all PTY scripts. Process signal handlers trigger Fastify close and allow persist queues to flush before exit.
- **Startup reconciliation**: `reconcileStaleWorkspaces()` runs before route registration on boot — scans all projects and resets any workspaces stuck in `busy` state from a previous unclean shutdown.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 2154/2154 tests pass, zero regressions
- [ ] Manual: start server, kill with SIGTERM, verify log output and workspaces reset to idle on restart
- [ ] Manual: start dragging panel divider, navigate away, verify no leaked listeners in DevTools