### PR TITLE
perf: workspace index, per-automation locks, parallel git sync

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -500,6 +500,7 @@ async function createSession(
         currentBranch: ctx.workspace.branch,
         workspaceName: ctx.workspace.name,
         command: options?.command,
+        withBranchRenameLock: (fn) => withWorkspaceLock(ctx.workspace.id, fn),
       },
       (title: string) => session.setTitle(title),
     ).catch((err) => {

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -13,6 +13,7 @@ vi.mock("node:child_process", () => ({
 
 import { spawn } from "node:child_process";
 import { ConversationSession } from "./conversation-session.js";
+import * as providerRegistry from "./providers/registry.js";
 
 const mockSpawn = vi.mocked(spawn);
 
@@ -1421,6 +1422,16 @@ describe("ConversationSession", () => {
 
     session.sendMessage("Hello");
     expect(session.metadata.lockedProvider).toBe("claude");
+  });
+
+  it("resolves provider once per sendMessage call", () => {
+    const resolveSpy = vi.spyOn(providerRegistry, "resolveProvider");
+    const session = createSession({ sessionId: "resolve-once" });
+
+    session.sendMessage("Hello", { model: "claude:opus-4-6" });
+
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    expect(resolveSpy).toHaveBeenCalledWith("claude:opus-4-6");
   });
 
   it("throws when trying to switch providers mid-session", () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -9,7 +9,7 @@ import { resolveProvider } from "./providers/registry.js";
 import { CodexStreamAdapter } from "./providers/codex-stream-adapter.js";
 import { GeminiStreamAdapter } from "./providers/gemini-stream-adapter.js";
 import type { AgentProvider, StreamAdapter } from "./providers/types.js";
-import { buildWorkspaceEnv } from "../utils/env.js";
+import { buildWorkspaceEnv, DEBUG_AGENT_LOGS } from "../utils/env.js";
 import type {
   ChatMessage,
   ContentBlock,
@@ -25,9 +25,6 @@ import type {
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
 const MAX_ERROR_DETAIL_LENGTH = 280;
-const DEBUG_AGENT_LOGS = ["1", "true", "yes", "on"].includes(
-  (process.env.HIVE_DEBUG_AGENT_LOGS ?? "").trim().toLowerCase(),
-);
 
 /** Gemini CLI writes informational/retry messages to stderr; suppress these from error events. */
 const GEMINI_STDERR_NOISE = [
@@ -211,12 +208,13 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     }
 
     // Lock provider on first message, validate on subsequent messages
+    let resolved: { provider: AgentProvider; modelId: string } | undefined;
     if (!this.testCommand) {
-      const { provider: resolvedProvider } = resolveProvider(msgOptions?.model);
+      resolved = resolveProvider(msgOptions?.model);
 
       if (!this._metadata.lockedProvider) {
-        this._metadata.lockedProvider = resolvedProvider.id;
-      } else if (this._metadata.lockedProvider !== resolvedProvider.id) {
+        this._metadata.lockedProvider = resolved.provider.id;
+      } else if (this._metadata.lockedProvider !== resolved.provider.id) {
         throw new Error(`Provider mismatch: session locked to "${this._metadata.lockedProvider}"`);
       }
     }
@@ -236,7 +234,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           dataUrl: `/api/workspaces/${this.workspaceId}/sessions/${this.sessionId}/attachments/${s.filename}`,
         }));
         this.emitUserMessage(content, urlImages, fileMentions);
-        this.spawnCli(this.buildPromptWithImages(promptContent, saved.map((s) => s.path)), msgOptions);
+        this.spawnCli(this.buildPromptWithImages(promptContent, saved.map((s) => s.path)), msgOptions, resolved);
       }).catch((err) => {
         this._status = "error";
         this._streamingStartedAt = null;
@@ -244,7 +242,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       });
     } else {
       this.emitUserMessage(content, undefined, fileMentions);
-      this.spawnCli(promptContent, msgOptions);
+      this.spawnCli(promptContent, msgOptions, resolved);
     }
   }
 
@@ -312,13 +310,17 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   /** Spawn a CLI process for a single turn, delegating to the resolved provider. */
-  private spawnCli(content: string, msgOptions?: MessageOptions): void {
+  private spawnCli(
+    content: string,
+    msgOptions?: MessageOptions,
+    preResolved?: { provider: AgentProvider; modelId: string },
+  ): void {
     const isFirstMessage = this.messageCount === 1;
 
-    // Resolve which provider handles this model
+    // Use pre-resolved provider when available, otherwise resolve fresh
     const { provider, modelId } = this.testCommand
       ? { provider: null as AgentProvider | null, modelId: "" }
-      : resolveProvider(msgOptions?.model);
+      : (preResolved ?? resolveProvider(msgOptions?.model));
 
     // Pre-generate a session ID for CLI continuity
     if (!this.cliSessionId) {

--- a/backend/src/agents/naming.test.ts
+++ b/backend/src/agents/naming.test.ts
@@ -327,6 +327,76 @@ describe("runNamingTask", () => {
     expect(mockGit).not.toHaveBeenCalledWith(["branch", "-m", "valid-name"], "/tmp/workspace");
   });
 
+  it("runs rename inside withBranchRenameLock when provided", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    queueMicrotask(() => {
+      proc._stdout.emit("data", Buffer.from(JSON.stringify({
+        branch_name: "valid-name",
+        session_title: "Valid title",
+      })));
+      proc.emit("close", 0);
+    });
+
+    mockGit
+      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "workspace/hyderabad", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    const order: string[] = [];
+    let lockCalls = 0;
+    const withBranchRenameLock: NonNullable<Parameters<typeof runNamingTask>[0]["withBranchRenameLock"]> = async <T>(fn: () => Promise<T>) => {
+      lockCalls++;
+      order.push("lock-start");
+      const result = await fn();
+      order.push("lock-end");
+      return result;
+    };
+
+    await runNamingTask(
+      { ...baseContext("claude"), withBranchRenameLock },
+      vi.fn(),
+    );
+
+    expect(lockCalls).toBe(1);
+    expect(order).toEqual(["lock-start", "lock-end"]);
+    expect(mockGit).toHaveBeenNthCalledWith(
+      2,
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      "/tmp/workspace",
+    );
+    expect(mockGit).toHaveBeenNthCalledWith(
+      3,
+      ["branch", "-m", "valid-name"],
+      "/tmp/workspace",
+    );
+  });
+
+  it("does not call withBranchRenameLock when rename is skipped", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    queueMicrotask(() => {
+      proc._stdout.emit("data", Buffer.from(JSON.stringify({
+        branch_name: "valid-name",
+        session_title: "Valid title",
+      })));
+      proc.emit("close", 0);
+    });
+
+    let lockCalls = 0;
+    const withBranchRenameLock: NonNullable<Parameters<typeof runNamingTask>[0]["withBranchRenameLock"]> = async <T>(fn: () => Promise<T>) => {
+      lockCalls++;
+      return fn();
+    };
+
+    await runNamingTask(
+      { ...baseContext("claude"), currentBranch: "feature/manual", withBranchRenameLock },
+      vi.fn(),
+    );
+
+    expect(lockCalls).toBe(0);
+  });
+
   it("swallows rev-parse failure and does not rename", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/naming.ts
+++ b/backend/src/agents/naming.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { git } from "../utils/git.js";
-import { buildWorkspaceEnv } from "../utils/env.js";
+import { buildWorkspaceEnv, DEBUG_AGENT_LOGS } from "../utils/env.js";
 
 export interface NamingContext {
   userMessage: string;
@@ -9,6 +9,7 @@ export interface NamingContext {
   currentBranch: string;
   workspaceName: string;
   command?: string;
+  withBranchRenameLock?: <T>(fn: () => Promise<T>) => Promise<T>;
 }
 
 export interface NamingResult {
@@ -38,9 +39,6 @@ Rules for session_title:
 - No commit-style prefixes (Add, Fix, Update, Refactor)`;
 
 const TIMEOUT_MS = 15_000;
-const DEBUG_AGENT_LOGS = ["1", "true", "yes", "on"].includes(
-  (process.env.HIVE_DEBUG_AGENT_LOGS ?? "").trim().toLowerCase(),
-);
 
 const PREFIX_PATTERN = /^(?:feat|fix|chore|docs|refactor|test|style|perf|ci|build|workspace)\//;
 
@@ -174,23 +172,30 @@ export async function runNamingTask(
 
     const existing = await listExistingBranches(ctx.bareRepo);
     const finalName = ensureUniqueBranch(sanitized, existing);
-
-    // Guard: branch may have been renamed manually in the meantime
-    try {
-      const { stdout: currentBranch } = await git(["rev-parse", "--abbrev-ref", "HEAD"], ctx.cwd);
-      if (!currentBranch.startsWith("workspace/")) {
-        if (DEBUG_AGENT_LOGS) {
-          console.log("[naming] branch already renamed, skipping:", currentBranch);
+    const renameIfStillWorkspaceBranch = async (): Promise<void> => {
+      // Guard: branch may have been renamed manually in the meantime
+      try {
+        const { stdout: currentBranch } = await git(["rev-parse", "--abbrev-ref", "HEAD"], ctx.cwd);
+        if (!currentBranch.startsWith("workspace/")) {
+          if (DEBUG_AGENT_LOGS) {
+            console.log("[naming] branch already renamed, skipping:", currentBranch);
+          }
+          return;
         }
+      } catch {
         return;
       }
-    } catch {
-      return;
-    }
 
-    await git(["branch", "-m", finalName], ctx.cwd);
-    if (DEBUG_AGENT_LOGS) {
-      console.log(`[naming] renamed branch: ${ctx.currentBranch} → ${finalName}`);
+      await git(["branch", "-m", finalName], ctx.cwd);
+      if (DEBUG_AGENT_LOGS) {
+        console.log(`[naming] renamed branch: ${ctx.currentBranch} → ${finalName}`);
+      }
+    };
+
+    if (ctx.withBranchRenameLock) {
+      await ctx.withBranchRenameLock(renameIfStillWorkspaceBranch);
+    } else {
+      await renameIfStillWorkspaceBranch();
     }
   }
 }

--- a/backend/src/agents/stream-parser.ts
+++ b/backend/src/agents/stream-parser.ts
@@ -1,9 +1,6 @@
 import { EventEmitter } from "node:events";
 import type { CliJsonLine } from "../types.js";
-
-const DEBUG_AGENT_LOGS = ["1", "true", "yes", "on"].includes(
-  (process.env.HIVE_DEBUG_AGENT_LOGS ?? "").trim().toLowerCase(),
-);
+import { DEBUG_AGENT_LOGS } from "../utils/env.js";
 
 export type StreamParserEvent = {
   assistant: [data: Extract<CliJsonLine, { type: "assistant" }>];

--- a/backend/src/api/workspaces.pr-status.test.ts
+++ b/backend/src/api/workspaces.pr-status.test.ts
@@ -239,6 +239,69 @@ describe("GET /api/workspaces/:wsId/pr-status", () => {
     nowSpy.mockRestore();
   });
 
+  it("invalidates cached PR status after workspace deletion", async () => {
+    mocks.fetchPrForBranch
+      .mockResolvedValueOnce({ pr: makePr({ number: 1 }) })
+      .mockResolvedValueOnce({ pr: makePr({ number: 2 }) });
+    mocks.deleteWorkspace.mockResolvedValueOnce(undefined);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(100_000);
+
+    await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
+    });
+    expect(mocks.fetchPrForBranch).toHaveBeenCalledTimes(1);
+
+    const del = await app.inject({
+      method: "DELETE",
+      url: `/api/workspaces/${WORKSPACE_ID}`,
+    });
+    expect(del.statusCode).toBe(204);
+
+    const afterDelete = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
+    });
+
+    expect(afterDelete.statusCode).toBe(200);
+    expect(afterDelete.json()).toEqual({ pr: makePr({ number: 2 }) });
+    expect(mocks.fetchPrForBranch).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
+  it("invalidates cached PR status after workspace archival", async () => {
+    mocks.fetchPrForBranch
+      .mockResolvedValueOnce({ pr: makePr({ number: 10 }) })
+      .mockResolvedValueOnce({ pr: makePr({ number: 11 }) });
+    mocks.endSession.mockResolvedValueOnce(undefined);
+    mocks.archiveWorkspace.mockResolvedValueOnce(undefined);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(200_000);
+
+    await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
+    });
+    expect(mocks.fetchPrForBranch).toHaveBeenCalledTimes(1);
+
+    const archived = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WORKSPACE_ID}/archive`,
+    });
+    expect(archived.statusCode).toBe(204);
+
+    const afterArchive = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
+    });
+
+    expect(afterArchive.statusCode).toBe(200);
+    expect(afterArchive.json()).toEqual({ pr: makePr({ number: 11 }) });
+    expect(mocks.fetchPrForBranch).toHaveBeenCalledTimes(2);
+
+    nowSpy.mockRestore();
+  });
+
   it("returns 500 when an unexpected error bubbles up", async () => {
     mocks.fetchPrForBranch.mockRejectedValueOnce(new Error("boom"));
 

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -94,6 +94,7 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
   app.delete<{ Params: { wsId: string } }>("/api/workspaces/:wsId", async (req, reply) => {
     try {
       await deleteWorkspace(req.params.wsId, dataDir);
+      prCache.delete(req.params.wsId);
       return reply.status(204).send();
     } catch (err: unknown) {
       return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed") });
@@ -281,6 +282,7 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       // End loaded sessions before archiving to avoid stale in-memory state.
       await endSession(req.params.wsId, dataDir);
       await archiveWorkspace(req.params.wsId, dataDir);
+      prCache.delete(req.params.wsId);
       return reply.status(204).send();
     } catch (err: unknown) {
       return reply

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ import type { StreamRoutesOptions } from "./ws/stream.js";
 import { preflight } from "./utils/preflight.js";
 import { detectAvailableProviders } from "./agents/providers/registry.js";
 import { stopAllScripts } from "./services/script-runner.js";
+import { initWorkspaceIndex } from "./state/workspace-index.js";
 
 const HOST = process.env.HOST ?? "127.0.0.1";
 const PORT = Number(process.env.PORT ?? 3000);
@@ -144,6 +145,7 @@ async function main() {
   const dataDir = getDataDir();
   await ensureDataDir(dataDir);
   await reconcileStaleWorkspaces(dataDir);
+  await initWorkspaceIndex(dataDir);
 
   const config = await loadConfig(dataDir);
   rebuildNotifier(config);

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -4,6 +4,7 @@ import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
 import { bareRepoPath } from "../utils/paths.js";
 import { saveProject, loadProject, loadAllProjects, getDataDir } from "../state/state.js";
+import { notifyProjectDeleted } from "../state/workspace-index.js";
 import { validateRepositoryUrl } from "../utils/repo-url.js";
 import { NotFoundError } from "../utils/errors.js";
 import type { ProjectState } from "../types.js";
@@ -62,6 +63,7 @@ export async function deleteProject(
 ): Promise<void> {
   const projectDir = join(dataDir, projectId);
   await rm(projectDir, { recursive: true, force: true });
+  notifyProjectDeleted(projectId);
 }
 
 export async function fetchProject(

--- a/backend/src/services/git-sync.test.ts
+++ b/backend/src/services/git-sync.test.ts
@@ -295,6 +295,57 @@ describe("GitSyncService", () => {
     expect(state!.workspaces.find((w) => w.id === ws3.id)!.branch).toBe("branch-three");
   });
 
+  it("ignores a concurrent poll call while one sync cycle is already running", async () => {
+    await createWorkspace(projectId, dataDir);
+
+    const serviceWithPrivateSync = service as unknown as {
+      syncWorkspace: (...args: unknown[]) => Promise<void>;
+    };
+    const originalSyncWorkspace = serviceWithPrivateSync.syncWorkspace.bind(serviceWithPrivateSync);
+    let releaseFirstSync: (() => void) | undefined;
+    const firstSyncGate = new Promise<void>((resolve) => {
+      releaseFirstSync = resolve;
+    });
+
+    const syncWorkspaceSpy = vi.spyOn(serviceWithPrivateSync, "syncWorkspace");
+    syncWorkspaceSpy.mockImplementationOnce(async (...args: unknown[]) => {
+      await firstSyncGate;
+      return originalSyncWorkspace(...args);
+    });
+
+    const firstPoll = service.poll();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const secondPoll = service.poll();
+
+    // Should resolve immediately because `syncing` is already true.
+    await expect(secondPoll).resolves.toBeUndefined();
+
+    releaseFirstSync?.();
+    await firstPoll;
+
+    expect(syncWorkspaceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("continues syncing healthy workspaces when one worktree is missing", async () => {
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws2 = await createWorkspace(projectId, dataDir);
+    const ws3 = await createWorkspace(projectId, dataDir);
+    const ws2Path = join(workspacesDir(dataDir, projectId), ws2.name);
+    const ws3Path = join(workspacesDir(dataDir, projectId), ws3.name);
+
+    await rm(ws2Path, { recursive: true, force: true });
+    await git(["branch", "-m", "healthy-branch"], ws3Path);
+
+    await expect(service.poll()).resolves.not.toThrow();
+
+    expect(service.getCachedBranchInfo(ws1.id)?.name).toBe(`workspace/${ws1.name}`);
+    expect(service.getCachedBranchInfo(ws2.id)).toBeUndefined();
+    expect(service.getCachedBranchInfo(ws3.id)?.name).toBe("healthy-branch");
+
+    const state = await loadProject(projectId, dataDir);
+    expect(state!.workspaces.find((w) => w.id === ws3.id)!.branch).toBe("healthy-branch");
+  });
+
   it("maintains independent caches per workspace", async () => {
     const ws1 = await createWorkspace(projectId, dataDir);
     const ws2 = await createWorkspace(projectId, dataDir);

--- a/backend/src/services/git-sync.test.ts
+++ b/backend/src/services/git-sync.test.ts
@@ -271,6 +271,30 @@ describe("GitSyncService", () => {
     expect(service.getCachedDiffStats(ws.id)).toBeUndefined();
   });
 
+  it("syncs all workspaces correctly with concurrent execution", async () => {
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws2 = await createWorkspace(projectId, dataDir);
+    const ws3 = await createWorkspace(projectId, dataDir);
+    const ws1Path = join(workspacesDir(dataDir, projectId), ws1.name);
+    const ws3Path = join(workspacesDir(dataDir, projectId), ws3.name);
+
+    // Rename branches on ws1 and ws3 to verify all workspaces are processed
+    await git(["branch", "-m", "branch-one"], ws1Path);
+    await git(["branch", "-m", "branch-three"], ws3Path);
+
+    await service.poll();
+
+    // All 3 workspaces were synced with correct data
+    expect(service.getCachedBranchInfo(ws1.id)?.name).toBe("branch-one");
+    expect(service.getCachedBranchInfo(ws2.id)?.name).toBe(`workspace/${ws2.name}`);
+    expect(service.getCachedBranchInfo(ws3.id)?.name).toBe("branch-three");
+
+    // Branch renames persisted to disk
+    const state = await loadProject(projectId, dataDir);
+    expect(state!.workspaces.find((w) => w.id === ws1.id)!.branch).toBe("branch-one");
+    expect(state!.workspaces.find((w) => w.id === ws3.id)!.branch).toBe("branch-three");
+  });
+
   it("maintains independent caches per workspace", async () => {
     const ws1 = await createWorkspace(projectId, dataDir);
     const ws2 = await createWorkspace(projectId, dataDir);

--- a/backend/src/services/git-sync.ts
+++ b/backend/src/services/git-sync.ts
@@ -13,6 +13,24 @@ import type { BranchInfo, DiffStatResponse, Workspace } from "../types.js";
 type BranchChangeCallback = (wsId: string, info: BranchInfo) => void;
 type DiffStatsChangeCallback = (wsId: string, stats: DiffStatResponse) => void;
 
+const GIT_SYNC_CONCURRENCY = 6;
+
+async function withConcurrency<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  const executing = new Set<Promise<void>>();
+  for (const item of items) {
+    const p = fn(item).finally(() => executing.delete(p));
+    executing.add(p);
+    if (executing.size >= limit) {
+      await Promise.race(executing);
+    }
+  }
+  await Promise.allSettled([...executing]);
+}
+
 export async function getBranchName(wsPath: string): Promise<string> {
   const { stdout } = await git(["rev-parse", "--abbrev-ref", "HEAD"], wsPath);
   return stdout;
@@ -76,14 +94,11 @@ export class GitSyncService {
           continue;
         }
 
-        for (const workspace of project.workspaces) {
-          await this.syncWorkspace(
-            project.id,
-            workspace,
-            bare,
-            defaultBranch,
-          );
-        }
+        await withConcurrency(
+          project.workspaces,
+          GIT_SYNC_CONCURRENCY,
+          (workspace) => this.syncWorkspace(project.id, workspace, bare, defaultBranch),
+        );
       }
     } finally {
       this.syncing = false;

--- a/backend/src/state/automations-extended.test.ts
+++ b/backend/src/state/automations-extended.test.ts
@@ -13,6 +13,8 @@ import {
   addRun,
   updateRun,
   withAutomationsLock,
+  withAutomationRunLock,
+  _clearAutomationLocksForTests,
 } from "./automations.js";
 import type { Automation, AutomationRun } from "../types.js";
 
@@ -50,6 +52,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  _clearAutomationLocksForTests();
   await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
 });
 
@@ -207,5 +210,67 @@ describe("loadRuns edge cases", () => {
   it("returns empty array for non-existent automation", async () => {
     const result = await loadRuns("nonexistent", dataDir);
     expect(result).toEqual([]);
+  });
+});
+
+describe("withAutomationRunLock", () => {
+  it("serializes concurrent addRun calls for the same automation", async () => {
+    const calls = Array.from({ length: 5 }, (_, i) =>
+      addRun("auto-1", makeRun({ id: `run-${i}`, automationId: "auto-1" }), dataDir),
+    );
+    await Promise.all(calls);
+
+    const loaded = await loadRuns("auto-1", dataDir);
+    expect(loaded).toHaveLength(5);
+    for (let i = 0; i < 5; i++) {
+      expect(loaded.find((r) => r.id === `run-${i}`)).toBeDefined();
+    }
+  });
+
+  it("allows concurrent addRun calls for different automations", async () => {
+    const calls = [
+      addRun("auto-1", makeRun({ id: "run-a", automationId: "auto-1" }), dataDir),
+      addRun("auto-2", makeRun({ id: "run-b", automationId: "auto-2" }), dataDir),
+      addRun("auto-3", makeRun({ id: "run-c", automationId: "auto-3" }), dataDir),
+    ];
+    await Promise.all(calls);
+
+    expect(await loadRuns("auto-1", dataDir)).toHaveLength(1);
+    expect(await loadRuns("auto-2", dataDir)).toHaveLength(1);
+    expect(await loadRuns("auto-3", dataDir)).toHaveLength(1);
+  });
+
+  it("serializes addRun and updateRun for the same automation", async () => {
+    await addRun("auto-1", makeRun({ id: "run-1", automationId: "auto-1" }), dataDir);
+
+    // Fire concurrent update + add
+    await Promise.all([
+      updateRun("auto-1", "run-1", { status: "failure" }, dataDir),
+      addRun("auto-1", makeRun({ id: "run-2", automationId: "auto-1" }), dataDir),
+    ]);
+
+    const loaded = await loadRuns("auto-1", dataDir);
+    expect(loaded).toHaveLength(2);
+    const run1 = loaded.find((r) => r.id === "run-1");
+    expect(run1?.status).toBe("failure");
+  });
+
+  it("releases lock even when inner function throws", async () => {
+    await expect(
+      withAutomationRunLock("auto-1", async () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    // Lock should be released — this should not deadlock
+    const result = await withAutomationRunLock("auto-1", async () => "ok");
+    expect(result).toBe("ok");
+  });
+
+  it("cleans up lock Map entry when queue drains", async () => {
+    await withAutomationRunLock("auto-1", async () => {});
+    // After the lock fully drains, _clearAutomationLocksForTests should be a no-op
+    // (the Map entry was already deleted by the cleanup in finally)
+    _clearAutomationLocksForTests();
   });
 });

--- a/backend/src/state/automations-extended.test.ts
+++ b/backend/src/state/automations-extended.test.ts
@@ -214,6 +214,44 @@ describe("loadRuns edge cases", () => {
 });
 
 describe("withAutomationRunLock", () => {
+  it("executes queued operations in FIFO order for the same automation", async () => {
+    const order: string[] = [];
+
+    await Promise.all([
+      withAutomationRunLock("auto-1", async () => {
+        order.push("first-start");
+        await new Promise((resolve) => setTimeout(resolve, 30));
+        order.push("first-end");
+      }),
+      withAutomationRunLock("auto-1", async () => {
+        order.push("second-start");
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        order.push("second-end");
+      }),
+    ]);
+
+    expect(order).toEqual(["first-start", "first-end", "second-start", "second-end"]);
+  });
+
+  it("does not block different automation IDs behind each other", async () => {
+    let firstEndedAt = 0;
+    let secondStartedAt = 0;
+    const base = Date.now();
+
+    await Promise.all([
+      withAutomationRunLock("auto-1", async () => {
+        await new Promise((resolve) => setTimeout(resolve, 60));
+        firstEndedAt = Date.now() - base;
+      }),
+      withAutomationRunLock("auto-2", async () => {
+        secondStartedAt = Date.now() - base;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }),
+    ]);
+
+    expect(secondStartedAt).toBeLessThan(firstEndedAt);
+  });
+
   it("serializes concurrent addRun calls for the same automation", async () => {
     const calls = Array.from({ length: 5 }, (_, i) =>
       addRun("auto-1", makeRun({ id: `run-${i}`, automationId: "auto-1" }), dataDir),
@@ -253,6 +291,36 @@ describe("withAutomationRunLock", () => {
     expect(loaded).toHaveLength(2);
     const run1 = loaded.find((r) => r.id === "run-1");
     expect(run1?.status).toBe("failure");
+  });
+
+  it("applies concurrent updates to the same run deterministically in call order", async () => {
+    await addRun("auto-1", makeRun({ id: "run-ordered", automationId: "auto-1" }), dataDir);
+
+    await Promise.all([
+      updateRun("auto-1", "run-ordered", { status: "failure" }, dataDir),
+      updateRun("auto-1", "run-ordered", { status: "success" }, dataDir),
+      updateRun("auto-1", "run-ordered", { status: "failure" }, dataDir),
+    ]);
+
+    const loaded = await loadRuns("auto-1", dataDir);
+    const run = loaded.find((r) => r.id === "run-ordered");
+    expect(run?.status).toBe("failure");
+  });
+
+  it("handles high-concurrency addRun without lost writes and keeps max cap", async () => {
+    const calls = Array.from({ length: 80 }, (_, i) =>
+      addRun("auto-1", makeRun({ id: `run-${i}`, automationId: "auto-1" }), dataDir),
+    );
+    await Promise.all(calls);
+
+    const loaded = await loadRuns("auto-1", dataDir);
+    expect(loaded).toHaveLength(50);
+
+    // With newest-first ordering and MAX_RUNS=50, retained IDs are run-79..run-30
+    for (let i = 79; i >= 30; i--) {
+      expect(loaded.find((r) => r.id === `run-${i}`)).toBeDefined();
+    }
+    expect(loaded.find((r) => r.id === "run-29")).toBeUndefined();
   });
 
   it("releases lock even when inner function throws", async () => {

--- a/backend/src/state/automations.ts
+++ b/backend/src/state/automations.ts
@@ -6,6 +6,8 @@ import type { Automation, AutomationRun } from "../types.js";
 
 const MAX_RUNS = 50;
 
+// Global lock for automations.json (shared array of all automation definitions).
+// CRUD operations must serialize on this because they load-modify-save the same file.
 let automationsLock: Promise<void> = Promise.resolve();
 
 export async function withAutomationsLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -22,6 +24,38 @@ export async function withAutomationsLock<T>(fn: () => Promise<T>): Promise<T> {
   } finally {
     release?.();
   }
+}
+
+// Per-automation lock for runs.json (each automation has its own file at
+// ~/.hive/automations/<autoId>/runs.json). This allows concurrent run
+// writes for different automations without blocking each other.
+const runLocks = new Map<string, Promise<void>>();
+
+export async function withAutomationRunLock<T>(
+  automationId: string,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const prev = runLocks.get(automationId) ?? Promise.resolve();
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = prev.then(() => current);
+  runLocks.set(automationId, queued);
+
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release?.();
+    if (runLocks.get(automationId) === queued) {
+      runLocks.delete(automationId);
+    }
+  }
+}
+
+export function _clearAutomationLocksForTests(): void {
+  runLocks.clear();
 }
 
 function automationsFilePath(dataDir: string): string {
@@ -87,11 +121,13 @@ export async function addRun(
   run: AutomationRun,
   dataDir = getDataDir(),
 ): Promise<void> {
-  const runs = await loadRuns(automationId, dataDir);
-  runs.unshift(run);
-  // Cap at MAX_RUNS, keeping newest first
-  if (runs.length > MAX_RUNS) runs.length = MAX_RUNS;
-  await saveRuns(automationId, runs, dataDir);
+  return withAutomationRunLock(automationId, async () => {
+    const runs = await loadRuns(automationId, dataDir);
+    runs.unshift(run);
+    // Cap at MAX_RUNS, keeping newest first
+    if (runs.length > MAX_RUNS) runs.length = MAX_RUNS;
+    await saveRuns(automationId, runs, dataDir);
+  });
 }
 
 export async function updateRun(
@@ -100,9 +136,11 @@ export async function updateRun(
   updates: Partial<AutomationRun>,
   dataDir = getDataDir(),
 ): Promise<void> {
-  const runs = await loadRuns(automationId, dataDir);
-  const idx = runs.findIndex((r) => r.id === runId);
-  if (idx === -1) return;
-  runs[idx] = { ...runs[idx], ...updates };
-  await saveRuns(automationId, runs, dataDir);
+  return withAutomationRunLock(automationId, async () => {
+    const runs = await loadRuns(automationId, dataDir);
+    const idx = runs.findIndex((r) => r.id === runId);
+    if (idx === -1) return;
+    runs[idx] = { ...runs[idx], ...updates };
+    await saveRuns(automationId, runs, dataDir);
+  });
 }

--- a/backend/src/state/state.ts
+++ b/backend/src/state/state.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { ProjectState } from "../types.js";
 import { DEFAULT_BASE_PROMPT } from "../agents/system-prompt.js";
+import { notifyProjectSaved } from "./workspace-index.js";
 
 const projectLocks = new Map<string, Promise<void>>();
 
@@ -60,6 +61,7 @@ export async function saveProject(
   const tmp = join(dir, `state.${randomUUID()}.tmp`);
   await writeFile(tmp, JSON.stringify(state, null, 2), "utf-8");
   await rename(tmp, target);
+  notifyProjectSaved(state);
 }
 
 function projectLockKey(projectId: string, dataDir: string): string {

--- a/backend/src/state/workspace-index.test.ts
+++ b/backend/src/state/workspace-index.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { createProject } from "../projects/project-manager.js";
 import { createWorkspace } from "../workspaces/workspace-manager.js";
+import { deleteWorkspace, archiveWorkspace } from "../workspaces/workspace-manager.js";
 import { saveProject, loadProject } from "./state.js";
 import { deleteProject } from "../projects/project-manager.js";
 import {
@@ -267,5 +268,51 @@ describe("workspace-index", () => {
     await deleteProject(project.id, dataDir);
 
     expect(lookupWorkspace(ws.id)).toBeNull();
+  });
+
+  it("integrates with deleteWorkspace and removes the index entry", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    await initWorkspaceIndex(dataDir);
+    const ws = await createWorkspace(project.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)).not.toBeNull();
+
+    await deleteWorkspace(ws.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)).toBeNull();
+  });
+
+  it("integrates with archiveWorkspace and removes the index entry", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    await initWorkspaceIndex(dataDir);
+    const ws = await createWorkspace(project.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)).not.toBeNull();
+
+    await archiveWorkspace(ws.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)).toBeNull();
+  });
+
+  it("tracks branch updates persisted through saveProject", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    await initWorkspaceIndex(dataDir);
+    const ws = await createWorkspace(project.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)!.workspace.branch).toBe(`workspace/${ws.name}`);
+
+    const state = await loadProject(project.id, dataDir);
+    expect(state).not.toBeNull();
+    const target = state!.workspaces.find((w) => w.id === ws.id);
+    expect(target).toBeDefined();
+    target!.branch = "workspace/renamed-from-test";
+    await saveProject(state!, dataDir);
+
+    const updated = lookupWorkspace(ws.id);
+    expect(updated).not.toBeNull();
+    expect(updated!.workspace.branch).toBe("workspace/renamed-from-test");
+    expect(updated!.projectState.workspaces.find((w) => w.id === ws.id)?.branch).toBe(
+      "workspace/renamed-from-test",
+    );
   });
 });

--- a/backend/src/state/workspace-index.test.ts
+++ b/backend/src/state/workspace-index.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
+import { createProject } from "../projects/project-manager.js";
+import { createWorkspace } from "../workspaces/workspace-manager.js";
+import { saveProject, loadProject } from "./state.js";
+import { deleteProject } from "../projects/project-manager.js";
+import {
+  initWorkspaceIndex,
+  isInitialized,
+  lookupWorkspace,
+  notifyProjectSaved,
+  notifyProjectDeleted,
+  _clearForTests,
+} from "./workspace-index.js";
+import type { ProjectState } from "../types.js";
+
+let tempDir: string;
+let dataDir: string;
+let fixtureRepoUrl: string;
+
+beforeEach(async () => {
+  _clearForTests();
+  tempDir = await createTempDir("hive-ws-index-test-");
+  dataDir = join(tempDir, "data");
+  const fixtureDir = join(tempDir, "fixtures");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(dataDir, { recursive: true });
+  await mkdir(fixtureDir, { recursive: true });
+  fixtureRepoUrl = await createFixtureRepo(fixtureDir);
+});
+
+afterEach(async () => {
+  _clearForTests();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("workspace-index", () => {
+  it("isInitialized returns false before init", () => {
+    expect(isInitialized()).toBe(false);
+  });
+
+  it("lookupWorkspace returns null when index is empty", () => {
+    expect(lookupWorkspace("ws-nonexistent")).toBeNull();
+  });
+
+  it("initWorkspaceIndex loads projects and populates the index", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    const ws = await createWorkspace(project.id, dataDir);
+
+    // Index not yet initialized — lookupWorkspace won't find anything
+    // even though the data is on disk, because init hasn't run.
+    // (notifyProjectSaved fires from saveProject but is a no-op before init)
+    _clearForTests();
+    expect(lookupWorkspace(ws.id)).toBeNull();
+
+    await initWorkspaceIndex(dataDir);
+
+    expect(isInitialized()).toBe(true);
+    const entry = lookupWorkspace(ws.id);
+    expect(entry).not.toBeNull();
+    expect(entry!.projectId).toBe(project.id);
+    expect(entry!.workspace.id).toBe(ws.id);
+    expect(entry!.projectState.id).toBe(project.id);
+  });
+
+  it("notifyProjectSaved adds new workspace entries", async () => {
+    await initWorkspaceIndex(dataDir, async () => []);
+
+    const state: ProjectState = {
+      id: "proj-test1",
+      name: "test",
+      url: "https://example.com/test.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        {
+          id: "ws-aaa",
+          name: "tokyo",
+          projectId: "proj-test1",
+          branch: "workspace/tokyo",
+          status: "idle",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "ws-bbb",
+          name: "paris",
+          projectId: "proj-test1",
+          branch: "workspace/paris",
+          status: "idle",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    };
+
+    notifyProjectSaved(state);
+
+    expect(lookupWorkspace("ws-aaa")).not.toBeNull();
+    expect(lookupWorkspace("ws-bbb")).not.toBeNull();
+    expect(lookupWorkspace("ws-aaa")!.workspace.name).toBe("tokyo");
+    expect(lookupWorkspace("ws-bbb")!.workspace.name).toBe("paris");
+  });
+
+  it("notifyProjectSaved replaces entries when workspace is removed", async () => {
+    await initWorkspaceIndex(dataDir, async () => []);
+
+    const state: ProjectState = {
+      id: "proj-test1",
+      name: "test",
+      url: "https://example.com/test.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        {
+          id: "ws-aaa",
+          name: "tokyo",
+          projectId: "proj-test1",
+          branch: "workspace/tokyo",
+          status: "idle",
+          createdAt: new Date().toISOString(),
+        },
+        {
+          id: "ws-bbb",
+          name: "paris",
+          projectId: "proj-test1",
+          branch: "workspace/paris",
+          status: "idle",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    };
+    notifyProjectSaved(state);
+
+    // Remove ws-bbb
+    const updated = { ...state, workspaces: [state.workspaces[0]] };
+    notifyProjectSaved(updated);
+
+    expect(lookupWorkspace("ws-aaa")).not.toBeNull();
+    expect(lookupWorkspace("ws-bbb")).toBeNull();
+  });
+
+  it("notifyProjectSaved updates workspace fields", async () => {
+    await initWorkspaceIndex(dataDir, async () => []);
+
+    const state: ProjectState = {
+      id: "proj-test1",
+      name: "test",
+      url: "https://example.com/test.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        {
+          id: "ws-aaa",
+          name: "tokyo",
+          projectId: "proj-test1",
+          branch: "workspace/tokyo",
+          status: "idle",
+          createdAt: new Date().toISOString(),
+        },
+      ],
+    };
+    notifyProjectSaved(state);
+    expect(lookupWorkspace("ws-aaa")!.workspace.status).toBe("idle");
+
+    // Update status
+    const updated: ProjectState = {
+      ...state,
+      workspaces: [{ ...state.workspaces[0], status: "busy" }],
+    };
+    notifyProjectSaved(updated);
+    expect(lookupWorkspace("ws-aaa")!.workspace.status).toBe("busy");
+  });
+
+  it("notifyProjectDeleted removes all entries for a project", async () => {
+    await initWorkspaceIndex(dataDir, async () => []);
+
+    const state1: ProjectState = {
+      id: "proj-1",
+      name: "project-one",
+      url: "https://example.com/one.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        { id: "ws-1a", name: "a", projectId: "proj-1", branch: "workspace/a", status: "idle", createdAt: new Date().toISOString() },
+      ],
+    };
+    const state2: ProjectState = {
+      id: "proj-2",
+      name: "project-two",
+      url: "https://example.com/two.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        { id: "ws-2a", name: "b", projectId: "proj-2", branch: "workspace/b", status: "idle", createdAt: new Date().toISOString() },
+      ],
+    };
+    notifyProjectSaved(state1);
+    notifyProjectSaved(state2);
+
+    expect(lookupWorkspace("ws-1a")).not.toBeNull();
+    expect(lookupWorkspace("ws-2a")).not.toBeNull();
+
+    notifyProjectDeleted("proj-1");
+
+    expect(lookupWorkspace("ws-1a")).toBeNull();
+    expect(lookupWorkspace("ws-2a")).not.toBeNull();
+  });
+
+  it("notifyProjectSaved is no-op before initialization", () => {
+    // Should not throw
+    notifyProjectSaved({
+      id: "proj-1",
+      name: "test",
+      url: "https://example.com/test.git",
+      createdAt: new Date().toISOString(),
+      workspaces: [
+        { id: "ws-1", name: "a", projectId: "proj-1", branch: "b", status: "idle", createdAt: new Date().toISOString() },
+      ],
+    });
+    // Still not initialized, so lookup returns null
+    expect(lookupWorkspace("ws-1")).toBeNull();
+  });
+
+  it("notifyProjectDeleted is no-op before initialization", () => {
+    // Should not throw
+    notifyProjectDeleted("proj-nonexistent");
+  });
+
+  it("_clearForTests resets the index", async () => {
+    await initWorkspaceIndex(dataDir, async () => [
+      {
+        id: "proj-1",
+        name: "test",
+        url: "https://example.com/test.git",
+        createdAt: new Date().toISOString(),
+        workspaces: [
+          { id: "ws-1", name: "a", projectId: "proj-1", branch: "b", status: "idle", createdAt: new Date().toISOString() },
+        ],
+      },
+    ]);
+
+    expect(isInitialized()).toBe(true);
+    expect(lookupWorkspace("ws-1")).not.toBeNull();
+
+    _clearForTests();
+
+    expect(isInitialized()).toBe(false);
+    expect(lookupWorkspace("ws-1")).toBeNull();
+  });
+
+  it("integrates with real createWorkspace and deleteWorkspace flows", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    await initWorkspaceIndex(dataDir);
+
+    // Create a workspace — saveProject fires notifyProjectSaved
+    const ws = await createWorkspace(project.id, dataDir);
+
+    const entry = lookupWorkspace(ws.id);
+    expect(entry).not.toBeNull();
+    expect(entry!.projectId).toBe(project.id);
+    expect(entry!.workspace.name).toBe(ws.name);
+  });
+
+  it("integrates with deleteProject", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+    const ws = await createWorkspace(project.id, dataDir);
+    await initWorkspaceIndex(dataDir);
+
+    expect(lookupWorkspace(ws.id)).not.toBeNull();
+
+    await deleteProject(project.id, dataDir);
+
+    expect(lookupWorkspace(ws.id)).toBeNull();
+  });
+});

--- a/backend/src/state/workspace-index.ts
+++ b/backend/src/state/workspace-index.ts
@@ -1,0 +1,115 @@
+/**
+ * In-memory workspace-to-project index.
+ *
+ * Eliminates the O(projects × workspaces) disk scan that `getWorkspace()`
+ * previously performed on every API call.  The index is populated once at
+ * startup and kept in sync via `notifyProjectSaved` (called from
+ * `saveProject`) and `notifyProjectDeleted` (called from `deleteProject`).
+ */
+import type { ProjectState, Workspace } from "../types.js";
+
+interface IndexEntry {
+  projectId: string;
+  projectState: ProjectState;
+  workspace: Workspace;
+}
+
+// Primary index: wsId → entry
+const index = new Map<string, IndexEntry>();
+
+// Secondary index for fast project-level deletion: projectId → Set<wsId>
+const projectToWsIds = new Map<string, Set<string>>();
+
+let initialized = false;
+
+/**
+ * Populate the index from all projects on disk.  Must be called once at
+ * server startup after `reconcileStaleWorkspaces()` has run.
+ */
+export async function initWorkspaceIndex(
+  dataDir: string,
+  loader?: (dataDir: string) => Promise<ProjectState[]>,
+): Promise<void> {
+  // Accept an injected loader to avoid circular import at call site;
+  // the default defers the import to runtime.
+  const load = loader ?? (await import("./state.js")).loadAllProjects;
+  const projects = await load(dataDir);
+  for (const project of projects) {
+    rebuildProjectEntries(project);
+  }
+  initialized = true;
+}
+
+export function isInitialized(): boolean {
+  return initialized;
+}
+
+/**
+ * O(1) workspace lookup.  Returns null when the workspace is not in the
+ * index (i.e. does not exist).
+ */
+export function lookupWorkspace(
+  wsId: string,
+): { projectId: string; projectState: ProjectState; workspace: Workspace } | null {
+  const entry = index.get(wsId);
+  return entry ?? null;
+}
+
+/**
+ * Called after every successful `saveProject()`.  Replaces all cached
+ * entries for the given project with the new state snapshot.
+ *
+ * Safe to call before `initWorkspaceIndex()` — it is a no-op when the
+ * index has not been initialized yet.
+ */
+export function notifyProjectSaved(state: ProjectState): void {
+  if (!initialized) return;
+  rebuildProjectEntries(state);
+}
+
+/**
+ * Called after a project is deleted from disk.  Removes all cached entries
+ * for that project.
+ */
+export function notifyProjectDeleted(projectId: string): void {
+  if (!initialized) return;
+  const wsIds = projectToWsIds.get(projectId);
+  if (wsIds) {
+    for (const wsId of wsIds) {
+      index.delete(wsId);
+    }
+    projectToWsIds.delete(projectId);
+  }
+}
+
+// ── internals ───────────────────────────────────────────────────────────
+
+function rebuildProjectEntries(state: ProjectState): void {
+  // Remove stale entries for this project
+  const oldWsIds = projectToWsIds.get(state.id);
+  if (oldWsIds) {
+    for (const wsId of oldWsIds) {
+      index.delete(wsId);
+    }
+  }
+
+  // Insert fresh entries
+  const newWsIds = new Set<string>();
+  for (const workspace of state.workspaces) {
+    index.set(workspace.id, {
+      projectId: state.id,
+      projectState: state,
+      workspace,
+    });
+    newWsIds.add(workspace.id);
+  }
+  projectToWsIds.set(state.id, newWsIds);
+}
+
+// ── test helpers ────────────────────────────────────────────────────────
+
+export function _clearForTests(): void {
+  index.clear();
+  projectToWsIds.clear();
+  initialized = false;
+}

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -25,6 +25,10 @@ const STRIPPED_PREFIXES = [
  * Build a clean environment for workspace child processes.
  * Strips backend-specific vars, then merges optional provider overrides.
  */
+export const DEBUG_AGENT_LOGS = ["1", "true", "yes", "on"].includes(
+  (process.env.HIVE_DEBUG_AGENT_LOGS ?? "").trim().toLowerCase(),
+);
+
 export function buildWorkspaceEnv(
   extra?: Record<string, string>,
 ): Record<string, string> {

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { rm, writeFile, mkdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -16,6 +16,8 @@ import {
 } from "./workspace-manager.js";
 import { git } from "../utils/git.js";
 import { loadProject, saveProject } from "../state/state.js";
+import * as stateStore from "../state/state.js";
+import { initWorkspaceIndex, _clearForTests as clearWorkspaceIndexForTests } from "../state/workspace-index.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -23,6 +25,7 @@ let fixtureRepoUrl: string;
 let projectId: string;
 
 beforeEach(async () => {
+  clearWorkspaceIndexForTests();
   tempDir = await createTempDir("hive-ws-test-");
   dataDir = join(tempDir, "data");
   const fixtureDir = join(tempDir, "fixtures");
@@ -36,6 +39,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
+  clearWorkspaceIndexForTests();
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -157,6 +161,19 @@ describe("getWorkspace", () => {
   it("returns null for non-existent workspace", async () => {
     const result = await getWorkspace("nonexistent", dataDir);
     expect(result).toBeNull();
+  });
+
+  it("uses the in-memory index path after initialization (no loadAllProjects scan)", async () => {
+    const created = await createWorkspace(projectId, dataDir);
+    await initWorkspaceIndex(dataDir);
+
+    const loadAllSpy = vi.spyOn(stateStore, "loadAllProjects");
+
+    const result = await getWorkspace(created.id, dataDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.workspace.id).toBe(created.id);
+    expect(loadAllSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -4,7 +4,8 @@ import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
 import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/paths.js";
 import { pickCityName } from "../utils/city-names.js";
-import { loadProject, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
+import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
+import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.js";
 import { stopAllForWorkspace } from "../services/script-runner.js";
 import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffStatResponse } from "../types.js";
@@ -161,7 +162,13 @@ export async function getWorkspace(
   wsId: string,
   dataDir = getDataDir()
 ): Promise<{ projectState: ProjectState; workspace: Workspace } | null> {
-  const { loadAllProjects } = await import("../state/state.js");
+  // Fast path: O(1) lookup from the in-memory index
+  if (isInitialized()) {
+    const entry = lookupWorkspace(wsId);
+    if (entry) return { projectState: entry.projectState, workspace: entry.workspace };
+    return null;
+  }
+  // Fallback: disk scan (before index is initialized, or in tests)
   const all = await loadAllProjects(dataDir);
   const found = findProjectByWorkspace(all, wsId);
   if (!found) return null;


### PR DESCRIPTION
## Summary

Three performance/reliability fixes from code audit:

- **In-memory workspace-to-project index** — `getWorkspace()` was doing O(projects × workspaces) disk scans on every API call (reading every `state.json` from disk). New `workspace-index.ts` module provides O(1) lookups, populated at startup and kept in sync via `saveProject`/`deleteProject` hooks. Affects ~18 call sites across the hot path.
- **Per-automation run locks** — `addRun`/`updateRun` now use per-automation-id locks instead of the single global `automationsLock`. Different automations' run writes no longer serialize against each other. Global lock retained for CRUD on the shared `automations.json`.
- **Parallel git sync polling** — Workspace sync within each project now runs with bounded concurrency (limit 6) instead of sequential `for...await`. Reduces poll cycle time from O(N × time_per_workspace) to O(time_per_workspace) for typical workloads.

## Test plan

- [x] All 1032 existing tests pass (backend + frontend)
- [x] Typecheck passes (`npm run typecheck`)
- [x] New workspace-index tests (12 tests): init, lookup, add/remove/update workspace, project deletion, pre-init no-ops, integration with real create/delete flows
- [x] New automation lock tests (5 tests): concurrent addRun serialization, cross-automation independence, addRun+updateRun interleaving, error recovery, lock cleanup
- [x] New git-sync test: concurrent multi-workspace sync with branch renames