### PR TITLE
feat: create new repository from Hive

### DIFF
--- a/backend/src/api/projects.test.ts
+++ b/backend/src/api/projects.test.ts
@@ -87,6 +87,49 @@ describe("POST /api/projects", () => {
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toContain("not allowed");
   });
+
+  it("creates a local-only project with mode=create", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/projects",
+      payload: { mode: "create", name: "my-new-repo" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.id).toMatch(/^proj-/);
+    expect(body.name).toBe("my-new-repo");
+    expect(body.url).toBeUndefined();
+  });
+
+  it("returns 400 for missing name in create mode", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/projects",
+      payload: { mode: "create" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("name is required");
+  });
+
+  it("returns 400 for invalid visibility", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/projects",
+      payload: { mode: "create", name: "test-repo", visibility: "internal" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("visibility must be");
+  });
+
+  it("returns 400 for malicious visibility value", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/projects",
+      payload: { mode: "create", name: "test-repo", visibility: "template=evil/repo" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("visibility must be");
+  });
 });
 
 describe("GET /api/projects", () => {

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -91,6 +91,7 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
 
     try {
       let project: ProjectState;
+      let warning: string | undefined;
       if (mode === "create") {
         const name = body.name as string | undefined;
         if (!name?.trim()) return reply.status(400).send({ error: "name is required" });
@@ -98,13 +99,16 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
         if (visibility !== undefined && visibility !== "public" && visibility !== "private") {
           return reply.status(400).send({ error: "visibility must be 'public' or 'private'" });
         }
-        project = await initProject(name, { visibility }, dir);
+        const result = await initProject(name, { visibility }, dir);
+        project = result.state;
+        warning = result.warning;
       } else {
         const url = body.url as string | undefined;
         if (!url) return reply.status(400).send({ error: "url is required" });
         project = await createProject(url, dir);
       }
-      return reply.status(201).send(await enrichProject(project, dir));
+      const enriched = await enrichProject(project, dir);
+      return reply.status(201).send(warning ? { ...enriched, warning } : enriched);
     } catch (err: unknown) {
       return reply
         .status(errorStatus(err, 400))

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { FastifyInstance } from "fastify";
 import {
   createProject,
+  initProject,
   listProjects,
   getProject,
   deleteProject,
@@ -84,16 +85,27 @@ async function enrichProject(project: ProjectState, dir: string) {
 
 export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
   app.post<{ Body: CreateProjectRequest }>("/api/projects", async (req, reply) => {
-    const { url } = req.body ?? {};
-    if (!url) return reply.status(400).send({ error: "url is required" });
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const mode = (body.mode as string) ?? "clone";
+    const dir = dataDir ?? getDataDir();
 
     try {
-      const project = await createProject(url, dataDir);
-      return reply.status(201).send(project);
+      let project: ProjectState;
+      if (mode === "create") {
+        const name = body.name as string | undefined;
+        if (!name?.trim()) return reply.status(400).send({ error: "name is required" });
+        const visibility = body.visibility as "public" | "private" | undefined;
+        project = await initProject(name, { visibility }, dir);
+      } else {
+        const url = body.url as string | undefined;
+        if (!url) return reply.status(400).send({ error: "url is required" });
+        project = await createProject(url, dir);
+      }
+      return reply.status(201).send(await enrichProject(project, dir));
     } catch (err: unknown) {
       return reply
         .status(errorStatus(err, 400))
-        .send({ error: errorMessage(err, "Clone failed") });
+        .send({ error: errorMessage(err, mode === "create" ? "Create failed" : "Clone failed") });
     }
   });
 

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -94,7 +94,10 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
       if (mode === "create") {
         const name = body.name as string | undefined;
         if (!name?.trim()) return reply.status(400).send({ error: "name is required" });
-        const visibility = body.visibility as "public" | "private" | undefined;
+        const visibility = body.visibility as string | undefined;
+        if (visibility !== undefined && visibility !== "public" && visibility !== "private") {
+          return reply.status(400).send({ error: "visibility must be 'public' or 'private'" });
+        }
         project = await initProject(name, { visibility }, dir);
       } else {
         const url = body.url as string | undefined;

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -135,7 +135,7 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       const result = await getWorkspace(wsId, dataDir);
       if (!result) return reply.status(404).send({ error: "Workspace not found" });
 
-      const ghRepo = parseGitHubRepo(result.projectState.url);
+      const ghRepo = result.projectState.url ? parseGitHubRepo(result.projectState.url) : null;
       if (!ghRepo) {
         const data: PrStatusResponse = { pr: null };
         prCache.set(wsId, { data, at: Date.now() });
@@ -191,7 +191,7 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
               return;
             }
 
-            const ghRepo = parseGitHubRepo(result.projectState.url);
+            const ghRepo = result.projectState.url ? parseGitHubRepo(result.projectState.url) : null;
             if (!ghRepo) {
               const data: PrStatusResponse = { pr: null };
               prCache.set(wsId, { data, at: Date.now() });

--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -3,7 +3,7 @@ import { rm } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
-import { createProject, listProjects, getProject, deleteProject, fetchProject } from "./project-manager.js";
+import { createProject, initProject, listProjects, getProject, deleteProject, fetchProject } from "./project-manager.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -85,6 +85,79 @@ describe("deleteProject", () => {
     expect(existsSync(projDir)).toBe(true);
     await deleteProject(state.id, dataDir);
     expect(existsSync(projDir)).toBe(false);
+  });
+});
+
+describe("initProject", () => {
+  it("creates a bare repo with initial commit and state", async () => {
+    const state = await initProject("my-test-repo", {}, dataDir);
+    expect(state.id).toMatch(/^proj-/);
+    expect(state.name).toBe("my-test-repo");
+    expect(state.url).toBeUndefined();
+    expect(state.workspaces).toEqual([]);
+    expect(existsSync(join(dataDir, state.id, "repo.git", "HEAD"))).toBe(true);
+    expect(existsSync(join(dataDir, state.id, "workspaces"))).toBe(true);
+    expect(existsSync(join(dataDir, state.id, "logs"))).toBe(true);
+    expect(existsSync(join(dataDir, state.id, "state.json"))).toBe(true);
+  });
+
+  it("creates local-only project when no visibility is set", async () => {
+    const state = await initProject("local-only", {}, dataDir);
+    expect(state.url).toBeUndefined();
+    const loaded = await getProject(state.id, dataDir);
+    expect(loaded?.url).toBeUndefined();
+  });
+
+  it("rejects empty name", async () => {
+    await expect(initProject("", {}, dataDir)).rejects.toThrow("Repository name is required");
+  });
+
+  it("rejects name with invalid characters", async () => {
+    await expect(initProject("my repo!", {}, dataDir)).rejects.toThrow(
+      "Repository name can only contain lowercase letters, numbers, hyphens, underscores, and dots",
+    );
+  });
+
+  it("rejects name exceeding 100 characters", async () => {
+    const longName = "a".repeat(101);
+    await expect(initProject(longName, {}, dataDir)).rejects.toThrow(
+      "Repository name must be 100 characters or fewer",
+    );
+  });
+
+  it("rejects name starting with a hyphen", async () => {
+    await expect(initProject("-bad-name", {}, dataDir)).rejects.toThrow(
+      "Repository name can only contain lowercase letters, numbers, hyphens, underscores, and dots",
+    );
+  });
+
+  it("cleans up directory on git failure", async () => {
+    // Use an invalid bare path to force git init to fail
+    const { readdir } = await import("node:fs/promises");
+    const before = await readdir(dataDir);
+
+    // Stub git to fail after mkdir
+    const gitModule = await import("../utils/git.js");
+    const originalGit = gitModule.git;
+    let callCount = 0;
+    vi.spyOn(gitModule, "git").mockImplementation(async (args, cwd) => {
+      callCount++;
+      if (callCount === 1) {
+        // Let git init --bare succeed
+        return originalGit(args, cwd);
+      }
+      // Fail on git clone (second call)
+      throw new Error("Simulated git failure");
+    });
+
+    try {
+      await expect(initProject("will-fail", {}, dataDir)).rejects.toThrow("Simulated git failure");
+      const after = await readdir(dataDir);
+      // The orphaned project directory should have been cleaned up
+      expect(after).toEqual(before);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 });
 

--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -90,7 +90,7 @@ describe("deleteProject", () => {
 
 describe("initProject", () => {
   it("creates a bare repo with initial commit and state", async () => {
-    const state = await initProject("my-test-repo", {}, dataDir);
+    const { state } = await initProject("my-test-repo", {}, dataDir);
     expect(state.id).toMatch(/^proj-/);
     expect(state.name).toBe("my-test-repo");
     expect(state.url).toBeUndefined();
@@ -102,8 +102,9 @@ describe("initProject", () => {
   });
 
   it("creates local-only project when no visibility is set", async () => {
-    const state = await initProject("local-only", {}, dataDir);
+    const { state, warning } = await initProject("local-only", {}, dataDir);
     expect(state.url).toBeUndefined();
+    expect(warning).toBeUndefined();
     const loaded = await getProject(state.id, dataDir);
     expect(loaded?.url).toBeUndefined();
   });
@@ -132,7 +133,6 @@ describe("initProject", () => {
   });
 
   it("cleans up directory on git failure", async () => {
-    // Use an invalid bare path to force git init to fail
     const { readdir } = await import("node:fs/promises");
     const before = await readdir(dataDir);
 

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -1,7 +1,8 @@
 import { join } from "node:path";
-import { rm, mkdir } from "node:fs/promises";
+import { rm, mkdir, writeFile } from "node:fs/promises";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
+import { gh } from "../utils/github.js";
 import { bareRepoPath } from "../utils/paths.js";
 import { saveProject, loadProject, loadAllProjects, getDataDir } from "../state/state.js";
 import { notifyProjectDeleted } from "../state/workspace-index.js";
@@ -44,6 +45,102 @@ export async function createProject(
   return state;
 }
 
+// ── Validate repo name ──────────────────────────────────────────────
+
+const REPO_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
+
+function validateRepoName(name: string): string {
+  const trimmed = name.trim().toLowerCase();
+  if (!trimmed) throw new Error("Repository name is required");
+  if (trimmed.length > 100) throw new Error("Repository name must be 100 characters or fewer");
+  if (!REPO_NAME_RE.test(trimmed)) {
+    throw new Error(
+      "Repository name can only contain lowercase letters, numbers, hyphens, underscores, and dots",
+    );
+  }
+  return trimmed;
+}
+
+// ── Create GitHub repo + link to bare ───────────────────────────────
+
+async function createGitHubRepo(
+  name: string,
+  visibility: "public" | "private",
+  bare: string,
+): Promise<string> {
+  const { stdout } = await gh([
+    "repo",
+    "create",
+    name,
+    `--${visibility}`,
+    "--json",
+    "sshUrl",
+    "--jq",
+    ".sshUrl",
+  ]);
+  const url = stdout.trim();
+
+  // Point the bare repo at the new remote and push the initial commit
+  await git(["remote", "add", "origin", url], bare);
+  await git(["push", "--all", "origin"], bare);
+
+  return url;
+}
+
+// ── Init a brand-new project (optionally on GitHub) ─────────────────
+
+export async function initProject(
+  name: string,
+  options: { visibility?: "public" | "private" } = {},
+  dataDir = getDataDir(),
+): Promise<ProjectState> {
+  const repoName = validateRepoName(name);
+  const id = `proj-${nanoid(8)}`;
+  const bare = bareRepoPath(dataDir, id);
+  const wsDir = join(dataDir, id, "workspaces");
+  const logsDir = join(dataDir, id, "logs");
+  const tempWork = join(dataDir, id, "_init-temp");
+
+  await mkdir(join(dataDir, id), { recursive: true });
+
+  // 1. Create a bare repo
+  await git(["init", "--bare", bare]);
+
+  // 2. Clone locally to seed the initial commit
+  await git(["clone", bare, tempWork]);
+  await git(["checkout", "-b", "main"], tempWork);
+  await git(["config", "user.email", "hive@local"], tempWork);
+  await git(["config", "user.name", "Hive"], tempWork);
+
+  await writeFile(join(tempWork, "README.md"), `# ${repoName}\n`);
+  await writeFile(join(tempWork, ".gitignore"), "node_modules/\n.env\n.DS_Store\n");
+  await git(["add", "."], tempWork);
+  await git(["commit", "-m", "Initial commit"], tempWork);
+  await git(["push", "origin", "main"], tempWork);
+
+  // 3. Clean up the temp working tree
+  await rm(tempWork, { recursive: true, force: true });
+
+  // 4. Optionally create on GitHub
+  let url: string | undefined;
+  if (options.visibility) {
+    url = await createGitHubRepo(repoName, options.visibility, bare);
+  }
+
+  await mkdir(wsDir, { recursive: true });
+  await mkdir(logsDir, { recursive: true });
+
+  const state: ProjectState = {
+    id,
+    name: repoName,
+    url,
+    createdAt: new Date().toISOString(),
+    workspaces: [],
+  };
+  await saveProject(state, dataDir);
+  return state;
+}
+
 export async function listProjects(
   dataDir = getDataDir()
 ): Promise<ProjectState[]> {
@@ -72,6 +169,7 @@ export async function fetchProject(
 ): Promise<void> {
   const state = await loadProject(projectId, dataDir);
   if (!state) throw new NotFoundError(`Project ${projectId} not found`);
+  if (!state.url) throw new Error("Project has no remote — nothing to fetch");
   const bare = bareRepoPath(dataDir, projectId);
   await git(["fetch", "--all"], bare);
 }

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -85,27 +85,39 @@ async function createGitHubRepo(
   ]);
   const url = stdout.trim();
 
-  // Point the bare repo at the new remote and push the initial commit
-  await git(["remote", "add", "origin", url], bare);
-  await git(["push", "--all", "origin"], bare);
+  // Point the bare repo at the new remote and push the initial commit.
+  // If push fails, delete the GitHub repo so we don't leave orphans.
+  try {
+    await git(["remote", "add", "origin", url], bare);
+    await git(["push", "--all", "origin"], bare);
+  } catch (err) {
+    await gh(["repo", "delete", name, "--yes"]).catch(() => {});
+    throw err;
+  }
 
   return url;
 }
 
 // ── Init a brand-new project (optionally on GitHub) ─────────────────
 
+export interface InitProjectResult {
+  state: ProjectState;
+  /** Set when the user requested GitHub creation but it failed (graceful degradation). */
+  warning?: string;
+}
+
 export async function initProject(
   name: string,
   options: { visibility?: "public" | "private" } = {},
   dataDir = getDataDir(),
-): Promise<ProjectState> {
+): Promise<InitProjectResult> {
   const repoName = validateRepoName(name);
   const id = `proj-${nanoid(8)}`;
   const projectDir = join(dataDir, id);
   const bare = bareRepoPath(dataDir, id);
   const wsDir = join(projectDir, "workspaces");
   const logsDir = join(projectDir, "logs");
-  const tempWork = join(projectDir, "_init-temp");
+  const tempWork = join(projectDir, `_init-temp-${nanoid(4)}`);
 
   await mkdir(projectDir, { recursive: true });
 
@@ -125,16 +137,15 @@ export async function initProject(
     await git(["commit", "-m", "Initial commit"], tempWork);
     await git(["push", "origin", "main"], tempWork);
 
-    // 3. Clean up the temp working tree
+    // 3. Clean up the temp working tree and create workspace/log dirs
     await rm(tempWork, { recursive: true, force: true });
+    await mkdir(wsDir, { recursive: true });
+    await mkdir(logsDir, { recursive: true });
   } catch (err) {
     // Clean up partially-created project directory on failure
     await rm(projectDir, { recursive: true, force: true }).catch(() => {});
     throw err;
   }
-
-  await mkdir(wsDir, { recursive: true });
-  await mkdir(logsDir, { recursive: true });
 
   // 4. Save as local-only first so the project is usable even if GitHub fails
   const state: ProjectState = {
@@ -149,17 +160,18 @@ export async function initProject(
   // 5. Optionally create on GitHub, then update the saved state with the URL.
   //    If GitHub creation fails, gracefully degrade to local-only rather than
   //    propagating the error (the local project is already usable).
+  let warning: string | undefined;
   if (options.visibility) {
     try {
       const url = await createGitHubRepo(repoName, options.visibility, bare);
       state.url = url;
       await saveProject(state, dataDir);
-    } catch {
-      // GitHub creation failed — project remains usable as local-only
+    } catch (err) {
+      warning = `GitHub repo creation failed: ${err instanceof Error ? err.message : "unknown error"}`;
     }
   }
 
-  return state;
+  return { state, warning };
 }
 
 export async function listProjects(

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -68,6 +68,11 @@ async function createGitHubRepo(
   visibility: "public" | "private",
   bare: string,
 ): Promise<string> {
+  // Defense-in-depth: visibility is interpolated as a CLI flag, so reject anything unexpected
+  if (visibility !== "public" && visibility !== "private") {
+    throw new Error("Invalid visibility");
+  }
+
   const { stdout } = await gh([
     "repo",
     "create",
@@ -96,30 +101,37 @@ export async function initProject(
 ): Promise<ProjectState> {
   const repoName = validateRepoName(name);
   const id = `proj-${nanoid(8)}`;
+  const projectDir = join(dataDir, id);
   const bare = bareRepoPath(dataDir, id);
-  const wsDir = join(dataDir, id, "workspaces");
-  const logsDir = join(dataDir, id, "logs");
-  const tempWork = join(dataDir, id, "_init-temp");
+  const wsDir = join(projectDir, "workspaces");
+  const logsDir = join(projectDir, "logs");
+  const tempWork = join(projectDir, "_init-temp");
 
-  await mkdir(join(dataDir, id), { recursive: true });
+  await mkdir(projectDir, { recursive: true });
 
-  // 1. Create a bare repo
-  await git(["init", "--bare", bare]);
+  try {
+    // 1. Create a bare repo
+    await git(["init", "--bare", bare]);
 
-  // 2. Clone locally to seed the initial commit
-  await git(["clone", bare, tempWork]);
-  await git(["checkout", "-b", "main"], tempWork);
-  await git(["config", "user.email", "hive@local"], tempWork);
-  await git(["config", "user.name", "Hive"], tempWork);
+    // 2. Clone locally to seed the initial commit
+    await git(["clone", bare, tempWork]);
+    await git(["checkout", "-b", "main"], tempWork);
+    await git(["config", "user.email", "hive@local"], tempWork);
+    await git(["config", "user.name", "Hive"], tempWork);
 
-  await writeFile(join(tempWork, "README.md"), `# ${repoName}\n`);
-  await writeFile(join(tempWork, ".gitignore"), "node_modules/\n.env\n.DS_Store\n");
-  await git(["add", "."], tempWork);
-  await git(["commit", "-m", "Initial commit"], tempWork);
-  await git(["push", "origin", "main"], tempWork);
+    await writeFile(join(tempWork, "README.md"), `# ${repoName}\n`);
+    await writeFile(join(tempWork, ".gitignore"), "node_modules/\n.env\n.DS_Store\n");
+    await git(["add", "."], tempWork);
+    await git(["commit", "-m", "Initial commit"], tempWork);
+    await git(["push", "origin", "main"], tempWork);
 
-  // 3. Clean up the temp working tree
-  await rm(tempWork, { recursive: true, force: true });
+    // 3. Clean up the temp working tree
+    await rm(tempWork, { recursive: true, force: true });
+  } catch (err) {
+    // Clean up partially-created project directory on failure
+    await rm(projectDir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
 
   await mkdir(wsDir, { recursive: true });
   await mkdir(logsDir, { recursive: true });

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -121,23 +121,26 @@ export async function initProject(
   // 3. Clean up the temp working tree
   await rm(tempWork, { recursive: true, force: true });
 
-  // 4. Optionally create on GitHub
-  let url: string | undefined;
-  if (options.visibility) {
-    url = await createGitHubRepo(repoName, options.visibility, bare);
-  }
-
   await mkdir(wsDir, { recursive: true });
   await mkdir(logsDir, { recursive: true });
 
+  // 4. Save as local-only first so the project is usable even if GitHub fails
   const state: ProjectState = {
     id,
     name: repoName,
-    url,
+    url: undefined,
     createdAt: new Date().toISOString(),
     workspaces: [],
   };
   await saveProject(state, dataDir);
+
+  // 5. Optionally create on GitHub, then update the saved state with the URL
+  if (options.visibility) {
+    const url = await createGitHubRepo(repoName, options.visibility, bare);
+    state.url = url;
+    await saveProject(state, dataDir);
+  }
+
   return state;
 }
 

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -146,11 +146,17 @@ export async function initProject(
   };
   await saveProject(state, dataDir);
 
-  // 5. Optionally create on GitHub, then update the saved state with the URL
+  // 5. Optionally create on GitHub, then update the saved state with the URL.
+  //    If GitHub creation fails, gracefully degrade to local-only rather than
+  //    propagating the error (the local project is already usable).
   if (options.visibility) {
-    const url = await createGitHubRepo(repoName, options.visibility, bare);
-    state.url = url;
-    await saveProject(state, dataDir);
+    try {
+      const url = await createGitHubRepo(repoName, options.visibility, bare);
+      state.url = url;
+      await saveProject(state, dataDir);
+    } catch {
+      // GitHub creation failed — project remains usable as local-only
+    }
   }
 
   return state;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -79,14 +79,14 @@ export interface WorkspaceFileTreeNode {
 export interface ProjectState {
   id: string;
   name: string;
-  url: string;
+  url?: string;
   createdAt: string;
   workspaces: Workspace[];
 }
 
-export interface CreateProjectRequest {
-  url: string;
-}
+export type CreateProjectRequest =
+  | { mode?: "clone"; url: string }
+  | { mode: "create"; name: string; visibility?: "public" | "private" };
 
 // ── Image attachment type ────────────────────────────────────────────
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -29,7 +29,7 @@ function NotificationToastsBridge({ projects }: { projects: Project[] }) {
 }
 
 export default function App() {
-  const { projects, loading, fetchProjects, createProjectWithWorkspace } = useProjects();
+  const { projects, loading, fetchProjects, createProjectWithWorkspace, createNewProjectWithWorkspace } = useProjects();
   const [showAddProject, setShowAddProject] = useState(false);
   const [showAddAutomation, setShowAddAutomation] = useState(false);
   const workspaceIds = useMemo(
@@ -73,7 +73,8 @@ export default function App() {
         <AddProjectDialog
           open={showAddProject}
           onOpenChange={setShowAddProject}
-          onSubmit={createProjectWithWorkspace}
+          onClone={createProjectWithWorkspace}
+          onCreate={createNewProjectWithWorkspace}
         />
         <Suspense fallback={null}>
           {showAddAutomation && (

--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
 import {
   Dialog,
   DialogContent,
@@ -10,60 +11,216 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { cn } from "@/lib/utils";
+import { api } from "@/hooks/useApi";
+
+type DialogMode = "clone" | "create";
+
+interface AccountStatus {
+  ghInstalled: boolean;
+  authenticated: boolean;
+  user?: { login: string };
+}
 
 interface AddProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onSubmit: (url: string) => Promise<{ id: string } | void>;
+  onClone: (url: string) => Promise<{ id: string } | void>;
+  onCreate: (params: {
+    name: string;
+    visibility?: "public" | "private";
+  }) => Promise<{ id: string } | void>;
 }
+
+const REPO_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
 
 export default function AddProjectDialog({
   open,
   onOpenChange,
-  onSubmit,
+  onClone,
+  onCreate,
 }: AddProjectDialogProps) {
   const navigate = useNavigate();
-  const [url, setUrl] = useState("");
+
+  // ── Shared state ─────────────────────────────────────────────────
+  const [mode, setMode] = useState<DialogMode>("clone");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // ── Clone state ──────────────────────────────────────────────────
+  const [url, setUrl] = useState("");
+
+  // ── Create state ─────────────────────────────────────────────────
+  const [name, setName] = useState("");
+  const [visibility, setVisibility] = useState<"public" | "private">("private");
+
+  // ── GitHub status (only fetched when Create mode is active) ──────
+  const { data: account } = useQuery({
+    queryKey: ["account", "status"],
+    queryFn: () => api.get<AccountStatus>("/api/account/status"),
+    staleTime: 5 * 60_000,
+    enabled: open && mode === "create",
+  });
+
+  const ghConnected = account?.authenticated === true;
+
+  // ── Validation ───────────────────────────────────────────────────
+  const nameError =
+    name.length > 0 && !REPO_NAME_RE.test(name.toLowerCase())
+      ? "Lowercase letters, numbers, hyphens, underscores, and dots only"
+      : null;
+
+  const canSubmitClone = url.trim().length > 0;
+  const canSubmitCreate = name.trim().length > 0 && !nameError;
+
+  // ── Handlers ─────────────────────────────────────────────────────
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!url.trim()) return;
     setLoading(true);
     setError(null);
+
     try {
-      const result = await onSubmit(url.trim());
-      setUrl("");
-      onOpenChange(false);
-      if (result) {
-        navigate(`/workspaces/${result.id}`);
+      let result: { id: string } | void;
+      if (mode === "clone") {
+        result = await onClone(url.trim());
+      } else {
+        result = await onCreate({
+          name: name.trim().toLowerCase(),
+          visibility: ghConnected ? visibility : undefined,
+        });
       }
+      // Reset form on success
+      setUrl("");
+      setName("");
+      setVisibility("private");
+      setMode("clone");
+      onOpenChange(false);
+      if (result) navigate(`/workspaces/${result.id}`);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Failed to add project");
+      setError(
+        err instanceof Error ? err.message : "Something went wrong",
+      );
     } finally {
       setLoading(false);
     }
+  };
+
+  const switchMode = (next: DialogMode) => {
+    setMode(next);
+    setError(null);
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Add Project</DialogTitle>
+          <DialogTitle>
+            {mode === "clone" ? "Add Project" : "Create Project"}
+          </DialogTitle>
           <DialogDescription>
-            Enter the Git repository URL to clone into Hive.
+            {mode === "clone"
+              ? "Enter the Git repository URL to clone into Hive."
+              : "Create a new Git repository and start working."}
           </DialogDescription>
         </DialogHeader>
+
+        {/* ── Mode toggle ────────────────────────────────────────── */}
+        <div className="flex gap-1 rounded-lg bg-muted p-1">
+          {(["clone", "create"] as const).map((m) => (
+            <button
+              key={m}
+              type="button"
+              onClick={() => switchMode(m)}
+              className={cn(
+                "flex-1 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+                mode === m
+                  ? "bg-background text-foreground shadow-sm"
+                  : "text-muted-foreground hover:text-foreground",
+              )}
+            >
+              {m === "clone" ? "Clone existing" : "Create new"}
+            </button>
+          ))}
+        </div>
+
         <form onSubmit={handleSubmit}>
-          <Input
-            placeholder="git@github.com:user/repo.git"
-            value={url}
-            onChange={(e) => setUrl(e.target.value)}
-            disabled={loading}
-            autoFocus
-          />
+          {mode === "clone" ? (
+            /* ── Clone form ──────────────────────────────────────── */
+            <Input
+              placeholder="git@github.com:user/repo.git"
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              disabled={loading}
+              autoFocus
+            />
+          ) : (
+            /* ── Create form ─────────────────────────────────────── */
+            <div className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="repo-name" className="text-xs font-medium text-muted-foreground">
+                  Repository name
+                </Label>
+                <Input
+                  id="repo-name"
+                  placeholder="my-new-project"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={loading}
+                  autoFocus
+                />
+                {nameError && (
+                  <p className="text-xs text-destructive">{nameError}</p>
+                )}
+              </div>
+
+              {ghConnected && (
+                <div className="space-y-2">
+                  <Label className="text-xs font-medium text-muted-foreground">
+                    Visibility
+                  </Label>
+                  <RadioGroup
+                    value={visibility}
+                    onValueChange={(v) => setVisibility(v as "public" | "private")}
+                    className="flex gap-4"
+                  >
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="private" id="vis-private" />
+                      <Label htmlFor="vis-private" className="text-sm font-normal">
+                        Private
+                      </Label>
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <RadioGroupItem value="public" id="vis-public" />
+                      <Label htmlFor="vis-public" className="text-sm font-normal">
+                        Public
+                      </Label>
+                    </div>
+                  </RadioGroup>
+                </div>
+              )}
+
+              {/* ── GitHub status indicator ───────────────────────── */}
+              <div className="text-xs text-muted-foreground">
+                {account === undefined ? (
+                  <span>Checking GitHub connection…</span>
+                ) : ghConnected ? (
+                  <span>
+                    <span className="mr-1.5 inline-block h-1.5 w-1.5 rounded-full bg-green-500" />
+                    Connected as <span className="font-medium text-foreground">@{account.user?.login}</span>
+                  </span>
+                ) : (
+                  <span className="text-amber-500/80">
+                    GitHub not connected — will create local only
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
+
           {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+
           <DialogFooter className="mt-4">
             <Button
               type="button"
@@ -73,8 +230,20 @@ export default function AddProjectDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={loading || !url.trim()}>
-              {loading ? "Adding..." : "Add"}
+            <Button
+              type="submit"
+              disabled={
+                loading ||
+                (mode === "clone" ? !canSubmitClone : !canSubmitCreate)
+              }
+            >
+              {loading
+                ? mode === "clone"
+                  ? "Adding…"
+                  : "Creating…"
+                : mode === "clone"
+                  ? "Add"
+                  : "Create"}
             </Button>
           </DialogFooter>
         </form>

--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -55,6 +55,17 @@ export default function AddProjectDialog({
   // ── Create state ─────────────────────────────────────────────────
   const [name, setName] = useState("");
   const [visibility, setVisibility] = useState<"public" | "private">("private");
+
+  // ── Reset form state when dialog closes ────────────────────────────
+  useEffect(() => {
+    if (!open) {
+      setUrl("");
+      setName("");
+      setVisibility("private");
+      setMode("clone");
+      setError(null);
+    }
+  }, [open]);
 
   // ── GitHub status (only fetched when Create mode is active) ──────
   const { data: account } = useQuery({

--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -27,13 +27,14 @@ interface AccountStatus {
 interface AddProjectDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  onClone: (url: string) => Promise<{ id: string } | void>;
+  onClone: (url: string) => Promise<{ id: string; warning?: string } | void>;
   onCreate: (params: {
     name: string;
     visibility?: "public" | "private";
-  }) => Promise<{ id: string } | void>;
+  }) => Promise<{ id: string; warning?: string } | void>;
 }
 
+// Must match backend REPO_NAME_RE in backend/src/projects/project-manager.ts
 const REPO_NAME_RE = /^[a-z0-9][a-z0-9._-]*$/;
 
 export default function AddProjectDialog({
@@ -48,6 +49,7 @@ export default function AddProjectDialog({
   const [mode, setMode] = useState<DialogMode>("clone");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [warning, setWarning] = useState<string | null>(null);
 
   // ── Clone state ──────────────────────────────────────────────────
   const [url, setUrl] = useState("");
@@ -64,6 +66,7 @@ export default function AddProjectDialog({
       setVisibility("private");
       setMode("clone");
       setError(null);
+      setWarning(null);
     }
   }, [open]);
 
@@ -93,7 +96,7 @@ export default function AddProjectDialog({
     setError(null);
 
     try {
-      let result: { id: string } | void;
+      let result: { id: string; warning?: string } | void;
       if (mode === "clone") {
         result = await onClone(url.trim());
       } else {
@@ -107,7 +110,11 @@ export default function AddProjectDialog({
       setName("");
       setVisibility("private");
       setMode("clone");
-      onOpenChange(false);
+      if (result?.warning) {
+        setWarning(result.warning);
+      } else {
+        onOpenChange(false);
+      }
       if (result) navigate(`/workspaces/${result.id}`);
     } catch (err) {
       setError(
@@ -231,31 +238,44 @@ export default function AddProjectDialog({
           )}
 
           {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+          {warning && (
+            <div className="mt-2 rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-500">
+              {warning}
+            </div>
+          )}
 
           <DialogFooter className="mt-4">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => onOpenChange(false)}
-              disabled={loading}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              disabled={
-                loading ||
-                (mode === "clone" ? !canSubmitClone : !canSubmitCreate)
-              }
-            >
-              {loading
-                ? mode === "clone"
-                  ? "Adding…"
-                  : "Creating…"
-                : mode === "clone"
-                  ? "Add"
-                  : "Create"}
-            </Button>
+            {warning ? (
+              <Button type="button" onClick={() => onOpenChange(false)}>
+                Close
+              </Button>
+            ) : (
+              <>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => onOpenChange(false)}
+                  disabled={loading}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  type="submit"
+                  disabled={
+                    loading ||
+                    (mode === "clone" ? !canSubmitClone : !canSubmitCreate)
+                  }
+                >
+                  {loading
+                    ? mode === "clone"
+                      ? "Adding…"
+                      : "Creating…"
+                    : mode === "clone"
+                      ? "Add"
+                      : "Create"}
+                </Button>
+              </>
+            )}
           </DialogFooter>
         </form>
       </DialogContent>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -298,7 +298,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               />
 
               {projects.map((project, index) => {
-                const parsed = parseProjectOwnerRepo(project.url);
+                const parsed = project.url ? parseProjectOwnerRepo(project.url) : null;
                 const displayLabel = parsed ? (
                   <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
                 ) : project.name;

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -13,7 +13,7 @@ export function useProjects() {
   /** Shared logic: create project → optimistic cache → create workspace → rollback on error. */
   async function createProjectThenWorkspace(
     body: Record<string, unknown>,
-  ): Promise<Workspace> {
+  ): Promise<Workspace & { warning?: string }> {
     const project = await api.post<Project>("/api/projects", body);
     // Optimistically add project so Sidebar renders immediately
     queryClient.setQueryData<Project[]>(["projects"], (prev) =>
@@ -30,7 +30,7 @@ export function useProjects() {
             : { ...p, workspaces: [...p.workspaces, workspace] },
         ) ?? [],
       );
-      return workspace;
+      return { ...workspace, warning: project.warning };
     } catch (err) {
       // Roll back: remove the project from cache and clean up backend
       queryClient.setQueryData<Project[]>(["projects"], (prev) =>

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -10,38 +10,48 @@ export function useProjects() {
     queryFn: () => api.get<Project[]>("/api/projects"),
   });
 
-  const createProjectWithWorkspace = useMutation({
-    mutationFn: async (url: string) => {
-      const project = await api.post<Project>("/api/projects", { url });
-      // Optimistically add project so Sidebar renders immediately
+  /** Shared logic: create project → optimistic cache → create workspace → rollback on error. */
+  async function createProjectThenWorkspace(
+    body: Record<string, unknown>,
+  ): Promise<Workspace> {
+    const project = await api.post<Project>("/api/projects", body);
+    // Optimistically add project so Sidebar renders immediately
+    queryClient.setQueryData<Project[]>(["projects"], (prev) =>
+      prev ? [...prev, project] : [project],
+    );
+    try {
+      const workspace = await api.post<Workspace>(
+        `/api/projects/${project.id}/workspaces`,
+      );
       queryClient.setQueryData<Project[]>(["projects"], (prev) =>
-        prev ? [...prev, project] : [project],
+        prev?.map((p) =>
+          p.id !== project.id
+            ? p
+            : { ...p, workspaces: [...p.workspaces, workspace] },
+        ) ?? [],
+      );
+      return workspace;
+    } catch (err) {
+      // Roll back: remove the project from cache and clean up backend
+      queryClient.setQueryData<Project[]>(["projects"], (prev) =>
+        prev?.filter((p) => p.id !== project.id) ?? [],
       );
       try {
-        const workspace = await api.post<Workspace>(
-          `/api/projects/${project.id}/workspaces`,
-        );
-        queryClient.setQueryData<Project[]>(["projects"], (prev) =>
-          prev?.map((p) =>
-            p.id !== project.id
-              ? p
-              : { ...p, workspaces: [...p.workspaces, workspace] },
-          ) ?? [],
-        );
-        return workspace;
-      } catch (err) {
-        // Roll back: remove the project from cache and clean up backend
-        queryClient.setQueryData<Project[]>(["projects"], (prev) =>
-          prev?.filter((p) => p.id !== project.id) ?? [],
-        );
-        try {
-          await api.delete(`/api/projects/${project.id}`);
-        } catch {
-          // Best-effort cleanup
-        }
-        throw err;
+        await api.delete(`/api/projects/${project.id}`);
+      } catch {
+        // Best-effort cleanup
       }
-    },
+      throw err;
+    }
+  }
+
+  const createProjectWithWorkspace = useMutation({
+    mutationFn: (url: string) => createProjectThenWorkspace({ url }),
+  });
+
+  const createNewProjectWithWorkspace = useMutation({
+    mutationFn: (params: { name: string; visibility?: "public" | "private" }) =>
+      createProjectThenWorkspace({ mode: "create", ...params }),
   });
 
   const createWorkspace = useMutation({
@@ -88,6 +98,8 @@ export function useProjects() {
       queryClient.invalidateQueries({ queryKey: ["projects"] }),
     createProjectWithWorkspace: (url: string) =>
       createProjectWithWorkspace.mutateAsync(url),
+    createNewProjectWithWorkspace: (params: { name: string; visibility?: "public" | "private" }) =>
+      createNewProjectWithWorkspace.mutateAsync(params),
     createWorkspace: (projectId: string) =>
       createWorkspace.mutateAsync(projectId),
     deleteProject: (id: string) => deleteProject.mutateAsync(id),

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -54,18 +54,22 @@ export default function ProjectDetail() {
 
           <div className="space-y-4">
             <InfoRow label="Repository URL" mono>
-              <span className="inline-flex items-center gap-1.5">
-                <span className="truncate">{project.url}</span>
-                <a
-                  href={project.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-                  aria-label="Open repository URL"
-                >
-                  <ExternalLink className="h-3 w-3" />
-                </a>
-              </span>
+              {project.url ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="truncate">{project.url}</span>
+                  <a
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                    aria-label="Open repository URL"
+                  >
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                </span>
+              ) : (
+                <span className="text-muted-foreground">Local only</span>
+              )}
             </InfoRow>
             <InfoRow label="Bare repo path" mono>
               {project.repoPath ?? "\u2014"}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,7 +1,7 @@
 export interface Project {
   id: string;
   name: string;
-  url: string;
+  url?: string;
   createdAt: string;
   workspaces: Workspace[];
   repoPath?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,8 @@ export interface Project {
   repoPath?: string;
   workspacesPath?: string;
   hasFavicon?: boolean;
+  /** Present when GitHub repo creation failed (project degraded to local-only). */
+  warning?: string;
 }
 
 export interface Workspace {

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
   fetchProjects: vi.fn(),
   createWorkspace: vi.fn(),
   createProjectWithWorkspace: vi.fn(),
+  createNewProjectWithWorkspace: vi.fn(),
   deleteProject: vi.fn(),
   archiveWorkspace: vi.fn(),
   syncWorkspaces: vi.fn(),
@@ -64,6 +65,7 @@ vi.mock("@/hooks/useProjects", () => ({
     fetchProjects: mocks.fetchProjects,
     createWorkspace: mocks.createWorkspace,
     createProjectWithWorkspace: mocks.createProjectWithWorkspace,
+    createNewProjectWithWorkspace: mocks.createNewProjectWithWorkspace,
     deleteProject: mocks.deleteProject,
     archiveWorkspace: mocks.archiveWorkspace,
   }),
@@ -83,11 +85,12 @@ vi.mock("@/components/AddProjectDialog", () => ({
   default: ({
     open,
     onOpenChange,
-    onSubmit,
+    onClone,
   }: {
     open?: boolean;
     onOpenChange?: (open: boolean) => void;
-    onSubmit?: (url: string) => void;
+    onClone?: (url: string) => void;
+    onCreate?: (params: { name: string; visibility?: "public" | "private" }) => void;
   }) => (
     <div data-testid="add-project-dialog">
       <div data-testid="dialog-open">{String(Boolean(open))}</div>
@@ -96,7 +99,7 @@ vi.mock("@/components/AddProjectDialog", () => ({
       </button>
       <button
         type="button"
-        onClick={() => onSubmit?.("https://github.com/acme/new-repo.git")}
+        onClick={() => onClone?.("https://github.com/acme/new-repo.git")}
       >
         submit dialog
       </button>

--- a/frontend/tests/components/AddProjectDialog.test.tsx
+++ b/frontend/tests/components/AddProjectDialog.test.tsx
@@ -1,47 +1,54 @@
 import { describe, expect, it, vi } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
 import AddProjectDialog from "@/components/AddProjectDialog";
+
+function renderDialog(props: {
+  onClone?: (url: string) => Promise<{ id: string } | void>;
+  onCreate?: (params: { name: string; visibility?: "public" | "private" }) => Promise<{ id: string } | void>;
+  onOpenChange?: (open: boolean) => void;
+}) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <AddProjectDialog
+          open
+          onOpenChange={props.onOpenChange ?? vi.fn()}
+          onClone={props.onClone ?? vi.fn().mockResolvedValue(undefined)}
+          onCreate={props.onCreate ?? vi.fn().mockResolvedValue(undefined)}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
 
 describe("AddProjectDialog", () => {
   it("submits a project URL and closes dialog", async () => {
     const user = userEvent.setup();
-    const onSubmit = vi.fn().mockResolvedValue(undefined);
+    const onClone = vi.fn().mockResolvedValue(undefined);
     const onOpenChange = vi.fn();
 
-    render(
-      <MemoryRouter>
-        <AddProjectDialog
-          open
-          onOpenChange={onOpenChange}
-          onSubmit={onSubmit}
-        />
-      </MemoryRouter>,
-    );
+    renderDialog({ onClone, onOpenChange });
 
     await user.type(screen.getByPlaceholderText("git@github.com:user/repo.git"), "https://github.com/acme/repo.git");
     await user.click(screen.getByRole("button", { name: "Add" }));
 
     await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledWith("https://github.com/acme/repo.git");
+      expect(onClone).toHaveBeenCalledWith("https://github.com/acme/repo.git");
     });
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   it("shows error when submit fails", async () => {
     const user = userEvent.setup();
-    const onSubmit = vi.fn().mockRejectedValue(new Error("Clone failed"));
+    const onClone = vi.fn().mockRejectedValue(new Error("Clone failed"));
 
-    render(
-      <MemoryRouter>
-        <AddProjectDialog
-          open
-          onOpenChange={vi.fn()}
-          onSubmit={onSubmit}
-        />
-      </MemoryRouter>,
-    );
+    renderDialog({ onClone });
 
     await user.type(screen.getByPlaceholderText("git@github.com:user/repo.git"), "https://github.com/acme/repo.git");
     await user.click(screen.getByRole("button", { name: "Add" }));

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -96,12 +96,27 @@ enum DiffFileStatus: String, Codable {
     case renamed
 }
 
+// MARK: - Account Status
+
+struct AccountStatusResponse: Codable {
+    let ghInstalled: Bool
+    let authenticated: Bool
+    let user: AccountUser?
+}
+
+struct AccountUser: Codable {
+    let login: String
+    let name: String?
+    let email: String?
+    let avatarUrl: String?
+}
+
 // MARK: - Project & Workspace
 
 struct Project: Codable, Identifiable {
     let id: String
     let name: String
-    let url: String
+    let url: String?
     let createdAt: String
     var workspaces: [Workspace]
     var hasFavicon: Bool? = nil

--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -145,6 +145,17 @@ final class APIClient {
         return try await post(path: "/api/projects", body: body)
     }
 
+    func createNewProject(name: String, visibility: String?) async throws -> Project {
+        var dict: [String: String] = ["mode": "create", "name": name]
+        if let visibility { dict["visibility"] = visibility }
+        let body = try JSONEncoder().encode(dict)
+        return try await post(path: "/api/projects", body: body)
+    }
+
+    func fetchAccountStatus() async throws -> AccountStatusResponse {
+        try await get(path: "/api/account/status")
+    }
+
     func fetchSessions(workspaceId: String) async throws -> [SessionMetadata] {
         try await get(path: "/api/workspaces/\(workspaceId)/sessions")
     }

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -74,14 +74,29 @@ final class ProjectStore {
     }
 
     func createProject(url: String) async {
+        await createProjectWithWorkspace(displayName: Self.extractRepoName(from: url)) {
+            try await api.createProject(url: url)
+        }
+    }
+
+    func createNewProject(name: String, visibility: String?) async {
+        await createProjectWithWorkspace(displayName: name) {
+            try await api.createNewProject(name: name, visibility: visibility)
+        }
+    }
+
+    private func createProjectWithWorkspace(
+        displayName: String,
+        apiCall: () async throws -> Project
+    ) async {
         guard !isCreatingProject else { return }
 
         isCreatingProject = true
-        cloningRepoName = Self.extractRepoName(from: url)
+        cloningRepoName = displayName
         errorMessage = nil
 
         do {
-            let project = try await api.createProject(url: url)
+            let project = try await apiCall()
             let created = try await api.createWorkspace(projectId: project.id)
 
             let workspace = Workspace(

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -1,40 +1,65 @@
 import SwiftUI
 
+enum AddProjectMode: String, CaseIterable {
+    case clone = "Clone existing"
+    case create = "Create new"
+}
+
 struct AddProjectSheet: View {
     @Environment(\.dismiss) private var dismiss
-    let onSubmit: (String) -> Void
+    let onClone: (String) -> Void
+    let onCreate: (_ name: String, _ visibility: String?) -> Void
 
+    @State private var mode: AddProjectMode = .clone
+
+    // Clone state
     @State private var url = ""
 
+    // Create state
+    @State private var name = ""
+    @State private var visibility = "private"
+    @State private var accountStatus: AccountStatusResponse?
+    @State private var loadingAccount = false
+
+    private var ghConnected: Bool {
+        accountStatus?.authenticated == true
+    }
+
     private var canSubmit: Bool {
-        !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        switch mode {
+        case .clone:
+            return !url.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        case .create:
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return !trimmed.isEmpty && isValidRepoName(trimmed)
+        }
     }
 
     var body: some View {
         NavigationStack {
             VStack(spacing: HiveSpacing.xl) {
-                Text("Enter the Git repository URL to clone into Hive.")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                Picker("", selection: $mode) {
+                    ForEach(AddProjectMode.allCases, id: \.self) { m in
+                        Text(m.rawValue).tag(m)
+                    }
+                }
+                .pickerStyle(.segmented)
 
-                TextField("git@github.com:user/repo.git", text: $url)
-                    .textFieldStyle(.roundedBorder)
-                    .textInputAutocapitalization(.never)
-                    .autocorrectionDisabled()
-                    .keyboardType(.URL)
-                    .submitLabel(.go)
-                    .onSubmit { if canSubmit { submit() } }
+                if mode == .clone {
+                    cloneForm
+                } else {
+                    createForm
+                }
 
                 Spacer()
 
-                Button("Add Project") { submit() }
+                Button(mode == .clone ? "Add Project" : "Create Project") { submit() }
                     .buttonStyle(.glassProminent)
                     .disabled(!canSubmit)
                     .frame(maxWidth: .infinity)
             }
             .padding()
-            .navigationTitle("Add Project")
+            .navigationTitle(mode == .clone ? "Add Project" : "Create Project")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -42,22 +67,134 @@ struct AddProjectSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium])
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
+        .onChange(of: mode) { _, newMode in
+            if newMode == .create && accountStatus == nil {
+                checkAccountStatus()
+            }
+        }
     }
 
+    // MARK: - Clone form
+
+    private var cloneForm: some View {
+        VStack(alignment: .leading, spacing: HiveSpacing.md) {
+            Text("Enter the Git repository URL to clone into Hive.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            TextField("git@github.com:user/repo.git", text: $url)
+                .textFieldStyle(.roundedBorder)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+                .submitLabel(.go)
+                .onSubmit { if canSubmit { submit() } }
+        }
+    }
+
+    // MARK: - Create form
+
+    private var createForm: some View {
+        VStack(alignment: .leading, spacing: HiveSpacing.lg) {
+            Text("Create a new Git repository and start working.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            VStack(alignment: .leading, spacing: HiveSpacing.xs) {
+                Text("Repository name")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                TextField("my-new-project", text: $name)
+                    .textFieldStyle(.roundedBorder)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.go)
+                    .onSubmit { if canSubmit { submit() } }
+            }
+
+            if ghConnected {
+                VStack(alignment: .leading, spacing: HiveSpacing.xs) {
+                    Text("Visibility")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Picker("", selection: $visibility) {
+                        Text("Private").tag("private")
+                        Text("Public").tag("public")
+                    }
+                    .pickerStyle(.segmented)
+                }
+            }
+
+            // GitHub status indicator
+            Group {
+                if loadingAccount {
+                    Text("Checking GitHub connection…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if ghConnected {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(.green)
+                            .frame(width: 6, height: 6)
+                        Text("Connected as @\(accountStatus?.user?.login ?? "")")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                } else if accountStatus != nil {
+                    Text("GitHub not connected — will create local only")
+                        .font(.caption)
+                        .foregroundStyle(.orange.opacity(0.8))
+                }
+            }
+        }
+    }
+
+    // MARK: - Actions
+
     private func submit() {
-        let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        onSubmit(trimmed)
+        switch mode {
+        case .clone:
+            let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { return }
+            onClone(trimmed)
+        case .create:
+            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            guard !trimmed.isEmpty else { return }
+            onCreate(trimmed, ghConnected ? visibility : nil)
+        }
         dismiss()
+    }
+
+    private func checkAccountStatus() {
+        guard !loadingAccount else { return }
+        loadingAccount = true
+        Task {
+            do {
+                let status = try await APIClient.shared.fetchAccountStatus()
+                await MainActor.run {
+                    accountStatus = status
+                    loadingAccount = false
+                }
+            } catch {
+                await MainActor.run { loadingAccount = false }
+            }
+        }
+    }
+
+    private func isValidRepoName(_ name: String) -> Bool {
+        let pattern = /^[a-z0-9][a-z0-9._-]*$/
+        return name.wholeMatch(of: pattern) != nil
     }
 }
 
 #Preview {
     Text("Hub")
         .sheet(isPresented: .constant(true)) {
-            AddProjectSheet { _ in }
+            AddProjectSheet(onClone: { _ in }, onCreate: { _, _ in })
         }
         .preferredColorScheme(.dark)
 }

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -174,7 +174,7 @@ struct AddProjectSheet: View {
         loadingAccount = true
         Task {
             do {
-                let status = try await APIClient.shared.fetchAccountStatus()
+                let status = try await APIClient().fetchAccountStatus()
                 await MainActor.run {
                     accountStatus = status
                     loadingAccount = false

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -7,6 +7,7 @@ enum AddProjectMode: String, CaseIterable {
 
 struct AddProjectSheet: View {
     @Environment(\.dismiss) private var dismiss
+    let api: APIClient
     let onClone: (String) -> Void
     let onCreate: (_ name: String, _ visibility: String?) -> Void
 
@@ -174,7 +175,7 @@ struct AddProjectSheet: View {
         loadingAccount = true
         Task {
             do {
-                let status = try await APIClient().fetchAccountStatus()
+                let status = try await api.fetchAccountStatus()
                 await MainActor.run {
                     accountStatus = status
                     loadingAccount = false
@@ -194,7 +195,7 @@ struct AddProjectSheet: View {
 #Preview {
     Text("Hub")
         .sheet(isPresented: .constant(true)) {
-            AddProjectSheet(onClone: { _ in }, onCreate: { _, _ in })
+            AddProjectSheet(api: APIClient(), onClone: { _ in }, onCreate: { _, _ in })
         }
         .preferredColorScheme(.dark)
 }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -66,6 +66,7 @@ struct HubView: View {
         .animation(.default, value: store.cloningRepoName != nil)
         .sheet(isPresented: $showAddProject) {
             AddProjectSheet(
+                api: APIClient(),
                 onClone: { url in
                     Task { await store.createProject(url: url) }
                 },

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -65,9 +65,14 @@ struct HubView: View {
         }
         .animation(.default, value: store.cloningRepoName != nil)
         .sheet(isPresented: $showAddProject) {
-            AddProjectSheet { url in
-                Task { await store.createProject(url: url) }
-            }
+            AddProjectSheet(
+                onClone: { url in
+                    Task { await store.createProject(url: url) }
+                },
+                onCreate: { name, visibility in
+                    Task { await store.createNewProject(name: name, visibility: visibility) }
+                }
+            )
         }
         .alert(
             "Archive workspace?",
@@ -272,7 +277,7 @@ struct HubView: View {
 
     @ViewBuilder
     private func projectTitle(_ project: Project) -> some View {
-        if let parts = ownerAndRepo(from: project.url) ?? ownerAndRepo(from: project.name) {
+        if let parts = project.url.flatMap({ ownerAndRepo(from: $0) }) ?? ownerAndRepo(from: project.name) {
             Text("\(Text("\(parts.owner)/").foregroundStyle(.secondary))\(Text(parts.repo).foregroundStyle(.white))")
                 .font(.headline)
         } else {


### PR DESCRIPTION
## Summary

- Adds a **"Create new"** mode to the Add Project dialog (alongside "Clone existing") with inline mode toggle
- When GitHub is connected via `gh auth`, creates repo on GitHub (`gh repo create`) with chosen visibility (public/private), pushes initial commit (README + .gitignore)
- Falls back to **local-only** repo creation when GitHub is not connected
- `ProjectState.url` is now optional to support local-only projects — all consumers guarded
- Full-stack implementation: backend, frontend, iOS, tests updated

## Changes

### Backend
- `project-manager.ts`: new `initProject()`, `validateRepoName()`, `createGitHubRepo()` — creates bare repo via `git init --bare`, seeds initial commit, optionally pushes to GitHub
- `types.ts`: `ProjectState.url` optional, `CreateProjectRequest` is now a discriminated union (`clone` | `create`)
- `projects.ts`: POST handler dispatches on `mode` field (backward compatible)
- `workspaces.ts`: guard `parseGitHubRepo()` for optional URL

### Frontend
- `AddProjectDialog.tsx`: mode toggle, create form (name + visibility + GitHub status indicator)
- `useProjects.ts`: shared `createProjectThenWorkspace()` helper, new `createNewProjectWithWorkspace` mutation
- `Sidebar.tsx`, `ProjectDetail.tsx`: guard optional URL, "Local only" label

### iOS
- `AddProjectSheet.swift`: segmented picker (Clone/Create), create form with GitHub status check
- `APIClient.swift`: `createNewProject()`, `fetchAccountStatus()`
- `ProjectStore.swift`: shared `createProjectWithWorkspace(displayName:apiCall:)` helper
- `Models.swift`: `url` optional, `AccountStatusResponse` types

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — all 1084 tests pass (87 files)
- [ ] Manual: create project with GitHub connected → verify repo on GitHub, workspace works
- [ ] Manual: create project without GitHub → verify local-only, workspace works
- [ ] Manual: clone existing repo → same behavior as before