### PR TITLE
fix: accept renamed Agent tool from Claude CLI v2.1.63+

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -429,7 +429,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
               });
             }
 
-            if (block.name === "Task") {
+            if (block.name === "Task" || block.name === "Agent") {
               pendingTaskStack.push(block.id);
             }
 

--- a/frontend/src/components/chat/ToolCallList.tsx
+++ b/frontend/src/components/chat/ToolCallList.tsx
@@ -27,8 +27,8 @@ export function ToolCallTree({
       {tools.map((tool) => {
         const children = childrenMap.get(tool.id);
 
-        // Render Task tools as rich SubAgentNode
-        if (tool.name === "Task") {
+        // Render Task/Agent tools as rich SubAgentNode
+        if (tool.name === "Task" || tool.name === "Agent") {
           const info = parseSubAgentInfo(tool);
           if (info) {
             return (
@@ -152,7 +152,7 @@ export function ToolCallList({
   // Build summary label: "N tool calls, M subagents"
   const summaryLabel = (() => {
     if (!shouldCollapse) return "";
-    const subagentCount = rootTools.filter((t) => t.name === "Task").length;
+    const subagentCount = rootTools.filter((t) => t.name === "Task" || t.name === "Agent").length;
     const toolCount = rootTools.length - subagentCount;
     const parts: string[] = [];
     if (toolCount > 0) parts.push(`${toolCount} tool call${toolCount !== 1 ? "s" : ""}`);

--- a/frontend/src/hooks/useBackgroundAgents.ts
+++ b/frontend/src/hooks/useBackgroundAgents.ts
@@ -36,7 +36,7 @@ export function useBackgroundAgents(
     const agents: BackgroundAgent[] = [];
 
     for (const tool of allTools) {
-      if (tool.name !== "Task") continue;
+      if (tool.name !== "Task" && tool.name !== "Agent") continue;
       const info = parseSubAgentInfo(tool);
       if (!info || !info.runInBackground) continue;
 

--- a/frontend/src/lib/sub-agent.ts
+++ b/frontend/src/lib/sub-agent.ts
@@ -8,9 +8,9 @@ export interface SubAgentInfo {
   model?: string;
 }
 
-/** Parse sub-agent metadata from a Task tool's input JSON. */
+/** Parse sub-agent metadata from a Task/Agent tool's input JSON. */
 export function parseSubAgentInfo(tool: ToolCall): SubAgentInfo | null {
-  if (tool.name !== "Task") return null;
+  if (tool.name !== "Task" && tool.name !== "Agent") return null;
   try {
     const input = JSON.parse(tool.input);
     return {

--- a/frontend/tests/lib/sub-agent.test.ts
+++ b/frontend/tests/lib/sub-agent.test.ts
@@ -7,10 +7,32 @@ function tool(overrides: Partial<ToolCall> & { name: string; input: string }): T
 }
 
 describe("parseSubAgentInfo", () => {
-  it("returns null for non-Task tools", () => {
+  it("returns null for non-Task/Agent tools", () => {
     expect(parseSubAgentInfo(tool({ name: "Bash", input: '{"command":"ls"}' }))).toBeNull();
     expect(parseSubAgentInfo(tool({ name: "Read", input: '{"file_path":"/a.ts"}' }))).toBeNull();
     expect(parseSubAgentInfo(tool({ name: "Edit", input: "{}" }))).toBeNull();
+  });
+
+  it("parses 'Agent' tool name (v2.1.63+ CLI rename)", () => {
+    const result = parseSubAgentInfo(
+      tool({
+        name: "Agent",
+        input: JSON.stringify({
+          subagent_type: "Explore",
+          description: "Search codebase",
+          prompt: "Find all test files",
+          run_in_background: true,
+        }),
+      }),
+    );
+
+    expect(result).toEqual({
+      subagentType: "Explore",
+      description: "Search codebase",
+      prompt: "Find all test files",
+      runInBackground: true,
+      model: undefined,
+    });
   });
 
   it("parses a complete Task input", () => {

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -309,7 +309,7 @@ private func toolIcon(for name: String) -> String {
     case "Edit": return "pencil"
     case "Bash": return "terminal"
     case "Grep", "Glob": return "magnifyingglass"
-    case "Task": return "arrow.triangle.branch"
+    case "Task", "Agent": return "arrow.triangle.branch"
     case "TaskCreate", "TaskUpdate", "TaskList", "TaskGet": return "checklist"
     case "WebSearch", "WebFetch": return "globe"
     case "AskUserQuestion": return "bubble.left"
@@ -444,7 +444,7 @@ private func getToolDisplay(_ tool: ToolCall, isPending: Bool = false, isDismiss
         globDisplay.stats = computeToolStats(tool)
         return globDisplay
 
-    case "Task":
+    case "Task", "Agent":
         let subagentType = input["subagent_type"] as? String
         let description = input["description"] as? String
         let label = subagentType != nil ? "Task (\(subagentType!))" : "Task"
@@ -597,7 +597,7 @@ private struct CollapsedToolSummary: View {
     let onToggle: () -> Void
 
     private var summaryLabel: String {
-        let subagentCount = tools.filter { $0.name == "Task" }.count
+        let subagentCount = tools.filter { $0.name == "Task" || $0.name == "Agent" }.count
         let toolCount = tools.count - subagentCount
         var parts: [String] = []
         if toolCount > 0 { parts.append("\(toolCount) tool call\(toolCount != 1 ? "s" : "")") }


### PR DESCRIPTION
## Summary
- Claude Code v2.1.63 silently renamed the `Task` tool to `Agent` in its streaming JSON output ([#29677](https://github.com/anthropics/claude-code/issues/29677))
- All tool name checks now accept both `"Task"` and `"Agent"` for backward compat with existing sessions and forward compat with the new CLI
- Fixes sub-agent cards rendering as raw JSON, background agent counter, and parent-child tool tracking

## Changes
- `frontend/src/lib/sub-agent.ts` — `parseSubAgentInfo()` accepts both names
- `frontend/src/components/chat/ToolCallList.tsx` — SubAgentNode rendering + summary count
- `frontend/src/hooks/useBackgroundAgents.ts` — background agent detection
- `backend/src/agents/conversation-session.ts` — parent-child tool stack
- `ios/.../MessageBubble.swift` — icon, display, and summary count (3 spots)
- `frontend/tests/lib/sub-agent.test.ts` — new test for `"Agent"` tool name

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1166 backend + 1019 frontend)
- [ ] Verify sub-agent cards render correctly in chat with Claude CLI >= 2.1.63
- [ ] Verify existing session history (with `"Task"` tool name) still renders correctly