### PR TITLE
fix(backend): make server CPU metric cgroup quota-aware

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,5 +1,5 @@
 import os from "node:os";
-import { statfsSync } from "node:fs";
+import { readFileSync, statfsSync } from "node:fs";
 import Fastify from "fastify";
 import type { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
@@ -57,7 +57,130 @@ interface BuildAppOptions {
 }
 
 // ── CPU usage sampling ──────────────────────────────────────────────
-// Sample os.cpus() periodically and compute real CPU % from idle delta.
+// Prefer cgroup quota-aware CPU usage (Linux containers) and fall back to host CPU usage.
+
+type CgroupVersion = "v1" | "v2";
+
+interface CgroupReader {
+  version: CgroupVersion;
+  dir: string;
+}
+
+interface CgroupSample {
+  usageMicros: number;
+  quotaCores: number | null;
+}
+
+function readTextFile(path: string): string | null {
+  try {
+    return readFileSync(path, "utf8").trim();
+  } catch {
+    return null;
+  }
+}
+
+function parsePositiveFiniteNumber(value: string | null): number | null {
+  if (!value) return null;
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) return null;
+  return num;
+}
+
+function normalizeCgroupRelativePath(path: string): string {
+  return path === "/" ? "" : path;
+}
+
+function parseSelfCgroupPathV2(): string | null {
+  const raw = readTextFile("/proc/self/cgroup");
+  if (!raw) return null;
+  for (const line of raw.split("\n")) {
+    const [hierarchyId, controllers, path] = line.split(":");
+    if (!hierarchyId || controllers !== "" || !path) continue;
+    return normalizeCgroupRelativePath(path);
+  }
+  return null;
+}
+
+function parseSelfCgroupPathV1(): string | null {
+  const raw = readTextFile("/proc/self/cgroup");
+  if (!raw) return null;
+  for (const line of raw.split("\n")) {
+    const [, controllers, path] = line.split(":");
+    if (!controllers || !path) continue;
+    const set = new Set(controllers.split(","));
+    if (set.has("cpu") || set.has("cpuacct")) {
+      return normalizeCgroupRelativePath(path);
+    }
+  }
+  return null;
+}
+
+function uniqueNonEmpty(paths: Array<string | null | undefined>): string[] {
+  return [...new Set(paths.filter((value): value is string => Boolean(value)))];
+}
+
+function detectCgroupReader(): CgroupReader | null {
+  if (process.platform !== "linux") return null;
+
+  const v2Path = parseSelfCgroupPathV2();
+  const v2Candidates = uniqueNonEmpty([v2Path ? `/sys/fs/cgroup${v2Path}` : null, "/sys/fs/cgroup"]);
+  for (const dir of v2Candidates) {
+    if (readTextFile(`${dir}/cpu.max`) && readTextFile(`${dir}/cpu.stat`)) {
+      return { version: "v2", dir };
+    }
+  }
+
+  const v1Path = parseSelfCgroupPathV1();
+  const v1Candidates = uniqueNonEmpty([
+    v1Path ? `/sys/fs/cgroup/cpu,cpuacct${v1Path}` : null,
+    v1Path ? `/sys/fs/cgroup/cpu${v1Path}` : null,
+    "/sys/fs/cgroup/cpu,cpuacct",
+    "/sys/fs/cgroup/cpu",
+  ]);
+  for (const dir of v1Candidates) {
+    if (
+      readTextFile(`${dir}/cpu.cfs_quota_us`) &&
+      readTextFile(`${dir}/cpu.cfs_period_us`) &&
+      readTextFile(`${dir}/cpuacct.usage`)
+    ) {
+      return { version: "v1", dir };
+    }
+  }
+
+  return null;
+}
+
+function readCgroupSample(reader: CgroupReader): CgroupSample | null {
+  if (reader.version === "v2") {
+    const cpuStat = readTextFile(`${reader.dir}/cpu.stat`);
+    const cpuMax = readTextFile(`${reader.dir}/cpu.max`);
+    if (!cpuStat || !cpuMax) return null;
+
+    const usageMatch = cpuStat.match(/(?:^|\n)usage_usec\s+(\d+)\b/);
+    if (!usageMatch) return null;
+    const usageMicros = Number(usageMatch[1]);
+    if (!Number.isFinite(usageMicros) || usageMicros < 0) return null;
+
+    const [quotaRaw, periodRaw] = cpuMax.split(/\s+/, 2);
+    let quotaCores: number | null = null;
+    if (quotaRaw && periodRaw && quotaRaw !== "max") {
+      const quota = Number(quotaRaw);
+      const period = Number(periodRaw);
+      if (Number.isFinite(quota) && Number.isFinite(period) && quota > 0 && period > 0) {
+        quotaCores = quota / period;
+      }
+    }
+    return { usageMicros, quotaCores };
+  }
+
+  const quota = parsePositiveFiniteNumber(readTextFile(`${reader.dir}/cpu.cfs_quota_us`));
+  const period = parsePositiveFiniteNumber(readTextFile(`${reader.dir}/cpu.cfs_period_us`));
+  const usageNanos = parsePositiveFiniteNumber(readTextFile(`${reader.dir}/cpuacct.usage`));
+  if (usageNanos === null) return null;
+
+  const quotaCores = quota !== null && period !== null ? quota / period : null;
+  return { usageMicros: usageNanos / 1_000, quotaCores };
+}
 
 function snapshotCpuTimes() {
   let idle = 0;
@@ -71,18 +194,53 @@ function snapshotCpuTimes() {
 }
 
 let prevCpu = snapshotCpuTimes();
-let cpuPercentCache = -1; // -1 = no sample yet
+let hostCpuPercentCache = -1; // -1 = no sample yet
+const cgroupReader = detectCgroupReader();
+let prevCgroupUsageMicros: number | null = null;
+let prevCgroupSampleTime = process.hrtime.bigint();
+let cgroupCpuPercentCache: number | null = null;
 
 setInterval(() => {
   const curr = snapshotCpuTimes();
   const idleDelta = curr.idle - prevCpu.idle;
   const totalDelta = curr.total - prevCpu.total;
-  cpuPercentCache = totalDelta > 0 ? Math.round((1 - idleDelta / totalDelta) * 100) : 0;
+  hostCpuPercentCache = totalDelta > 0 ? Math.round((1 - idleDelta / totalDelta) * 100) : 0;
   prevCpu = curr;
+
+  if (!cgroupReader) return;
+
+  const cgroupSample = readCgroupSample(cgroupReader);
+  const now = process.hrtime.bigint();
+  if (!cgroupSample) {
+    cgroupCpuPercentCache = null;
+    prevCgroupUsageMicros = null;
+    prevCgroupSampleTime = now;
+    return;
+  }
+
+  const elapsedMicros = Number(now - prevCgroupSampleTime) / 1_000;
+  if (
+    prevCgroupUsageMicros !== null &&
+    elapsedMicros > 0 &&
+    cgroupSample.quotaCores !== null &&
+    cgroupSample.quotaCores > 0
+  ) {
+    const usageDelta = cgroupSample.usageMicros - prevCgroupUsageMicros;
+    if (usageDelta >= 0) {
+      const rawPercent = (usageDelta / (elapsedMicros * cgroupSample.quotaCores)) * 100;
+      cgroupCpuPercentCache = Math.max(0, Math.min(100, Math.round(rawPercent)));
+    }
+  } else {
+    cgroupCpuPercentCache = null;
+  }
+
+  prevCgroupUsageMicros = cgroupSample.usageMicros;
+  prevCgroupSampleTime = now;
 }, 5_000).unref();
 
 function getCpuPercent(): number {
-  if (cpuPercentCache >= 0) return cpuPercentCache;
+  if (cgroupCpuPercentCache !== null) return cgroupCpuPercentCache;
+  if (hostCpuPercentCache >= 0) return hostCpuPercentCache;
   // No delta yet — fall back to load average as rough estimate
   return Math.min(100, Math.round((os.loadavg()[0] / (os.cpus().length || 1)) * 100));
 }

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -67,6 +67,31 @@ function getSessionVisualState({
   return { isActive, isSessionStreaming, isSessionUnread };
 }
 
+function getFallbackVisualState({
+  activeSessionId,
+  isStreaming,
+  isFileTabActive,
+  streamingSessions,
+  unreadSessions,
+}: {
+  activeSessionId?: string;
+  isStreaming: boolean;
+  isFileTabActive?: boolean;
+  streamingSessions?: Record<string, boolean>;
+  unreadSessions?: Record<string, boolean>;
+}) {
+  const sessionIdsFromStream = Object.keys(streamingSessions ?? {});
+  const fallbackSessionId = activeSessionId ?? sessionIdsFromStream[0];
+  const isSessionStreaming = fallbackSessionId
+    ? Boolean(streamingSessions?.[fallbackSessionId] ?? isStreaming)
+    : isStreaming || sessionIdsFromStream.length > 0;
+  const isSessionVisible = !isFileTabActive;
+  const hasUnread = Object.keys(unreadSessions ?? {}).length > 0;
+  const isSessionUnread = !isSessionVisible && !isSessionStreaming && hasUnread;
+
+  return { isSessionStreaming, isSessionUnread };
+}
+
 function SessionStatusIndicator({
   isStreaming,
   isUnread,
@@ -132,6 +157,13 @@ export function ConversationTabs({
   const [visibleCount, setVisibleCount] = useState(sessions.length);
   const tabsRef = useRef<HTMLDivElement>(null);
   const visibleSessionCount = Math.max(0, visibleCount - (openFile ? 1 : 0));
+  const { isSessionStreaming: isFallbackStreaming, isSessionUnread: isFallbackUnread } = getFallbackVisualState({
+    activeSessionId,
+    isStreaming,
+    isFileTabActive,
+    streamingSessions,
+    unreadSessions,
+  });
 
   const measureTabs = useCallback(() => {
     const tabsEl = tabsRef.current;
@@ -207,7 +239,7 @@ export function ConversationTabs({
               )}
               onClick={onConversationActivate}
             >
-              <MessageSquareIcon className="size-3 shrink-0" />
+              <SessionStatusIndicator isStreaming={isFallbackStreaming} isUnread={isFallbackUnread} />
               <span className="truncate">Untitled</span>
             </button>
           )}

--- a/frontend/src/hooks/useWsCacheInvalidation.ts
+++ b/frontend/src/hooks/useWsCacheInvalidation.ts
@@ -34,6 +34,11 @@ export function useWsCacheInvalidation(workspaceIds: string[]): void {
           case "status":
             // Workspace busy/idle transition.
             void queryClient.invalidateQueries({ queryKey: ["workspace", wsId] });
+            // Auto-created sessions (first user message) should appear in tabs
+            // immediately, not only after done/cancelled events.
+            if (msg.sessionId && msg.streaming) {
+              void queryClient.invalidateQueries({ queryKey: ["sessions", wsId] });
+            }
             break;
         }
       }),

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -153,6 +153,13 @@ describe("ConversationTabs", () => {
     expect(screen.getByTitle("New conversation")).toBeInTheDocument();
   });
 
+  it("shows streaming indicator on empty Untitled tab when streaming", () => {
+    renderTabs({ sessions: [], activeSessionId: undefined, isStreaming: true });
+
+    const untitledTab = screen.getByRole("button", { name: /Untitled/ });
+    expect(untitledTab.querySelector("[aria-label='Agent thinking']")).toBeInTheDocument();
+  });
+
   it("dims the empty Untitled tab when file tab is active", () => {
     renderTabs({
       sessions: [],

--- a/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
+++ b/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
@@ -5,6 +5,8 @@ import { createWrapper } from "../test-utils";
 
 interface Message {
   type: string;
+  sessionId?: string;
+  streaming?: boolean;
 }
 
 interface Listener {
@@ -83,6 +85,17 @@ describe("useWsCacheInvalidation", () => {
 
     expect(invalidateSpy).toHaveBeenCalledTimes(1);
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["workspace", "ws-1"] });
+  });
+
+  it("invalidates sessions on streaming status messages tied to a session", () => {
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
+    renderHook(() => useWsCacheInvalidation(["ws-1"]), { wrapper });
+
+    emit("ws-1", { type: "status", sessionId: "sess-1", streaming: true });
+
+    expect(invalidateSpy).toHaveBeenNthCalledWith(1, { queryKey: ["workspace", "ws-1"] });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(2, { queryKey: ["sessions", "ws-1"] });
   });
 
   it("ignores unsupported message types", () => {


### PR DESCRIPTION
## Summary
- compute sidebar server CPU with Linux cgroup awareness when available
- support cgroup v2 (`cpu.max` + `cpu.stat`) and cgroup v1 (`cpu.cfs_quota_us` + `cpu.cfs_period_us` + `cpuacct.usage`)
- keep current host-level CPU sampling and loadavg startup fallback when cgroup data is unavailable

## Why
Host dashboards usually report CPU against container quota. The previous metric used host-wide CPU time, which could diverge heavily in containerized/shared environments.

## Validation
- npm --prefix backend run typecheck
- npm --prefix backend run test
