### PR TITLE
fix: clear streaming indicator on done/cancelled without waiting for exit

### DIFF
--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -636,46 +636,48 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         : undefined;
 
       void (async () => {
-        await this.persistQueue;
-        if (shouldSurfaceCancelled) {
-          const cancelDurationMs = resultDurationMs
-            ?? (capturedStreamingStart ? Date.now() - capturedStreamingStart : undefined);
-          this.emit("message", {
-            type: "cancelled",
-            sessionId: this.sessionId,
-            errorDetail: cancellationErrorDetail,
-            userInitiated: capturedStopReason === "user",
-            durationMs: cancelDurationMs,
-          });
-        } else if (!cancelledByPark) {
-          this.emit("message", {
-            type: "done",
-            sessionId: this.sessionId,
-            durationMs: resultDurationMs,
-            inputTokens: resultInputTokens,
-            outputTokens: resultOutputTokens,
-            pendingToolName,
-          });
-        }
-
-        for (const tool of unansweredBlockingTools) {
-          let input: unknown;
-          try {
-            input = JSON.parse(tool.input);
-          } catch {
-            input = {};
+        try {
+          await this.persistQueue;
+          if (shouldSurfaceCancelled) {
+            const cancelDurationMs = resultDurationMs
+              ?? (capturedStreamingStart ? Date.now() - capturedStreamingStart : undefined);
+            this.emit("message", {
+              type: "cancelled",
+              sessionId: this.sessionId,
+              errorDetail: cancellationErrorDetail,
+              userInitiated: capturedStopReason === "user",
+              durationMs: cancelDurationMs,
+            });
+          } else if (!cancelledByPark) {
+            this.emit("message", {
+              type: "done",
+              sessionId: this.sessionId,
+              durationMs: resultDurationMs,
+              inputTokens: resultInputTokens,
+              outputTokens: resultOutputTokens,
+              pendingToolName,
+            });
           }
-          this.emit("message", {
-            type: "tool_input_required",
-            sessionId: this.sessionId,
-            requestId: nanoid(12),
-            toolName: tool.name,
-            toolUseId: tool.id,
-            input,
-          });
-        }
 
-        this.emit("exit", exitCode);
+          for (const tool of unansweredBlockingTools) {
+            let input: unknown;
+            try {
+              input = JSON.parse(tool.input);
+            } catch {
+              input = {};
+            }
+            this.emit("message", {
+              type: "tool_input_required",
+              sessionId: this.sessionId,
+              requestId: nanoid(12),
+              toolName: tool.name,
+              toolUseId: tool.id,
+              input,
+            });
+          }
+        } finally {
+          this.emit("exit", exitCode);
+        }
       })();
     });
   }

