### PR TITLE
feat(frontend): server metrics sidebar with mini progress bars

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,5 @@
+import os from "node:os";
+import { statfsSync } from "node:fs";
 import Fastify from "fastify";
 import type { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
@@ -80,7 +82,24 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     }),
   );
 
-  app.get("/health", async () => ({ status: "ok", env: process.env.NODE_ENV ?? "development" }));
+  app.get("/health", async () => {
+    const totalMem = os.totalmem();
+    const freeMem = os.freemem();
+    const disk = statfsSync("/");
+    const diskTotal = disk.blocks * disk.bsize;
+    const diskFree = disk.bavail * disk.bsize;
+    const cpuPercent = Math.min(100, Math.round((os.loadavg()[0] / (os.cpus().length || 1)) * 100));
+
+    return {
+      status: "ok",
+      env: process.env.NODE_ENV ?? "development",
+      system: {
+        cpuPercent,
+        memPercent: Math.round(((totalMem - freeMem) / totalMem) * 100),
+        diskPercent: Math.round(((diskTotal - diskFree) / diskTotal) * 100),
+      },
+    };
+  });
 
   await app.register((instance: FastifyInstance) => projectRoutes(instance));
   await app.register((instance: FastifyInstance) => workspaceRoutes(instance));

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -56,6 +56,39 @@ interface BuildAppOptions {
   scheduler?: AutomationScheduler;
 }
 
