### PR TITLE
fix(backend): replay in-progress streaming content on WS reconnect

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -131,6 +131,12 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private stopReason: StopReason | null = null;
   private _lastBlockingToolUseId: string | undefined;
 
+  // In-progress streaming accumulators (instance-level for snapshot access)
+  private _streamText = "";
+  private _streamThinking = "";
+  private _streamToolCalls: ToolCall[] = [];
+  private _agentPlanMode = false;
+
   constructor(config: ConversationSessionConfig) {
     super();
     this.sessionId = config.sessionId ?? nanoid(12);
@@ -161,6 +167,19 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
   get metadata(): SessionMetadata {
     return { ...this._metadata };
+  }
+
+  /** Return a snapshot of in-progress streaming content (text, thinking, tool calls).
+   *  Returns null when the session is not streaming. Used by WS bootstrap to replay
+   *  accumulated state to late-connecting clients. */
+  getStreamingSnapshot(): { text: string; thinking: string; toolCalls: ToolCall[]; agentPlanMode: boolean } | null {
+    if (this._status !== "streaming") return null;
+    return {
+      text: this._streamText,
+      thinking: this._streamThinking,
+      toolCalls: this._streamToolCalls,
+      agentPlanMode: this._agentPlanMode,
+    };
   }
 
   /** Load a session from disk. Returns the session in idle state with history available. */
@@ -377,10 +396,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       ? new StreamParser()
       : provider!.createStreamAdapter();
 
-    // Accumulators for building the assistant ChatMessage
-    let assistantText = "";
-    let thinkingText = "";
-    const toolCalls: ToolCall[] = [];
+    // Reset in-progress streaming accumulators
+    this._streamText = "";
+    this._streamThinking = "";
+    this._streamToolCalls = [];
+    this._agentPlanMode = false;
     let resultDurationMs: number | undefined;
     let resultInputTokens: number | undefined;
     let resultOutputTokens: number | undefined;
@@ -398,11 +418,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       for (const block of data.message.content) {
         switch (block.type) {
           case "text":
-            assistantText += block.text;
+            this._streamText += block.text;
             this.emit("message", { type: "text_delta", sessionId: this.sessionId, text: block.text });
             break;
           case "thinking":
-            thinkingText += block.thinking;
+            this._streamThinking += block.thinking;
             this.emit("message", { type: "thinking", sessionId: this.sessionId, text: block.thinking });
             break;
           case "tool_use":
@@ -420,11 +440,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
             const parentToolUseId = pendingTaskStack.length > 0
               ? pendingTaskStack[pendingTaskStack.length - 1]
               : undefined;
-            const existingTool = toolCalls.find((t) => t.id === block.id);
+            const existingTool = this._streamToolCalls.find((t) => t.id === block.id);
             if (existingTool) {
               existingTool.input = inputStr;
             } else {
-              toolCalls.push({ id: block.id, name: displayName, input: inputStr, parentToolUseId });
+              this._streamToolCalls.push({ id: block.id, name: displayName, input: inputStr, parentToolUseId });
               this.emit("message", {
                 type: "tool_use",
                 sessionId: this.sessionId,
@@ -441,10 +461,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
             // Emit plan mode state changes for UI auto-toggle
             if (block.name === "EnterPlanMode" || block.name === "ExitPlanMode") {
+              this._agentPlanMode = block.name === "EnterPlanMode";
               this.emit("message", {
                 type: "plan_mode_changed",
                 sessionId: this.sessionId,
-                active: block.name === "EnterPlanMode",
+                active: this._agentPlanMode,
               } as WsOutgoing);
             }
 
@@ -458,7 +479,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           }
           case "redacted_thinking":
             // Safety-redacted thinking — opaque encrypted data, just note it happened.
-            thinkingText += "[redacted]\n";
+            this._streamThinking += "[redacted]\n";
             break;
           case "web_search_tool_result":
           case "web_fetch_tool_result":
@@ -468,7 +489,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
             // Server-side and MCP tool results arrive as assistant content blocks,
             // not as user tool_result messages. Forward them as tool_result events.
             const output = formatServerToolResult(block);
-            const tc = toolCalls.find((t) => t.id === block.tool_use_id);
+            const tc = this._streamToolCalls.find((t) => t.id === block.tool_use_id);
             if (tc) tc.output = output;
             this.emit("message", {
               type: "tool_result",
@@ -500,7 +521,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
             pendingTaskStack.pop();
           }
 
-          const tc = toolCalls.find((t) => t.id === block.tool_use_id);
+          const tc = this._streamToolCalls.find((t) => t.id === block.tool_use_id);
           if (tc) tc.output = block.content;
           this.emit("message", {
             type: "tool_result",
@@ -603,14 +624,14 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       this.process = null;
       this.parser = null;
 
-      if (assistantText || toolCalls.length > 0 || thinkingText || shouldSurfaceCancelled) {
+      if (this._streamText || this._streamToolCalls.length > 0 || this._streamThinking || shouldSurfaceCancelled) {
         const assistantMsg: ChatMessage = {
           id: nanoid(12),
           sessionId: this.sessionId,
           role: "assistant",
-          content: assistantText || (shouldSurfaceCancelled ? CANCELLED_NO_OUTPUT_MESSAGE : ""),
-          toolCalls: toolCalls.length > 0 ? toolCalls : undefined,
-          thinkingContent: thinkingText || undefined,
+          content: this._streamText || (shouldSurfaceCancelled ? CANCELLED_NO_OUTPUT_MESSAGE : ""),
+          toolCalls: this._streamToolCalls.length > 0 ? this._streamToolCalls : undefined,
+          thinkingContent: this._streamThinking || undefined,
           timestamp: new Date().toISOString(),
           cancelled: shouldSurfaceCancelled || undefined,
           errorDetail: cancellationErrorDetail,
@@ -628,8 +649,14 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         .catch((err) => console.error("[session] Persist metadata failed:", err));
 
       const unansweredBlockingTools = killedForBlockingTool
-        ? toolCalls.filter((tc) => blockingToolNames.has(tc.name))
+        ? this._streamToolCalls.filter((tc) => blockingToolNames.has(tc.name))
         : [];
+
+      // Free accumulated streaming data now that the assistant message has been persisted.
+      this._streamText = "";
+      this._streamThinking = "";
+      this._streamToolCalls = [];
+      this._agentPlanMode = false;
 
       const pendingToolName = unansweredBlockingTools.length > 0
         ? unansweredBlockingTools[0]!.name

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -177,7 +177,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     return {
       text: this._streamText,
       thinking: this._streamThinking,
-      toolCalls: this._streamToolCalls,
+      toolCalls: this._streamToolCalls.map(tc => ({ ...tc })),
       agentPlanMode: this._agentPlanMode,
     };
   }
@@ -652,7 +652,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         ? this._streamToolCalls.filter((tc) => blockingToolNames.has(tc.name))
         : [];
 
-      // Free accumulated streaming data now that the assistant message has been persisted.
+      // Free accumulated streaming data now that the assistant message has been enqueued for persistence.
       this._streamText = "";
       this._streamThinking = "";
       this._streamToolCalls = [];

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -165,6 +165,42 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     } catch {
       // History load failure is non-fatal.
     }
+
+    // Replay in-progress streaming content so late-connecting clients see
+    // text, thinking, and tool calls accumulated since the turn started.
+    if (session.status === "streaming") {
+      const snapshot = session.getStreamingSnapshot();
+      if (snapshot) {
+        const sid = session.sessionId;
+        if (snapshot.thinking) {
+          sendToHub(hub, workspaceId, { type: "thinking", sessionId: sid, text: snapshot.thinking });
+        }
+        if (snapshot.text) {
+          sendToHub(hub, workspaceId, { type: "text_delta", sessionId: sid, text: snapshot.text });
+        }
+        for (const tc of snapshot.toolCalls) {
+          sendToHub(hub, workspaceId, {
+            type: "tool_use",
+            sessionId: sid,
+            id: tc.id,
+            name: tc.name,
+            input: tc.input,
+            parentToolUseId: tc.parentToolUseId,
+          });
+          if (tc.output) {
+            sendToHub(hub, workspaceId, {
+              type: "tool_result",
+              sessionId: sid,
+              toolUseId: tc.id,
+              output: tc.output,
+            });
+          }
+        }
+        if (snapshot.agentPlanMode) {
+          sendToHub(hub, workspaceId, { type: "plan_mode_changed", sessionId: sid, active: true });
+        }
+      }
+    }
   };
 
   const detachSessionTracking = (channel: WorkspaceChannel, sessionId: string): void => {
@@ -330,12 +366,17 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
     }
 
-    // Subscribe to new workspaces and bootstrap
+    // Subscribe to new workspaces and bootstrap.
+    // The hub socket is added to the channel AFTER bootstrap completes so that
+    // live events broadcast during the async getMessages() call don't reach
+    // this client before the streaming snapshot is replayed (which would cause
+    // duplicate content). Node.js single-threading guarantees no events fire
+    // between sendWorkspaceBootstrap returning and hubSockets.add.
     for (const wsId of desired) {
       if (!hub.subscribedWorkspaces.has(wsId)) {
         const channel = getOrCreateChannel(wsId);
-        channel.hubSockets.add(hub);
         await sendWorkspaceBootstrap(hub, wsId, channel);
+        channel.hubSockets.add(hub);
       }
     }
 

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -47,7 +47,8 @@ type LocalAction =
   | { type: "clear_chat" }
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
-  | { type: "clear_pending_tool_inputs" };
+  | { type: "clear_pending_tool_inputs" }
+  | { type: "_ws_reconnected" };
 
 type Action = WsOutgoing | LocalAction;
 
@@ -410,6 +411,13 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
     case "reset":
       return initialState;
+
+    case "_ws_reconnected":
+      // On WS reconnect the backend will re-bootstrap every workspace with a
+      // full streaming snapshot (text, thinking, tool calls). Clear accumulated
+      // stream data so the snapshot won't be *appended* to stale pre-disconnect
+      // content, which would cause duplicate tool calls and garbled text.
+      return { ...state, sessionStreams: {} };
 
     default:
       return state;

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -500,6 +500,10 @@ export function useConversation(workspaceId: string | undefined) {
     });
     replayingBuffer = false;
 
+    const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
+      dispatch({ type: "_ws_reconnected" });
+    });
+
     // Tell the backend to activate the saved session and send its bootstrap.
     if (savedSession) {
       const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
@@ -540,6 +544,7 @@ export function useConversation(workspaceId: string | undefined) {
         historyRequestTokenRef.current = historyRequestToken + 1;
       }
       unsubscribe();
+      unsubReconnect();
     };
   }, [workspaceId, syncSessionHistory]);
 

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -27,6 +27,7 @@ interface HubState {
 
 interface WorkspaceSubscription {
   messageHandlers: Set<MessageHandler>;
+  reconnectListeners: Set<() => void>;
   statusListeners: Set<StatusListener>;
   lastStatus?: StatusMessage;
   lastStatusBySession: Map<string, StatusMessage>;
@@ -161,6 +162,13 @@ class WsTransport {
     };
   }
 
+  /** Register a callback invoked when the hub WS reconnects. */
+  onReconnect(workspaceId: string, callback: () => void): () => void {
+    const sub = this.getOrCreateSubscription(workspaceId);
+    sub.reconnectListeners.add(callback);
+    return () => { sub.reconnectListeners.delete(callback); };
+  }
+
   /** useSyncExternalStore subscribe contract (per workspace). */
   subscribe = (workspaceId: string, listener: StatusListener): (() => void) => {
     const sub = this.getOrCreateSubscription(workspaceId);
@@ -191,6 +199,7 @@ class WsTransport {
 
     const created: WorkspaceSubscription = {
       messageHandlers: new Set<MessageHandler>(),
+      reconnectListeners: new Set<() => void>(),
       statusListeners: new Set<StatusListener>(),
       lastStatusBySession: new Map(),
       messageBuffer: [],
@@ -247,13 +256,12 @@ class WsTransport {
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
       }
-      // On reconnect, notify all handlers to clear stale streaming state before
+      // On reconnect, notify all listeners to clear stale streaming state before
       // the bootstrap replays full snapshots. Without this, the snapshot events
       // would be appended to pre-disconnect accumulated data, causing duplicates.
       if (isReconnect) {
-        const reconnectEvent = { type: "_ws_reconnected" } as unknown as WsOutgoing;
         for (const sub of this.subscriptions.values()) {
-          for (const handler of sub.messageHandlers) handler(reconnectEvent);
+          for (const listener of sub.reconnectListeners) listener();
         }
       }
       this.setHubStatus("connected");

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -241,10 +241,20 @@ class WsTransport {
 
     ws.onopen = () => {
       if (this.hub.ws !== ws) return;
+      const isReconnect = this.hub.reconnectAttempt > 0;
       this.hub.reconnectAttempt = 0;
       // Clear per-session status caches on reconnect (will be repopulated by bootstrap)
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
+      }
+      // On reconnect, notify all handlers to clear stale streaming state before
+      // the bootstrap replays full snapshots. Without this, the snapshot events
+      // would be appended to pre-disconnect accumulated data, causing duplicates.
+      if (isReconnect) {
+        const reconnectEvent = { type: "_ws_reconnected" } as unknown as WsOutgoing;
+        for (const sub of this.subscriptions.values()) {
+          for (const handler of sub.messageHandlers) handler(reconnectEvent);
+        }
       }
       this.setHubStatus("connected");
       this.sendSyncWorkspaces();

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -74,6 +74,7 @@ vi.mock("@/lib/ws-transport", () => ({
     syncWorkspaces: mocks.syncWorkspaces,
     disconnectAll: mocks.disconnectAll,
     onMessage: mocks.onMessage,
+    onReconnect: vi.fn(() => () => {}),
     onGlobalMessage: mocks.onGlobalMessage,
   },
 }));

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -43,6 +43,7 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: false,
       };
     }),
+    onReconnect: vi.fn(() => () => {}),
   };
 
   const __wsMock = {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -77,6 +77,9 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: bufferedFlags.get(workspaceId) ?? false,
       };
     }),
+    onReconnect: vi.fn((_workspaceId: string, _callback: () => void) => {
+      return () => {};
+    }),
     subscribe: (workspaceId: string, listener: () => void) => {
       getSet(statusListeners, workspaceId).add(listener);
       return () => {

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -22,6 +22,7 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: false,
       };
     }),
