### PR TITLE
fix(backend): finalize audit follow-ups and harden reliability

### DIFF
--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -279,15 +279,19 @@ describe("stopAllSessions", () => {
     const { session: sessionB } = await getOrCreateSession(otherWs.id, dataDir, CONV_CMD);
     const stopA = vi.spyOn(sessionA, "stop");
     const stopB = vi.spyOn(sessionB, "stop");
+    const drainA = vi.spyOn(sessionA, "drain");
+    const drainB = vi.spyOn(sessionB, "drain");
 
-    stopAllSessions();
+    await stopAllSessions();
 
     expect(stopA).toHaveBeenCalledWith("park");
     expect(stopB).toHaveBeenCalledWith("park");
+    expect(drainA).toHaveBeenCalledTimes(1);
+    expect(drainB).toHaveBeenCalledTimes(1);
   });
 
-  it("is a no-op when no sessions are loaded", () => {
-    expect(() => stopAllSessions()).not.toThrow();
+  it("is a no-op when no sessions are loaded", async () => {
+    await expect(stopAllSessions()).resolves.toBeUndefined();
   });
 });
 

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -754,13 +754,16 @@ export function getStreamingSessionIds(wsId: string): string[] {
     .map((s) => s.sessionId);
 }
 
-/** Park all in-memory sessions (for graceful shutdown). */
-export function stopAllSessions(): void {
+/** Park all in-memory sessions and drain persist queues (for graceful shutdown). */
+export async function stopAllSessions(): Promise<void> {
+  const drains: Promise<void>[] = [];
   for (const sessions of loadedSessionsByWorkspace.values()) {
     for (const session of sessions.values()) {
       session.stop("park");
+      drains.push(session.drain());
     }
   }
+  await Promise.allSettled(drains);
 }
 
 // ── Test helpers ────────────────────────────────────────────────────

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1401,6 +1401,27 @@ describe("ConversationSession", () => {
     vi.useRealTimers();
   });
 
+  it("drain waits for a streaming turn to exit before resolving", async () => {
+    const session = createSession({ sessionId: "drain-waits" });
+    session.sendMessage("Hello");
+
+    let resolved = false;
+    const drainPromise = session.drain().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    mockProc._stdout.push(assistantLine("Done"));
+    mockProc._stdout.push(resultLine());
+    mockProc._emitClose(0);
+
+    await drainPromise;
+    expect(resolved).toBe(true);
+    expect(session.status).toBe("idle");
+  });
+
   // ── Provider locking tests ───────────────────────────────────────
 
   it("locks provider on first sendMessage based on model prefix", () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -768,6 +768,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     return this.persistQueue;
   }
 
+  /** Await pending persist operations (for graceful shutdown). */
+  async drain(): Promise<void> {
+    await this.persistQueue;
+  }
+
   async persistMetadata(): Promise<void> {
     await this.saveMetadata();
   }

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -770,6 +770,27 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
   /** Await pending persist operations (for graceful shutdown). */
   async drain(): Promise<void> {
+    if (this._status === "streaming") {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          this.off("exit", onExit);
+          this.off("error", onError);
+          resolve();
+        };
+        const onExit = () => finish();
+        const onError = () => finish();
+
+        this.on("exit", onExit);
+        this.on("error", onError);
+
+        if (this._status !== "streaming") {
+          finish();
+        }
+      });
+    }
     await this.persistQueue;
   }
 

--- a/backend/src/agents/system-prompt.test.ts
+++ b/backend/src/agents/system-prompt.test.ts
@@ -3,7 +3,14 @@ import { join } from "node:path";
 import { rm, writeFile, mkdir } from "node:fs/promises";
 import { createTempDir } from "../utils/test-helpers.js";
 import { git } from "../utils/git.js";
-import { getGitContext, buildSystemPrompt, loadBasePrompt, formatGitContextBlock, DEFAULT_BASE_PROMPT } from "./system-prompt.js";
+import {
+  getGitContext,
+  buildSystemPrompt,
+  loadBasePrompt,
+  formatGitContextBlock,
+  interpolatePromptVariables,
+  DEFAULT_BASE_PROMPT,
+} from "./system-prompt.js";
 import type { GitContext } from "./system-prompt.js";
 
 let tempDir: string;
@@ -174,6 +181,34 @@ describe("buildSystemPrompt", () => {
     });
     expect(prompt).toContain("Explicit override.");
     expect(prompt).not.toContain("From file.");
+  });
+});
+
+describe("interpolatePromptVariables", () => {
+  it("replaces all supported placeholders", () => {
+    const result = interpolatePromptVariables(
+      "Project={PROJECT}; Dir={DIR}; Branch={DEFAULT_BRANCH}",
+      {
+        projectName: "hive",
+        cwd: "/tmp/workspace",
+        defaultBranch: "main",
+      },
+    );
+
+    expect(result).toBe("Project=hive; Dir=/tmp/workspace; Branch=main");
+  });
+
+  it("replaces repeated placeholders globally", () => {
+    const result = interpolatePromptVariables(
+      "{PROJECT}:{PROJECT}:{DEFAULT_BRANCH}:{DEFAULT_BRANCH}",
+      {
+        projectName: "hive",
+        cwd: "/tmp/workspace",
+        defaultBranch: "develop",
+      },
+    );
+
+    expect(result).toBe("hive:hive:develop:develop");
   });
 });
 