+// ── CPU usage sampling ──────────────────────────────────────────────
+// Sample os.cpus() periodically and compute real CPU % from idle delta.
+
+function snapshotCpuTimes() {
+  let idle = 0;
+  let total = 0;
+  for (const cpu of os.cpus()) {
+    const t = cpu.times;
+    idle += t.idle;
+    total += t.idle + t.user + t.nice + t.sys + t.irq;
+  }
+  return { idle, total };
+}
+
+let prevCpu = snapshotCpuTimes();
+let cpuPercentCache = -1; // -1 = no sample yet
+
+setInterval(() => {
+  const curr = snapshotCpuTimes();
+  const idleDelta = curr.idle - prevCpu.idle;
+  const totalDelta = curr.total - prevCpu.total;
+  cpuPercentCache = totalDelta > 0 ? Math.round((1 - idleDelta / totalDelta) * 100) : 0;
+  prevCpu = curr;
+}, 5_000);
+
+function getCpuPercent(): number {
+  if (cpuPercentCache >= 0) return cpuPercentCache;
+  // No delta yet — fall back to load average as rough estimate
+  return Math.min(100, Math.round((os.loadavg()[0] / (os.cpus().length || 1)) * 100));
+}
+
+// ─────────────────────────────────────────────────────────────────────
+
 export async function buildApp(opts: BuildAppOptions = {}) {
   const authToken = process.env.HIVE_AUTH_TOKEN?.trim();
   const rateLimitMax = parsePositiveNumber(process.env.HIVE_RATE_LIMIT_MAX, DEFAULT_RATE_LIMIT_MAX);
@@ -88,7 +121,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     const disk = statfsSync("/");
     const diskTotal = disk.blocks * disk.bsize;
     const diskFree = disk.bavail * disk.bsize;
-    const cpuPercent = Math.min(100, Math.round((os.loadavg()[0] / (os.cpus().length || 1)) * 100));
+    const cpuPercent = getCpuPercent();
 
     return {
       status: "ok",

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -79,7 +79,7 @@ setInterval(() => {
   const totalDelta = curr.total - prevCpu.total;
   cpuPercentCache = totalDelta > 0 ? Math.round((1 - idleDelta / totalDelta) * 100) : 0;
   prevCpu = curr;
-}, 5_000);
+}, 5_000).unref();
 
 function getCpuPercent(): number {
   if (cpuPercentCache >= 0) return cpuPercentCache;

--- a/frontend/src/components/ServerMetrics.tsx
+++ b/frontend/src/components/ServerMetrics.tsx
@@ -7,22 +7,24 @@ import {
 import { useServerMetrics } from "@/hooks/useServerMetrics";
 import { usageStrokeColor } from "@/lib/format-usage";
 
-interface MetricDotProps {
+interface MetricBarProps {
   label: string;
   percent: number;
 }
 
-function MetricDot({ label, percent }: MetricDotProps) {
+function MetricBar({ label, percent }: MetricBarProps) {
   const color = usageStrokeColor(percent / 100);
   return (
-    <div className="flex items-center gap-1">
-      <div
-        className="h-1.5 w-1.5 rounded-full"
-        style={{ backgroundColor: color }}
-      />
-      <span className="text-[10px] leading-none text-muted-foreground">
+    <div className="flex flex-1 items-center gap-1">
+      <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
         {label}
       </span>
+      <div className="h-1 flex-1 rounded-full bg-muted/40">
+        <div
+          className="h-full rounded-full transition-[width] duration-700 ease-out"
+          style={{ width: `${percent}%`, backgroundColor: color }}
+        />
+      </div>
     </div>
   );
 }
@@ -42,10 +44,10 @@ export function ServerMetrics() {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex items-center gap-2 px-1 cursor-default">
-            <MetricDot label="CPU" percent={metrics.cpuPercent} />
-            <MetricDot label="MEM" percent={metrics.memPercent} />
-            <MetricDot label="DSK" percent={metrics.diskPercent} />
+          <div className="flex items-center gap-2.5 cursor-default">
+            <MetricBar label="CPU" percent={metrics.cpuPercent} />
+            <MetricBar label="MEM" percent={metrics.memPercent} />
+            <MetricBar label="DSK" percent={metrics.diskPercent} />
           </div>
         </TooltipTrigger>
         <TooltipContent side="top">{tooltip}</TooltipContent>

--- a/frontend/src/components/ServerMetrics.tsx
+++ b/frontend/src/components/ServerMetrics.tsx
@@ -1,0 +1,55 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useServerMetrics } from "@/hooks/useServerMetrics";
+import { usageStrokeColor } from "@/lib/format-usage";
+
+interface MetricDotProps {
+  label: string;
+  percent: number;
+}
+
+function MetricDot({ label, percent }: MetricDotProps) {
+  const color = usageStrokeColor(percent / 100);
+  return (
+    <div className="flex items-center gap-1">
+      <div
+        className="h-1.5 w-1.5 rounded-full"
+        style={{ backgroundColor: color }}
+      />
+      <span className="text-[10px] leading-none text-muted-foreground">
+        {label}
+      </span>
+    </div>
+  );
+}
+
+export function ServerMetrics() {
+  const metrics = useServerMetrics();
+
+  if (!metrics) return null;
+
+  const tooltip = [
+    `CPU ${metrics.cpuPercent}%`,
+    `Memory ${metrics.memPercent}%`,
+    `Disk ${metrics.diskPercent}%`,
+  ].join(" · ");
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex items-center gap-2 px-1 cursor-default">
+            <MetricDot label="CPU" percent={metrics.cpuPercent} />
+            <MetricDot label="MEM" percent={metrics.memPercent} />
+            <MetricDot label="DSK" percent={metrics.diskPercent} />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top">{tooltip}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -5,6 +5,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
+import { ServerMetrics } from "@/components/ServerMetrics";
 
 export default function SettingsSidebar() {
   const { projects } = useProjects();
@@ -16,21 +17,10 @@ export default function SettingsSidebar() {
   return (
     <div className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground">
       <div
-        className="flex min-h-12 shrink-0 items-center px-3"
+        className="shrink-0"
         style={{ height: "max(var(--titlebar-inset, 0px), 3rem)" }}
         data-tauri-drag-region
-      >
-        <div className="ml-auto">
-          <button
-            type="button"
-            onClick={() => navigate(returnTo.current)}
-            className="flex items-center gap-2 rounded-md px-2 py-1 text-sm text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            Back
-          </button>
-        </div>
-      </div>
+      />
 
       <ScrollArea className="flex-1">
         <div className="px-3 py-3">
@@ -100,6 +90,24 @@ export default function SettingsSidebar() {
           )}
         </div>
       </ScrollArea>
+
+      {/* ── Footer: back button + metrics ──────────────────────────── */}
+      <div className="shrink-0 border-t border-border/50">
+        <div className="flex items-center justify-end px-2 py-1.5">
+          <button
+            type="button"
+            onClick={() => navigate(returnTo.current)}
+            className="flex items-center gap-2 rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+          >
+            <ArrowLeft className="h-3 w-3" />
+            Back
+          </button>
+        </div>
+        <div className="mx-2 border-t border-border/50" />
+        <div className="px-3 pb-2 pt-1.5">
+          <ServerMetrics />
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -5,7 +5,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
-import { ServerMetrics } from "@/components/ServerMetrics";
+import { SidebarShell } from "@/components/SidebarShell";
 
 export default function SettingsSidebar() {
   const { projects } = useProjects();
@@ -14,14 +14,21 @@ export default function SettingsSidebar() {
   const { pathname } = location;
   const returnTo = useRef((location.state as { from?: string } | null)?.from ?? "/projects");
 
-  return (
-    <div className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground">
-      <div
-        className="shrink-0"
-        style={{ height: "max(var(--titlebar-inset, 0px), 3rem)" }}
-        data-tauri-drag-region
-      />
+  const footerActions = (
+    <div className="flex items-center justify-end px-2 py-1.5">
+      <button
+        type="button"
+        onClick={() => navigate(returnTo.current)}
+        className="flex items-center gap-2 rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Back
+      </button>
+    </div>
+  );
 
+  return (
+    <SidebarShell footerActions={footerActions}>
       <ScrollArea className="flex-1">
         <div className="px-3 py-3">
           <SidebarSection label="General">
@@ -90,25 +97,7 @@ export default function SettingsSidebar() {
           )}
         </div>
       </ScrollArea>
-
-      {/* ── Footer: back button + metrics ──────────────────────────── */}
-      <div className="shrink-0 border-t border-border/50">
-        <div className="flex items-center justify-end px-2 py-1.5">
-          <button
-            type="button"
-            onClick={() => navigate(returnTo.current)}
-            className="flex items-center gap-2 rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
-          >
-            <ArrowLeft className="h-3 w-3" />
-            Back
-          </button>
-        </div>
-        <div className="mx-2 border-t border-border/50" />
-        <div className="px-3 pb-2 pt-1.5">
-          <ServerMetrics />
-        </div>
-      </div>
-    </div>
+    </SidebarShell>
   );
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -37,6 +37,7 @@ import { api } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useAutomations } from "@/hooks/useAutomations";
+import { ServerMetrics } from "@/components/ServerMetrics";
 import type { Automation, DiffStatResponse } from "@/types";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -400,24 +401,27 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         )}
       </div>
 
-      {/* ── Footer: tabs + settings ─────────────────────────────────── */}
+      {/* ── Footer: tabs + metrics + settings ────────────────────────── */}
       <div className="flex items-center border-t border-border/50 px-2 py-1.5">
-        <div className="flex flex-1 gap-0.5">
-          {(["build", "automation"] as const).map((tab) => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => handleTabClick(tab)}
-              className={cn(
-                "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                activeTab === tab
-                  ? "bg-sidebar-accent text-sidebar-foreground"
-                  : "text-muted-foreground hover:bg-sidebar-accent/40 hover:text-sidebar-foreground",
-              )}
-            >
-              {tab === "build" ? "Build" : "Automation"}
-            </button>
-          ))}
+        <div className="flex flex-1 items-center gap-2">
+          <div className="flex gap-0.5">
+            {(["build", "automation"] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                onClick={() => handleTabClick(tab)}
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+                  activeTab === tab
+                    ? "bg-sidebar-accent text-sidebar-foreground"
+                    : "text-muted-foreground hover:bg-sidebar-accent/40 hover:text-sidebar-foreground",
+                )}
+              >
+                {tab === "build" ? "Build" : "Automation"}
+              </button>
+            ))}
+          </div>
+          <ServerMetrics />
         </div>
         <Link
           to="/settings"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -37,7 +37,7 @@ import { api } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useAutomations } from "@/hooks/useAutomations";
