### PR TITLE
fix(naming): harden branch auto-rename flow

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -64,6 +64,7 @@ export function updateLiveApnsToken(token: string): void {
 const loadedSessionsByWorkspace = new Map<string, Map<string, ConversationSession>>();
 const activeSessionIds = new Map<string, string>();
 const workspaceLocks = new Map<string, Promise<void>>();
+const workspaceBranchRenameLocks = new Map<string, Promise<void>>();
 
 export interface SessionOptions {
   command?: string;
@@ -87,6 +88,26 @@ async function withWorkspaceLock<T>(wsId: string, fn: () => Promise<T>): Promise
     release?.();
     if (workspaceLocks.get(wsId) === queued) {
       workspaceLocks.delete(wsId);
+    }
+  }
+}
+
+async function withWorkspaceBranchRenameLock<T>(wsId: string, fn: () => Promise<T>): Promise<T> {
+  const prev = workspaceBranchRenameLocks.get(wsId) ?? Promise.resolve();
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const queued = prev.then(() => current);
+  workspaceBranchRenameLocks.set(wsId, queued);
+
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release?.();
+    if (workspaceBranchRenameLocks.get(wsId) === queued) {
+      workspaceBranchRenameLocks.delete(wsId);
     }
   }
 }
@@ -500,7 +521,7 @@ async function createSession(
         currentBranch: ctx.workspace.branch,
         workspaceName: ctx.workspace.name,
         command: options?.command,
-        withBranchRenameLock: (fn) => withWorkspaceLock(ctx.workspace.id, fn),
+        withBranchRenameLock: (fn) => withWorkspaceBranchRenameLock(ctx.workspace.id, fn),
       },
       (title: string) => session.setTitle(title),
     ).catch((err) => {

--- a/backend/src/agents/naming.test.ts
+++ b/backend/src/agents/naming.test.ts
@@ -188,7 +188,7 @@ describe("generateNames", () => {
     mockSpawn.mockReturnValue(proc);
 
     const pending = generateNames(baseContext("claude"));
-    await vi.advanceTimersByTimeAsync(15_000);
+    await vi.advanceTimersByTimeAsync(30_000);
 
     await expect(pending).resolves.toEqual({});
     expect(proc.kill).toHaveBeenCalledWith("SIGKILL");
@@ -216,13 +216,38 @@ describe("generateNames", () => {
 });
 
 describe("runNamingTask", () => {
-  it("skips the naming task when command is not claude", async () => {
+  it("skips the naming task when command is a shell test harness", async () => {
     const onTitleReady = vi.fn();
     await runNamingTask(baseContext("bash"), onTitleReady);
 
     expect(mockSpawn).not.toHaveBeenCalled();
     expect(mockGit).not.toHaveBeenCalled();
     expect(onTitleReady).not.toHaveBeenCalled();
+  });
+
+  it("falls back to claude naming when session command is codex", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    queueMicrotask(() => {
+      proc._stdout.emit("data", Buffer.from(JSON.stringify({
+        branch_name: "valid-name",
+        session_title: "Valid title",
+      })));
+      proc.emit("close", 0);
+    });
+
+    const onTitleReady = vi.fn();
+    await runNamingTask(
+      { ...baseContext("codex"), currentBranch: "feature/manual-branch" },
+      onTitleReady,
+    );
+
+    expect(onTitleReady).toHaveBeenCalledWith("Valid title");
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "claude",
+      expect.any(Array),
+      expect.any(Object),
+    );
   });
 
   it("sets title even when branch should not be renamed", async () => {
@@ -261,8 +286,8 @@ describe("runNamingTask", () => {
     });
 
     mockGit
-      .mockResolvedValueOnce({ stdout: "main\nadd-auth", stderr: "" })
       .mockResolvedValueOnce({ stdout: "workspace/hyderabad", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "main\nadd-auth", stderr: "" })
       .mockResolvedValueOnce({ stdout: "", stderr: "" });
 
     const onTitleReady = vi.fn();
@@ -271,19 +296,72 @@ describe("runNamingTask", () => {
     expect(onTitleReady).toHaveBeenCalledWith("Add auth");
     expect(mockGit).toHaveBeenNthCalledWith(
       1,
-      ["branch", "--format=%(refname:short)"],
-      "/tmp/repo.git",
+      ["rev-parse", "--abbrev-ref", "HEAD"],
+      "/tmp/workspace",
     );
     expect(mockGit).toHaveBeenNthCalledWith(
       2,
-      ["rev-parse", "--abbrev-ref", "HEAD"],
-      "/tmp/workspace",
+      ["branch", "--format=%(refname:short)"],
+      "/tmp/repo.git",
     );
     expect(mockGit).toHaveBeenNthCalledWith(
       3,
       ["branch", "-m", "add-auth-2"],
       "/tmp/workspace",
     );
+  });
+
+  it("retries branch rename on transient git lock contention", async () => {
+    vi.useFakeTimers();
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    queueMicrotask(() => {
+      proc._stdout.emit("data", Buffer.from(JSON.stringify({
+        branch_name: "valid-name",
+        session_title: "Valid title",
+      })));
+      proc.emit("close", 0);
+    });
+
+    mockGit
+      .mockResolvedValueOnce({ stdout: "workspace/hyderabad", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
+      .mockRejectedValueOnce(new Error("fatal: cannot lock ref 'refs/heads/valid-name'"))
+      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    const pending = runNamingTask(baseContext("claude"), vi.fn());
+    await vi.advanceTimersByTimeAsync(500);
+    await pending;
+
+    expect(mockGit).toHaveBeenCalledWith(["branch", "-m", "valid-name"], "/tmp/workspace");
+    const renameCalls = mockGit.mock.calls.filter(
+      (c) => c[0][0] === "branch" && c[0][1] === "-m",
+    );
+    expect(renameCalls).toHaveLength(2);
+  });
+
+  it("does not retry branch rename on non-transient git errors", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    queueMicrotask(() => {
+      proc._stdout.emit("data", Buffer.from(JSON.stringify({
+        branch_name: "valid-name",
+        session_title: "Valid title",
+      })));
+      proc.emit("close", 0);
+    });
+
+    mockGit
+      .mockResolvedValueOnce({ stdout: "workspace/hyderabad", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
+      .mockRejectedValueOnce(new Error("fatal: invalid branch name"));
+
+    await expect(runNamingTask(baseContext("claude"), vi.fn())).rejects.toThrow("invalid branch name");
+    const renameCalls = mockGit.mock.calls.filter(
+      (c) => c[0][0] === "branch" && c[0][1] === "-m",
+    );
+    expect(renameCalls).toHaveLength(1);
   });
 
   it("does not rename when sanitized branch name is empty", async () => {
@@ -316,14 +394,13 @@ describe("runNamingTask", () => {
     });
 
     mockGit
-      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
       .mockResolvedValueOnce({ stdout: "feature/already-renamed", stderr: "" });
 
     const onTitleReady = vi.fn();
     await runNamingTask(baseContext("claude"), onTitleReady);
 
     expect(onTitleReady).toHaveBeenCalledWith("Valid title");
-    expect(mockGit).toHaveBeenCalledTimes(2);
+    expect(mockGit).toHaveBeenCalledTimes(1);
     expect(mockGit).not.toHaveBeenCalledWith(["branch", "-m", "valid-name"], "/tmp/workspace");
   });
 
@@ -339,8 +416,8 @@ describe("runNamingTask", () => {
     });
 
     mockGit
-      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
       .mockResolvedValueOnce({ stdout: "workspace/hyderabad", stderr: "" })
+      .mockResolvedValueOnce({ stdout: "main", stderr: "" })
       .mockResolvedValueOnce({ stdout: "", stderr: "" });
 
     const order: string[] = [];
@@ -361,9 +438,14 @@ describe("runNamingTask", () => {
     expect(lockCalls).toBe(1);
     expect(order).toEqual(["lock-start", "lock-end"]);
     expect(mockGit).toHaveBeenNthCalledWith(
-      2,
+      1,
       ["rev-parse", "--abbrev-ref", "HEAD"],
       "/tmp/workspace",
+    );
+    expect(mockGit).toHaveBeenNthCalledWith(
+      2,
+      ["branch", "--format=%(refname:short)"],
+      "/tmp/repo.git",
     );
     expect(mockGit).toHaveBeenNthCalledWith(
       3,
@@ -409,10 +491,9 @@ describe("runNamingTask", () => {
     });
 
     mockGit
-      .mockResolvedValueOnce({ stdout: "", stderr: "" })
       .mockRejectedValueOnce(new Error("git failed"));
 
     await expect(runNamingTask(baseContext("claude"), vi.fn())).resolves.toBeUndefined();
-    expect(mockGit).toHaveBeenCalledTimes(2);
+    expect(mockGit).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend/src/agents/naming.ts
+++ b/backend/src/agents/naming.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { basename } from "node:path";
 import { git } from "../utils/git.js";
 import { buildWorkspaceEnv, DEBUG_AGENT_LOGS } from "../utils/env.js";
 
@@ -38,7 +39,8 @@ Rules for session_title:
 - Sentence case, concise summary of the task
 - No commit-style prefixes (Add, Fix, Update, Refactor)`;
 
-const TIMEOUT_MS = 15_000;
+const TIMEOUT_MS = 30_000;
+const RENAME_RETRY_DELAYS_MS = [120, 250];
 
 const PREFIX_PATTERN = /^(?:feat|fix|chore|docs|refactor|test|style|perf|ci|build|workspace)\//;
 
@@ -149,17 +151,45 @@ export async function generateNames(ctx: NamingContext): Promise<NamingResult> {
   });
 }
 
+function resolveNamingCommand(command?: string): string | null {
+  const fallback = command ?? "claude";
+  const cmd = basename(fallback).toLowerCase();
+  // Test harnesses pass shell binaries here; skip naming in that case.
+  if (["bash", "sh", "zsh"].includes(cmd)) return null;
+  // Naming prompt/args are Claude-specific; fall back to Claude for other providers.
+  if (["codex", "gemini"].includes(cmd)) return "claude";
+  return fallback;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function errorText(err: unknown): string {
+  return err instanceof Error ? err.message.toLowerCase() : String(err).toLowerCase();
+}
+
+function isTransientGitRenameError(err: unknown): boolean {
+  const text = errorText(err);
+  return (
+    text.includes("cannot lock ref") ||
+    text.includes("unable to create") ||
+    text.includes("another git process seems to be running") ||
+    text.includes("index.lock") ||
+    text.includes("refs/heads")
+  );
+}
+
 export async function runNamingTask(
   ctx: NamingContext,
   onTitleReady: (title: string) => void,
 ): Promise<void> {
-  // Skip in test mode (tests use command = "bash")
-  const command = ctx.command ?? "claude";
-  if (command !== "claude") return;
+  const command = resolveNamingCommand(ctx.command);
+  if (!command) return;
 
   const shouldRenameBranch = ctx.currentBranch.startsWith("workspace/");
 
-  const result = await generateNames(ctx);
+  const result = await generateNames({ ...ctx, command });
 
   if (result.sessionTitle) {
     const title = result.sessionTitle.slice(0, 60);
@@ -170,8 +200,6 @@ export async function runNamingTask(
     const sanitized = sanitizeBranchName(result.branchName);
     if (!sanitized) return;
 
-    const existing = await listExistingBranches(ctx.bareRepo);
-    const finalName = ensureUniqueBranch(sanitized, existing);
     const renameIfStillWorkspaceBranch = async (): Promise<void> => {
       // Guard: branch may have been renamed manually in the meantime
       try {
@@ -182,13 +210,32 @@ export async function runNamingTask(
           }
           return;
         }
-      } catch {
+      } catch (err) {
+        if (DEBUG_AGENT_LOGS) {
+          console.log("[naming] failed to resolve current branch, skipping rename:", errorText(err));
+        }
         return;
       }
 
-      await git(["branch", "-m", finalName], ctx.cwd);
-      if (DEBUG_AGENT_LOGS) {
-        console.log(`[naming] renamed branch: ${ctx.currentBranch} → ${finalName}`);
+      let finalName = ensureUniqueBranch(sanitized, await listExistingBranches(ctx.bareRepo));
+      for (let attempt = 0; ; attempt++) {
+        try {
+          await git(["branch", "-m", finalName], ctx.cwd);
+          if (DEBUG_AGENT_LOGS) {
+            console.log(`[naming] renamed branch: ${ctx.currentBranch} → ${finalName}`);
+          }
+          return;
+        } catch (err) {
+          const hasRetryLeft = attempt < RENAME_RETRY_DELAYS_MS.length;
+          if (!hasRetryLeft || !isTransientGitRenameError(err)) {
+            throw err;
+          }
+          if (DEBUG_AGENT_LOGS) {
+            console.log(`[naming] transient rename failure (attempt ${attempt + 1}), retrying:`, errorText(err));
+          }
+          await sleep(RENAME_RETRY_DELAYS_MS[attempt]!);
+          finalName = ensureUniqueBranch(sanitized, await listExistingBranches(ctx.bareRepo));
+        }
       }
     };
 


### PR DESCRIPTION
## Summary\n- keep branch auto-rename enabled regardless of active session provider by resolving a dedicated naming command\n- use a dedicated per-workspace branch-rename lock instead of the broader workspace lock\n- add transient retry logic around  to reduce lock contention failures\n- increase naming generation timeout from 15s to 30s\n- simplify naming command resolution and expand test coverage for fallback/retry paths\n\n## Validation\n- npm --prefix backend test -- src/agents/naming.test.ts\n- npm --prefix backend test -- src/agents/agent-manager.test.ts\n