### PR TITLE
feat: add light/system/dark theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -10,6 +10,19 @@
     <meta name="apple-mobile-web-app-title" content="HIVE" />
     <link rel="manifest" href="/site.webmanifest" />
     <title>Hive</title>
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem("hive-theme");
+          var mode = stored === "light" || stored === "dark" || stored === "system" ? stored : "system";
+          var isDark = mode === "dark" || (mode === "system" && window.matchMedia("(prefers-color-scheme: dark)").matches);
+          document.documentElement.classList.toggle("dark", isDark);
+          document.documentElement.classList.toggle("light", !isDark);
+        } catch (e) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import type { Project } from "@/types";
 import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
+import { useThemeType } from "@/hooks/useThemeType";
 import { wsTransport } from "@/lib/ws-transport";
 
 const AutomationDetail = lazy(() => import("@/pages/AutomationDetail"));
@@ -32,6 +33,8 @@ export default function App() {
   const { projects, loading, fetchProjects, createProjectWithWorkspace, createNewProjectWithWorkspace } = useProjects();
   const [showAddProject, setShowAddProject] = useState(false);
   const [showAddAutomation, setShowAddAutomation] = useState(false);
+  const themeType = useThemeType();
+  const isDark = themeType === "dark";
   const workspaceIds = useMemo(
     () =>
       Array.from(
@@ -58,16 +61,30 @@ export default function App() {
       <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
         <Toaster
           position="top-right"
-          theme="dark"
-          options={{
-            fill: "#16161e",
-            styles: {
-              title: "text-[oklch(0.93_0.005_260)]!",
-              description: "text-[oklch(0.707_0.022_261.325)]!",
-              badge: "bg-[#262636]!",
-              button: "bg-[#262636]! text-[oklch(0.93_0.005_260)]! hover:bg-[#2e2e40]!",
-            },
-          }}
+          theme={isDark ? "dark" : "light"}
+          options={
+            isDark
+              ? {
+                  fill: "#16161e",
+                  styles: {
+                    title: "text-[oklch(0.93_0.005_260)]!",
+                    description: "text-[oklch(0.707_0.022_261.325)]!",
+                    badge: "bg-[#262636]!",
+                    button:
+                      "bg-[#262636]! text-[oklch(0.93_0.005_260)]! hover:bg-[#2e2e40]!",
+                  },
+                }
+              : {
+                  fill: "#ffffff",
+                  styles: {
+                    title: "text-[oklch(0.145_0_0)]!",
+                    description: "text-[oklch(0.556_0_0)]!",
+                    badge: "bg-[oklch(0.97_0_0)]!",
+                    button:
+                      "bg-[oklch(0.97_0_0)]! text-[oklch(0.145_0_0)]! hover:bg-[oklch(0.94_0_0)]!",
+                  },
+                }
+          }
         />
         <NotificationToastsBridge projects={projects} />
         <AddProjectDialog

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -344,7 +344,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   return (
     <div className="relative z-50 bg-background p-4">
       <div className={cn(
-        "relative rounded-lg border border-transparent [&_[data-slot=input-group]]:!border-border/30 [&_[data-slot=input-group]]:!bg-[#1e1e28]",
+        "relative rounded-lg border border-transparent [&_[data-slot=input-group]]:!border-border/50 [&_[data-slot=input-group]]:!bg-card dark:[&_[data-slot=input-group]]:!border-border/30 dark:[&_[data-slot=input-group]]:!bg-[#1e1e28]",
         showPopup && "[&_[data-slot=input-group]]:rounded-t-none [&_[data-slot=input-group]]:!border-t-transparent",
         planMode && supportsPlanMode && "[&_[data-slot=input-group]]:!border-transparent border-dashed border-primary",
         planMode && supportsPlanMode && showPopup && "rounded-t-none border-t-0",

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -78,7 +78,7 @@ const ChatMessage = memo(function ChatMessage({
         className={cn(
           "max-w-[85%] text-sm leading-relaxed",
           isUser
-            ? "group/user-msg relative rounded-[10px] rounded-br-[2px] border border-primary/15 bg-primary/20 px-3.5 py-2 text-white"
+            ? "group/user-msg relative rounded-[10px] rounded-br-[2px] border border-primary/25 bg-primary/10 px-3.5 py-2 text-foreground dark:border-primary/15 dark:bg-primary/20 dark:text-white"
             : "text-foreground",
         )}
       >

--- a/frontend/src/components/EmptyStateLogo.tsx
+++ b/frontend/src/components/EmptyStateLogo.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { FolderGit2, Settings } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTailscaleConfig } from "@/hooks/useTailscaleConfig";
+import { useThemeType } from "@/hooks/useThemeType";
 
 interface EmptyStateLogoProps {
   className?: string;
@@ -11,7 +12,8 @@ interface EmptyStateLogoProps {
 }
 
 const CELL_SIZE = 8;
-const BG = "#09090f";
+const BG_DARK = "#09090f";
+const BG_LIGHT = "#f7f7f8";
 
 function hexToRgb(hex: string): [number, number, number] {
   const h = hex.replace("#", "");
@@ -27,10 +29,10 @@ function rgbToHex(r: number, g: number, b: number): string {
   return `#${[clamp(r), clamp(g), clamp(b)].map((v) => v.toString(16).padStart(2, "0")).join("")}`;
 }
 
-function buildPalette(accent: string) {
+function buildPalette(accent: string, bg: string) {
   const [r, g, b] = hexToRgb(accent);
   return {
-    bg: BG,
+    bg,
     bright: rgbToHex(r * 0.8, g * 0.8, b * 0.8),
     hot: rgbToHex(
       r + (255 - r) * 0.45,
@@ -50,6 +52,7 @@ function getAccentHex(): string {
 function renderStaticLogo(
   canvas: HTMLCanvasElement,
   ctx: CanvasRenderingContext2D,
+  bg: string,
 ) {
   ctx.imageSmoothingEnabled = false;
   let resizeRafId = 0;
@@ -69,7 +72,7 @@ function renderStaticLogo(
     const rows = Math.max(1, Math.floor(height / CELL_SIZE));
 
     const accent = getAccentHex();
-    const palette = buildPalette(accent);
+    const palette = buildPalette(accent, bg);
     const [acR, acG, acB] = hexToRgb(accent);
 
     const off = document.createElement("canvas");
@@ -143,13 +146,14 @@ function renderLogo(
   canvas: HTMLCanvasElement,
   ctx: CanvasRenderingContext2D,
   enableAnimation: boolean,
+  bg: string,
 ) {
   if (enableAnimation) {
     // Animation path intentionally disabled for now due to perf concerns.
-    return renderStaticLogo(canvas, ctx);
+    return renderStaticLogo(canvas, ctx, bg);
   }
 
-  return renderStaticLogo(canvas, ctx);
+  return renderStaticLogo(canvas, ctx, bg);
 }
 
 export default function EmptyStateLogo({
@@ -159,19 +163,21 @@ export default function EmptyStateLogo({
 }: EmptyStateLogoProps) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const { isConfigured } = useTailscaleConfig();
+  const theme = useThemeType();
+  const bg = theme === "dark" ? BG_DARK : BG_LIGHT;
 
   useEffect(() => {
     const canvas = canvasRef.current;
     if (!canvas) return;
     const ctx = canvas.getContext("2d");
     if (!ctx) return;
-    return renderLogo(canvas, ctx, enableAnimation);
-  }, [enableAnimation]);
+    return renderLogo(canvas, ctx, enableAnimation, bg);
+  }, [enableAnimation, bg]);
 
   return (
     <div
       className={cn("relative h-full w-full", className)}
-      style={{ background: BG }}
+      style={{ background: bg }}
     >
       <canvas
         ref={canvasRef}

--- a/frontend/src/components/FileViewer.tsx
+++ b/frontend/src/components/FileViewer.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import { highlightCode } from "@/lib/shiki";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useThemeType } from "@/hooks/useThemeType";
 
 const EXT_TO_LANG: Record<string, string> = {
   ts: "typescript",
@@ -46,6 +47,9 @@ interface FileViewerProps {
 }
 
 export function FileViewer({ wsId, filePath }: FileViewerProps) {
+  const theme = useThemeType();
+  const shikiTheme = theme === "dark" ? "github-dark" : "github-light";
+
   const fileQuery = useQuery({
     queryKey: ["file", wsId, filePath],
     queryFn: () =>
@@ -56,7 +60,6 @@ export function FileViewer({ wsId, filePath }: FileViewerProps) {
     staleTime: 2 * 60 * 1000,
   });
 
-  // Async Shiki highlighting — runs after fetch resolves
   const [html, setHtml] = useState("");
   useEffect(() => {
     if (!fileQuery.data) {
@@ -64,13 +67,13 @@ export function FileViewer({ wsId, filePath }: FileViewerProps) {
       return;
     }
     let cancelled = false;
-    highlightCode(fileQuery.data.content, getLang(filePath)).then((result) => {
+    highlightCode(fileQuery.data.content, getLang(filePath), shikiTheme).then((result) => {
       if (!cancelled) setHtml(result);
     });
     return () => {
       cancelled = true;
     };
-  }, [fileQuery.data, filePath]);
+  }, [fileQuery.data, filePath, shikiTheme]);
 
   const loading = fileQuery.isLoading || (!!fileQuery.data && !html);
   const error = fileQuery.error?.message ?? null;
@@ -126,7 +129,7 @@ export function FileViewer({ wsId, filePath }: FileViewerProps) {
           user-select: none;
         }
         .file-viewer-content .line:hover {
-          background: hsl(var(--accent) / 0.3);
+          background: color-mix(in oklch, var(--foreground) 5%, transparent);
         }
       `}</style>
     </div>

--- a/frontend/src/components/ServerMetrics.tsx
+++ b/frontend/src/components/ServerMetrics.tsx
@@ -19,7 +19,7 @@ function MetricBar({ label, percent }: MetricBarProps) {
       <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
         {label}
       </span>
-      <div className="h-1 flex-1 rounded-full bg-muted/40">
+      <div className="h-1 flex-1 rounded-full bg-border dark:bg-muted/40">
         <div
           className="h-full rounded-full transition-[width] duration-700 ease-out"
           style={{ width: `${percent}%`, backgroundColor: color }}

--- a/frontend/src/components/SidebarShell.tsx
+++ b/frontend/src/components/SidebarShell.tsx
@@ -16,9 +16,9 @@ export function SidebarShell({ children, footerActions }: SidebarShellProps) {
 
       {children}
 
-      <div className="shrink-0 border-t border-border/50">
+      <div className="shrink-0 border-t border-border">
         {footerActions}
-        <div className="mx-2 border-t border-border/50" />
+        <div className="mx-2 border-t border-border" />
         <div className="px-3 pb-2 pt-1.5">
           <ServerMetrics />
         </div>

--- a/frontend/src/hooks/useThemeMode.ts
+++ b/frontend/src/hooks/useThemeMode.ts
@@ -1,0 +1,62 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export type ThemeMode = "system" | "light" | "dark";
+
+export const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
+
+const STORAGE_KEY = "hive-theme";
+const DEFAULT_MODE: ThemeMode = "system";
+
+const listeners = new Set<() => void>();
+
+function isThemeMode(value: string | null): value is ThemeMode {
+  return value === "system" || value === "light" || value === "dark";
+}
+
+function getSnapshot(): ThemeMode {
+  const raw = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+  return isThemeMode(raw) ? raw : DEFAULT_MODE;
+}
+
+function getServerSnapshot(): ThemeMode {
+  return DEFAULT_MODE;
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => {
+    listeners.delete(callback);
+  };
+}
+
+function systemPrefersDark(): boolean {
+  return typeof window !== "undefined" && window.matchMedia("(prefers-color-scheme: dark)").matches;
+}
+
+export function applyTheme(mode: ThemeMode) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  const effectivelyDark = mode === "dark" || (mode === "system" && systemPrefersDark());
+  root.classList.toggle("dark", effectivelyDark);
+  root.classList.toggle("light", !effectivelyDark);
+}
+
+// System preference listener — re-apply when in "system" mode
+if (typeof window !== "undefined") {
+  const mq = window.matchMedia("(prefers-color-scheme: dark)");
+  mq.addEventListener("change", () => {
+    if (getSnapshot() === "system") applyTheme("system");
+  });
+}
+
+export function useThemeMode() {
+  const mode = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+  const setMode = useCallback((next: ThemeMode) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    applyTheme(next);
+    for (const listener of listeners) listener();
+  }, []);
+
+  return { mode, setMode, options: THEME_MODES };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -94,7 +94,7 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.92 0 0);
+  --border: oklch(0.86 0 0);
   --input: oklch(0.94 0 0);
   --ring: var(--hive-accent, #635BFF);
   --chart-1: var(--hive-accent, #635BFF);
@@ -108,22 +108,22 @@
   --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.92 0 0);
+  --sidebar-border: oklch(0.86 0 0);
   --sidebar-ring: var(--hive-accent, #635BFF);
   --sidebar-card-bg: oklch(1 0 0);
   --sidebar-card-bg-hover: oklch(0.975 0 0);
   --sidebar-card-bg-active: color-mix(in oklch, var(--hive-accent, #635BFF) 8%, transparent);
-  --sidebar-card-border: oklch(0.92 0 0);
-  --sidebar-card-border-hover: oklch(0.86 0 0);
+  --sidebar-card-border: oklch(0.88 0 0);
+  --sidebar-card-border-hover: oklch(0.82 0 0);
   --sidebar-card-border-active: color-mix(in oklch, var(--hive-accent, #635BFF) 40%, transparent);
   --sidebar-card-text: var(--sidebar-foreground);
   --sidebar-card-text-muted: var(--muted-foreground);
   --sidebar-card-text-active: var(--sidebar-foreground);
 
-  /* Sidebar card shadows — subtle in light mode */
-  --sidebar-card-shadow: 0 1px 2px oklch(0 0 0 / 4%);
-  --sidebar-card-shadow-hover: 0 4px 10px oklch(0 0 0 / 6%);
-  --sidebar-card-shadow-active: 0 2px 6px oklch(0 0 0 / 5%);
+  /* Sidebar card shadows — flat in light mode */
+  --sidebar-card-shadow: none;
+  --sidebar-card-shadow-hover: none;
+  --sidebar-card-shadow-active: none;
 
   /* Accent glow for focus rings & highlights */
   --hive-accent-glow: color-mix(in oklch, var(--hive-accent, #635BFF) 12%, transparent);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -82,40 +82,51 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
+
+  /* Primary = accent color (set dynamically via useAccentColor) */
+  --primary: var(--hive-accent, #635BFF);
+  --primary-foreground: #ffffff;
+
   --secondary: oklch(0.97 0 0);
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
+  --muted-foreground: oklch(0.45 0 0);
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
+  --border: oklch(0.92 0 0);
+  --input: oklch(0.94 0 0);
+  --ring: var(--hive-accent, #635BFF);
+  --chart-1: var(--hive-accent, #635BFF);
   --chart-2: oklch(0.6 0.118 184.704);
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(0.985 0 0);
   --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
+  --sidebar-primary: var(--hive-accent, #635BFF);
+  --sidebar-primary-foreground: #ffffff;
   --sidebar-accent: oklch(0.97 0 0);
   --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  --sidebar-border: oklch(0.92 0 0);
+  --sidebar-ring: var(--hive-accent, #635BFF);
   --sidebar-card-bg: oklch(1 0 0);
-  --sidebar-card-bg-hover: oklch(0.985 0 0);
-  --sidebar-card-bg-active: color-mix(in oklch, var(--primary) 8%, transparent);
-  --sidebar-card-border: oklch(0.922 0 0);
-  --sidebar-card-border-hover: oklch(0.85 0 0);
-  --sidebar-card-border-active: color-mix(in oklch, var(--primary) 35%, transparent);
+  --sidebar-card-bg-hover: oklch(0.975 0 0);
+  --sidebar-card-bg-active: color-mix(in oklch, var(--hive-accent, #635BFF) 8%, transparent);
+  --sidebar-card-border: oklch(0.92 0 0);
+  --sidebar-card-border-hover: oklch(0.86 0 0);
+  --sidebar-card-border-active: color-mix(in oklch, var(--hive-accent, #635BFF) 40%, transparent);
   --sidebar-card-text: var(--sidebar-foreground);
   --sidebar-card-text-muted: var(--muted-foreground);
   --sidebar-card-text-active: var(--sidebar-foreground);
+
+  /* Sidebar card shadows — subtle in light mode */
+  --sidebar-card-shadow: 0 1px 2px oklch(0 0 0 / 4%);
+  --sidebar-card-shadow-hover: 0 4px 10px oklch(0 0 0 / 6%);
+  --sidebar-card-shadow-active: 0 2px 6px oklch(0 0 0 / 5%);
+
+  /* Accent glow for focus rings & highlights */
+  --hive-accent-glow: color-mix(in oklch, var(--hive-accent, #635BFF) 12%, transparent);
 }
 
 .dark {
@@ -166,6 +177,11 @@
   --sidebar-card-text: var(--sidebar-foreground);
   --sidebar-card-text-muted: var(--muted-foreground);
   --sidebar-card-text-active: var(--sidebar-foreground);
+
+  /* Sidebar card shadows — elevated in dark mode */
+  --sidebar-card-shadow: inset 0 1px 0 oklch(1 0 0 / 3%), 0 10px 20px oklch(0 0 0 / 18%);
+  --sidebar-card-shadow-hover: inset 0 1px 0 oklch(1 0 0 / 4%), 0 12px 26px oklch(0 0 0 / 24%);
+  --sidebar-card-shadow-active: inset 0 1px 0 oklch(1 0 0 / 5%), 0 12px 26px oklch(0 0 0 / 24%);
 
   /* Accent glow for focus rings & highlights */
   --hive-accent-glow: color-mix(in oklch, var(--hive-accent, #635BFF) 15%, transparent);
@@ -248,9 +264,7 @@
     background: var(--sidebar-card-bg);
     border-color: var(--sidebar-card-border);
     color: var(--sidebar-card-text-muted);
-    box-shadow:
-      inset 0 1px 0 oklch(1 0 0 / 3%),
-      0 10px 20px oklch(0 0 0 / 18%);
+    box-shadow: var(--sidebar-card-shadow);
     transition:
       background-color 0.2s ease,
       border-color 0.2s ease,
@@ -262,18 +276,14 @@
     background: var(--sidebar-card-bg-hover);
     border-color: var(--sidebar-card-border-hover);
     color: var(--sidebar-card-text);
-    box-shadow:
-      inset 0 1px 0 oklch(1 0 0 / 4%),
-      0 12px 26px oklch(0 0 0 / 24%);
+    box-shadow: var(--sidebar-card-shadow-hover);
   }
 
   .sidebar-card-active {
     background: var(--sidebar-card-bg-active);
     border-color: var(--sidebar-card-border-active);
     color: var(--sidebar-card-text-active);
-    box-shadow:
-      inset 0 1px 0 oklch(1 0 0 / 5%),
-      0 12px 26px oklch(0 0 0 / 24%);
+    box-shadow: var(--sidebar-card-shadow-active);
   }
 
   .sidebar-card-active:hover {

--- a/frontend/src/lib/shiki.ts
+++ b/frontend/src/lib/shiki.ts
@@ -1,18 +1,24 @@
 import { createHighlighter, type Highlighter } from "shiki";
 
+export type ShikiTheme = "github-dark" | "github-light";
+
 let instance: Promise<Highlighter> | null = null;
 
 function getOrCreateHighlighter() {
   if (!instance) {
     instance = createHighlighter({
-      themes: ["github-dark"],
+      themes: ["github-dark", "github-light"],
       langs: [],
     });
   }
   return instance;
 }
 
-export async function highlightCode(code: string, lang: string): Promise<string> {
+export async function highlightCode(
+  code: string,
+  lang: string,
+  theme: ShikiTheme = "github-dark",
+): Promise<string> {
   const highlighter = await getOrCreateHighlighter();
   const loaded = highlighter.getLoadedLanguages();
   if (!loaded.includes(lang)) {
@@ -24,7 +30,7 @@ export async function highlightCode(code: string, lang: string): Promise<string>
   }
   return highlighter.codeToHtml(code, {
     lang,
-    theme: "github-dark",
+    theme,
     transformers: [
       {
         line(node, line) {

--- a/frontend/src/pages/settings/AppearanceSettings.tsx
+++ b/frontend/src/pages/settings/AppearanceSettings.tsx
@@ -1,10 +1,18 @@
-import { Check } from "lucide-react";
+import { Check, Monitor, Moon, Sun } from "lucide-react";
 import { useAccentColor } from "@/hooks/useAccentColor";
+import { useThemeMode, type ThemeMode } from "@/hooks/useThemeMode";
 import { SettingsHeader } from "@/components/AppLayout";
 import { cn } from "@/lib/utils";
 
+const THEME_OPTIONS: { id: ThemeMode; label: string; Icon: typeof Sun }[] = [
+  { id: "system", label: "System", Icon: Monitor },
+  { id: "light", label: "Light", Icon: Sun },
+  { id: "dark", label: "Dark", Icon: Moon },
+];
+
 export default function AppearanceSettings() {
   const { accentId, setAccent, options } = useAccentColor();
+  const { mode, setMode } = useThemeMode();
 
   return (
     <div className="flex h-full flex-col overflow-auto">
@@ -12,7 +20,49 @@ export default function AppearanceSettings() {
         <h1 className="text-sm font-medium">Appearance</h1>
       </SettingsHeader>
 
-      <div className="max-w-2xl space-y-8 px-4 py-5">
+      <div className="max-w-2xl space-y-5 px-4 py-5">
+        <section>
+          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
+            <h2 className="text-sm font-medium text-foreground">Theme</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Choose how Hive looks. System follows your OS preference.
+            </p>
+            <div
+              role="radiogroup"
+              aria-label="Theme mode"
+              className="mt-5 grid grid-cols-3 gap-2"
+            >
+              {THEME_OPTIONS.map(({ id, label, Icon }) => {
+                const isActive = id === mode;
+                return (
+                  <button
+                    key={id}
+                    type="button"
+                    role="radio"
+                    aria-checked={isActive}
+                    onClick={() => setMode(id)}
+                    className={cn(
+                      "group flex cursor-pointer flex-col items-center gap-2 rounded-lg border px-3 py-4 transition-all duration-200",
+                      isActive
+                        ? "border-primary/40 bg-primary/8 text-foreground"
+                        : "border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+                    )}
+                  >
+                    <Icon
+                      className={cn(
+                        "h-5 w-5 transition-colors",
+                        isActive ? "text-primary" : "text-muted-foreground group-hover:text-foreground",
+                      )}
+                      strokeWidth={1.75}
+                    />
+                    <span className="text-xs font-medium">{label}</span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </section>
+
         <section>
           <div className="rounded-lg border border-border/50 bg-card/50 p-5">
             <h2 className="text-sm font-medium text-foreground">Accent color</h2>

--- a/frontend/tests/components/FileViewer.test.tsx
+++ b/frontend/tests/components/FileViewer.test.tsx
@@ -69,7 +69,7 @@ describe("FileViewer", () => {
     expect(apiMock).toHaveBeenCalledWith(
       "/api/workspaces/ws-1/file?path=src%2Fapp.ts",
     );
-    expect(highlightMock).toHaveBeenCalledWith("const x = 1;", "typescript");
+    expect(highlightMock).toHaveBeenCalledWith("const x = 1;", "typescript", expect.any(String));
   });
 
   it("shows error message when API fails", async () => {
@@ -135,7 +135,7 @@ describe("FileViewer", () => {
       const { unmount } = renderFileViewer({ wsId: "ws-1", filePath: path });
 
       await waitFor(() => {
-        expect(highlightMock).toHaveBeenCalledWith("code", lang);
+        expect(highlightMock).toHaveBeenCalledWith("code", lang, expect.any(String));
       });
 
       unmount();

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -6,8 +6,10 @@ import AppearanceSettings from "@/pages/settings/AppearanceSettings";
 
 const mocks = vi.hoisted(() => ({
   setAccent: vi.fn(),
+  setThemeMode: vi.fn(),
   useConnectionStatus: vi.fn(),
   useAccentColor: vi.fn(),
+  useThemeMode: vi.fn(),
 }));
 
 vi.mock("@/hooks/useConnectionStatus", () => ({
@@ -16,6 +18,11 @@ vi.mock("@/hooks/useConnectionStatus", () => ({
 
 vi.mock("@/hooks/useAccentColor", () => ({
   useAccentColor: mocks.useAccentColor,
+}));
+
+vi.mock("@/hooks/useThemeMode", () => ({
+  useThemeMode: mocks.useThemeMode,
+  THEME_MODES: ["system", "light", "dark"],
 }));
 
 describe("ConnectionSettings", () => {
@@ -182,6 +189,14 @@ describe("AppearanceSettings", () => {
         { id: "emerald", label: "Emerald", color: "#10b981" },
       ],
     });
+
+    mocks.setThemeMode.mockReset();
+    mocks.useThemeMode.mockReset();
+    mocks.useThemeMode.mockReturnValue({
+      mode: "system",
+      setMode: mocks.setThemeMode,
+      options: ["system", "light", "dark"],
+    });
   });
 
   it("updates accent color from accent option buttons", async () => {
@@ -192,5 +207,29 @@ describe("AppearanceSettings", () => {
     await user.click(screen.getByRole("button", { name: "Accent color: Emerald" }));
 
     expect(mocks.setAccent).toHaveBeenCalledWith("emerald");
+  });
+
+  it("switches theme mode when selecting an option", async () => {
+    const user = userEvent.setup();
+    render(<AppearanceSettings />);
+
+    await user.click(screen.getByRole("radio", { name: "Light" }));
+    expect(mocks.setThemeMode).toHaveBeenCalledWith("light");
+
+    await user.click(screen.getByRole("radio", { name: "Dark" }));
+    expect(mocks.setThemeMode).toHaveBeenCalledWith("dark");
+  });
+
+  it("marks the active theme mode as checked", () => {
+    mocks.useThemeMode.mockReturnValue({
+      mode: "dark",
+      setMode: mocks.setThemeMode,
+      options: ["system", "light", "dark"],
+    });
+    render(<AppearanceSettings />);
+
+    expect(screen.getByRole("radio", { name: "Dark" })).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "false");
+    expect(screen.getByRole("radio", { name: "System" })).toHaveAttribute("aria-checked", "false");
   });
 });


### PR DESCRIPTION
## Summary

- New user-selectable theme mode (**System / Light / Dark**, default: System) in Settings → Appearance, above the accent color picker.
- `useThemeMode` hook persists the choice in `localStorage` (`hive-theme`) and listens to `prefers-color-scheme` when in System mode.
- Pre-hydration inline script in `index.html` applies the saved mode before React mounts (replaces the previously hardcoded `class="dark"`), preventing FOUC.
- `Toaster` theme is now conditional on the resolved theme; `EmptyStateLogo` canvas adapts its background so the Home empty state doesn't stay dark in Light mode.

Only the frontend (web + Tauri) is touched — iOS is out of scope for this PR as requested.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` — 146 pre-existing failures unchanged (ConnectionSettings `localStorage.removeItem` mock issue), **2 new tests added** for the theme selector, all passing
- [x] Dev server: all three modes toggle instantly, no FOUC on reload, accent color preserved across modes
- [x] System mode follows the OS `prefers-color-scheme` media query live
- [ ] Verify in Tauri desktop build (follows same CSS pipeline, expected to work)