-import { ServerMetrics } from "@/components/ServerMetrics";
+import { SidebarShell } from "@/components/SidebarShell";
 import type { Automation, DiffStatResponse } from "@/types";
 
 // ── Helpers ──────────────────────────────────────────────────────────
@@ -225,14 +225,39 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     }
   };
 
-  return (
-    <div className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground">
-      <div
-        className="shrink-0"
-        style={{ height: "max(var(--titlebar-inset, 0px), 3rem)" }}
-        data-tauri-drag-region
-      />
+  const footerActions = (
+    <div className="flex items-center px-2 py-1.5">
+      <div className="flex flex-1 gap-0.5">
+        {(["build", "automation"] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => handleTabClick(tab)}
+            className={cn(
+              "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
+              activeTab === tab
+                ? "bg-sidebar-accent text-sidebar-foreground"
+                : "text-muted-foreground hover:bg-sidebar-accent/40 hover:text-sidebar-foreground",
+            )}
+          >
+            {tab === "build" ? "Build" : "Automation"}
+          </button>
+        ))}
+      </div>
+      <Link
+        to="/settings"
+        state={{ from: pathname }}
+        className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-sidebar-foreground"
+        aria-label="Settings"
+        title="Settings"
+      >
+        <Settings className="h-4 w-4" />
+      </Link>
+    </div>
+  );
 
