### PR TITLE
fix(backend): expand file tree IGNORED_DIRS to prevent node budget exhaustion

### DIFF
--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -14,7 +14,28 @@ import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.j
 import { stopAllForWorkspace } from "../services/script-runner.js";
 import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffStatResponse } from "../types.js";
 
-const IGNORED_DIRS = new Set([".git", "node_modules"]);
+const IGNORED_DIRS = new Set([
+  ".git",
+  "node_modules",
+  // Build output
+  "target",        // Rust/Cargo
+  "build",         // Java/Gradle, C/CMake
+  "dist",          // JS bundlers
+  ".next",         // Next.js
+  ".nuxt",         // Nuxt
+  ".svelte-kit",   // SvelteKit
+  ".output",       // Nitro/Nuxt
+  "__pycache__",   // Python
+  ".cache",        // Various tools
+  ".parcel-cache", // Parcel
+  ".turbo",        // Turborepo
+  // Dependency/env
+  ".venv",         // Python virtualenv
+  "venv",
+  ".tox",          // Python tox
+  // IDE
+  ".idea",         // JetBrains
+]);
 const MAX_TREE_DEPTH = 8;
 const MAX_TREE_NODES = 3000;
 


### PR DESCRIPTION
## Summary

- The file tree walker uses a shared 3000-node budget with depth-first traversal. For repos containing large build output directories (e.g. Rust `target/` with 50K+ files), the first alphabetical directory would exhaust the entire budget, preventing all other root-level entries from appearing in the tree.
- Adds 16 commonly bloated directories to `IGNORED_DIRS`: `target`, `build`, `dist`, `.next`, `.nuxt`, `.svelte-kit`, `.output`, `__pycache__`, `.cache`, `.parcel-cache`, `.turbo`, `.venv`, `venv`, `.tox`, `.idea`.

## Test plan

- [x] All 1081 tests pass
- [x] Typecheck passes
- [ ] Verify file tree now shows full root for `solana-arb-architecture-analysis` project