### PR TITLE
feat(ui): Write tool parity with Edit + terminal T1 label

### DIFF
--- a/frontend/src/components/ChatToolUse.tsx
+++ b/frontend/src/components/ChatToolUse.tsx
@@ -173,9 +173,15 @@ function getToolDisplay(tool: ToolCall): ToolDisplay {
         icon: icons.file,
         label: "Write",
         detail: filename,
-        expandedContent: filePath
-          ? `Path: ${filePath}\n\nContent:\n${content ?? "(empty)"}`
-          : "No file path specified",
+        expandedContent: filePath ? (
+          <DiffView
+            filePath={filePath}
+            oldText=""
+            newText={content ?? ""}
+          />
+        ) : (
+          "No file path specified"
+        ),
       };
     }
 
@@ -348,7 +354,7 @@ function getToolStats(tool: ToolCall): ToolStats | null {
       const content = (input.content as string | undefined) ?? "";
       if (!content) return null;
       const lineCount = content.split("\n").length;
-      return { type: "plain", label: `${lineCount} lines` };
+      return { type: "diff", added: lineCount, removed: 0 };
     }
     case "Grep": {
       if (!tool.output) return null;

--- a/frontend/src/components/ScriptPanel.tsx
+++ b/frontend/src/components/ScriptPanel.tsx
@@ -234,7 +234,7 @@ export default function ScriptPanel({
               {tab.isTerminal ? (
                 <>
                   {tabStatus.state === "running" && <WaveIndicator />}
-                  <TerminalSquareIcon className="size-3" />
+                  <span className="font-semibold">T1</span>
                 </>
               ) : (
                 <>

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -380,7 +380,7 @@ private func computeToolStats(_ tool: ToolCall) -> ToolStats? {
     case "Write":
         guard let content = input["content"] as? String, !content.isEmpty else { return nil }
         let lineCount = content.components(separatedBy: "\n").count
-        return ToolStats(kind: .plain, label: "\(lineCount) lines")
+        return ToolStats(kind: .diff, added: lineCount, removed: 0)
 
     case "Grep":
         guard let output = tool.output, !output.isEmpty else { return nil }
@@ -663,7 +663,7 @@ private struct WhisperToolCallRow: View {
 
             if isExpanded {
                 VStack(alignment: .leading, spacing: 0) {
-                    if tool.name == "Edit" {
+                    if tool.name == "Edit" || tool.name == "Write" {
                         DiffContentView(tool: tool)
                     } else if tool.name == "AskUserQuestion" {
                         AskUserQuestionContent(tool: tool)
@@ -792,6 +792,13 @@ private struct DiffContentView: View {
             return (nil, [])
         }
         let filePath = resolveFilePath(input)
+
+        // Write tool: all-new content
+        if let content = input["content"] as? String, !content.isEmpty {
+            let lines = content.split(separator: "\n", omittingEmptySubsequences: false)
+            let diffLines = lines.enumerated().map { DiffLine(id: $0.offset, kind: .added, text: String($0.element)) }
+            return (filePath, diffLines)
+        }
 
         // Codex format: unified diff string
         if let diff = input["diff"] as? String, !diff.isEmpty {


### PR DESCRIPTION
## Summary
- **Write tool rendering aligned with Edit**: green `+N` line count in summary (instead of gray "N lines"), colored diff card showing all lines as additions — applied to both frontend and iOS
- **Terminal tab label**: replaced `TerminalSquareIcon` with "T1" text in the script panel tab bar (icon kept in idle state and start button)

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (2199 tests)
- [ ] Verify Write tool calls show green `+N` stats and green diff card when expanded
- [ ] Verify Edit tool rendering unchanged
- [ ] Verify script panel terminal tab shows "T1" at same size as SETUP/FRONTEND labels
- [ ] Verify idle state and start button still show terminal icon