### PR TITLE
fix: store image attachments inside workspace worktree

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -744,7 +744,9 @@ export async function resolveSessionAttachmentPath(
 ): Promise<string | null> {
   const result = await getWorkspace(wsId, dataDir);
   if (!result) return null;
-  return join(dataDir, result.projectState.id, "sessions", sessionId, "attachments", filename);
+  const { projectState, workspace } = result;
+  const wsPath = join(dataDir, projectState.id, "workspaces", workspace.name);
+  return join(wsPath, ".attachments", filename);
 }
 
 /** Return session IDs currently streaming in a workspace. */

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -132,7 +132,7 @@ describe("ConversationSession", () => {
 
   function createSession(opts?: { sessionId?: string; command?: string; skipPermissions?: boolean }) {
     return new ConversationSession({
-      cwd: "/tmp/test",
+      cwd: join(tempDir, "worktree"),
       dataDir: tempDir,
       workspaceId: "ws-test",
       sessionId: opts?.sessionId,
@@ -798,7 +798,7 @@ describe("ConversationSession", () => {
 
     // Load from disk
     const session2 = await ConversationSession.load({
-      cwd: "/tmp/test",
+      cwd: join(tempDir, "worktree"),
       dataDir: tempDir,
       workspaceId: "ws-test",
       sessionId: "load-test",
@@ -1092,7 +1092,7 @@ describe("ConversationSession", () => {
     session.sendMessage("Photo", undefined, images);
     await new Promise((r) => setTimeout(r, 200));
 
-    const attachmentsDir = join(tempDir, "sessions", "img-ext", "attachments");
+    const attachmentsDir = join(tempDir, "worktree", ".attachments");
     const files = await readdir(attachmentsDir);
     expect(files).toHaveLength(1);
     expect(files[0]).toMatch(/\.jpg$/);
@@ -1111,7 +1111,7 @@ describe("ConversationSession", () => {
     session.sendMessage("Two images", undefined, images);
     await new Promise((r) => setTimeout(r, 200));
 
-    const attachmentsDir = join(tempDir, "sessions", "img-multi", "attachments");
+    const attachmentsDir = join(tempDir, "worktree", ".attachments");
     const files = await readdir(attachmentsDir);
     expect(files).toHaveLength(2);
   });
@@ -1156,7 +1156,7 @@ describe("ConversationSession", () => {
     session.sendMessage("Match test", undefined, images);
     await new Promise((r) => setTimeout(r, 200));
 
-    const attachmentsDir = join(tempDir, "sessions", "img-url-match", "attachments");
+    const attachmentsDir = join(tempDir, "worktree", ".attachments");
     const files = await readdir(attachmentsDir);
     expect(files).toHaveLength(1);
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -271,7 +271,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   private async saveImagesToDisk(images: ImageAttachment[]): Promise<{ path: string; filename: string }[]> {
-    const attachmentsDir = join(this.sessionDir, "attachments");
+    const attachmentsDir = join(this.cwd, ".attachments");
     await mkdir(attachmentsDir, { recursive: true });
 
     const results: { path: string; filename: string }[] = [];


### PR DESCRIPTION
## Summary

- Image attachments were saved to `~/.hive/<projectId>/sessions/<sessionId>/attachments/`, outside the agent CLI's working directory. Gemini CLI enforces path sandboxing and rejected reads to those paths with "Path not in workspace" errors.
- Moved attachment storage to `<wsPath>/.attachments/` (inside the worktree) so all providers (Claude, Codex, Gemini) can access attached images uniformly.
- Updated `resolveSessionAttachmentPath()` to resolve from the workspace worktree instead of the session directory.
- No frontend or iOS changes needed — they send base64 and receive HTTP URLs, resolution is transparent.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (1166 backend + 1018 frontend tests)
- [ ] Manual: attach an image in a Gemini workspace session, verify the agent reads it without sandbox error