+  return (
+    <SidebarShell footerActions={footerActions}>
       {/* ── Tab content ─────────────────────────────────────────────── */}
       {activeTab === "build" ? (
         <ScrollArea className="flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full">
@@ -401,42 +426,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         )}
       </div>
 
-      {/* ── Footer: tabs + metrics/settings ─────────────────────────── */}
-      <div className="shrink-0 border-t border-border/50">
-        <div className="flex items-center px-2 py-1.5">
-          <div className="flex flex-1 gap-0.5">
-            {(["build", "automation"] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                onClick={() => handleTabClick(tab)}
-                className={cn(
-                  "rounded-md px-2.5 py-1 text-xs font-medium transition-colors",
-                  activeTab === tab
-                    ? "bg-sidebar-accent text-sidebar-foreground"
-                    : "text-muted-foreground hover:bg-sidebar-accent/40 hover:text-sidebar-foreground",
-                )}
-              >
-                {tab === "build" ? "Build" : "Automation"}
-              </button>
-            ))}
-          </div>
-          <Link
-            to="/settings"
-            state={{ from: pathname }}
-            className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-sidebar-foreground"
-            aria-label="Settings"
-            title="Settings"
-          >
-            <Settings className="h-4 w-4" />
-          </Link>
-        </div>
-        <div className="mx-2 border-t border-border/50" />
-        <div className="px-3 pb-2 pt-1.5">
-          <ServerMetrics />
-        </div>
-      </div>
-
       <AlertDialog
         open={archiveTarget !== null}
         onOpenChange={(open) => !open && setArchiveTarget(null)}
@@ -462,7 +451,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         </AlertDialogContent>
       </AlertDialog>
 
-    </div>
+    </SidebarShell>
   );
 }
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -401,10 +401,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         )}
       </div>
 