--- a/frontend/src/hooks/useWorkspaceLiveData.ts
+++ b/frontend/src/hooks/useWorkspaceLiveData.ts
@@ -94,10 +94,22 @@ export function useWorkspaceLiveData(
           setLiveData((prev) => {
             const current = prev[wsId] ?? {};
             const prevUnread = current.unreadSessions ?? {};
-            if (prevUnread[msg.sessionId!]) return prev;
+            const wasStreaming = !!(current.streamingSessions ?? {})[msg.sessionId!];
+            const alreadyUnread = !!prevUnread[msg.sessionId!];
+            if (!wasStreaming && alreadyUnread) return prev;
+            const nextSessions = wasStreaming
+              ? { ...(current.streamingSessions ?? {}) }
+              : (current.streamingSessions ?? {});
+            if (wasStreaming) delete nextSessions[msg.sessionId!];
+            const anySessionStreaming = Object.keys(nextSessions).length > 0;
             return {
               ...prev,
-              [wsId]: { ...current, unreadSessions: { ...prevUnread, [msg.sessionId!]: true } },
+              [wsId]: {
+                ...current,
+                streaming: anySessionStreaming,
+                streamingSessions: nextSessions,
+                unreadSessions: { ...prevUnread, [msg.sessionId!]: true },
+              },
             };
           });
         } else if (msg.type === "script_status") {

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -301,6 +301,12 @@ class WsTransport {
       sub.lastBranchInfo = msg;
     }
 
+    // Clear stale per-session status cache on done/cancelled to prevent
+    // replay of streaming: true after re-subscribe.
+    if ((msg.type === "done" || msg.type === "cancelled") && msg.sessionId) {
+      sub.lastStatusBySession.delete(msg.sessionId);
+    }
+
     // Dispatch to handlers or buffer
     if (sub.messageHandlers.size > 0) {
       for (const handler of sub.messageHandlers) handler(msg);

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -464,6 +464,84 @@ describe("useWorkspaceLiveData", () => {
     expect(result.current.liveData).toBe(firstRef);
   });
 
+  it("clears streamingSessions on done event", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-a",
+        streaming: true,
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(true);
+    expect(result.current.liveData["ws-1"]?.streamingSessions).toEqual({ "sess-a": true });
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(false);
+    expect(result.current.liveData["ws-1"]?.streamingSessions).toEqual({});
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-a": true });
+  });
+
+  it("clears streamingSessions on cancelled event", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-a",
+        streaming: true,
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(true);
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "cancelled", sessionId: "sess-a" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(false);
+    expect(result.current.liveData["ws-1"]?.streamingSessions).toEqual({});
+    expect(result.current.liveData["ws-1"]?.unreadSessions).toEqual({ "sess-a": true });
+  });
+
+  it("keeps other sessions streaming when one session receives done", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-a",
+        streaming: true,
+      });
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-b",
+        streaming: true,
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(true);
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-a" });
+    });
+
+    expect(result.current.liveData["ws-1"]?.streaming).toBe(true);
+    expect(result.current.liveData["ws-1"]?.streamingSessions).toEqual({ "sess-b": true });
+  });
+
   it("clearUnread is a no-op when the target session is not unread", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -372,7 +372,13 @@ private final class HubConnection {
             monitor?.didReceiveBranchInfo(info, for: workspaceId)
 
         case .done:
+            monitor?.didReceiveStreaming(false, for: workspaceId)
             monitor?.didReceiveDone(for: workspaceId)
+
+        case .cancelled:
+            // Clear streaming but don't mark as completed — cancelled turns may require
+            // tool input or were user-interrupted, so no green "completed" badge.
+            monitor?.didReceiveStreaming(false, for: workspaceId)
 
         default:
             break

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -9,7 +9,9 @@ import Observation
 @MainActor
 @Observable
 final class HubStatusMonitor {
-    private(set) var streamingWorkspaces: Set<String> = []
+    /// Per-workspace, per-session streaming tracking.
+    /// Key = workspaceId, Value = set of sessionIds currently streaming.
+    private(set) var streamingSessions: [String: Set<String>] = [:]
     private(set) var workspaceDiffStats: [String: DiffStatResponse] = [:]
     private(set) var workspaceBranchInfo: [String: BranchInfo] = [:]
     private(set) var workspacePrStatus: [String: PrStatusResponse] = [:]
@@ -57,7 +59,7 @@ final class HubStatusMonitor {
     // MARK: - Public accessors
 
     func isStreaming(_ workspaceId: String) -> Bool {
-        streamingWorkspaces.contains(workspaceId)
+        !(streamingSessions[workspaceId]?.isEmpty ?? true)
     }
 
     func diffStats(for workspaceId: String) -> DiffStatResponse? {
@@ -97,7 +99,7 @@ final class HubStatusMonitor {
 
         // Clean up removed workspaces
         for id in subscribedWorkspaceIds.subtracting(desired) {
-            streamingWorkspaces.remove(id)
+            streamingSessions.removeValue(forKey: id)
             workspaceDiffStats.removeValue(forKey: id)
             workspaceBranchInfo.removeValue(forKey: id)
             workspacePrStatus.removeValue(forKey: id)
@@ -124,7 +126,7 @@ final class HubStatusMonitor {
         hubConnection?.cancel()
         hubConnection = nil
         subscribedWorkspaceIds.removeAll()
-        streamingWorkspaces.removeAll()
+        streamingSessions.removeAll()
         workspaceDiffStats.removeAll()
         workspaceBranchInfo.removeAll()
         bulkPrPollTask?.cancel()
@@ -180,16 +182,30 @@ final class HubStatusMonitor {
     /// Used to detect streaming→idle transitions after reconnect and mark them as completed.
     private var streamingBeforeBackground: Set<String> = []
 
-    fileprivate func didReceiveStreaming(_ streaming: Bool, for workspaceId: String) {
+    fileprivate func didReceiveStreaming(_ streaming: Bool, for workspaceId: String, sessionId: String?) {
         if streaming {
-            streamingWorkspaces.insert(workspaceId)
+            var sessions = streamingSessions[workspaceId] ?? []
+            if let sid = sessionId { sessions.insert(sid) }
+            streamingSessions[workspaceId] = sessions
         } else {
-            streamingWorkspaces.remove(workspaceId)
-            // If this workspace was streaming before the app went to background
-            // and is now idle, treat it as a completed turn (the .done event was lost).
-            if streamingBeforeBackground.remove(workspaceId) != nil {
-                didReceiveDone(for: workspaceId)
+            if let sid = sessionId {
+                streamingSessions[workspaceId]?.remove(sid)
+            } else {
+                // No sessionId (e.g. status with streaming=false) — clear all sessions for this workspace
+                streamingSessions[workspaceId]?.removeAll()
             }
+            // Clean up empty entries
+            if streamingSessions[workspaceId]?.isEmpty == true {
+                streamingSessions.removeValue(forKey: workspaceId)
+            }
+        }
+    }
+
+    /// Handle background→foreground streaming transition for a workspace.
+    /// Only called from status events (bootstrap), not from done/cancelled.
+    fileprivate func checkBackgroundCompletion(for workspaceId: String) {
+        if !isStreaming(workspaceId), streamingBeforeBackground.remove(workspaceId) != nil {
+            didReceiveDone(for: workspaceId)
         }
     }
 
@@ -225,7 +241,8 @@ final class HubStatusMonitor {
     /// Clears stale streaming state and forces an immediate hub reconnect so the
     /// backend bootstrap (status + history) writes into a clean slate.
     func appDidBecomeActive() {
-        streamingBeforeBackground = streamingWorkspaces
+        // Snapshot workspace IDs that had any streaming session
+        streamingBeforeBackground = Set(streamingSessions.keys)
         forceRefresh()
     }
 }
@@ -358,11 +375,16 @@ private final class HubConnection {
 
         // Hub-level processing
         switch event {
-        case .status(_, _, let streaming, _, _):
+        case .status(_, let sessionId, let streaming, _, _):
             let isStreaming = streaming ?? false
-            monitor?.didReceiveStreaming(isStreaming, for: workspaceId)
+            monitor?.didReceiveStreaming(isStreaming, for: workspaceId, sessionId: sessionId)
             if isStreaming {
                 monitor?.ensureStoreExists(for: workspaceId)
+            }
+            // Only status events (bootstrap) check background completion,
+            // not done/cancelled — those handle completion directly.
+            if !isStreaming {
+                monitor?.checkBackgroundCompletion(for: workspaceId)
             }
 
         case .diffStats(let stats):
@@ -371,14 +393,14 @@ private final class HubConnection {
         case .branchInfo(let info):
             monitor?.didReceiveBranchInfo(info, for: workspaceId)
 
-        case .done:
-            monitor?.didReceiveStreaming(false, for: workspaceId)
+        case .done(let sessionId, _, _, _, _):
+            monitor?.didReceiveStreaming(false, for: workspaceId, sessionId: sessionId)
             monitor?.didReceiveDone(for: workspaceId)
 
-        case .cancelled:
-            // Clear streaming but don't mark as completed — cancelled turns may require
-            // tool input or were user-interrupted, so no green "completed" badge.
-            monitor?.didReceiveStreaming(false, for: workspaceId)
+        case .cancelled(let sessionId, _, _, _):
+            // Clear streaming for this session but don't mark as completed —
+            // cancelled turns may require tool input or were user-interrupted.
+            monitor?.didReceiveStreaming(false, for: workspaceId, sessionId: sessionId)
 
         default:
             break


### PR DESCRIPTION
## Summary
- **Frontend**: `useWorkspaceLiveData` now clears `streamingSessions` on `done`/`cancelled` events, so the sidebar and session tabs stop showing the streaming indicator immediately — without waiting for the `exit` → `status: idle` event that could be delayed or lost.
- **Frontend**: `ws-transport` clears the stale per-session status cache on `done`/`cancelled` to prevent replaying `streaming: true` on re-subscribe.
- **Backend**: Wrapped the async IIFE in `conversation-session.ts` with `try-finally` so `exit` is always emitted even if a listener throws during `done`/`cancelled` dispatch.
- **iOS**: `HubStatusMonitor` now calls `didReceiveStreaming(false)` on `.done` and `.cancelled` events for parity with the frontend fix.

## Test plan
- [x] `npm run typecheck` passes (backend + frontend)
- [x] `npm test` passes (1084 tests across 87 files)
- [ ] Manual: start a session, let it complete, verify sidebar indicator clears immediately on `done` (not delayed until `exit`)
- [ ] Manual: cancel a streaming session, verify indicator clears immediately
- [ ] Manual: with 2 sessions streaming, complete one — verify the other stays animated