--- a/backend/src/agents/system-prompt.ts
+++ b/backend/src/agents/system-prompt.ts
@@ -35,7 +35,10 @@ All code, comments, and variable names must be in English.`;
 export async function loadBasePrompt(promptsDir: string): Promise<string> {
   try {
     return await readFile(join(promptsDir, "base.md"), "utf-8");
-  } catch {
+  } catch (err: unknown) {
+    if (err instanceof Error && "code" in err && (err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn("[system-prompt] Failed to load base.md, using default:", err);
+    }
     return DEFAULT_BASE_PROMPT;
   }
 }

--- a/backend/src/agents/system-prompt.ts
+++ b/backend/src/agents/system-prompt.ts
@@ -20,6 +20,12 @@ export interface SystemPromptOptions {
   promptsDir?: string;
 }
 
+export interface PromptInterpolationValues {
+  projectName: string;
+  cwd: string;
+  defaultBranch: string;
+}
+
 export const DEFAULT_BASE_PROMPT = `You are an AI coding agent running inside Hive, a macOS app that helps developers ship faster by running multiple coding agents in parallel across workspaces.
 You're working on a project called **{PROJECT}**. Your work should take place in the {DIR} directory (unless otherwise directed), which has been set up for you to work in.
 The target branch for this workspace is {DEFAULT_BRANCH}. Use this for actions like creating new PRs, bisecting, etc., unless you're told otherwise.
@@ -111,6 +117,17 @@ export function formatGitContextBlock(
   return gitLines.join("\n");
 }
 
+/** Replace prompt placeholders with concrete workspace/project values. */
+export function interpolatePromptVariables(
+  prompt: string,
+  values: PromptInterpolationValues,
+): string {
+  return prompt
+    .replace(/\{DIR}/g, values.cwd)
+    .replace(/\{DEFAULT_BRANCH}/g, values.defaultBranch)
+    .replace(/\{PROJECT}/g, values.projectName);
+}
+
 /**
  * Build a system prompt by merging a base prompt with dynamic git context.
  */
@@ -129,10 +146,11 @@ export async function buildSystemPrompt(opts: SystemPromptOptions): Promise<stri
   }
 
   // Interpolate template variables
-  basePrompt = basePrompt
-    .replace(/\{DIR}/g, cwd)
-    .replace(/\{DEFAULT_BRANCH}/g, ctx.defaultBranch)
-    .replace(/\{PROJECT}/g, projectName ?? "unknown");
+  basePrompt = interpolatePromptVariables(basePrompt, {
+    cwd,
+    defaultBranch: ctx.defaultBranch,
+    projectName: projectName ?? "unknown",
+  });
 
   const sections: string[] = [basePrompt];
   sections.push(formatGitContextBlock(ctx, { projectName, workspaceName }));

