### PR TITLE
feat(codex): add GPT-5.4 model with 1M context window

### DIFF
--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -36,9 +36,9 @@ describe("CodexProvider", () => {
     expect(defaults).toHaveLength(1);
   });
 
-  it("includes gpt-5.3-codex as default", () => {
+  it("includes gpt-5.4 as default", () => {
     const defaultModel = provider.models.find((m) => m.isDefault);
-    expect(defaultModel?.id).toBe("gpt-5.3-codex");
+    expect(defaultModel?.id).toBe("gpt-5.4");
   });
 
   // ── Capabilities ───────────────────────────────────────────────────

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -10,7 +10,8 @@ import type {
 } from "./types.js";
 
 const CODEX_MODELS: ModelDefinition[] = [
-  { id: "gpt-5.3-codex", label: "GPT-5.3-Codex", cliValue: "gpt-5.3-codex", isDefault: true },
+  { id: "gpt-5.4", label: "GPT-5.4", cliValue: "gpt-5.4", isDefault: true, isNew: true, contextWindow: 1_050_000 },
+  { id: "gpt-5.3-codex", label: "GPT-5.3-Codex", cliValue: "gpt-5.3-codex" },
 ];
 
 const CODEX_CAPABILITIES: ProviderCapabilities = {

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -220,12 +220,12 @@ describe("getModelCatalog", () => {
   });
 
   it("includes isNew flag from model definition", () => {
-    markProviderAvailable("claude");
+    markProviderAvailable("codex");
     const catalog = getModelCatalog();
 
-    // No models currently marked as new
     const newModels = catalog.models.filter((m) => m.isNew);
-    expect(newModels).toHaveLength(0);
+    expect(newModels.length).toBeGreaterThan(0);
+    expect(newModels[0].id).toBe("codex:gpt-5.4");
   });
 });
 
@@ -309,14 +309,16 @@ describe("contextWindow in catalog", () => {
     }
   });
 
-  it("omits contextWindow for providers that don't define it", () => {
+  it("includes contextWindow for Codex models that define it", () => {
     markProviderAvailable("codex");
     const catalog = getModelCatalog();
     const codexModels = catalog.models.filter((m) => m.provider === "codex");
 
-    for (const model of codexModels) {
-      expect(model.contextWindow).toBeUndefined();
-    }
+    const gpt54 = codexModels.find((m) => m.id === "codex:gpt-5.4");
+    expect(gpt54?.contextWindow).toBe(1_050_000);
+
+    const gpt53 = codexModels.find((m) => m.id === "codex:gpt-5.3-codex");
+    expect(gpt53?.contextWindow).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds GPT-5.4 (1,050,000 token context window) as the new default Codex model
- GPT-5.3-Codex demoted to secondary model
- Context ring and model picker work out of the box — no frontend/iOS changes needed
- Requires Codex CLI >= 0.111.0

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (1081/1081)