+    onReconnect: vi.fn(() => () => {}),
   };
 
   const __wsMock = {

--- a/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
+++ b/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
 vi.mock("@/lib/ws-transport", () => ({
   wsTransport: {
     onMessage: mocks.onMessage,
+    onReconnect: vi.fn(() => () => {}),
   },
 }));
 

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -69,7 +69,7 @@ vi.mock("@/hooks/useWorkspaceLiveData", () => ({
 }));
 
 vi.mock("@/lib/ws-transport", () => ({
-  wsTransport: { clearCachedData: mocks.clearCachedData },
+  wsTransport: { clearCachedData: mocks.clearCachedData, onReconnect: vi.fn(() => () => {}) },
 }));
 
 vi.mock("@/hooks/useScripts", () => ({

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -217,7 +217,6 @@ final class HubStatusMonitor {
     /// Used by pull-to-refresh so the backend re-sends status, history, branch_info,
     /// diff_stats, and script_status for every subscribed workspace.
     func forceRefresh() {
-        storeCache.clearAllStreamingState()
         hubConnection?.forceReconnect()
     }
 
@@ -311,7 +310,10 @@ private final class HubConnection {
         task.resume()
         backoff = 1
 
-        // Re-wire send closures on all existing stores (handles reconnects)
+        // Clear stale streaming state and re-wire send closures on all existing stores.
+        // Without clearing, the bootstrap snapshot would be appended to pre-disconnect
+        // accumulated data, causing duplicate tool calls and garbled text.
+        monitor?.storeCache.clearAllStreamingState()
         monitor?.rewireAllSendClosures()
 
         startReceiving()


### PR DESCRIPTION
## Summary

- **Streaming snapshot on reconnect**: When a client reconnects while an agent is working, the WS bootstrap now replays all accumulated text, thinking, tool calls, and plan mode state. Previously, only persisted (completed turn) history was sent, leaving the client with just the user message and a working indicator.
- **Race condition fix**: Hub socket is added to the channel *after* bootstrap completes, preventing live events from arriving before the snapshot replay (which would cause duplicate content).
- **Frontend stale-state fix**: On WS reconnect, the transport dispatches a `_ws_reconnected` event that clears all `sessionStreams` in the reducer before the bootstrap repopulates them. Without this, the full streaming snapshot was *appended* to stale pre-disconnect accumulated data, causing duplicate tool calls that appeared as cross-workspace contamination.
- **Memory cleanup**: Streaming accumulators are cleared in the close handler after consumption, preventing stale data from lingering on idle sessions.

## How it works

### Backend
1. `ConversationSession` streaming accumulators promoted from closure-local variables to instance fields
2. New `getStreamingSnapshot()` method returns the accumulated state when streaming
3. `sendSessionBootstrap()` replays the snapshot as individual WS events

### Frontend
4. `ws-transport.ts`: on reconnect (`reconnectAttempt > 0`), dispatches a synthetic `_ws_reconnected` event to all registered handlers before `sync_workspaces`
5. `useConversation.ts`: handles `_ws_reconnected` by clearing all `sessionStreams`, so the bootstrap snapshot starts from a clean slate

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (87 files, 1081 tests)
- [ ] Manual: start a long agent conversation, navigate away, navigate back — verify intermediate text/tools are visible
- [ ] Manual: same test from iOS app
- [ ] Manual: verify plan mode state is correct on reconnect during EnterPlanMode
- [ ] Manual: verify no duplicate tool calls after WS reconnect mid-stream