--- a/backend/src/api/automations.cleanup.test.ts
+++ b/backend/src/api/automations.cleanup.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { rm } from "node:fs/promises";
+import { join } from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import { createTempDir } from "../utils/test-helpers.js";
+import { saveAutomations } from "../state/automations.js";
+import type { Automation } from "../types.js";
+
+const mocks = vi.hoisted(() => ({
+  git: vi.fn(async () => ({ stdout: "", stderr: "" })),
+  bareRepoPath: vi.fn(() => "/tmp/bare-repo"),
+}));
+
+vi.mock("../utils/git.js", () => ({
+  git: mocks.git,
+}));
+
+vi.mock("../utils/paths.js", () => ({
+  bareRepoPath: mocks.bareRepoPath,
+}));
+
+import { automationRoutes } from "./automations.js";
+
+let tmpDir: string;
+let dataDir: string;
+let app: FastifyInstance;
+
+function makeAutomation(overrides: Partial<Automation> = {}): Automation {
+  return {
+    id: "auto-1",
+    name: "Test Auto",
+    enabled: true,
+    trigger: { type: "cron", expression: "0 * * * *" },
+    action: { type: "agent", modelId: "claude:opus-4-6", userPromptInline: "Do something" },
+    notification: { onComplete: true, onFailure: true },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks();
+  tmpDir = await createTempDir();
+  dataDir = join(tmpDir, "data");
+  app = Fastify();
+  await app.register((instance) => automationRoutes(instance, { dataDir }));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe("DELETE /api/automations/:id - git worktree cleanup", () => {
+  it("removes project-linked automation worktree before deleting automation dir", async () => {
+    await saveAutomations([makeAutomation({ projectId: "proj-1" })], dataDir);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/automations/auto-1" });
+    expect(res.statusCode).toBe(204);
+
+    const wsPath = join(dataDir, "automations", "auto-1", "workspace");
+    expect(mocks.bareRepoPath).toHaveBeenCalledWith(dataDir, "proj-1");
+    expect(mocks.git).toHaveBeenCalledWith(
+      ["worktree", "remove", "--force", wsPath],
+      "/tmp/bare-repo",
+    );
+  });
+
+  it("prunes stale worktree refs when worktree removal fails", async () => {
+    mocks.git
+      .mockRejectedValueOnce(new Error("worktree already missing"))
+      .mockResolvedValueOnce({ stdout: "", stderr: "" });
+    await saveAutomations([makeAutomation({ projectId: "proj-1" })], dataDir);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/automations/auto-1" });
+    expect(res.statusCode).toBe(204);
+
+    const wsPath = join(dataDir, "automations", "auto-1", "workspace");
+    expect(mocks.git).toHaveBeenNthCalledWith(
+      1,
+      ["worktree", "remove", "--force", wsPath],
+      "/tmp/bare-repo",
+    );
+    expect(mocks.git).toHaveBeenNthCalledWith(
+      2,
+      ["worktree", "prune"],
+      "/tmp/bare-repo",
+    );
+  });
+
+  it("skips git cleanup for non project-linked automations", async () => {
+    await saveAutomations([makeAutomation({ projectId: undefined })], dataDir);
+
+    const res = await app.inject({ method: "DELETE", url: "/api/automations/auto-1" });
+    expect(res.statusCode).toBe(204);
+    expect(mocks.git).not.toHaveBeenCalled();
+    expect(mocks.bareRepoPath).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/api/automations.ts
+++ b/backend/src/api/automations.ts
@@ -2,6 +2,8 @@ import type { FastifyInstance } from "fastify";
 import { nanoid } from "nanoid";
 import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
+import { git } from "../utils/git.js";
+import { bareRepoPath } from "../utils/paths.js";
 import { Cron } from "croner";
 import {
   loadAutomations,
@@ -167,23 +169,34 @@ export async function automationRoutes(
   app.delete<{ Params: { id: string } }>("/api/automations/:id", async (req, reply) => {
     const { id } = req.params;
 
-    const found = await withAutomationsLock(async () => {
+    const auto = await withAutomationsLock(async () => {
       const automations = await loadAutomations(dataDir);
       const idx = automations.findIndex((a) => a.id === id);
-      if (idx === -1) return false;
+      if (idx === -1) return null;
+      const deleted = automations[idx];
       automations.splice(idx, 1);
       await saveAutomations(automations, dataDir);
-      return true;
+      return deleted;
     });
 
-    if (!found) return reply.status(404).send({ error: "Automation not found" });
+    if (!auto) return reply.status(404).send({ error: "Automation not found" });
 
     if (opts.scheduler) {
       await opts.scheduler.onAutomationDeleted(id);
     }
 
-    // Clean up workspace directory
+    // Clean up git worktree if project-linked
     const autoDir = join(dataDir, "automations", id);
+    if (auto.projectId) {
+      const bare = bareRepoPath(dataDir, auto.projectId);
+      const wsPath = join(autoDir, "workspace");
+      try {
+        await git(["worktree", "remove", "--force", wsPath], bare);
+      } catch {
+        await git(["worktree", "prune"], bare).catch(() => {});
+      }
+    }
+
     await rm(autoDir, { recursive: true, force: true }).catch(() => {});
 
     return reply.status(204).send();

--- a/backend/src/api/automations.ts
+++ b/backend/src/api/automations.ts
@@ -2,7 +2,7 @@ import type { FastifyInstance } from "fastify";
 import { nanoid } from "nanoid";
 import { readFile, rm } from "node:fs/promises";
 import { join } from "node:path";
-import { git } from "../utils/git.js";
+import { removeWorktreeAndPruneBestEffort } from "../utils/git-worktree.js";
 import { bareRepoPath } from "../utils/paths.js";
 import { Cron } from "croner";
 import {
@@ -190,11 +190,7 @@ export async function automationRoutes(
     if (auto.projectId) {
       const bare = bareRepoPath(dataDir, auto.projectId);
       const wsPath = join(autoDir, "workspace");
-      try {
-        await git(["worktree", "remove", "--force", wsPath], bare);
-      } catch {
-        await git(["worktree", "prune"], bare).catch(() => {});
-      }
+      await removeWorktreeAndPruneBestEffort(bare, wsPath);
     }
 
     await rm(autoDir, { recursive: true, force: true }).catch(() => {});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -236,13 +236,15 @@ async function main() {
     shuttingDown = true;
     console.log(`[server] ${signal} received, shutting down...`);
 
-    stopAllSessions();
     stopAllScripts();
 
-    await app.close();
+    // Drain persist queues with timeout
+    await Promise.race([
+      stopAllSessions(),
+      new Promise((r) => setTimeout(r, 5000)),
+    ]);
 
-    // Give persist queues a moment to flush
-    await new Promise((r) => setTimeout(r, 1000));
+    await app.close();
     process.exit(0);
   };
 

--- a/backend/src/services/automation-scheduler.integration.test.ts
+++ b/backend/src/services/automation-scheduler.integration.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { rm, writeFile, readFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
+import { createProject } from "../projects/project-manager.js";
+import { saveAutomations } from "../state/automations.js";
+import { git } from "../utils/git.js";
+import { AutomationScheduler } from "./automation-scheduler.js";
+import type { Automation } from "../types.js";
+
+vi.mock("../agents/conversation-session.js", async () => {
+  const { EventEmitter } = await import("node:events");
+
+  class MockSession extends EventEmitter {
+    sendMessage() {
+      process.nextTick(() => this.emit("message", { type: "done" }));
+    }
+
+    stop() {
+      // No-op for tests.
+    }
+
+    async getMessages() {
+      return [
+        {
+          id: "m1",
+          sessionId: "sess-1",
+          role: "assistant",
+          content: "Work done.\n## Summary\nIntegration run ok.",
+          timestamp: new Date().toISOString(),
+        },
+      ];
+    }
+  }
+
+  return { ConversationSession: MockSession };
+});
+
+vi.mock("../agents/agent-manager.js", () => ({
+  getNotifier: vi.fn(() => null),
+}));
+
+let tmpDir: string;
+let dataDir: string;
+let fixtureRepoUrl: string;
+
+function makeAutomation(projectId: string): Automation {
+  return {
+    id: "auto-integration-1",
+    name: "Integration Automation",
+    enabled: true,
+    projectId,
+    trigger: { type: "cron", expression: "0 * * * *" },
+    action: { type: "agent", modelId: "claude:opus-4-6", userPromptInline: "Run" },
+    notification: { onComplete: false, onFailure: false },
+    createdAt: "2026-01-01T00:00:00Z",
+    updatedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+beforeEach(async () => {
+  tmpDir = await createTempDir("hive-auto-integration-");
+  dataDir = join(tmpDir, "data");
+  const fixtureDir = join(tmpDir, "fixtures");
+  await mkdir(fixtureDir, { recursive: true });
+  fixtureRepoUrl = await createFixtureRepo(fixtureDir);
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+});
+
+describe("AutomationScheduler integration (real git worktree lifecycle)", () => {
+  it("first run fetches latest remote commit before execution", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+
+    const pushClone = join(tmpDir, "push-clone-latest");
+    await git(["clone", fixtureRepoUrl, pushClone]);
+    await git(["config", "user.email", "test@hive.dev"], pushClone);
+    await git(["config", "user.name", "Test"], pushClone);
+    await writeFile(join(pushClone, "latest-before-first-run.txt"), "latest\n", "utf-8");
+    await git(["add", "."], pushClone);
+    await git(["commit", "-m", "add latest file before first automation run"], pushClone);
+    await git(["push", "origin", "main"], pushClone);
+    const { stdout: expectedHead } = await git(["rev-parse", "HEAD"], pushClone);
+
+    const auto = makeAutomation(project.id);
+    await saveAutomations([auto], dataDir);
+
+    const scheduler = new AutomationScheduler(dataDir);
+    const run = await scheduler.triggerNow(auto.id);
+    scheduler.stop();
+
+    expect(run.status, run.error).toBe("success");
+
+    const wsPath = join(dataDir, "automations", auto.id, "workspace");
+    expect(existsSync(join(wsPath, "latest-before-first-run.txt"))).toBe(true);
+    const latestFile = await readFile(join(wsPath, "latest-before-first-run.txt"), "utf-8");
+    expect(latestFile).toBe("latest\n");
+
+    const { stdout: workspaceHead } = await git(["rev-parse", "HEAD"], wsPath);
+    expect(workspaceHead).toBe(expectedHead);
+  });
+
+  it("second run removes untracked and ignored files from automation workspace", async () => {
+    const project = await createProject(fixtureRepoUrl, dataDir);
+
+    const pushClone = join(tmpDir, "push-clone-ignore");
+    await git(["clone", fixtureRepoUrl, pushClone]);
+    await git(["config", "user.email", "test@hive.dev"], pushClone);
+    await git(["config", "user.name", "Test"], pushClone);
+    await writeFile(join(pushClone, ".gitignore"), "ignored.tmp\nignored-dir/\n", "utf-8");
+    await git(["add", ".gitignore"], pushClone);
+    await git(["commit", "-m", "add ignore rules"], pushClone);
+    await git(["push", "origin", "main"], pushClone);
+
+    const auto = makeAutomation(project.id);
+    await saveAutomations([auto], dataDir);
+
+    const scheduler = new AutomationScheduler(dataDir);
+    const firstRun = await scheduler.triggerNow(auto.id);
+    expect(firstRun.status, firstRun.error).toBe("success");
+
+    const wsPath = join(dataDir, "automations", auto.id, "workspace");
+    await writeFile(join(wsPath, "scratch-untracked.txt"), "temp\n", "utf-8");
+    await writeFile(join(wsPath, "ignored.tmp"), "ignored\n", "utf-8");
+    await mkdir(join(wsPath, "ignored-dir"), { recursive: true });
+    await writeFile(join(wsPath, "ignored-dir", "artifact.txt"), "artifact\n", "utf-8");
+    expect(existsSync(join(wsPath, "scratch-untracked.txt"))).toBe(true);
+    expect(existsSync(join(wsPath, "ignored.tmp"))).toBe(true);
+    expect(existsSync(join(wsPath, "ignored-dir", "artifact.txt"))).toBe(true);
+
+    const secondRun = await scheduler.triggerNow(auto.id);
+    scheduler.stop();
+    expect(secondRun.status, secondRun.error).toBe("success");
+
+    expect(existsSync(join(wsPath, "scratch-untracked.txt"))).toBe(false);
+    expect(existsSync(join(wsPath, "ignored.tmp"))).toBe(false);
+    expect(existsSync(join(wsPath, "ignored-dir"))).toBe(false);
+  });
+});

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -646,6 +646,36 @@ describe("AutomationScheduler", () => {
       scheduler.stop();
     });
 
+    it("interpolates {PROJECT}, {DIR}, and {DEFAULT_BRANCH} in system prompts", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "My App", repoUrl: "https://github.com/test/repo" } as never);
+
+      const auto = makeAutomation({
+        projectId: "proj-1",
+        action: {
+          type: "agent",
+          modelId: "claude:opus-4-6",
+          userPromptInline: "Review code",
+          systemPromptInline: "Project={PROJECT}\nDir={DIR}\nBranch={DEFAULT_BRANCH}",
+        },
+      });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      await scheduler.triggerNow("auto-1");
+
+      const lastCall = sessionConstructorCalls[sessionConstructorCalls.length - 1];
+      const sysPrompt = lastCall.systemPrompt as string;
+      expect(sysPrompt).toContain("Project=My App");
+      expect(sysPrompt).toContain(`Dir=${join(dataDir, "automations", "auto-1", "workspace")}`);
+      expect(sysPrompt).toContain("Branch=main");
+      expect(sysPrompt).not.toContain("{PROJECT}");
+      expect(sysPrompt).not.toContain("{DIR}");
+      expect(sysPrompt).not.toContain("{DEFAULT_BRANCH}");
+
+      scheduler.stop();
+    });
+
     it("calls getGitContext with workspace path and default branch", async () => {
       const { loadProject } = await import("../state/state.js");
       vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -514,6 +514,26 @@ describe("AutomationScheduler", () => {
       scheduler.stop();
     });
 
+    it("cleans untracked and ignored files when reusing an existing project workspace", async () => {
+      const { loadProject } = await import("../state/state.js");
+      const { git } = await import("../utils/git.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+
+      const auto = makeAutomation({ projectId: "proj-1" });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("success");
+      expect(git).toHaveBeenCalledWith(
+        ["clean", "-ffdx"],
+        join(dataDir, "automations", "auto-1", "workspace"),
+      );
+
+      scheduler.stop();
+    });
+
     it("creates a worktree when existing workspace path is not a git repo", async () => {
       const { loadProject } = await import("../state/state.js");
       const { git } = await import("../utils/git.js");
@@ -532,6 +552,43 @@ describe("AutomationScheduler", () => {
       expect(git).toHaveBeenCalledWith(
         ["worktree", "add", expect.stringContaining("/workspace"), "main"],
         "/tmp/bare",
+      );
+      expect(git).toHaveBeenCalledWith(
+        ["reset", "--hard", "origin/main"],
+        join(dataDir, "automations", "auto-1", "workspace"),
+      );
+      expect(git).toHaveBeenCalledWith(
+        ["clean", "-ffdx"],
+        join(dataDir, "automations", "auto-1", "workspace"),
+      );
+
+      scheduler.stop();
+    });
+
+    it("falls back to FETCH_HEAD reset when origin branch ref is unavailable", async () => {
+      const { loadProject } = await import("../state/state.js");
+      const { git } = await import("../utils/git.js");
+      vi.mocked(loadProject).mockResolvedValue({ id: "proj-1", name: "Test Project", repoUrl: "https://github.com/test/repo" } as never);
+      vi.mocked(git).mockImplementation(async (args) => {
+        if (args[0] === "status") {
+          throw new Error("not a git repository");
+        }
+        if (args[0] === "reset" && args[2] === "origin/main") {
+          throw new Error("unknown revision");
+        }
+        return { stdout: "", stderr: "" };
+      });
+
+      const auto = makeAutomation({ projectId: "proj-1" });
+      await saveAutomations([auto], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("success");
+      expect(git).toHaveBeenCalledWith(
+        ["reset", "--hard", "FETCH_HEAD"],
+        join(dataDir, "automations", "auto-1", "workspace"),
       );
 
       scheduler.stop();

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -85,6 +85,13 @@ vi.mock("../agents/system-prompt.js", () => ({
     (_ctx: unknown, opts?: { projectName?: string }) =>
       `# Git Context (snapshot at session start)\n\nProject: ${opts?.projectName ?? "unknown"}\nCurrent branch: main\nMain branch: main\n\nStatus: (clean)\n\nRecent commits:\nabc1234 initial commit`,
   ),
+  interpolatePromptVariables: vi.fn(
+    (prompt: string, values: { projectName: string; cwd: string; defaultBranch: string }) =>
+      prompt
+        .replace(/\{DIR}/g, values.cwd)
+        .replace(/\{DEFAULT_BRANCH}/g, values.defaultBranch)
+        .replace(/\{PROJECT}/g, values.projectName),
+  ),
 }));
 
 // ── Helpers ─────────────────────────────────────────────────────────

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -16,6 +16,11 @@ import { extractSummary } from "../utils/summary-extractor.js";
 import { getNotifier } from "../agents/agent-manager.js";
 import { loadProject } from "../state/state.js";
 import { git } from "../utils/git.js";
+import {
+  addWorktreeFromBranch,
+  isMissingOrNotGitRepositoryError,
+  refreshWorktreeToRemoteBranch,
+} from "../utils/git-worktree.js";
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
 import { getGitContext, formatGitContextBlock, interpolatePromptVariables } from "../agents/system-prompt.js";
 import type { Automation, AutomationRun, WsOutgoing } from "../types.js";
@@ -295,20 +300,17 @@ export class AutomationScheduler {
         await git(["status", "--porcelain"], wsPath);
         // Exists — update to latest
         const defaultBranch = await resolveDefaultBranch(bareRepo);
-        await git(["fetch", "origin", defaultBranch], wsPath);
-        await git(["checkout", defaultBranch], wsPath);
-        await git(["reset", "--hard", `origin/${defaultBranch}`], wsPath);
+        await refreshWorktreeToRemoteBranch(wsPath, defaultBranch);
         return { workspacePath: wsPath, defaultBranch };
       } catch (err) {
         // Only treat "not a git repo" / missing directory as "needs worktree creation"
-        const msg = err instanceof Error ? err.message : "";
-        const isNotExists =
-          /not a git repository/i.test(msg) || /no such file or directory/i.test(msg);
-        if (!isNotExists) throw err;
+        if (!isMissingOrNotGitRepositoryError(err)) throw err;
 
         await mkdir(join(this.dataDir, "automations", auto.id), { recursive: true });
         const defaultBranch = await resolveDefaultBranch(bareRepo);
-        await git(["worktree", "add", wsPath, defaultBranch], bareRepo);
+        await addWorktreeFromBranch(bareRepo, wsPath, defaultBranch);
+        // Ensure first-run worktree also starts from latest remote state.
+        await refreshWorktreeToRemoteBranch(wsPath, defaultBranch);
         return { workspacePath: wsPath, defaultBranch };
       }
     } else {

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -188,6 +188,7 @@ export class AutomationScheduler {
     }
 
     // Inject git context for project-linked automations
+    let projectName = "";
     if (auto.projectId) {
       const project = await loadProject(auto.projectId, this.dataDir);
       if (!project) {
@@ -195,9 +196,18 @@ export class AutomationScheduler {
         await this.completeRun(auto, run.id, "failure", undefined, error, now);
         return { ...run, status: "failure", error };
       }
+      projectName = project.name;
       const ctx = await getGitContext(workspacePath, defaultBranch);
-      const gitBlock = formatGitContextBlock(ctx, { projectName: project.name });
+      const gitBlock = formatGitContextBlock(ctx, { projectName });
       systemPrompt = systemPrompt ? systemPrompt + "\n\n" + gitBlock : gitBlock;
+    }
+
+    // Interpolate template variables
+    if (systemPrompt) {
+      systemPrompt = systemPrompt
+        .replace(/\{PROJECT}/g, projectName)
+        .replace(/\{DIR}/g, workspacePath)
+        .replace(/\{DEFAULT_BRANCH}/g, defaultBranch ?? "main");
     }
 
     // Create session

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -188,7 +188,7 @@ export class AutomationScheduler {
     }
 
     // Inject git context for project-linked automations
-    let projectName = "";
+    let projectName = "unknown";
     if (auto.projectId) {
       const project = await loadProject(auto.projectId, this.dataDir);
       if (!project) {

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -17,7 +17,7 @@ import { getNotifier } from "../agents/agent-manager.js";
 import { loadProject } from "../state/state.js";
 import { git } from "../utils/git.js";
 import { bareRepoPath, resolveDefaultBranch } from "../utils/paths.js";
-import { getGitContext, formatGitContextBlock } from "../agents/system-prompt.js";
+import { getGitContext, formatGitContextBlock, interpolatePromptVariables } from "../agents/system-prompt.js";
 import type { Automation, AutomationRun, WsOutgoing } from "../types.js";
 
 const SUMMARY_INSTRUCTION =
@@ -204,10 +204,11 @@ export class AutomationScheduler {
 
     // Interpolate template variables
     if (systemPrompt) {
-      systemPrompt = systemPrompt
-        .replace(/\{PROJECT}/g, projectName)
-        .replace(/\{DIR}/g, workspacePath)
-        .replace(/\{DEFAULT_BRANCH}/g, defaultBranch ?? "main");
+      systemPrompt = interpolatePromptVariables(systemPrompt, {
+        projectName,
+        cwd: workspacePath,
+        defaultBranch: defaultBranch ?? "main",
+      });
     }
 
     // Create session

--- a/backend/src/utils/git-worktree.ts
+++ b/backend/src/utils/git-worktree.ts
@@ -1,0 +1,71 @@
+import { rm } from "node:fs/promises";
+import { git } from "./git.js";
+
+export function isMissingOrNotGitRepositoryError(err: unknown): boolean {
+  if (typeof err === "object" && err !== null && "code" in err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return true;
+  }
+  const message = err instanceof Error ? err.message : "";
+  return (
+    /not a git repository/i.test(message) ||
+    /no such file or directory/i.test(message) ||
+    /spawn git ENOENT/i.test(message)
+  );
+}
+
+export async function addWorktreeFromBranch(
+  bareRepoPath: string,
+  workspacePath: string,
+  branch: string,
+): Promise<void> {
+  await git(["worktree", "add", workspacePath, branch], bareRepoPath);
+}
+
+export async function addWorktreeWithNewBranch(
+  bareRepoPath: string,
+  workspacePath: string,
+  branch: string,
+  startPoint: string,
+): Promise<void> {
+  await git(["worktree", "add", "-b", branch, workspacePath, startPoint], bareRepoPath);
+}
+
+export async function refreshWorktreeToRemoteBranch(
+  workspacePath: string,
+  branch: string,
+): Promise<void> {
+  await git(["fetch", "origin", branch], workspacePath);
+  await git(["checkout", branch], workspacePath);
+  try {
+    await git(["reset", "--hard", `origin/${branch}`], workspacePath);
+  } catch {
+    // Worktrees attached to bare repos may not always expose origin/<branch>.
+    // FETCH_HEAD still points to the freshly fetched remote commit.
+    await git(["reset", "--hard", "FETCH_HEAD"], workspacePath);
+  }
+  await git(["clean", "-ffdx"], workspacePath);
+}
+
+export async function removeWorktreeAndPruneBestEffort(
+  bareRepoPath: string,
+  workspacePath: string,
+): Promise<void> {
+  try {
+    await git(["worktree", "remove", "--force", workspacePath], bareRepoPath);
+  } catch {
+    await git(["worktree", "prune"], bareRepoPath).catch(() => {});
+  }
+}
+
+export async function removeWorktreeOrDeleteDirectory(
+  bareRepoPath: string,
+  workspacePath: string,
+): Promise<void> {
+  try {
+    await git(["worktree", "remove", workspacePath, "--force"], bareRepoPath);
+  } catch {
+    await rm(workspacePath, { recursive: true, force: true });
+    await git(["worktree", "prune"], bareRepoPath);
+  }
+}

--- a/backend/src/utils/github.test.ts
+++ b/backend/src/utils/github.test.ts
@@ -131,6 +131,25 @@ describe("isGhInstalled", () => {
     execFileMock.mockImplementation(mockExecFileSuccess("gh version 2.40.0"));
     expect(await isGhInstalled()).toBe(true);
   });
+
+  it("rechecks gh after ENOENT cooldown expires", async () => {
+    const execFileMock = await getExecFileMock();
+    let now = 100_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    execFileMock.mockImplementationOnce(mockExecFileError({ code: "ENOENT" }));
+
+    expect(await isGhInstalled()).toBe(false);
+
+    execFileMock.mockClear();
+    expect(await isGhInstalled()).toBe(false);
+    expect(execFileMock).not.toHaveBeenCalled();
+
+    now += 60_001;
+    execFileMock.mockImplementationOnce(mockExecFileSuccess("gh version 2.40.0"));
+    expect(await isGhInstalled()).toBe(true);
+
+    nowSpy.mockRestore();
+  });
 });
 
 // ── gh() wrapper ────────────────────────────────────────────────────
@@ -503,22 +522,32 @@ describe("fetchPrForBranch", () => {
 
   // ── Error handling ──────────────────────────────────────────────────
 
-  it("permanently disables gh on ENOENT error", async () => {
+  it("temporarily disables gh on ENOENT and retries after cooldown", async () => {
     const execFileMock = await getExecFileMock();
-    execFileMock.mockImplementation(
-      mockExecFileError({ code: "ENOENT" }),
-    );
+    let now = 100_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    execFileMock.mockImplementationOnce(mockExecFileError({ code: "ENOENT" }));
 
     const first = await fetchPrForBranch("acme", "widget", "branch-1");
     expect(first.pr).toBeNull();
     expect(first.error).toBe("gh CLI not installed");
 
-    // Second call should skip gh entirely (fast-path)
+    // Second call should skip gh entirely while in cooldown
     execFileMock.mockClear();
     const second = await fetchPrForBranch("acme", "widget", "branch-2");
     expect(second.pr).toBeNull();
     expect(second.error).toBe("gh CLI not installed");
     expect(execFileMock).not.toHaveBeenCalled();
+
+    // After cooldown, gh should be tried again
+    now += 60_001;
+    execFileMock.mockImplementationOnce(mockExecFileSuccess("[]"));
+    const third = await fetchPrForBranch("acme", "widget", "branch-3");
+    expect(third.pr).toBeNull();
+    expect(third.error).toBeUndefined();
+    expect(execFileMock).toHaveBeenCalled();
+
+    nowSpy.mockRestore();
   });
 
   it("returns auth error message when stderr contains 'auth login'", async () => {

--- a/backend/src/utils/github.ts
+++ b/backend/src/utils/github.ts
@@ -4,9 +4,12 @@ import type { PullRequestInfo } from "../types.js";
 
 const execFile = promisify(execFileCb);
 
-// After the first ENOENT, skip all future `gh` calls for this process.
+const GH_RETRY_COOLDOWN_MS = 60_000;
+
+// After ENOENT, skip `gh` calls until cooldown expires.
 let ghAvailable: boolean | null = null;
 let ghUnavailableReason = "";
+let ghUnavailableAt = 0;
 
 export function parseGitHubRepo(
   url: string,
@@ -40,19 +43,27 @@ export async function gh(
 
 /** Check whether the `gh` binary is on PATH. Caches the result. */
 export async function isGhInstalled(): Promise<boolean> {
-  if (ghAvailable !== null) return ghAvailable;
+  if (ghAvailable === true) return true;
+  if (ghAvailable === false && Date.now() - ghUnavailableAt < GH_RETRY_COOLDOWN_MS) {
+    return false;
+  }
   try {
     await execFile("gh", ["--version"]);
     ghAvailable = true;
+    ghUnavailableReason = "";
+    ghUnavailableAt = 0;
     return true;
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       ghAvailable = false;
       ghUnavailableReason = "gh CLI not installed";
+      ghUnavailableAt = Date.now();
       return false;
     }
     // gh exists but errored for some other reason
     ghAvailable = true;
+    ghUnavailableReason = "";
+    ghUnavailableAt = 0;
     return true;
   }
 }
@@ -152,8 +163,8 @@ export async function fetchPrForBranch(
   repo: string,
   branch: string,
 ): Promise<{ pr: PullRequestInfo | null; error?: string }> {
-  // Fast-path: gh was already found to be unavailable.
-  if (ghAvailable === false) {
+  // Fast-path: gh was recently found unavailable.
+  if (ghAvailable === false && Date.now() - ghUnavailableAt < GH_RETRY_COOLDOWN_MS) {
     return { pr: null, error: ghUnavailableReason };
   }
 
@@ -174,6 +185,8 @@ export async function fetchPrForBranch(
     ]);
 
     ghAvailable = true;
+    ghUnavailableReason = "";
+    ghUnavailableAt = 0;
 
     const items: GhPrItem[] = JSON.parse(stdout);
     if (!items.length) return { pr: null };
@@ -196,10 +209,11 @@ export async function fetchPrForBranch(
   } catch (err: unknown) {
     const error = err as NodeJS.ErrnoException;
 
-    // gh binary not found — disable permanently.
+    // gh binary not found — disable until cooldown expires.
     if (error.code === "ENOENT") {
       ghAvailable = false;
       ghUnavailableReason = "gh CLI not installed";
+      ghUnavailableAt = Date.now();
       return { pr: null, error: ghUnavailableReason };
     }
 
@@ -218,4 +232,5 @@ export async function fetchPrForBranch(
 export function _resetGhState(): void {
   ghAvailable = null;
   ghUnavailableReason = "";
+  ghUnavailableAt = 0;
 }

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -1,7 +1,11 @@
-import { rm, readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promises";
+import { readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promises";
 import { join, relative, resolve, sep } from "node:path";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
+import {
+  addWorktreeWithNewBranch,
+  removeWorktreeOrDeleteDirectory,
+} from "../utils/git-worktree.js";
 import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/paths.js";
 import { pickCityName } from "../utils/city-names.js";
 import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
@@ -130,7 +134,7 @@ export async function createWorkspace(
       }
 
       // Create worktree from the default branch
-      await git(["worktree", "add", "-b", branch, wsPath, defaultBranch], bare);
+      await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranch);
 
       const workspace: Workspace = {
         id: `ws-${nanoid(8)}`,
@@ -197,13 +201,7 @@ export async function deleteWorkspace(
       const wsPath = join(workspacesDir(dataDir, projectId), workspace.name);
 
       // Remove the worktree
-      try {
-        await git(["worktree", "remove", wsPath, "--force"], bare);
-      } catch {
-        // Fallback: just remove the directory
-        await rm(wsPath, { recursive: true, force: true });
-        await git(["worktree", "prune"], bare);
-      }
+      await removeWorktreeOrDeleteDirectory(bare, wsPath);
 
       // Remove the branch
       try {
@@ -278,12 +276,7 @@ export async function archiveWorkspace(
       }
 
       // Remove the worktree (keep the branch for potential restore)
-      try {
-        await git(["worktree", "remove", wsPath, "--force"], bare);
-      } catch {
-        await rm(wsPath, { recursive: true, force: true });
-        await git(["worktree", "prune"], bare);
-      }
+      await removeWorktreeOrDeleteDirectory(bare, wsPath);
 
       // Update state — remove workspace from project
       latest.workspaces = latest.workspaces.filter((ws) => ws.id !== wsId);
@@ -582,12 +575,7 @@ export async function mergeWorkspace(
     await git(["update-ref", `refs/heads/${defaultBranch}`, mergeHash], bare);
   } finally {
     // Cleanup temp worktree
-    try {
-      await git(["worktree", "remove", tempPath, "--force"], bare);
-    } catch {
-      await rm(tempPath, { recursive: true, force: true });
-      await git(["worktree", "prune"], bare);
-    }
+    await removeWorktreeOrDeleteDirectory(bare, tempPath);
   }
 
   // Now delete the workspace

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,48 @@
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error("[ErrorBoundary]", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div style={{ padding: 40, textAlign: "center", fontFamily: "system-ui" }}>
+          <h2>Something went wrong</h2>
+          <p style={{ color: "#888", marginBottom: 16 }}>
+            An unexpected error crashed the UI.
+          </p>
+          <button
+            onClick={() => window.location.reload()}
+            style={{
+              padding: "8px 16px",
+              borderRadius: 6,
+              border: "1px solid #555",
+              background: "transparent",
+              color: "inherit",
+              cursor: "pointer",
+            }}
+          >
+            Reload
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { queryClient } from "@/lib/query-client";
 import "./index.css";
 import { copyToClipboard } from "@/lib/clipboard";
 import App from "./App";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 
 // Fallback for streamdown's code block copy button in non-secure contexts
 // where navigator.clipboard is unavailable (HTTP, remote IP).
@@ -49,8 +50,10 @@ if ("__TAURI_INTERNALS__" in window) {
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>
+    <ErrorBoundary>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 );


### PR DESCRIPTION
## Summary
- harden graceful shutdown persistence by waiting for session stream exit before drain flush completes
- add dedicated automation deletion cleanup tests for git worktree remove/prune behavior
- add gh CLI ENOENT retry cooldown (60s) instead of permanently disabling checks
- add automation system-prompt interpolation coverage for placeholders `{PROJECT}`, `{DIR}`, `{DEFAULT_BRANCH}`
- refactor prompt placeholder interpolation into a shared helper to remove duplication (no intended behavior change)

## Behavior Notes
- no intended functional change from the refactor commit; it centralizes existing placeholder replacement logic
- operational reliability is improved for shutdown and gh re-availability scenarios

## Validation
- `npm run -w backend test -- src/agents/conversation-session.test.ts src/agents/agent-manager.test.ts src/api/automations.cleanup.test.ts src/services/automation-scheduler.test.ts src/utils/github.test.ts`
- `npm run -w backend test -- src/agents/system-prompt.test.ts src/services/automation-scheduler.test.ts`
- `npm run -w backend lint -- --max-warnings=0`