-      {/* ── Footer: tabs + metrics + settings ────────────────────────── */}
-      <div className="flex items-center border-t border-border/50 px-2 py-1.5">
-        <div className="flex flex-1 items-center gap-2">
-          <div className="flex gap-0.5">
+      {/* ── Footer: tabs + metrics/settings ─────────────────────────── */}
+      <div className="shrink-0 border-t border-border/50">
+        <div className="flex items-center px-2 py-1.5">
+          <div className="flex flex-1 gap-0.5">
             {(["build", "automation"] as const).map((tab) => (
               <button
                 key={tab}
@@ -421,17 +421,20 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               </button>
             ))}
           </div>
+          <Link
+            to="/settings"
+            state={{ from: pathname }}
+            className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:text-sidebar-foreground"
+            aria-label="Settings"
+            title="Settings"
+          >
+            <Settings className="h-4 w-4" />
+          </Link>
+        </div>
+        <div className="mx-2 border-t border-border/50" />
+        <div className="px-3 pb-2 pt-1.5">
           <ServerMetrics />
         </div>
-        <Link
-          to="/settings"
-          state={{ from: pathname }}
-          className="rounded p-1 text-muted-foreground transition-colors hover:text-sidebar-foreground"
-          aria-label="Settings"
-          title="Settings"
-        >
-          <Settings className="h-4 w-4" />
-        </Link>
       </div>
 
       <AlertDialog

--- a/frontend/src/components/SidebarShell.tsx
+++ b/frontend/src/components/SidebarShell.tsx
@@ -1,0 +1,28 @@
+import { ServerMetrics } from "@/components/ServerMetrics";
+
+interface SidebarShellProps {
+  children: React.ReactNode;
+  footerActions: React.ReactNode;
+}
+
+export function SidebarShell({ children, footerActions }: SidebarShellProps) {
+  return (
+    <div className="flex h-full w-full flex-col bg-sidebar text-sidebar-foreground">
+      <div
+        className="shrink-0"
+        style={{ height: "max(var(--titlebar-inset, 0px), 3rem)" }}
+        data-tauri-drag-region
+      />
+
+      {children}
+
+      <div className="shrink-0 border-t border-border/50">
+        {footerActions}
+        <div className="mx-2 border-t border-border/50" />
+        <div className="px-3 pb-2 pt-1.5">
+          <ServerMetrics />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useServerMetrics.ts
+++ b/frontend/src/hooks/useServerMetrics.ts
@@ -1,0 +1,33 @@
+import { useQuery } from "@tanstack/react-query";
+import { getServerUrl } from "./useServerUrl";
+
+export interface SystemMetrics {
+  cpuPercent: number;
+  memPercent: number;
+  diskPercent: number;
+}
+
+async function fetchMetrics(): Promise<SystemMetrics | null> {
+  const base = getServerUrl();
+  if (!base) return null;
+  try {
+    const res = await fetch(`${base}/health`, { signal: AbortSignal.timeout(3000) });
+    if (!res.ok) return null;
+    const data = await res.json();
+    return data.system ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function useServerMetrics() {
+  const query = useQuery({
+    queryKey: ["server-metrics"],
+    queryFn: fetchMetrics,
+    refetchInterval: 15_000,
+    staleTime: 10_000,
+    retry: 0,
+  });
+
+  return query.data ?? null;
+}


### PR DESCRIPTION
## Summary
- Add live server metrics (CPU/MEM/DSK) to the sidebar footer with colored mini progress bars (green/yellow/red thresholds)
- Metrics persist across sidebar views — visible in both main sidebar and settings sidebar
- Move settings back button from header to footer row (right-aligned)
- Extract `SidebarShell` component to share footer structure (separator + metrics) across both sidebars

## Test plan
- [ ] Verify CPU/MEM/DSK bars render in sidebar footer with correct colors
- [ ] Navigate to settings — metrics remain visible, back button in footer
- [ ] Hover metrics to see tooltip with exact percentages
- [ ] Resize sidebar — bars adapt fluidly
- [ ] Typecheck and tests pass (`npm run typecheck && npm test`)