### PR TITLE
fix: harden automation failure handling + regression coverage

### DIFF
--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -17,6 +17,7 @@ import {
   activateSession,
   hardDeleteSession,
   getSpecificSessionMessages,
+  stopAllSessions,
   _clearActiveSessions,
   setNotifier,
 } from "./agent-manager.js";
@@ -268,6 +269,25 @@ describe("stopStreaming", () => {
 
   it("throws when no session exists", () => {
     expect(() => stopStreaming(wsId)).toThrow("No active session");
+  });
+});
+
+describe("stopAllSessions", () => {
+  it("parks all loaded sessions across workspaces", async () => {
+    const otherWs = await createWorkspace(projectId, dataDir);
+    const { session: sessionA } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    const { session: sessionB } = await getOrCreateSession(otherWs.id, dataDir, CONV_CMD);
+    const stopA = vi.spyOn(sessionA, "stop");
+    const stopB = vi.spyOn(sessionB, "stop");
+
+    stopAllSessions();
+
+    expect(stopA).toHaveBeenCalledWith("park");
+    expect(stopB).toHaveBeenCalledWith("park");
+  });
+
+  it("is a no-op when no sessions are loaded", () => {
+    expect(() => stopAllSessions()).not.toThrow();
   });
 });
 

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -506,6 +506,76 @@ describe("AutomationScheduler", () => {
 
       scheduler.stop();
     });
