### PR TITLE
fix(claude): align context window display with actual CLI capacity

### DIFF
--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -9,8 +9,8 @@ import type {
 } from "./types.js";
 
 const CLAUDE_MODELS: ModelDefinition[] = [
-  { id: "opus-4-7", label: "Opus 4.7", cliValue: "claude-opus-4-7", isDefault: true, contextWindow: 1_000_000 },
-  { id: "sonnet-4-6", label: "Sonnet 4.6", cliValue: "claude-sonnet-4-6", contextWindow: 1_000_000 },
+  { id: "opus-4-7", label: "Opus 4.7", cliValue: "claude-opus-4-7[1m]", isDefault: true, contextWindow: 1_000_000 },
+  { id: "sonnet-4-6", label: "Sonnet 4.6", cliValue: "claude-sonnet-4-6", contextWindow: 200_000 },
   { id: "haiku-4-5", label: "Haiku 4.5", cliValue: "claude-haiku-4-5", contextWindow: 200_000 },
 ];
 

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -307,7 +307,7 @@ describe("contextWindow in catalog", () => {
     const opus = claudeModels.find((m) => m.id === "claude:opus-4-7");
     expect(opus?.contextWindow).toBe(1_000_000);
     const sonnet = claudeModels.find((m) => m.id === "claude:sonnet-4-6");
-    expect(sonnet?.contextWindow).toBe(1_000_000);
+    expect(sonnet?.contextWindow).toBe(200_000);
     const haiku = claudeModels.find((m) => m.id === "claude:haiku-4-5");
     expect(haiku?.contextWindow).toBe(200_000);
   });


### PR DESCRIPTION
## Summary

- The model catalog declared `contextWindow: 1_000_000` for Opus 4.7 and Sonnet 4.6, but the CLI was invoked with bare `claude-opus-4-7` / `claude-sonnet-4-6` — no `[1m]` suffix. Per the [Claude Code docs](https://code.claude.com/docs/en/model-config), 1M context requires that suffix (Opus auto-upgrades only on Max/Team/Enterprise; Sonnet 1M is gated behind extra usage everywhere).
- Net effect: the context ring divided real usage by 1M while the CLI was actually running at 200K → users could appear at ~18% while truly at 90% and hit auto-compact without warning.

### Changes

- **Opus 4.7**: append `[1m]` to `cliValue` (`claude-opus-4-7[1m]`) so 1M is actually requested. Claude Code strips the suffix before hitting the provider.
- **Sonnet 4.6**: revert `contextWindow` to `200_000` to match the real default capacity and avoid surprise API errors for users without extra-usage entitlement.
- **Haiku 4.5**: unchanged.
- Updated `registry.test.ts` Sonnet expectation accordingly.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm test` — 1193 tests pass
- [ ] Manual: open a long Opus session, confirm ring reaches towards 1M
- [ ] Manual: open a long Sonnet session, confirm ring reaches towards 200K and auto-compact triggers as expected