+
+    it("creates a worktree when existing workspace path is not a git repo", async () => {
+      const { loadProject } = await import("../state/state.js");
+      const { git } = await import("../utils/git.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+      vi.mocked(git).mockImplementationOnce(async () => {
+        throw new Error("not a git repository");
+      });
+
+      const auto = makeAutomation({ projectId: "proj-1" });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("success");
+      expect(git).toHaveBeenCalledWith(
+        ["worktree", "add", expect.stringContaining("/workspace"), "main"],
+        "/tmp/bare",
+      );
+
+      scheduler.stop();
+    });
+
+    it("marks run as failure when workspace setup throws unexpected git errors", async () => {
+      const { loadProject } = await import("../state/state.js");
+      const { git } = await import("../utils/git.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+      vi.mocked(git).mockImplementationOnce(async () => {
+        throw new Error("Permission denied");
+      });
+
+      const auto = makeAutomation({
+        projectId: "proj-1",
+        notification: { onComplete: false, onFailure: false },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("failure");
+      expect(run.error).toContain("Permission denied");
+      const persistedRuns = await loadRuns("auto-1", dataDir);
+      expect(persistedRuns[0]?.status).toBe("failure");
+      expect(persistedRuns[0]?.error).toContain("Permission denied");
+
+      scheduler.stop();
+    });
+
+    it("fails cleanly when project is deleted between workspace setup and git-context injection", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject)
+        .mockResolvedValueOnce({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never)
+        .mockResolvedValueOnce(null as never);
+
+      const auto = makeAutomation({
+        projectId: "proj-1",
+        notification: { onComplete: false, onFailure: false },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("failure");
+      expect(run.error).toBe("Project proj-1 not found (deleted?)");
+
+      scheduler.stop();
+    });
   });
 
   describe("git context injection", () => {

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -155,7 +155,15 @@ export class AutomationScheduler {
     await addRun(autoId, run, this.dataDir);
 
     // Ensure workspace
-    const { workspacePath, defaultBranch } = await this.ensureWorkspace(auto);
+    let workspacePath: string;
+    let defaultBranch: string | undefined;
+    try {
+      ({ workspacePath, defaultBranch } = await this.ensureWorkspace(auto));
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      await this.completeRun(auto, run.id, "failure", undefined, error, now);
+      return { ...run, status: "failure", error };
+    }
 
     // Update automation with workspace path if needed
     if (!auto.workspacePath) {

--- a/backend/src/services/script-runner.test.ts
+++ b/backend/src/services/script-runner.test.ts
@@ -77,6 +77,7 @@ import {
   startScript,
   stopScript,
   stopAllForWorkspace,
+  stopAllScripts,
   getScriptStatus,
   getScriptProcess,
   _clearAll,
@@ -296,6 +297,20 @@ describe("script-runner", () => {
     expect(getScriptProcess("ws-1", "setup")).toBeUndefined();
     expect(getScriptProcess("ws-1", "backend")).toBeUndefined();
     expect(getScriptProcess("ws-1", "frontend")).toBeUndefined();
+  });
+
+  it("stops all scripts across all workspaces", () => {
+    startScript("ws-1", "setup", "npm ci", "/tmp/workspace");
+    startScript("ws-1", "run:watch", "npm run dev", "/tmp/workspace");
+    startScript("ws-2", "backend", "npm run dev", "/tmp/workspace");
+
+    stopAllScripts();
+
+    expect(mocks.processes[0]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[1]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[2]?.kill).toHaveBeenCalledTimes(1);
+    expect(Object.keys(getScriptStatus("ws-1"))).toHaveLength(0);
+    expect(Object.keys(getScriptStatus("ws-2"))).toHaveLength(0);
   });
 
   it("clears all active scripts during test cleanup", () => {

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -212,6 +212,7 @@ describe("wsTransport", () => {
   });
 
   it("dispatches parsed incoming messages to handlers (via hub envelope)", () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
@@ -225,6 +226,10 @@ describe("wsTransport", () => {
     socket.message("not-json");
 
     expect(received).toEqual([{ type: "status", status: "idle", streaming: false }]);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[ws] Failed to parse message:",
+      expect.any(SyntaxError),
+    );
     unsubscribe();
   });
 

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -1566,6 +1566,14 @@ describe("WorkspaceView sidebar split resize", () => {
     expect(separator.className).toContain("cursor-row-resize");
   });
 
+  it("adds an accessible label on the drag handle", async () => {
+    setupMocks(SCRIPTS_CONFIG);
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.getByRole("separator", { name: "Resize panel" })).toBeInTheDocument();
+  });
+
   it("initializes split from localStorage", async () => {
     localStorage.setItem("sidebar-split", "0.3");
     setupMocks(SCRIPTS_CONFIG);
@@ -1702,6 +1710,35 @@ describe("WorkspaceView sidebar split resize", () => {
     });
 
     fireEvent(document, new PointerEvent("pointerup", { clientX: 210, clientY: 280, bubbles: true }));
+  });
+
+  it("removes document pointer listeners when unmounting mid-drag", async () => {
+    setupMocks(SCRIPTS_CONFIG);
+    const view = renderWorkspace();
+    await screen.findByText("tokyo");
+
+    const separator = screen.getByRole("separator");
+    const container = separator.parentElement as HTMLElement;
+    vi.spyOn(container, "getBoundingClientRect").mockReturnValue({
+      top: 0, left: 0, bottom: 400, right: 420,
+      width: 420, height: 400,
+      x: 0, y: 0, toJSON: () => {},
+    });
+
+    const addSpy = vi.spyOn(document, "addEventListener");
+    const removeSpy = vi.spyOn(document, "removeEventListener");
+
+    fireEvent.pointerDown(separator, { clientX: 210, clientY: 200 });
+
+    const pointerMoveHandler = addSpy.mock.calls.find((call) => call[0] === "pointermove")?.[1];
+    const pointerUpHandler = addSpy.mock.calls.find((call) => call[0] === "pointerup")?.[1];
+    expect(pointerMoveHandler).toBeDefined();
+    expect(pointerUpHandler).toBeDefined();
+
+    view.unmount();
+
+    expect(removeSpy).toHaveBeenCalledWith("pointermove", pointerMoveHandler);
+    expect(removeSpy).toHaveBeenCalledWith("pointerup", pointerUpHandler);
   });
 
   it("file tree uses split sizing even when no scripts are configured", async () => {


### PR DESCRIPTION
## Summary
- mark automation runs as `failure` when workspace setup fails unexpectedly, instead of leaving runs stuck in `running`
- add regression tests for automation workspace setup error paths and deleted-project guard
- add coverage for graceful shutdown helpers (`stopAllSessions`, `stopAllScripts`)
- add frontend regression tests for:
  - WS malformed message DEV warning behavior
  - workspace split separator accessibility label
  - pointer listener cleanup on unmount during drag

## Why
A run could remain stuck if git workspace setup threw a non-recoverable error. This change makes failure state explicit and persisted.

## Testing
- `npm test --workspace @hive/backend --workspace @hive/frontend`
- all tests passed:
  - backend: 61 files / 1130 tests
  - frontend: 85 files / 1032 tests
