### PR TITLE
Sidebar project folders: organization, persistence, and hardening

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `backend/src/api/scripts.ts`: workspace setup/run script lifecycle (start/stop/status)
 - `backend/src/api/agents-settings.ts`: `GET /api/settings/agents` — provider version check + npm update detection
 - `backend/src/api/base-prompt.ts`: `GET/PUT/DELETE /api/prompts/base` — base system prompt CRUD
+- `backend/src/api/ui-preferences.ts`: `GET/PUT /api/ui-preferences` — global UI preferences (sidebar folders + folderOpenState), sanitized against known project IDs on read and write
 - `backend/src/api/automations.ts`: automation CRUD + manual trigger + run history + run messages
 - `backend/src/api/prompt-templates.ts`: prompt template CRUD (deletion guard if referenced by automation)
 - `backend/src/ws/stream.ts`: multiplexed hub WebSocket protocol (`/ws/hub`; `sync_workspaces` subscription, `HubOutgoing` envelopes)
@@ -91,6 +92,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `backend/src/state/automations.ts`: automation + run persistence (atomic writes, run capping at 50)
 - `backend/src/state/prompt-templates.ts`: template persistence (`.md` files with YAML frontmatter in `~/.hive/prompts/`)
 - `backend/src/state/base-prompt.ts`: base prompt persistence (`~/.hive/prompts/base.md`), atomic write, reset-to-default
+- `backend/src/state/ui-preferences.ts`: UI preferences persistence (`$DATA_DIR/ui-preferences.json`) — atomic write, sanitize helper drops folders/project refs that no longer exist
 - `backend/src/state/state.ts`: JSON persistence + per-project locks
 - `backend/src/state/config.ts`: file-based app config (`$DATA_DIR/config.json`)
 - `backend/src/utils/preflight.ts`: startup dependency checks (git >= 2.17, claude, gh; codex/gemini optional)
@@ -174,6 +176,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/hooks/useTasks.ts`: derives `TrackedTask[]` from `TaskCreate`/`TaskUpdate` tool calls for task tracker display
 - `frontend/src/hooks/useDiff.ts`: diff fetching via `@pierre/diffs` for inline diff viewer
 - `frontend/src/hooks/useSidebarCollapsed.ts`: localStorage-backed sidebar collapsed state, Cmd/Ctrl+B keyboard shortcut
+- `frontend/src/hooks/useSidebarProjectFolders.ts`: sidebar folder organization — TanStack Query fetch + optimistic mutations with 300ms debounced PUT to `/api/ui-preferences`, localStorage cache for first-render bootstrap, one-shot migration from legacy `hive:sidebar-project-folders:v1` key
 - `frontend/src/hooks/useThemeType.ts`: dark/light theme detection via DOM class mutations + `prefers-color-scheme`
 - `frontend/src/hooks/useWsCacheInvalidation.ts`: centralized WS-driven TanStack Query invalidation (sessions, files, diff-stat, file-completions)
 - `frontend/src/hooks/useTerminalApps.ts`: detect available terminal emulators (Tauri)

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,16 +4,21 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "npm --prefix ../shared run build",
     "dev": "tsx watch src/index.ts",
+    "prebuild": "npm --prefix ../shared run build",
     "build": "tsc",
+    "pretypecheck": "npm --prefix ../shared run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "pretest": "npm --prefix ../shared run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "postinstall": "chmod +x ../node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
+    "@hive/shared": "^0.1.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/websocket": "^11.2.0",
     "croner": "^10.0.1",

--- a/backend/src/api/ui-preferences.test.ts
+++ b/backend/src/api/ui-preferences.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm, readFile } from "node:fs/promises";
+import { join } from "node:path";
+import Fastify, { type FastifyInstance } from "fastify";
+import { createTempDir } from "../utils/test-helpers.js";
+import { saveProject } from "../state/state.js";
+import { uiPreferencesRoutes } from "./ui-preferences.js";
+
+let tmpDir: string;
+let dataDir: string;
+let app: FastifyInstance;
+
+async function seedProject(id: string): Promise<void> {
+  await saveProject(
+    {
+      id,
+      name: id,
+      url: `https://example.test/${id}.git`,
+      createdAt: new Date().toISOString(),
+      workspaces: [],
+    },
+    dataDir,
+  );
+}
+
+beforeEach(async () => {
+  tmpDir = await createTempDir("hive-ui-prefs-api-test-");
+  dataDir = join(tmpDir, "data");
+  app = Fastify();
+  await app.register((instance) => uiPreferencesRoutes(instance, { dataDir }));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+describe("GET /api/ui-preferences", () => {
+  it("returns empty defaults when nothing is stored", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/ui-preferences" });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ sidebar: { folders: [], folderOpenState: {} } });
+  });
+
+  it("prunes folders referencing deleted projects at read time", async () => {
+    await seedProject("p-alive");
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: {
+        sidebar: {
+          folders: [{ id: "f1", name: "Work", projectIds: ["p-alive"] }],
+          folderOpenState: { f1: true },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+
+    // Now write a raw file that references a dead project — simulate a project deletion
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(
+      join(dataDir, "ui-preferences.json"),
+      JSON.stringify({
+        sidebar: {
+          folders: [
+            { id: "f1", name: "Work", projectIds: ["p-alive", "p-dead"] },
+          ],
+          folderOpenState: { f1: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    const getRes = await app.inject({ method: "GET", url: "/api/ui-preferences" });
+    expect(getRes.json().sidebar.folders[0].projectIds).toEqual(["p-alive"]);
+  });
+});
+
+describe("PUT /api/ui-preferences", () => {
+  it("stores and returns the payload", async () => {
+    await seedProject("p1");
+    await seedProject("p2");
+
+    const payload = {
+      sidebar: {
+        folders: [{ id: "f1", name: "Work", projectIds: ["p1", "p2"] }],
+        folderOpenState: { f1: true },
+      },
+    };
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(payload);
+
+    const onDisk = JSON.parse(
+      await readFile(join(dataDir, "ui-preferences.json"), "utf-8"),
+    );
+    expect(onDisk).toEqual(payload);
+  });
+
+  it("strips unknown project ids before saving", async () => {
+    await seedProject("p1");
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: {
+        sidebar: {
+          folders: [{ id: "f1", name: "Work", projectIds: ["p1", "bogus"] }],
+          folderOpenState: { f1: true },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().sidebar.folders[0].projectIds).toEqual(["p1"]);
+  });
+
+  it("rejects payload missing sidebar (400)", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: {},
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects folder entries with wrong shape (400)", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: {
+        sidebar: {
+          folders: [{ id: "f1", name: "Work", projectIds: [42] }],
+          folderOpenState: {},
+        },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("rejects non-boolean folderOpenState values (400)", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: {
+        sidebar: {
+          folders: [],
+          folderOpenState: { f1: "yes" },
+        },
+      },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+});

--- a/backend/src/api/ui-preferences.ts
+++ b/backend/src/api/ui-preferences.ts
@@ -1,0 +1,72 @@
+import type { FastifyInstance } from "fastify";
+import {
+  loadUiPreferences,
+  saveUiPreferences,
+  sanitizeUiPreferences,
+  type UiPreferences,
+  type SidebarFolder,
+} from "../state/ui-preferences.js";
+import { getDataDir } from "../state/state.js";
+import { listProjects } from "../projects/project-manager.js";
+
+interface UiPreferencesRoutesOptions {
+  dataDir?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseBody(body: unknown): UiPreferences | null {
+  if (!isRecord(body)) return null;
+  if (!isRecord(body.sidebar)) return null;
+
+  const foldersRaw = Array.isArray(body.sidebar.folders) ? body.sidebar.folders : null;
+  if (!foldersRaw) return null;
+
+  const folders: SidebarFolder[] = [];
+  for (const entry of foldersRaw) {
+    if (!isRecord(entry)) return null;
+    if (typeof entry.id !== "string" || typeof entry.name !== "string") return null;
+    if (!Array.isArray(entry.projectIds)) return null;
+    const projectIds = entry.projectIds.filter((id): id is string => typeof id === "string");
+    if (projectIds.length !== entry.projectIds.length) return null;
+    folders.push({ id: entry.id, name: entry.name, projectIds });
+  }
+
+  const openStateRaw = isRecord(body.sidebar.folderOpenState) ? body.sidebar.folderOpenState : {};
+  const folderOpenState: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(openStateRaw)) {
+    if (typeof value !== "boolean") return null;
+    folderOpenState[key] = value;
+  }
+
+  return { sidebar: { folders, folderOpenState } };
+}
+
+export async function uiPreferencesRoutes(
+  app: FastifyInstance,
+  opts: UiPreferencesRoutesOptions = {},
+): Promise<void> {
+  const dataDir = opts.dataDir ?? getDataDir();
+
+  app.get("/api/ui-preferences", async () => {
+    const [prefs, projects] = await Promise.all([
+      loadUiPreferences(dataDir),
+      listProjects(dataDir),
+    ]);
+    return sanitizeUiPreferences(prefs, projects.map((p) => p.id));
+  });
+
+  app.put<{ Body: unknown }>("/api/ui-preferences", async (req, reply) => {
+    const parsed = parseBody(req.body);
+    if (!parsed) {
+      return reply.status(400).send({ error: "Invalid ui-preferences payload" });
+    }
+
+    const projects = await listProjects(dataDir);
+    const sanitized = sanitizeUiPreferences(parsed, projects.map((p) => p.id));
+    await saveUiPreferences(sanitized, dataDir);
+    return sanitized;
+  });
+}

--- a/backend/src/api/ui-preferences.ts
+++ b/backend/src/api/ui-preferences.ts
@@ -1,47 +1,16 @@
 import type { FastifyInstance } from "fastify";
+import { parseUiPreferencesPayload } from "../../../shared/sidebar-preferences.js";
 import {
   loadUiPreferences,
   saveUiPreferences,
   sanitizeUiPreferences,
   type UiPreferences,
-  type SidebarFolder,
 } from "../state/ui-preferences.js";
 import { getDataDir } from "../state/state.js";
 import { listProjects } from "../projects/project-manager.js";
 
 interface UiPreferencesRoutesOptions {
   dataDir?: string;
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseBody(body: unknown): UiPreferences | null {
-  if (!isRecord(body)) return null;
-  if (!isRecord(body.sidebar)) return null;
-
-  const foldersRaw = Array.isArray(body.sidebar.folders) ? body.sidebar.folders : null;
-  if (!foldersRaw) return null;
-
-  const folders: SidebarFolder[] = [];
-  for (const entry of foldersRaw) {
-    if (!isRecord(entry)) return null;
-    if (typeof entry.id !== "string" || typeof entry.name !== "string") return null;
-    if (!Array.isArray(entry.projectIds)) return null;
-    const projectIds = entry.projectIds.filter((id): id is string => typeof id === "string");
-    if (projectIds.length !== entry.projectIds.length) return null;
-    folders.push({ id: entry.id, name: entry.name, projectIds });
-  }
-
-  const openStateRaw = isRecord(body.sidebar.folderOpenState) ? body.sidebar.folderOpenState : {};
-  const folderOpenState: Record<string, boolean> = {};
-  for (const [key, value] of Object.entries(openStateRaw)) {
-    if (typeof value !== "boolean") return null;
-    folderOpenState[key] = value;
-  }
-
-  return { sidebar: { folders, folderOpenState } };
 }
 
 export async function uiPreferencesRoutes(
@@ -59,7 +28,7 @@ export async function uiPreferencesRoutes(
   });
 
   app.put<{ Body: unknown }>("/api/ui-preferences", async (req, reply) => {
-    const parsed = parseBody(req.body);
+    const parsed = parseUiPreferencesPayload(req.body, { mode: "strict" });
     if (!parsed) {
       return reply.status(400).send({ error: "Invalid ui-preferences payload" });
     }

--- a/backend/src/api/ui-preferences.ts
+++ b/backend/src/api/ui-preferences.ts
@@ -1,5 +1,5 @@
 import type { FastifyInstance } from "fastify";
-import { parseUiPreferencesPayload } from "../../../shared/sidebar-preferences.js";
+import { parseUiPreferencesPayload } from "@hive/shared/sidebar-preferences";
 import {
   loadUiPreferences,
   saveUiPreferences,

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,7 @@ import { scriptWsRoutes } from "./ws/script.js";
 import { automationRoutes } from "./api/automations.js";
 import { promptTemplateRoutes } from "./api/prompt-templates.js";
 import { basePromptRoutes } from "./api/base-prompt.js";
+import { uiPreferencesRoutes } from "./api/ui-preferences.js";
 import { AutomationScheduler } from "./services/automation-scheduler.js";
 import { loadConfig } from "./state/config.js";
 import { broadcastToWorkspace } from "./ws/stream.js";
@@ -320,6 +321,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   );
   await app.register((instance: FastifyInstance) => promptTemplateRoutes(instance));
   await app.register((instance: FastifyInstance) => basePromptRoutes(instance));
+  await app.register((instance: FastifyInstance) => uiPreferencesRoutes(instance));
 
   return app;
 }

--- a/backend/src/state/ui-preferences.test.ts
+++ b/backend/src/state/ui-preferences.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  loadUiPreferences,
+  saveUiPreferences,
+  sanitizeUiPreferences,
+  type UiPreferences,
+} from "./ui-preferences.js";
+
+let dataDir: string;
+
+const EMPTY: UiPreferences = { sidebar: { folders: [], folderOpenState: {} } };
+
+beforeEach(async () => {
+  dataDir = await mkdtemp(join(tmpdir(), "hive-ui-prefs-test-"));
+});
+
+afterEach(async () => {
+  await rm(dataDir, { recursive: true, force: true });
+});
+
+describe("loadUiPreferences", () => {
+  it("returns defaults when file is missing", async () => {
+    const prefs = await loadUiPreferences(dataDir);
+    expect(prefs).toEqual(EMPTY);
+  });
+
+  it("returns defaults when file is invalid JSON", async () => {
+    await writeFile(join(dataDir, "ui-preferences.json"), "{not-json", "utf-8");
+    const prefs = await loadUiPreferences(dataDir);
+    expect(prefs).toEqual(EMPTY);
+  });
+
+  it("parses a well-formed file", async () => {
+    const full: UiPreferences = {
+      sidebar: {
+        folders: [
+          { id: "f1", name: "Work", projectIds: ["p1", "p2"] },
+          { id: "f2", name: "Personal", projectIds: [] },
+        ],
+        folderOpenState: { f1: true, f2: false },
+      },
+    };
+    await writeFile(join(dataDir, "ui-preferences.json"), JSON.stringify(full), "utf-8");
+
+    const prefs = await loadUiPreferences(dataDir);
+    expect(prefs).toEqual(full);
+  });
+
+  it("drops malformed folder entries without failing", async () => {
+    await writeFile(
+      join(dataDir, "ui-preferences.json"),
+      JSON.stringify({
+        sidebar: {
+          folders: [
+            { id: "f1", name: "Valid", projectIds: ["p1"] },
+            { id: "", name: "Missing id", projectIds: [] },
+            { id: "f2", name: "   ", projectIds: [] },
+            "not-an-object",
+            { id: "f1", name: "Duplicate id", projectIds: [] },
+          ],
+          folderOpenState: { f1: true, unknown: true, f1b: "not-boolean" },
+        },
+      }),
+      "utf-8",
+    );
+
+    const prefs = await loadUiPreferences(dataDir);
+    expect(prefs.sidebar.folders).toEqual([{ id: "f1", name: "Valid", projectIds: ["p1"] }]);
+    expect(prefs.sidebar.folderOpenState).toEqual({ f1: true });
+  });
+
+  it("returns defaults when top-level JSON is not an object", async () => {
+    await writeFile(join(dataDir, "ui-preferences.json"), JSON.stringify([1, 2, 3]), "utf-8");
+    const prefs = await loadUiPreferences(dataDir);
+    expect(prefs).toEqual(EMPTY);
+  });
+});
+
+describe("saveUiPreferences", () => {
+  it("round-trips through loadUiPreferences", async () => {
+    const prefs: UiPreferences = {
+      sidebar: {
+        folders: [{ id: "a", name: "Alpha", projectIds: ["p-1"] }],
+        folderOpenState: { a: false },
+      },
+    };
+    await saveUiPreferences(prefs, dataDir);
+
+    const raw = await readFile(join(dataDir, "ui-preferences.json"), "utf-8");
+    expect(raw).toContain("\n"); // pretty-printed
+    expect(JSON.parse(raw)).toEqual(prefs);
+
+    const loaded = await loadUiPreferences(dataDir);
+    expect(loaded).toEqual(prefs);
+  });
+
+  it("creates dataDir recursively", async () => {
+    const nested = join(dataDir, "deep", "nested");
+    await saveUiPreferences(EMPTY, nested);
+    expect(await loadUiPreferences(nested)).toEqual(EMPTY);
+  });
+});
+
+describe("sanitizeUiPreferences", () => {
+  it("drops projects that no longer exist", async () => {
+    const prefs: UiPreferences = {
+      sidebar: {
+        folders: [{ id: "f1", name: "Work", projectIds: ["p1", "gone", "p2"] }],
+        folderOpenState: { f1: true },
+      },
+    };
+    const sanitized = sanitizeUiPreferences(prefs, ["p1", "p2"]);
+    expect(sanitized.sidebar.folders[0].projectIds).toEqual(["p1", "p2"]);
+  });
+
+  it("dedupes projects across folders (first wins)", async () => {
+    const prefs: UiPreferences = {
+      sidebar: {
+        folders: [
+          { id: "f1", name: "Work", projectIds: ["p1", "p2"] },
+          { id: "f2", name: "Personal", projectIds: ["p1", "p3"] },
+        ],
+        folderOpenState: { f1: true, f2: true },
+      },
+    };
+    const sanitized = sanitizeUiPreferences(prefs, ["p1", "p2", "p3"]);
+    expect(sanitized.sidebar.folders[0].projectIds).toEqual(["p1", "p2"]);
+    expect(sanitized.sidebar.folders[1].projectIds).toEqual(["p3"]);
+  });
+
+  it("drops empty-name folders and trims names", async () => {
+    const prefs: UiPreferences = {
+      sidebar: {
+        folders: [
+          { id: "f1", name: "  Work  ", projectIds: [] },
+          { id: "f2", name: "   ", projectIds: [] },
+        ],
+        folderOpenState: { f1: true, f2: true },
+      },
+    };
+    const sanitized = sanitizeUiPreferences(prefs, []);
+    expect(sanitized.sidebar.folders).toEqual([
+      { id: "f1", name: "Work", projectIds: [] },
+    ]);
+    expect(sanitized.sidebar.folderOpenState).toEqual({ f1: true });
+  });
+
+  it("drops folderOpenState entries for unknown folder ids", async () => {
+    const prefs: UiPreferences = {
+      sidebar: {
+        folders: [{ id: "f1", name: "Work", projectIds: [] }],
+        folderOpenState: { f1: true, ghost: false },
+      },
+    };
+    const sanitized = sanitizeUiPreferences(prefs, []);
+    expect(sanitized.sidebar.folderOpenState).toEqual({ f1: true });
+  });
+});

--- a/backend/src/state/ui-preferences.ts
+++ b/backend/src/state/ui-preferences.ts
@@ -1,81 +1,31 @@
 import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
+import {
+  EMPTY_UI_PREFERENCES_PAYLOAD,
+  parseUiPreferencesPayload,
+  sanitizeUiPreferencesPayload,
+  type SidebarProjectFolder,
+  type SidebarProjectFoldersState,
+  type UiPreferencesPayload,
+} from "../../../shared/sidebar-preferences.js";
 import { getDataDir } from "./state.js";
 
-export interface SidebarFolder {
-  id: string;
-  name: string;
-  projectIds: string[];
-}
-
-export interface SidebarPreferences {
-  folders: SidebarFolder[];
-  folderOpenState: Record<string, boolean>;
-}
-
-export interface UiPreferences {
-  sidebar: SidebarPreferences;
-}
-
-const DEFAULT_SIDEBAR: SidebarPreferences = {
-  folders: [],
-  folderOpenState: {},
-};
-
-const DEFAULT_PREFERENCES: UiPreferences = {
-  sidebar: { ...DEFAULT_SIDEBAR },
-};
+export type SidebarFolder = SidebarProjectFolder;
+export type SidebarPreferences = SidebarProjectFoldersState;
+export type UiPreferences = UiPreferencesPayload;
 
 function filePath(dataDir: string): string {
   return join(dataDir, "ui-preferences.json");
 }
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-function parseSidebar(raw: unknown): SidebarPreferences {
-  if (!isRecord(raw)) return { ...DEFAULT_SIDEBAR, folders: [], folderOpenState: {} };
-
-  const foldersRaw = Array.isArray(raw.folders) ? raw.folders : [];
-  const folders: SidebarFolder[] = [];
-  const seenFolderIds = new Set<string>();
-
-  for (const entry of foldersRaw) {
-    if (!isRecord(entry)) continue;
-    if (typeof entry.id !== "string" || typeof entry.name !== "string") continue;
-    if (seenFolderIds.has(entry.id)) continue;
-
-    const name = entry.name.trim();
-    if (!entry.id || !name) continue;
-
-    const projectIdsRaw = Array.isArray(entry.projectIds) ? entry.projectIds : [];
-    const projectIds = projectIdsRaw.filter((id): id is string => typeof id === "string");
-
-    seenFolderIds.add(entry.id);
-    folders.push({ id: entry.id, name, projectIds });
-  }
-
-  const openStateRaw = isRecord(raw.folderOpenState) ? raw.folderOpenState : {};
-  const folderOpenState: Record<string, boolean> = {};
-  for (const [key, value] of Object.entries(openStateRaw)) {
-    if (typeof value === "boolean" && seenFolderIds.has(key)) {
-      folderOpenState[key] = value;
-    }
-  }
-
-  return { folders, folderOpenState };
-}
-
 export async function loadUiPreferences(dataDir = getDataDir()): Promise<UiPreferences> {
   try {
     const raw = await readFile(filePath(dataDir), "utf-8");
-    const parsed = JSON.parse(raw);
-    if (!isRecord(parsed)) return structuredClone(DEFAULT_PREFERENCES);
-    return { sidebar: parseSidebar(parsed.sidebar) };
+    const parsed = parseUiPreferencesPayload(JSON.parse(raw), { mode: "permissive" });
+    return parsed ?? structuredClone(EMPTY_UI_PREFERENCES_PAYLOAD);
   } catch {
-    return structuredClone(DEFAULT_PREFERENCES);
+    return structuredClone(EMPTY_UI_PREFERENCES_PAYLOAD);
   }
 }
 
@@ -98,34 +48,5 @@ export function sanitizeUiPreferences(
   prefs: UiPreferences,
   knownProjectIds: string[],
 ): UiPreferences {
-  const known = new Set(knownProjectIds);
-  const used = new Set<string>();
-  const seenFolderIds = new Set<string>();
-
-  const folders: SidebarFolder[] = [];
-  for (const folder of prefs.sidebar.folders) {
-    const name = folder.name.trim();
-    if (!folder.id || !name || seenFolderIds.has(folder.id)) continue;
-    seenFolderIds.add(folder.id);
-
-    const seenInFolder = new Set<string>();
-    const projectIds: string[] = [];
-    for (const id of folder.projectIds) {
-      if (!known.has(id) || used.has(id) || seenInFolder.has(id)) continue;
-      used.add(id);
-      seenInFolder.add(id);
-      projectIds.push(id);
-    }
-
-    folders.push({ id: folder.id, name, projectIds });
-  }
-
-  const folderOpenState: Record<string, boolean> = {};
-  for (const [key, value] of Object.entries(prefs.sidebar.folderOpenState)) {
-    if (typeof value === "boolean" && seenFolderIds.has(key)) {
-      folderOpenState[key] = value;
-    }
-  }
-
-  return { sidebar: { folders, folderOpenState } };
+  return sanitizeUiPreferencesPayload(prefs, knownProjectIds);
 }

--- a/backend/src/state/ui-preferences.ts
+++ b/backend/src/state/ui-preferences.ts
@@ -1,0 +1,131 @@
+import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { getDataDir } from "./state.js";
+
+export interface SidebarFolder {
+  id: string;
+  name: string;
+  projectIds: string[];
+}
+
+export interface SidebarPreferences {
+  folders: SidebarFolder[];
+  folderOpenState: Record<string, boolean>;
+}
+
+export interface UiPreferences {
+  sidebar: SidebarPreferences;
+}
+
+const DEFAULT_SIDEBAR: SidebarPreferences = {
+  folders: [],
+  folderOpenState: {},
+};
+
+const DEFAULT_PREFERENCES: UiPreferences = {
+  sidebar: { ...DEFAULT_SIDEBAR },
+};
+
+function filePath(dataDir: string): string {
+  return join(dataDir, "ui-preferences.json");
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseSidebar(raw: unknown): SidebarPreferences {
+  if (!isRecord(raw)) return { ...DEFAULT_SIDEBAR, folders: [], folderOpenState: {} };
+
+  const foldersRaw = Array.isArray(raw.folders) ? raw.folders : [];
+  const folders: SidebarFolder[] = [];
+  const seenFolderIds = new Set<string>();
+
+  for (const entry of foldersRaw) {
+    if (!isRecord(entry)) continue;
+    if (typeof entry.id !== "string" || typeof entry.name !== "string") continue;
+    if (seenFolderIds.has(entry.id)) continue;
+
+    const name = entry.name.trim();
+    if (!entry.id || !name) continue;
+
+    const projectIdsRaw = Array.isArray(entry.projectIds) ? entry.projectIds : [];
+    const projectIds = projectIdsRaw.filter((id): id is string => typeof id === "string");
+
+    seenFolderIds.add(entry.id);
+    folders.push({ id: entry.id, name, projectIds });
+  }
+
+  const openStateRaw = isRecord(raw.folderOpenState) ? raw.folderOpenState : {};
+  const folderOpenState: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(openStateRaw)) {
+    if (typeof value === "boolean" && seenFolderIds.has(key)) {
+      folderOpenState[key] = value;
+    }
+  }
+
+  return { folders, folderOpenState };
+}
+
+export async function loadUiPreferences(dataDir = getDataDir()): Promise<UiPreferences> {
+  try {
+    const raw = await readFile(filePath(dataDir), "utf-8");
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return structuredClone(DEFAULT_PREFERENCES);
+    return { sidebar: parseSidebar(parsed.sidebar) };
+  } catch {
+    return structuredClone(DEFAULT_PREFERENCES);
+  }
+}
+
+export async function saveUiPreferences(
+  prefs: UiPreferences,
+  dataDir = getDataDir(),
+): Promise<void> {
+  await mkdir(dataDir, { recursive: true });
+  const target = filePath(dataDir);
+  const tmp = join(dataDir, `ui-preferences.${randomUUID()}.tmp`);
+  await writeFile(tmp, JSON.stringify(prefs, null, 2), "utf-8");
+  await rename(tmp, target);
+}
+
+/**
+ * Drop folder entries whose projects no longer exist and orphaned open-state keys.
+ * Also dedupes project IDs across folders — a project can live in at most one folder.
+ */
+export function sanitizeUiPreferences(
+  prefs: UiPreferences,
+  knownProjectIds: string[],
+): UiPreferences {
+  const known = new Set(knownProjectIds);
+  const used = new Set<string>();
+  const seenFolderIds = new Set<string>();
+
+  const folders: SidebarFolder[] = [];
+  for (const folder of prefs.sidebar.folders) {
+    const name = folder.name.trim();
+    if (!folder.id || !name || seenFolderIds.has(folder.id)) continue;
+    seenFolderIds.add(folder.id);
+
+    const seenInFolder = new Set<string>();
+    const projectIds: string[] = [];
+    for (const id of folder.projectIds) {
+      if (!known.has(id) || used.has(id) || seenInFolder.has(id)) continue;
+      used.add(id);
+      seenInFolder.add(id);
+      projectIds.push(id);
+    }
+
+    folders.push({ id: folder.id, name, projectIds });
+  }
+
+  const folderOpenState: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(prefs.sidebar.folderOpenState)) {
+    if (typeof value === "boolean" && seenFolderIds.has(key)) {
+      folderOpenState[key] = value;
+    }
+  }
+
+  return { sidebar: { folders, folderOpenState } };
+}

--- a/backend/src/state/ui-preferences.ts
+++ b/backend/src/state/ui-preferences.ts
@@ -8,7 +8,7 @@ import {
   type SidebarProjectFolder,
   type SidebarProjectFoldersState,
   type UiPreferencesPayload,
-} from "../../../shared/sidebar-preferences.js";
+} from "@hive/shared/sidebar-preferences";
 import { getDataDir } from "./state.js";
 
 export type SidebarFolder = SidebarProjectFolder;

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": ".."
   },
-  "include": ["src"]
+  "include": ["src", "../shared/**/*.ts"]
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,17 +4,22 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "npm --prefix ../shared run build",
     "dev": "vite",
+    "prebuild": "npm --prefix ../shared run build",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
+    "pretypecheck": "npm --prefix ../shared run build",
     "typecheck": "tsc --noEmit",
     "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "lint:fix": "eslint \"src/**/*.{ts,tsx}\" --fix",
+    "pretest": "npm --prefix ../shared run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "tauri": "tauri"
   },
   "dependencies": {
+    "@hive/shared": "^0.1.0",
     "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.3",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -8,8 +8,10 @@ import {
   FolderOpen,
   FolderPlus,
   Loader2,
+  Pencil,
   Plus,
   Settings,
+  Trash2,
   X,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -240,6 +242,9 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [archivingWsId, setArchivingWsId] = useState<string | null>(null);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
+  const [deleteFolderTarget, setDeleteFolderTarget] = useState<{ id: string; name: string } | null>(null);
   const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<SidebarDropTarget | null>(null);
   const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
@@ -265,6 +270,8 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     folders,
     rootProjects,
     createFolder,
+    renameFolder,
+    deleteFolder,
     moveProjectToFolder,
     moveProjectToPosition,
     moveFolderById,
@@ -288,6 +295,33 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     const folderId = createFolder(newFolderName);
     if (!folderId) return;
     resetFolderComposer();
+  };
+
+  const startRenamingFolder = (folderId: string, currentName: string) => {
+    setRenamingFolderId(folderId);
+    setRenameDraft(currentName);
+  };
+
+  const cancelRenamingFolder = () => {
+    setRenamingFolderId(null);
+    setRenameDraft("");
+  };
+
+  const commitRenamingFolder = () => {
+    if (!renamingFolderId) return;
+    const trimmed = renameDraft.trim();
+    if (trimmed.length === 0) {
+      cancelRenamingFolder();
+      return;
+    }
+    renameFolder(renamingFolderId, trimmed);
+    cancelRenamingFolder();
+  };
+
+  const confirmDeleteFolder = () => {
+    if (!deleteFolderTarget) return;
+    deleteFolder(deleteFolderTarget.id);
+    setDeleteFolderTarget(null);
   };
 
   const handleAddWorkspace = async (projectId: string) => {
@@ -753,6 +787,9 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                       ? folderOrderDropTarget.position
                       : null;
 
+                    const isRenaming = renamingFolderId === folder.id;
+                    const isEmptyFolder = folder.projects.length === 0;
+
                     return (
                       <Collapsible
                         key={folder.id}
@@ -789,31 +826,95 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                               )}
                             />
                           )}
-                          <CollapsibleTrigger asChild>
-                            <button
-                              type="button"
-                              draggable
-                              onDragStart={(event) => handleFolderDragStart(event, folder.id)}
-                              onDragEnd={handleFolderDragEnd}
-                              aria-grabbed={isDraggedFolder}
-                              className={cn(
-                                "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-1.5 text-left transition-colors hover:bg-sidebar-accent/40",
-                                containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
-                                isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
-                                isDraggedFolder && "cursor-grabbing opacity-45",
-                              )}
+
+                          {isRenaming ? (
+                            <form
+                              className="flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-1.5"
+                              onSubmit={(event) => {
+                                event.preventDefault();
+                                commitRenamingFolder();
+                              }}
                             >
-                              <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
+                              <ChevronRight className={cn("h-3.5 w-3.5 shrink-0", expanded && "rotate-90")} />
                               {expanded ? (
                                 <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
                               ) : (
                                 <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
                               )}
-                              <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
-                                {folder.name}
-                              </span>
-                            </button>
-                          </CollapsibleTrigger>
+                              <Input
+                                value={renameDraft}
+                                onChange={(event) => setRenameDraft(event.target.value)}
+                                onKeyDown={(event) => {
+                                  if (event.key === "Escape") {
+                                    event.preventDefault();
+                                    cancelRenamingFolder();
+                                  }
+                                }}
+                                onFocus={(event) => event.currentTarget.select()}
+                                onBlur={commitRenamingFolder}
+                                autoFocus
+                                aria-label="Rename folder"
+                                className="h-6 min-w-0 flex-1 bg-background/80 px-1.5 py-0 text-[12px] font-medium"
+                              />
+                            </form>
+                          ) : (
+                            <div className="group/folder relative flex w-full items-center">
+                              <CollapsibleTrigger asChild>
+                                <button
+                                  type="button"
+                                  draggable
+                                  onDragStart={(event) => handleFolderDragStart(event, folder.id)}
+                                  onDragEnd={handleFolderDragEnd}
+                                  aria-grabbed={isDraggedFolder}
+                                  className={cn(
+                                    "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-12 text-left transition-colors hover:bg-sidebar-accent/40",
+                                    containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
+                                    isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
+                                    isDraggedFolder && "cursor-grabbing opacity-45",
+                                  )}
+                                >
+                                  <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
+                                  {expanded ? (
+                                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                  ) : (
+                                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                                  )}
+                                  <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+                                    {folder.name}
+                                  </span>
+                                </button>
+                              </CollapsibleTrigger>
+
+                              <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+                                <button
+                                  type="button"
+                                  onClick={(event) => {
+                                    event.preventDefault();
+                                    event.stopPropagation();
+                                    startRenamingFolder(folder.id, folder.name);
+                                  }}
+                                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50"
+                                  aria-label={`Rename folder ${folder.name}`}
+                                >
+                                  <Pencil className="h-3 w-3" />
+                                </button>
+                                {isEmptyFolder && (
+                                  <button
+                                    type="button"
+                                    onClick={(event) => {
+                                      event.preventDefault();
+                                      event.stopPropagation();
+                                      setDeleteFolderTarget({ id: folder.id, name: folder.name });
+                                    }}
+                                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/60"
+                                    aria-label={`Delete folder ${folder.name}`}
+                                  >
+                                    <Trash2 className="h-3 w-3" />
+                                  </button>
+                                )}
+                              </div>
+                            </div>
+                          )}
 
                           <CollapsibleContent>
                             <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
@@ -888,6 +989,24 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
           Add repository
         </button>
       </div>
+
+      <AlertDialog
+        open={deleteFolderTarget !== null}
+        onOpenChange={(open) => !open && setDeleteFolderTarget(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete folder</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove the folder “{deleteFolderTarget?.name}”? Repositories are not affected.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmDeleteFolder}>Delete</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
 
       <AlertDialog
         open={archiveTarget !== null}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -521,7 +521,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
             addLabel={`Add workspace to ${displayLabelPlain}`}
             variant="plain"
             buttonClassName={cn(
-              "rounded px-1.5 py-1 hover:bg-sidebar-accent/35",
+              "rounded py-1 pl-0 pr-1.5 hover:bg-sidebar-accent/35",
               isDragged && "cursor-grabbing opacity-45",
             )}
             buttonProps={{
@@ -797,7 +797,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                               onDragEnd={handleFolderDragEnd}
                               aria-grabbed={isDraggedFolder}
                               className={cn(
-                                "flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left transition-colors hover:bg-sidebar-accent/40",
+                                "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-1.5 text-left transition-colors hover:bg-sidebar-accent/40",
                                 containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
                                 isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
                                 isDraggedFolder && "cursor-grabbing opacity-45",

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -24,6 +24,11 @@ import { useProjects } from "@/hooks/useProjects";
 import { useBulkPrStatus, usePrStatusMap } from "@/hooks/usePrStatus";
 import { useSidebarProjectFolders } from "@/hooks/useSidebarProjectFolders";
 import { api } from "@/hooks/useApi";
+import {
+  automationSortKey,
+  describeSchedule,
+  parseProjectOwnerRepo,
+} from "@/lib/sidebar-helpers";
 import { cn } from "@/lib/utils";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
@@ -32,13 +37,8 @@ import { SidebarFolderItem } from "@/components/sidebar/SidebarFolderItem";
 import {
   SidebarSectionHeader,
 } from "@/components/sidebar/SidebarHeaders";
-import {
-  SidebarProjectItem,
-  parseProjectOwnerRepo,
-} from "@/components/sidebar/SidebarProjectItem";
+import { SidebarProjectItem } from "@/components/sidebar/SidebarProjectItem";
 import type { Automation, DiffStatResponse, Project } from "@/types";
-
-export { parseProjectOwnerRepo } from "@/components/sidebar/SidebarProjectItem";
 
 // ── Sidebar ──────────────────────────────────────────────────────────
 
@@ -574,27 +574,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
       </AlertDialog>
     </SidebarShell>
   );
-}
-
-// ── Automation sidebar list ──────────────────────────────────────────
-
-export function automationSortKey(a: Automation): number {
-  if (a.lastRunStatus === "running") return 0;
-  if (a.enabled) return 1;
-  return 2;
-}
-
-export function describeSchedule(expression: string): string {
-  const presets: Record<string, string> = {
-    "0 * * * *": "Hourly",
-    "0 */6 * * *": "Every 6h",
-    "0 2 * * *": "Daily 2am",
-    "0 8 * * *": "Daily 8am",
-    "0 0 * * *": "Daily midnight",
-    "0 9 * * 1-5": "Weekdays 9am",
-    "0 9 * * 1": "Weekly Mon",
-  };
-  return presets[expression] ?? expression;
 }
 
 function AutomationRow({ auto, pathname }: { auto: Automation; pathname: string }) {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -219,6 +219,11 @@ type SidebarDropTarget =
   | { type: "folder"; folderId: string }
   | { type: "root" };
 
+type FolderOrderDropTarget = {
+  folderId: string;
+  position: "before" | "after";
+};
+
 export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps) {
   const { projects, loading, createWorkspace, archiveWorkspace } = useProjects();
   const { data: automations, isLoading: automationsLoading } = useAutomations();
@@ -234,6 +239,8 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [newFolderName, setNewFolderName] = useState("");
   const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
   const [dropTarget, setDropTarget] = useState<SidebarDropTarget | null>(null);
+  const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
+  const [folderOrderDropTarget, setFolderOrderDropTarget] = useState<FolderOrderDropTarget | null>(null);
   const liveData = useWorkspaceLiveDataContext();
 
   const activeProjectId = projects.find((project) =>
@@ -255,6 +262,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     rootProjects,
     createFolder,
     moveProjectToFolder,
+    moveFolderById,
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,
@@ -383,6 +391,60 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     moveProjectToFolder(draggingProjectId, folderId);
     setDraggingProjectId(null);
     setDropTarget(null);
+  };
+
+  const handleFolderDragStart = (
+    event: React.DragEvent<HTMLButtonElement>,
+    folderId: string,
+  ) => {
+    setDraggingFolderId(folderId);
+    setFolderOrderDropTarget(null);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("application/x-hive-folder-id", folderId);
+    event.dataTransfer.setData("text/plain", folderId);
+  };
+
+  const handleFolderDragEnd = () => {
+    setDraggingFolderId(null);
+    setFolderOrderDropTarget(null);
+  };
+
+  const getDraggedFolderId = (event: React.DragEvent<HTMLDivElement>) =>
+    draggingFolderId
+    ?? event.dataTransfer.getData("application/x-hive-folder-id")
+    ?? null;
+
+  const handleFolderReorderDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+    position: "before" | "after",
+  ) => {
+    const sourceFolderId = getDraggedFolderId(event);
+    if (!sourceFolderId || sourceFolderId === folderId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    event.dataTransfer.dropEffect = "move";
+
+    if (
+      folderOrderDropTarget?.folderId !== folderId
+      || folderOrderDropTarget.position !== position
+    ) {
+      setFolderOrderDropTarget({ folderId, position });
+    }
+  };
+
+  const handleFolderReorderDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+    position: "before" | "after",
+  ) => {
+    const sourceFolderId = getDraggedFolderId(event);
+    if (!sourceFolderId || sourceFolderId === folderId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    moveFolderById(sourceFolderId, folderId, position);
+    setDraggingFolderId(null);
+    setFolderOrderDropTarget(null);
   };
 
   const renderProjectItem = (project: Project, className?: string) => {
@@ -636,6 +698,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                     const isActiveDropTarget =
                       dropTarget?.type === "folder" && dropTarget.folderId === folder.id;
                     const containsActiveProject = folder.projects.some((project) => project.id === activeProjectId);
+                    const isDraggedFolder = draggingFolderId === folder.id;
+                    const folderInsertIndicator = folderOrderDropTarget?.folderId === folder.id
+                      ? folderOrderDropTarget.position
+                      : null;
 
                     return (
                       <Collapsible
@@ -647,15 +713,44 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                           data-sidebar-folder={folder.id}
                           onDragOver={(event) => handleFolderDragOver(event, folder.id)}
                           onDrop={(event) => handleFolderDrop(event, folder.id)}
-                          className="rounded-lg"
+                          className="relative rounded-lg"
                         >
+                          {draggingFolderId !== null && draggingFolderId !== folder.id && (
+                            <>
+                              <div
+                                data-folder-reorder="before"
+                                className="absolute inset-x-0 top-0 z-20 h-3"
+                                onDragOver={(event) => handleFolderReorderDragOver(event, folder.id, "before")}
+                                onDrop={(event) => handleFolderReorderDrop(event, folder.id, "before")}
+                              />
+                              <div
+                                data-folder-reorder="after"
+                                className="absolute inset-x-0 bottom-0 z-20 h-3"
+                                onDragOver={(event) => handleFolderReorderDragOver(event, folder.id, "after")}
+                                onDrop={(event) => handleFolderReorderDrop(event, folder.id, "after")}
+                              />
+                            </>
+                          )}
+                          {folderInsertIndicator && (
+                            <div
+                              className={cn(
+                                "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
+                                folderInsertIndicator === "before" ? "top-0" : "bottom-0",
+                              )}
+                            />
+                          )}
                           <CollapsibleTrigger asChild>
                             <button
                               type="button"
+                              draggable
+                              onDragStart={(event) => handleFolderDragStart(event, folder.id)}
+                              onDragEnd={handleFolderDragEnd}
+                              aria-grabbed={isDraggedFolder}
                               className={cn(
                                 "flex min-h-9 w-full items-center gap-1.5 rounded-md px-1.5 text-left transition-colors hover:bg-sidebar-accent/40",
                                 containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
                                 isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
+                                isDraggedFolder && "cursor-grabbing opacity-45",
                               )}
                             >
                               <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -113,9 +113,9 @@ function SidebarGroupHeader({
           className={cn(
             "flex w-full min-w-0 items-center overflow-hidden text-left transition-colors",
             isPlain
-              ? "gap-2 px-0 py-1"
-              : "gap-2.5 rounded-md px-2.5 py-2.5 hover:bg-sidebar-accent/40",
-            count !== undefined && "pr-8",
+              ? "gap-1.5 px-0 py-0.5"
+              : "gap-2 rounded px-2 py-1 hover:bg-sidebar-accent/40",
+            count !== undefined && "pr-7",
             buttonClassName,
             buttonPropsClassName,
           )}
@@ -129,7 +129,7 @@ function SidebarGroupHeader({
         </button>
       </CollapsibleTrigger>
       {count !== undefined && (
-        <div className={cn("absolute inset-y-0 flex items-center", isPlain ? "right-0" : "right-2.5")}>
+        <div className={cn("absolute inset-y-0 flex items-center", isPlain ? "right-0" : "right-2")}>
           <div className="relative flex h-5 w-5 items-center justify-center">
             {isLoading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
@@ -521,7 +521,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
             addLabel={`Add workspace to ${displayLabelPlain}`}
             variant="plain"
             buttonClassName={cn(
-              "rounded-md px-1.5 hover:bg-sidebar-accent/35",
+              "rounded px-1.5 py-1 hover:bg-sidebar-accent/35",
               isDragged && "cursor-grabbing opacity-45",
             )}
             buttonProps={{
@@ -683,7 +683,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
             <TooltipProvider delayDuration={400}>
               <SidebarSectionHeader
                 label="Workspaces"
-                className="mb-2"
+                className="mb-1"
                 onAdd={() => {
                   setIsCreatingFolder(true);
                   setNewFolderName("");
@@ -742,7 +742,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               )}
 
               {folders.length > 0 && (
-                <div className="space-y-1.5">
+                <div className="space-y-px">
                   {folders.map((folder) => {
                     const expanded = isFolderExpanded(folder.id);
                     const isActiveDropTarget =
@@ -797,7 +797,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                               onDragEnd={handleFolderDragEnd}
                               aria-grabbed={isDraggedFolder}
                               className={cn(
-                                "flex min-h-9 w-full items-center gap-1.5 rounded-md px-1.5 text-left transition-colors hover:bg-sidebar-accent/40",
+                                "flex w-full items-center gap-1.5 rounded px-1.5 py-1 text-left transition-colors hover:bg-sidebar-accent/40",
                                 containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
                                 isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
                                 isDraggedFolder && "cursor-grabbing opacity-45",
@@ -816,15 +816,15 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                           </CollapsibleTrigger>
 
                           <CollapsibleContent>
-                            <div className="ml-3 mt-1 border-l border-sidebar-border/70 pl-2.5">
+                            <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
                               {folder.projects.length > 0 ? (
-                                <div className="space-y-1.5 py-0.5">
+                                <div className="space-y-px py-0.5">
                                   {folder.projects.map((project) => renderProjectItem(project, folder.id))}
                                 </div>
                               ) : (
                                 <div
                                   className={cn(
-                                    "py-2 text-xs text-muted-foreground/70 transition-colors",
+                                    "py-1.5 text-xs text-muted-foreground/70 transition-colors",
                                     isActiveDropTarget && "text-primary",
                                   )}
                                 >
@@ -841,13 +841,13 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               )}
 
               {rootProjects.length > 0 && (
-                <div className={cn("space-y-1.5", folders.length > 0 && "mt-2")}>
+                <div className={cn("space-y-px", folders.length > 0 && "mt-0.5")}>
                   {rootProjects.map((project) => renderProjectItem(project, null))}
                 </div>
               )}
 
-              <div className="mt-6">
-                <div className="mb-6 border-t border-white/15" />
+              <div className="mt-4">
+                <div className="mb-3 border-t border-white/10" />
                 <SidebarSectionHeader
                   label="Automations"
                   isLoading={automationsLoading}
@@ -865,7 +865,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                     <p className="text-xs text-muted-foreground/60">no automations</p>
                   </div>
                 ) : (
-                  <div className="mt-2 space-y-1.5">
+                  <div className="mt-1 space-y-px">
                     {sortedAutomations.map((auto) => (
                       <AutomationRow key={auto.id} auto={auto} pathname={pathname} />
                     ))}
@@ -955,43 +955,51 @@ function AutomationRow({ auto, pathname }: { auto: Automation; pathname: string 
   })();
 
   return (
-    <Link
-      to={`/automations/${auto.id}`}
-      className={cn(
-        "sidebar-card block rounded-md border px-2.5 py-1.5",
-        isActive && "sidebar-card-active",
-      )}
-    >
-      <div className="flex items-center gap-2">
+    <div className="relative">
+      {isActive && (
         <span
-          className={cn(
-            "h-1.5 w-1.5 shrink-0 rounded-full",
-            isRunning
-              ? "bg-green-500 animate-pulse"
-              : auto.enabled
-                ? "bg-green-500"
-                : "bg-muted-foreground/40",
-          )}
+          aria-hidden
+          className="pointer-events-none absolute left-0 top-1 bottom-1 w-0.5 rounded-full bg-primary"
         />
-        <span
-          className={cn(
-            "min-w-0 flex-1 truncate text-sm",
-            isActive || auto.enabled
-              ? "text-sidebar-foreground"
-              : "text-muted-foreground",
-          )}
-        >
-          {auto.name}
-        </span>
-        <span
-          className={cn(
-            "shrink-0 text-[11px]",
-            isActive ? "text-sidebar-foreground/70" : "text-muted-foreground",
-          )}
-        >
-          {rightLabel}
-        </span>
-      </div>
-    </Link>
+      )}
+      <Link
+        to={`/automations/${auto.id}`}
+        className={cn(
+          "block rounded px-2 py-1 transition-colors hover:bg-sidebar-accent/50",
+          isActive && "bg-sidebar-accent/70",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          <span
+            className={cn(
+              "h-1.5 w-1.5 shrink-0 rounded-full",
+              isRunning
+                ? "bg-green-500 animate-pulse"
+                : auto.enabled
+                  ? "bg-green-500"
+                  : "bg-muted-foreground/40",
+            )}
+          />
+          <span
+            className={cn(
+              "min-w-0 flex-1 truncate text-[13px]",
+              isActive || auto.enabled
+                ? "text-sidebar-foreground"
+                : "text-muted-foreground",
+            )}
+          >
+            {auto.name}
+          </span>
+          <span
+            className={cn(
+              "shrink-0 text-[11px]",
+              isActive ? "text-sidebar-foreground/70" : "text-muted-foreground",
+            )}
+          >
+            {rightLabel}
+          </span>
+        </div>
+      </Link>
+    </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,33 +1,13 @@
 import { useMemo, useState } from "react";
 import { getNextRun, formatTimeUntil } from "@/lib/cron";
 import {
-  ArchiveIcon,
-  Check,
-  ChevronRight,
-  Folder,
-  FolderOpen,
   FolderPlus,
-  Loader2,
-  Pencil,
-  Plus,
   Settings,
-  Trash2,
-  X,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -38,177 +18,27 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
-import { Button } from "@/components/ui/button";
 import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
 import { useProjects } from "@/hooks/useProjects";
 import { useBulkPrStatus, usePrStatusMap } from "@/hooks/usePrStatus";
 import { useSidebarProjectFolders } from "@/hooks/useSidebarProjectFolders";
-import { computePrDisplayCompact } from "@/lib/pr-display";
-import { BranchLabel } from "@/components/BranchLabel";
-import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
-import { ActivityWave } from "@/components/ui/activity-wave";
 import { api } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
-import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
-import { Input } from "@/components/ui/input";
+import { SidebarFolderComposer } from "@/components/sidebar/SidebarFolderComposer";
+import { SidebarFolderItem } from "@/components/sidebar/SidebarFolderItem";
+import {
+  SidebarSectionHeader,
+} from "@/components/sidebar/SidebarHeaders";
+import {
+  SidebarProjectItem,
+  parseProjectOwnerRepo,
+} from "@/components/sidebar/SidebarProjectItem";
 import type { Automation, DiffStatResponse, Project } from "@/types";
 
-// ── Helpers ──────────────────────────────────────────────────────────
-
-/** Extract { owner, repo } from any git URL, or null if unparseable. */
-export function parseProjectOwnerRepo(url: string): { owner: string; repo: string } | null {
-  // SCP-style: git@host:owner/repo.git
-  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
-
-  // URL-style: https://host/owner/repo.git or ssh://git@host/owner/repo
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    if (segments.length >= 2)
-      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
-  } catch {
-    // not a valid URL
-  }
-
-  return null;
-}
-
-// ── Shared sidebar group header ──────────────────────────────────────
-
-interface SidebarGroupHeaderProps {
-  icon: React.ReactNode;
-  label: React.ReactNode;
-  badge?: React.ReactNode;
-  count?: number;
-  isLoading?: boolean;
-  onAdd?: (e: React.MouseEvent) => void;
-  addLabel?: string;
-  variant?: "default" | "plain";
-  buttonClassName?: string;
-  buttonProps?: React.ComponentProps<"button">;
-}
-
-function SidebarGroupHeader({
-  icon,
-  label,
-  badge,
-  count,
-  isLoading,
-  onAdd,
-  addLabel,
-  variant = "default",
-  buttonClassName,
-  buttonProps,
-}: SidebarGroupHeaderProps) {
-  const isPlain = variant === "plain";
-  const { className: buttonPropsClassName, ...restButtonProps } = buttonProps ?? {};
-
-  return (
-    <div className="group relative flex w-full items-center">
-      <CollapsibleTrigger asChild>
-        <button
-          type="button"
-          className={cn(
-            "flex w-full min-w-0 items-center overflow-hidden text-left transition-colors",
-            isPlain
-              ? "gap-1.5 px-0 py-0.5"
-              : "gap-2 rounded px-2 py-1 hover:bg-sidebar-accent/40",
-            count !== undefined && "pr-7",
-            buttonClassName,
-            buttonPropsClassName,
-          )}
-          {...restButtonProps}
-        >
-          {icon}
-          <span className="min-w-0 flex-1 truncate text-xs font-semibold lowercase tracking-wider text-sidebar-foreground">
-            {label}
-          </span>
-          {badge}
-        </button>
-      </CollapsibleTrigger>
-      {count !== undefined && (
-        <div className={cn("absolute inset-y-0 flex items-center", isPlain ? "right-0" : "right-2")}>
-          <div className="relative flex h-5 w-5 items-center justify-center">
-            {isLoading ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-            ) : (
-              <>
-                <span className="text-xs tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0">
-                  {count}
-                </span>
-                {onAdd && (
-                  <button
-                    type="button"
-                    className="absolute inset-0 flex items-center justify-center text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      onAdd(e);
-                    }}
-                    aria-label={addLabel}
-                    title={addLabel}
-                  >
-                    <Plus className="h-4 w-4" />
-                  </button>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-      )}
-    </div>
-  );
-}
-
-interface SidebarSectionHeaderProps {
-  label: string;
-  isLoading?: boolean;
-  onAdd?: () => void;
-  addLabel?: string;
-  className?: string;
-  addIcon?: React.ReactNode;
-  addButtonClassName?: string;
-}
-
-function SidebarSectionHeader({
-  label,
-  isLoading = false,
-  onAdd,
-  addLabel,
-  className,
-  addIcon,
-  addButtonClassName,
-}: SidebarSectionHeaderProps) {
-  return (
-    <div className={cn("group relative flex w-full items-center", className)}>
-      <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-        {label}
-      </span>
-      <div className="relative flex h-5 w-5 items-center justify-center">
-        {isLoading ? (
-          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
-        ) : onAdd ? (
-          <button
-            type="button"
-            className={cn(
-              "flex items-center justify-center text-muted-foreground/70 transition-colors hover:text-sidebar-foreground",
-              addButtonClassName,
-            )}
-            onClick={onAdd}
-            aria-label={addLabel}
-            title={addLabel}
-          >
-            {addIcon ?? <Plus className="h-4 w-4" />}
-          </button>
-        ) : null
-        }
-      </div>
-    </div>
-  );
-}
+export { parseProjectOwnerRepo } from "@/components/sidebar/SidebarProjectItem";
 
 // ── Sidebar ──────────────────────────────────────────────────────────
 
@@ -278,7 +108,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,
-  } = useSidebarProjectFolders(projects);
+  } = useSidebarProjectFolders(projects, !loading);
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];
@@ -522,170 +352,37 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
       <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
     ) : project.name;
     const displayLabelPlain = parsed ? `${parsed.owner}/${parsed.repo}` : project.name;
-    const isDragged = draggingProjectId === project.id;
-    const showReorderZones =
-      folderId !== null
-      && draggingProjectId !== null
-      && draggingProjectId !== project.id;
     const projectInsertIndicator = projectOrderDropTarget?.projectId === project.id
       ? projectOrderDropTarget.position
       : null;
 
     return (
-      <div key={project.id} className={cn("relative", className)} data-sidebar-project={project.id}>
-        <Collapsible
-          open={isProjectExpanded(project.id)}
-          onOpenChange={(open) =>
-            setExpandedProjects((prev) => ({ ...prev, [project.id]: open }))
-          }
-        >
-          <SidebarGroupHeader
-            icon={
-              <ProjectAvatar
-                name={project.name}
-                projectId={project.id}
-                hasFavicon={project.hasFavicon}
-                className="h-[18px] w-[18px]"
-              />
-            }
-            label={displayLabel}
-            count={(project.workspaces ?? []).length}
-            isLoading={creatingProjectId === project.id}
-            onAdd={() => { void handleAddWorkspace(project.id); }}
-            addLabel={`Add workspace to ${displayLabelPlain}`}
-            variant="plain"
-            buttonClassName={cn(
-              "rounded py-1 pl-0 pr-1.5 hover:bg-sidebar-accent/35",
-              isDragged && "cursor-grabbing opacity-45",
-            )}
-            buttonProps={{
-              draggable: true,
-              onDragStart: (event) => handleProjectDragStart(event, project.id),
-              onDragEnd: handleProjectDragEnd,
-              "aria-grabbed": isDragged,
-            }}
-          />
-
-          <CollapsibleContent>
-            <div className="mt-1 space-y-1.5">
-              {(project.workspaces ?? []).map((ws) => {
-                const wsLive = liveData[ws.id];
-                const wsStreaming = wsLive?.streaming ?? false;
-                const wsScriptRunning = wsLive?.scriptRunning ?? false;
-                const displayBranch = wsLive?.branch ?? ws.branch;
-                const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
-                const prStatus = prStatuses[ws.id];
-                const wsArchiving = archivingWsId === ws.id;
-
-                return (
-                  <div key={ws.id} className={cn("group/ws relative transition-opacity", wsArchiving && "pointer-events-none opacity-40")}>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <Link
-                          to={`/workspaces/${ws.id}`}
-                          className={cn(
-                            "sidebar-card block rounded-md border py-1.5 pl-2 pr-2",
-                            activeWsId === ws.id && "sidebar-card-active",
-                          )}
-                        >
-                          <div className="flex items-center gap-1.5">
-                            <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
-                              {wsStreaming ? (
-                                <AgentActivityPreview size="small" />
-                              ) : wsUnread ? (
-                                <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                              ) : null}
-                            </div>
-                            <BranchLabel
-                              branch={displayBranch}
-                              showIcon={false}
-                              className={cn(
-                                "min-w-0 flex-1 text-sm",
-                                activeWsId === ws.id || wsUnread
-                                  ? "text-sidebar-foreground"
-                                  : "text-muted-foreground",
-                              )}
-                            />
-                            {wsScriptRunning && (
-                              <ActivityWave size="small" decorative className="shrink-0" />
-                            )}
-                          </div>
-
-                          <div className="mt-0.5 flex items-center gap-1 pl-5 text-[11px]">
-                            {prStatus?.pr ? (
-                              (() => {
-                                const display = computePrDisplayCompact(prStatus.pr);
-                                return (
-                                  <span className={cn("truncate", display.textClass)}>
-                                    #{prStatus.pr.number} {display.label}
-                                  </span>
-                                );
-                              })()
-                            ) : prLoading ? (
-                              <span className="text-muted-foreground">Loading…</span>
-                            ) : prStatus?.error ? (
-                              <span className="text-muted-foreground">Error fetching PR</span>
-                            ) : (
-                              <span className="text-muted-foreground">No PR</span>
-                            )}
-                          </div>
-                        </Link>
-                      </TooltipTrigger>
-                      <TooltipContent side="right" className="text-xs">
-                        {ws.name}
-                      </TooltipContent>
-                    </Tooltip>
-
-                    {wsArchiving ? (
-                      <div className="absolute right-1.5 top-1.5 p-0.5">
-                        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-                      </div>
-                    ) : !wsScriptRunning && (
-                      <button
-                        type="button"
-                        className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          void handleArchiveClick(ws.id);
-                        }}
-                        aria-label={`Archive workspace ${ws.name}`}
-                        title="Archive workspace"
-                      >
-                        <ArchiveIcon className="h-3 w-3" />
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-          </CollapsibleContent>
-        </Collapsible>
-        {showReorderZones && folderId !== null && (
-          <>
-            <div
-              data-project-reorder="before"
-              className="absolute inset-x-0 top-0 z-20 h-2.5"
-              onDragOver={(event) => handleProjectReorderDragOver(event, project.id, "before")}
-              onDrop={(event) => handleProjectReorderDrop(event, project.id, folderId, "before")}
-            />
-            <div
-              data-project-reorder="after"
-              className="absolute inset-x-0 bottom-0 z-20 h-2.5"
-              onDragOver={(event) => handleProjectReorderDragOver(event, project.id, "after")}
-              onDrop={(event) => handleProjectReorderDrop(event, project.id, folderId, "after")}
-            />
-          </>
-        )}
-        {projectInsertIndicator && (
-          <div
-            className={cn(
-              "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
-              projectInsertIndicator === "before" ? "top-0" : "bottom-0",
-            )}
-          />
-        )}
-      </div>
+      <SidebarProjectItem
+        key={project.id}
+        project={project}
+        folderId={folderId}
+        className={className}
+        displayLabel={displayLabel}
+        displayLabelPlain={displayLabelPlain}
+        isExpanded={isProjectExpanded(project.id)}
+        setExpanded={(open) =>
+          setExpandedProjects((prev) => ({ ...prev, [project.id]: open }))
+        }
+        activeWsId={activeWsId}
+        liveData={liveData}
+        prStatuses={prStatuses}
+        prLoading={prLoading}
+        creatingProjectId={creatingProjectId}
+        archivingWsId={archivingWsId}
+        draggingProjectId={draggingProjectId}
+        projectInsertIndicator={projectInsertIndicator}
+        onAddWorkspace={(projectId) => { void handleAddWorkspace(projectId); }}
+        onArchiveWorkspace={(wsId) => { void handleArchiveClick(wsId); }}
+        onProjectDragStart={handleProjectDragStart}
+        onProjectDragEnd={handleProjectDragEnd}
+        onProjectReorderDragOver={handleProjectReorderDragOver}
+        onProjectReorderDrop={handleProjectReorderDrop}
+      />
     );
   };
 
@@ -727,53 +424,13 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                 addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
               />
 
-              {isCreatingFolder && (
-                <form
-                  className="mb-2 rounded-lg border border-sidebar-border/80 bg-sidebar-accent/25 p-2"
-                  onSubmit={(e) => {
-                    e.preventDefault();
-                    handleCreateFolder();
-                  }}
-                >
-                  <div className="flex items-center gap-2">
-                    <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
-                    <Input
-                      value={newFolderName}
-                      onChange={(e) => setNewFolderName(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Escape") {
-                          e.preventDefault();
-                          resetFolderComposer();
-                        }
-                      }}
-                      placeholder="Folder name"
-                      aria-label="Folder name"
-                      autoFocus
-                      className="h-8 bg-background/80 text-sm"
-                    />
-                    <Button
-                      type="submit"
-                      variant="ghost"
-                      size="icon-xs"
-                      disabled={newFolderName.trim().length === 0}
-                      aria-label="Create folder"
-                      title="Create folder"
-                    >
-                      <Check />
-                    </Button>
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon-xs"
-                      onClick={resetFolderComposer}
-                      aria-label="Cancel folder creation"
-                      title="Cancel folder creation"
-                    >
-                      <X />
-                    </Button>
-                  </div>
-                </form>
-              )}
+              <SidebarFolderComposer
+                isOpen={isCreatingFolder}
+                name={newFolderName}
+                onNameChange={setNewFolderName}
+                onSubmit={handleCreateFolder}
+                onCancel={resetFolderComposer}
+              />
 
               {folders.length > 0 && (
                 <div className="space-y-px">
@@ -791,151 +448,34 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                     const isEmptyFolder = folder.projects.length === 0;
 
                     return (
-                      <Collapsible
+                      <SidebarFolderItem
                         key={folder.id}
-                        open={expanded}
+                        folder={folder}
+                        expanded={expanded}
+                        isActiveDropTarget={isActiveDropTarget}
+                        containsActiveProject={containsActiveProject}
+                        isDraggedFolder={isDraggedFolder}
+                        isRenaming={isRenaming}
+                        isEmptyFolder={isEmptyFolder}
+                        draggingFolderId={draggingFolderId}
+                        folderInsertIndicator={folderInsertIndicator}
+                        renameDraft={renameDraft}
                         onOpenChange={(open) => setFolderExpanded(folder.id, open)}
-                      >
-                        <div
-                          data-sidebar-folder={folder.id}
-                          onDragOver={(event) => handleFolderDragOver(event, folder.id)}
-                          onDrop={(event) => handleFolderDrop(event, folder.id)}
-                          className="relative rounded-lg"
-                        >
-                          {draggingFolderId !== null && draggingFolderId !== folder.id && (
-                            <>
-                              <div
-                                data-folder-reorder="before"
-                                className="absolute inset-x-0 top-0 z-20 h-3"
-                                onDragOver={(event) => handleFolderReorderDragOver(event, folder.id, "before")}
-                                onDrop={(event) => handleFolderReorderDrop(event, folder.id, "before")}
-                              />
-                              <div
-                                data-folder-reorder="after"
-                                className="absolute inset-x-0 bottom-0 z-20 h-3"
-                                onDragOver={(event) => handleFolderReorderDragOver(event, folder.id, "after")}
-                                onDrop={(event) => handleFolderReorderDrop(event, folder.id, "after")}
-                              />
-                            </>
-                          )}
-                          {folderInsertIndicator && (
-                            <div
-                              className={cn(
-                                "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
-                                folderInsertIndicator === "before" ? "top-0" : "bottom-0",
-                              )}
-                            />
-                          )}
-
-                          {isRenaming ? (
-                            <form
-                              className="flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-1.5"
-                              onSubmit={(event) => {
-                                event.preventDefault();
-                                commitRenamingFolder();
-                              }}
-                            >
-                              <ChevronRight className={cn("h-3.5 w-3.5 shrink-0", expanded && "rotate-90")} />
-                              {expanded ? (
-                                <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                              ) : (
-                                <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                              )}
-                              <Input
-                                value={renameDraft}
-                                onChange={(event) => setRenameDraft(event.target.value)}
-                                onKeyDown={(event) => {
-                                  if (event.key === "Escape") {
-                                    event.preventDefault();
-                                    cancelRenamingFolder();
-                                  }
-                                }}
-                                onFocus={(event) => event.currentTarget.select()}
-                                onBlur={commitRenamingFolder}
-                                autoFocus
-                                aria-label="Rename folder"
-                                className="h-6 min-w-0 flex-1 bg-background/80 px-1.5 py-0 text-[12px] font-medium"
-                              />
-                            </form>
-                          ) : (
-                            <div className="group/folder relative flex w-full items-center">
-                              <CollapsibleTrigger asChild>
-                                <button
-                                  type="button"
-                                  draggable
-                                  onDragStart={(event) => handleFolderDragStart(event, folder.id)}
-                                  onDragEnd={handleFolderDragEnd}
-                                  aria-grabbed={isDraggedFolder}
-                                  className={cn(
-                                    "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-12 text-left transition-colors hover:bg-sidebar-accent/40",
-                                    containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
-                                    isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
-                                    isDraggedFolder && "cursor-grabbing opacity-45",
-                                  )}
-                                >
-                                  <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
-                                  {expanded ? (
-                                    <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                                  ) : (
-                                    <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                                  )}
-                                  <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
-                                    {folder.name}
-                                  </span>
-                                </button>
-                              </CollapsibleTrigger>
-
-                              <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
-                                <button
-                                  type="button"
-                                  onClick={(event) => {
-                                    event.preventDefault();
-                                    event.stopPropagation();
-                                    startRenamingFolder(folder.id, folder.name);
-                                  }}
-                                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50"
-                                  aria-label={`Rename folder ${folder.name}`}
-                                >
-                                  <Pencil className="h-3 w-3" />
-                                </button>
-                                {isEmptyFolder && (
-                                  <button
-                                    type="button"
-                                    onClick={(event) => {
-                                      event.preventDefault();
-                                      event.stopPropagation();
-                                      setDeleteFolderTarget({ id: folder.id, name: folder.name });
-                                    }}
-                                    className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/60"
-                                    aria-label={`Delete folder ${folder.name}`}
-                                  >
-                                    <Trash2 className="h-3 w-3" />
-                                  </button>
-                                )}
-                              </div>
-                            </div>
-                          )}
-
-                          <CollapsibleContent>
-                            <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
-                              {folder.projects.length > 0 ? (
-                                <div className="space-y-px py-0.5">
-                                  {folder.projects.map((project) => renderProjectItem(project, folder.id))}
-                                </div>
-                              ) : (
-                                <div
-                                  className={cn(
-                                    "py-1.5 text-xs text-muted-foreground/70 transition-colors",
-                                    isActiveDropTarget && "text-primary",
-                                  )}
-                                >
-                                  Drop repositories here
-                                </div>
-                              )}
-                            </div>
-                          </CollapsibleContent>
-                        </div>
-                      </Collapsible>
+                        onFolderDragOver={handleFolderDragOver}
+                        onFolderDrop={handleFolderDrop}
+                        onFolderDragStart={handleFolderDragStart}
+                        onFolderDragEnd={handleFolderDragEnd}
+                        onFolderReorderDragOver={handleFolderReorderDragOver}
+                        onFolderReorderDrop={handleFolderReorderDrop}
+                        onStartRenaming={startRenamingFolder}
+                        onDeleteRequest={(folderId, folderName) =>
+                          setDeleteFolderTarget({ id: folderId, name: folderName })
+                        }
+                        onRenameDraftChange={setRenameDraft}
+                        onCommitRename={commitRenamingFolder}
+                        onCancelRename={cancelRenamingFolder}
+                        renderProjectItem={renderProjectItem}
+                      />
                     );
                   })}
                 </div>
@@ -1084,8 +624,8 @@ function AutomationRow({ auto, pathname }: { auto: Automation; pathname: string 
       <Link
         to={`/automations/${auto.id}`}
         className={cn(
-          "block rounded px-2 py-1 transition-colors hover:bg-sidebar-accent/50",
-          isActive && "bg-sidebar-accent/70",
+          "sidebar-card block rounded px-2 py-1 transition-colors hover:bg-sidebar-accent/50",
+          isActive && "sidebar-card-active bg-sidebar-accent/70",
         )}
       >
         <div className="flex items-center gap-2">

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,6 +1,17 @@
 import { useMemo, useState } from "react";
 import { getNextRun, formatTimeUntil } from "@/lib/cron";
-import { ArchiveIcon, FolderPlus, Loader2, Plus, Settings } from "lucide-react";
+import {
+  ArchiveIcon,
+  Check,
+  ChevronRight,
+  Folder,
+  FolderOpen,
+  FolderPlus,
+  Loader2,
+  Plus,
+  Settings,
+  X,
+} from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -25,10 +36,12 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
 import { useProjects } from "@/hooks/useProjects";
 import { useBulkPrStatus, usePrStatusMap } from "@/hooks/usePrStatus";
+import { useSidebarProjectFolders } from "@/hooks/useSidebarProjectFolders";
 import { computePrDisplayCompact } from "@/lib/pr-display";
 import { BranchLabel } from "@/components/BranchLabel";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
@@ -38,7 +51,8 @@ import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
-import type { Automation, DiffStatResponse } from "@/types";
+import { Input } from "@/components/ui/input";
+import type { Automation, DiffStatResponse, Project } from "@/types";
 
 // ── Helpers ──────────────────────────────────────────────────────────
 
@@ -73,6 +87,7 @@ interface SidebarGroupHeaderProps {
   addLabel?: string;
   variant?: "default" | "plain";
   buttonClassName?: string;
+  buttonProps?: React.ComponentProps<"button">;
 }
 
 function SidebarGroupHeader({
@@ -85,8 +100,10 @@ function SidebarGroupHeader({
   addLabel,
   variant = "default",
   buttonClassName,
+  buttonProps,
 }: SidebarGroupHeaderProps) {
   const isPlain = variant === "plain";
+  const { className: buttonPropsClassName, ...restButtonProps } = buttonProps ?? {};
 
   return (
     <div className="group relative flex w-full items-center">
@@ -100,7 +117,9 @@ function SidebarGroupHeader({
               : "gap-2.5 rounded-md px-2.5 py-2.5 hover:bg-sidebar-accent/40",
             count !== undefined && "pr-8",
             buttonClassName,
+            buttonPropsClassName,
           )}
+          {...restButtonProps}
         >
           {icon}
           <span className="min-w-0 flex-1 truncate text-xs font-semibold lowercase tracking-wider text-sidebar-foreground">
@@ -148,6 +167,8 @@ interface SidebarSectionHeaderProps {
   onAdd?: () => void;
   addLabel?: string;
   className?: string;
+  addIcon?: React.ReactNode;
+  addButtonClassName?: string;
 }
 
 function SidebarSectionHeader({
@@ -156,6 +177,8 @@ function SidebarSectionHeader({
   onAdd,
   addLabel,
   className,
+  addIcon,
+  addButtonClassName,
 }: SidebarSectionHeaderProps) {
   return (
     <div className={cn("group relative flex w-full items-center", className)}>
@@ -168,12 +191,15 @@ function SidebarSectionHeader({
         ) : onAdd ? (
           <button
             type="button"
-            className="flex items-center justify-center text-primary transition-colors hover:text-primary/80"
+            className={cn(
+              "flex items-center justify-center text-muted-foreground/70 transition-colors hover:text-sidebar-foreground",
+              addButtonClassName,
+            )}
             onClick={onAdd}
             aria-label={addLabel}
             title={addLabel}
           >
-            <Plus className="h-4 w-4" />
+            {addIcon ?? <Plus className="h-4 w-4" />}
           </button>
         ) : null
         }
@@ -189,6 +215,10 @@ interface SidebarProps {
   onAddAutomation?: () => void;
 }
 
+type SidebarDropTarget =
+  | { type: "folder"; folderId: string }
+  | { type: "root" };
+
 export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps) {
   const { projects, loading, createWorkspace, archiveWorkspace } = useProjects();
   const { data: automations, isLoading: automationsLoading } = useAutomations();
@@ -200,6 +230,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
   const [archiveTarget, setArchiveTarget] = useState<string | null>(null);
   const [archivingWsId, setArchivingWsId] = useState<string | null>(null);
+  const [isCreatingFolder, setIsCreatingFolder] = useState(false);
+  const [newFolderName, setNewFolderName] = useState("");
+  const [draggingProjectId, setDraggingProjectId] = useState<string | null>(null);
+  const [dropTarget, setDropTarget] = useState<SidebarDropTarget | null>(null);
   const liveData = useWorkspaceLiveDataContext();
 
   const activeProjectId = projects.find((project) =>
@@ -216,11 +250,32 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     if (!automations) return [];
     return [...automations].sort((a, b) => automationSortKey(a) - automationSortKey(b));
   }, [automations]);
+  const {
+    folders,
+    rootProjects,
+    createFolder,
+    moveProjectToFolder,
+    isFolderExpanded,
+    setFolderExpanded,
+    getFolderIdForProject,
+  } = useSidebarProjectFolders(projects);
+  const draggedProjectFolderId = draggingProjectId ? getFolderIdForProject(draggingProjectId) : null;
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];
     if (typeof expanded === "boolean") return expanded;
     return activeProjectId === projectId;
+  };
+
+  const resetFolderComposer = () => {
+    setIsCreatingFolder(false);
+    setNewFolderName("");
+  };
+
+  const handleCreateFolder = () => {
+    const folderId = createFolder(newFolderName);
+    if (!folderId) return;
+    resetFolderComposer();
   };
 
   const handleAddWorkspace = async (projectId: string) => {
@@ -266,6 +321,212 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     }
   };
 
+  const handleProjectDragStart = (
+    event: React.DragEvent<HTMLButtonElement>,
+    projectId: string,
+  ) => {
+    setDraggingProjectId(projectId);
+    setDropTarget(null);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("application/x-hive-project-id", projectId);
+    event.dataTransfer.setData("text/plain", projectId);
+  };
+
+  const handleProjectDragEnd = () => {
+    setDraggingProjectId(null);
+    setDropTarget(null);
+  };
+
+  const handleRootDragOver = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!draggingProjectId) return;
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+    if (dropTarget?.type !== "root") {
+      setDropTarget({ type: "root" });
+    }
+  };
+
+  const handleRootDrop = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!draggingProjectId) return;
+    event.preventDefault();
+    moveProjectToFolder(draggingProjectId, null);
+    setDraggingProjectId(null);
+    setDropTarget(null);
+  };
+
+  const handleFolderDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+  ) => {
+    if (!draggingProjectId) return;
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (getFolderIdForProject(draggingProjectId) === folderId) {
+      if (dropTarget !== null) setDropTarget(null);
+      return;
+    }
+
+    event.dataTransfer.dropEffect = "move";
+    if (dropTarget?.type !== "folder" || dropTarget.folderId !== folderId) {
+      setDropTarget({ type: "folder", folderId });
+    }
+  };
+
+  const handleFolderDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+  ) => {
+    if (!draggingProjectId) return;
+    event.preventDefault();
+    event.stopPropagation();
+    moveProjectToFolder(draggingProjectId, folderId);
+    setDraggingProjectId(null);
+    setDropTarget(null);
+  };
+
+  const renderProjectItem = (project: Project, className?: string) => {
+    const parsed = project.url ? parseProjectOwnerRepo(project.url) : null;
+    const displayLabel = parsed ? (
+      <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
+    ) : project.name;
+    const displayLabelPlain = parsed ? `${parsed.owner}/${parsed.repo}` : project.name;
+    const isDragged = draggingProjectId === project.id;
+
+    return (
+      <div key={project.id} className={className}>
+        <Collapsible
+          open={isProjectExpanded(project.id)}
+          onOpenChange={(open) =>
+            setExpandedProjects((prev) => ({ ...prev, [project.id]: open }))
+          }
+        >
+          <SidebarGroupHeader
+            icon={
+              <ProjectAvatar
+                name={project.name}
+                projectId={project.id}
+                hasFavicon={project.hasFavicon}
+                className="h-[18px] w-[18px]"
+              />
+            }
+            label={displayLabel}
+            count={(project.workspaces ?? []).length}
+            isLoading={creatingProjectId === project.id}
+            onAdd={() => { void handleAddWorkspace(project.id); }}
+            addLabel={`Add workspace to ${displayLabelPlain}`}
+            variant="plain"
+            buttonClassName={cn(
+              "rounded-md px-1.5 hover:bg-sidebar-accent/35",
+              isDragged && "cursor-grabbing opacity-45",
+            )}
+            buttonProps={{
+              draggable: true,
+              onDragStart: (event) => handleProjectDragStart(event, project.id),
+              onDragEnd: handleProjectDragEnd,
+              "aria-grabbed": isDragged,
+            }}
+          />
+
+          <CollapsibleContent>
+            <div className="mt-1 space-y-1.5">
+              {(project.workspaces ?? []).map((ws) => {
+                const wsLive = liveData[ws.id];
+                const wsStreaming = wsLive?.streaming ?? false;
+                const wsScriptRunning = wsLive?.scriptRunning ?? false;
+                const displayBranch = wsLive?.branch ?? ws.branch;
+                const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
+                const prStatus = prStatuses[ws.id];
+                const wsArchiving = archivingWsId === ws.id;
+
+                return (
+                  <div key={ws.id} className={cn("group/ws relative transition-opacity", wsArchiving && "pointer-events-none opacity-40")}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Link
+                          to={`/workspaces/${ws.id}`}
+                          className={cn(
+                            "sidebar-card block rounded-md border py-1.5 pl-2 pr-2",
+                            activeWsId === ws.id && "sidebar-card-active",
+                          )}
+                        >
+                          <div className="flex items-center gap-1.5">
+                            <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
+                              {wsStreaming ? (
+                                <AgentActivityPreview size="small" />
+                              ) : wsUnread ? (
+                                <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                              ) : null}
+                            </div>
+                            <BranchLabel
+                              branch={displayBranch}
+                              showIcon={false}
+                              className={cn(
+                                "min-w-0 flex-1 text-sm",
+                                activeWsId === ws.id || wsUnread
+                                  ? "text-sidebar-foreground"
+                                  : "text-muted-foreground",
+                              )}
+                            />
+                            {wsScriptRunning && (
+                              <ActivityWave size="small" decorative className="shrink-0" />
+                            )}
+                          </div>
+
+                          <div className="mt-0.5 flex items-center gap-1 pl-5 text-[11px]">
+                            {prStatus?.pr ? (
+                              (() => {
+                                const display = computePrDisplayCompact(prStatus.pr);
+                                return (
+                                  <span className={cn("truncate", display.textClass)}>
+                                    #{prStatus.pr.number} {display.label}
+                                  </span>
+                                );
+                              })()
+                            ) : prLoading ? (
+                              <span className="text-muted-foreground">Loading…</span>
+                            ) : prStatus?.error ? (
+                              <span className="text-muted-foreground">Error fetching PR</span>
+                            ) : (
+                              <span className="text-muted-foreground">No PR</span>
+                            )}
+                          </div>
+                        </Link>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="text-xs">
+                        {ws.name}
+                      </TooltipContent>
+                    </Tooltip>
+
+                    {wsArchiving ? (
+                      <div className="absolute right-1.5 top-1.5 p-0.5">
+                        <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : !wsScriptRunning && (
+                      <button
+                        type="button"
+                        className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          void handleArchiveClick(ws.id);
+                        }}
+                        aria-label={`Archive workspace ${ws.name}`}
+                        title="Archive workspace"
+                      >
+                        <ArchiveIcon className="h-3 w-3" />
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      </div>
+    );
+  };
+
   const footerActions = (
     <div className="flex items-center justify-end px-2 py-1.5">
       <Link
@@ -295,140 +556,150 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
               <SidebarSectionHeader
                 label="Workspaces"
                 className="mb-2"
+                onAdd={() => {
+                  setIsCreatingFolder(true);
+                  setNewFolderName("");
+                }}
+                addLabel="New folder"
+                addIcon={<FolderPlus className="h-4 w-4" />}
+                addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
               />
 
-              {projects.map((project, index) => {
-                const parsed = project.url ? parseProjectOwnerRepo(project.url) : null;
-                const displayLabel = parsed ? (
-                  <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
-                ) : project.name;
-                const displayLabelPlain = parsed ? `${parsed.owner}/${parsed.repo}` : project.name;
-                return (
-                <div
-                  key={project.id}
-                  className={cn(index > 0 && "mt-3")}
+              {isCreatingFolder && (
+                <form
+                  className="mb-2 rounded-lg border border-sidebar-border/80 bg-sidebar-accent/25 p-2"
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    handleCreateFolder();
+                  }}
                 >
-                  <Collapsible
-                    open={isProjectExpanded(project.id)}
-                    onOpenChange={(open) =>
-                      setExpandedProjects((prev) => ({ ...prev, [project.id]: open }))
-                    }
-                  >
-                    <SidebarGroupHeader
-                      icon={
-                        <ProjectAvatar
-                          name={project.name}
-                          projectId={project.id}
-                          hasFavicon={project.hasFavicon}
-                          className="h-[18px] w-[18px]"
-                        />
-                      }
-                      label={displayLabel}
-                      count={(project.workspaces ?? []).length}
-                      isLoading={creatingProjectId === project.id}
-                      onAdd={() => { void handleAddWorkspace(project.id); }}
-                      addLabel={`Add workspace to ${displayLabelPlain}`}
-                      variant="plain"
+                  <div className="flex items-center gap-2">
+                    <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
+                    <Input
+                      value={newFolderName}
+                      onChange={(e) => setNewFolderName(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          resetFolderComposer();
+                        }
+                      }}
+                      placeholder="Folder name"
+                      aria-label="Folder name"
+                      autoFocus
+                      className="h-8 bg-background/80 text-sm"
                     />
+                    <Button
+                      type="submit"
+                      variant="ghost"
+                      size="icon-xs"
+                      disabled={newFolderName.trim().length === 0}
+                      aria-label="Create folder"
+                      title="Create folder"
+                    >
+                      <Check />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon-xs"
+                      onClick={resetFolderComposer}
+                      aria-label="Cancel folder creation"
+                      title="Cancel folder creation"
+                    >
+                      <X />
+                    </Button>
+                  </div>
+                </form>
+              )}
 
-                    <CollapsibleContent>
-                      <div className="mt-1 space-y-1.5">
-                        {(project.workspaces ?? []).map((ws) => {
-                          const wsLive = liveData[ws.id];
-                          const wsStreaming = wsLive?.streaming ?? false;
-                          const wsScriptRunning = wsLive?.scriptRunning ?? false;
-                          const displayBranch = wsLive?.branch ?? ws.branch;
-                          const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
-                          const prStatus = prStatuses[ws.id];
-                          const wsArchiving = archivingWsId === ws.id;
+              {draggedProjectFolderId !== null && (
+                <div
+                  data-testid="sidebar-root-drop-zone"
+                  onDragOver={handleRootDragOver}
+                  onDrop={handleRootDrop}
+                  className={cn(
+                    "mb-2 rounded-md border border-dashed px-2 py-1.5 text-[11px] font-medium transition-colors",
+                    dropTarget?.type === "root"
+                      ? "border-primary/45 bg-primary/10 text-primary"
+                      : "border-sidebar-border/80 text-muted-foreground",
+                  )}
+                >
+                  Move to top level
+                </div>
+              )}
 
-                          return (
-                            <div key={ws.id} className={cn("group/ws relative transition-opacity", wsArchiving && "pointer-events-none opacity-40")}>
-                              <Tooltip>
-                                <TooltipTrigger asChild>
-                                  <Link
-                                    to={`/workspaces/${ws.id}`}
-                                    className={cn(
-                                      "sidebar-card block rounded-md border py-1.5 pl-2 pr-2",
-                                      activeWsId === ws.id && "sidebar-card-active",
-                                    )}
-                                  >
-                                    <div className="flex items-center gap-1.5">
-                                      <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
-                                        {wsStreaming ? (
-                                          <AgentActivityPreview size="small" />
-                                        ) : wsUnread ? (
-                                          <span className="h-1.5 w-1.5 rounded-full bg-primary" />
-                                        ) : null}
-                                      </div>
-                                      <BranchLabel
-                                        branch={displayBranch}
-                                        showIcon={false}
-                                        className={cn(
-                                          "min-w-0 flex-1 text-sm",
-                                          activeWsId === ws.id || wsUnread
-                                            ? "text-sidebar-foreground"
-                                            : "text-muted-foreground",
-                                        )}
-                                      />
-                                      {wsScriptRunning && (
-                                        <ActivityWave size="small" decorative className="shrink-0" />
-                                      )}
-                                    </div>
+              {folders.length > 0 && (
+                <div className="space-y-1.5">
+                  {folders.map((folder) => {
+                    const expanded = isFolderExpanded(folder.id);
+                    const isActiveDropTarget =
+                      dropTarget?.type === "folder" && dropTarget.folderId === folder.id;
+                    const containsActiveProject = folder.projects.some((project) => project.id === activeProjectId);
 
-                                    <div className="mt-0.5 flex items-center gap-1 pl-5 text-[11px]">
-                                      {prStatus?.pr ? (
-                                        (() => {
-                                          const display = computePrDisplayCompact(prStatus.pr);
-                                          return (
-                                            <span className={cn("truncate", display.textClass)}>
-                                              #{prStatus.pr.number} {display.label}
-                                            </span>
-                                          );
-                                        })()
-                                      ) : prLoading ? (
-                                        <span className="text-muted-foreground">Loading…</span>
-                                      ) : prStatus?.error ? (
-                                        <span className="text-muted-foreground">Error fetching PR</span>
-                                      ) : (
-                                        <span className="text-muted-foreground">No PR</span>
-                                      )}
-                                    </div>
-                                  </Link>
-                                </TooltipTrigger>
-                                <TooltipContent side="right" className="text-xs">
-                                  {ws.name}
-                                </TooltipContent>
-                              </Tooltip>
+                    return (
+                      <Collapsible
+                        key={folder.id}
+                        open={expanded}
+                        onOpenChange={(open) => setFolderExpanded(folder.id, open)}
+                      >
+                        <div
+                          data-sidebar-folder={folder.id}
+                          onDragOver={(event) => handleFolderDragOver(event, folder.id)}
+                          onDrop={(event) => handleFolderDrop(event, folder.id)}
+                          className="rounded-lg"
+                        >
+                          <CollapsibleTrigger asChild>
+                            <button
+                              type="button"
+                              className={cn(
+                                "flex min-h-9 w-full items-center gap-1.5 rounded-md px-1.5 text-left transition-colors hover:bg-sidebar-accent/40",
+                                containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
+                                isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
+                              )}
+                            >
+                              <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
+                              {expanded ? (
+                                <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                              ) : (
+                                <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                              )}
+                              <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+                                {folder.name}
+                              </span>
+                            </button>
+                          </CollapsibleTrigger>
 
-                              {wsArchiving ? (
-                                <div className="absolute right-1.5 top-1.5 p-0.5">
-                                  <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                          <CollapsibleContent>
+                            <div className="ml-3 mt-1 border-l border-sidebar-border/70 pl-2.5">
+                              {folder.projects.length > 0 ? (
+                                <div className="space-y-1.5 py-0.5">
+                                  {folder.projects.map((project) => renderProjectItem(project))}
                                 </div>
-                              ) : !wsScriptRunning && (
-                                <button
-                                  type="button"
-                                  className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
-                                  onClick={(e) => {
-                                    e.preventDefault();
-                                    e.stopPropagation();
-                                    void handleArchiveClick(ws.id);
-                                  }}
-                                  aria-label={`Archive workspace ${ws.name}`}
-                                  title="Archive workspace"
+                              ) : (
+                                <div
+                                  className={cn(
+                                    "py-2 text-xs text-muted-foreground/70 transition-colors",
+                                    isActiveDropTarget && "text-primary",
+                                  )}
                                 >
-                                  <ArchiveIcon className="h-3 w-3" />
-                                </button>
+                                  Drop repositories here
+                                </div>
                               )}
                             </div>
-                          );
-                        })}
-                      </div>
-                    </CollapsibleContent>
-                  </Collapsible>
+                          </CollapsibleContent>
+                        </div>
+                      </Collapsible>
+                    );
+                  })}
                 </div>
-                );
-              })}
+              )}
+
+              {rootProjects.length > 0 && (
+                <div className={cn("space-y-1.5", folders.length > 0 && "mt-2")}>
+                  {rootProjects.map((project) => renderProjectItem(project))}
+                </div>
+              )}
 
               <div className="mt-6">
                 <div className="mb-6 border-t border-white/15" />

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -99,6 +99,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const {
     folders,
     rootProjects,
+    hasInitialHydration,
     createFolder,
     renameFolder,
     deleteFolder,
@@ -122,12 +123,14 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   };
 
   const handleCreateFolder = () => {
+    if (!hasInitialHydration) return;
     const folderId = createFolder(newFolderName);
     if (!folderId) return;
     resetFolderComposer();
   };
 
   const startRenamingFolder = (folderId: string, currentName: string) => {
+    if (!hasInitialHydration) return;
     setRenamingFolderId(folderId);
     setRenameDraft(currentName);
   };
@@ -146,12 +149,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     }
     renameFolder(renamingFolderId, trimmed);
     cancelRenamingFolder();
-  };
-
-  const confirmDeleteFolder = () => {
-    if (!deleteFolderTarget) return;
-    deleteFolder(deleteFolderTarget.id);
-    setDeleteFolderTarget(null);
   };
 
   const handleAddWorkspace = async (projectId: string) => {
@@ -201,6 +198,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     event: React.DragEvent<HTMLButtonElement>,
     projectId: string,
   ) => {
+    if (!hasInitialHydration) return;
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("application/x-hive-project-id", projectId);
     event.dataTransfer.setData("text/plain", projectId);
@@ -225,6 +223,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     anchorProjectId: string,
     position: "before" | "after",
   ) => {
+    if (!hasInitialHydration) return;
     const sourceProjectId = getDraggedProjectId(event);
     if (!sourceProjectId || sourceProjectId === anchorProjectId) return;
     event.preventDefault();
@@ -246,6 +245,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     anchorFolderId: string,
     position: "before" | "after",
   ) => {
+    if (!hasInitialHydration) return;
     const sourceProjectId = getDraggedProjectId(event);
     if (!sourceProjectId || sourceProjectId === anchorProjectId) return;
     event.preventDefault();
@@ -260,6 +260,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     event: React.DragEvent<HTMLDivElement>,
     folderId: string,
   ) => {
+    if (!hasInitialHydration) return;
     if (!draggingProjectId) return;
     event.preventDefault();
     event.stopPropagation();
@@ -280,6 +281,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     event: React.DragEvent<HTMLDivElement>,
     folderId: string,
   ) => {
+    if (!hasInitialHydration) return;
     if (!draggingProjectId) return;
     event.preventDefault();
     event.stopPropagation();
@@ -292,6 +294,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     event: React.DragEvent<HTMLButtonElement>,
     folderId: string,
   ) => {
+    if (!hasInitialHydration) return;
     setDraggingFolderId(folderId);
     setFolderOrderDropTarget(null);
     event.dataTransfer.effectAllowed = "move";
@@ -314,6 +317,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     folderId: string,
     position: "before" | "after",
   ) => {
+    if (!hasInitialHydration) return;
     const sourceFolderId = getDraggedFolderId(event);
     if (!sourceFolderId || sourceFolderId === folderId) return;
     event.preventDefault();
@@ -333,6 +337,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     folderId: string,
     position: "before" | "after",
   ) => {
+    if (!hasInitialHydration) return;
     const sourceFolderId = getDraggedFolderId(event);
     if (!sourceFolderId || sourceFolderId === folderId) return;
     event.preventDefault();
@@ -374,6 +379,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         prLoading={prLoading}
         creatingProjectId={creatingProjectId}
         archivingWsId={archivingWsId}
+        canReorder={hasInitialHydration}
         draggingProjectId={draggingProjectId}
         projectInsertIndicator={projectInsertIndicator}
         onAddWorkspace={(projectId) => { void handleAddWorkspace(projectId); }}
@@ -399,6 +405,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
       </Link>
     </div>
   );
+  const deleteFolderTargetId = deleteFolderTarget?.id ?? null;
 
   return (
     <SidebarShell footerActions={footerActions}>
@@ -416,10 +423,12 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                 label="Workspaces"
                 className="mb-1"
                 onAdd={() => {
+                  if (!hasInitialHydration) return;
                   setIsCreatingFolder(true);
                   setNewFolderName("");
                 }}
                 addLabel="New folder"
+                addDisabled={!hasInitialHydration}
                 addIcon={<FolderPlus className="h-4 w-4" />}
                 addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
               />
@@ -452,6 +461,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                         key={folder.id}
                         folder={folder}
                         expanded={expanded}
+                        canInteract={hasInitialHydration}
                         isActiveDropTarget={isActiveDropTarget}
                         containsActiveProject={containsActiveProject}
                         isDraggedFolder={isDraggedFolder}
@@ -543,7 +553,15 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={confirmDeleteFolder}>Delete</AlertDialogAction>
+            <AlertDialogAction
+              onClick={() => {
+                if (!hasInitialHydration || !deleteFolderTargetId) return;
+                deleteFolder(deleteFolderTargetId);
+                setDeleteFolderTarget(null);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -215,12 +215,15 @@ interface SidebarProps {
   onAddAutomation?: () => void;
 }
 
-type SidebarDropTarget =
-  | { type: "folder"; folderId: string }
-  | { type: "root" };
+type SidebarDropTarget = { type: "folder"; folderId: string };
 
 type FolderOrderDropTarget = {
   folderId: string;
+  position: "before" | "after";
+};
+
+type ProjectOrderDropTarget = {
+  projectId: string;
   position: "before" | "after";
 };
 
@@ -241,6 +244,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [dropTarget, setDropTarget] = useState<SidebarDropTarget | null>(null);
   const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
   const [folderOrderDropTarget, setFolderOrderDropTarget] = useState<FolderOrderDropTarget | null>(null);
+  const [projectOrderDropTarget, setProjectOrderDropTarget] = useState<ProjectOrderDropTarget | null>(null);
   const liveData = useWorkspaceLiveDataContext();
 
   const activeProjectId = projects.find((project) =>
@@ -262,12 +266,12 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     rootProjects,
     createFolder,
     moveProjectToFolder,
+    moveProjectToPosition,
     moveFolderById,
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,
   } = useSidebarProjectFolders(projects);
-  const draggedProjectFolderId = draggingProjectId ? getFolderIdForProject(draggingProjectId) : null;
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];
@@ -333,33 +337,59 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     event: React.DragEvent<HTMLButtonElement>,
     projectId: string,
   ) => {
-    setDraggingProjectId(projectId);
-    setDropTarget(null);
     event.dataTransfer.effectAllowed = "move";
     event.dataTransfer.setData("application/x-hive-project-id", projectId);
     event.dataTransfer.setData("text/plain", projectId);
+    setDraggingProjectId(projectId);
+    setDropTarget(null);
+    setProjectOrderDropTarget(null);
   };
 
   const handleProjectDragEnd = () => {
     setDraggingProjectId(null);
     setDropTarget(null);
+    setProjectOrderDropTarget(null);
   };
 
-  const handleRootDragOver = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!draggingProjectId) return;
+  const getDraggedProjectId = (event: React.DragEvent<HTMLDivElement>) =>
+    draggingProjectId
+    ?? event.dataTransfer.getData("application/x-hive-project-id")
+    ?? null;
+
+  const handleProjectReorderDragOver = (
+    event: React.DragEvent<HTMLDivElement>,
+    anchorProjectId: string,
+    position: "before" | "after",
+  ) => {
+    const sourceProjectId = getDraggedProjectId(event);
+    if (!sourceProjectId || sourceProjectId === anchorProjectId) return;
     event.preventDefault();
+    event.stopPropagation();
     event.dataTransfer.dropEffect = "move";
-    if (dropTarget?.type !== "root") {
-      setDropTarget({ type: "root" });
+    if (dropTarget !== null) setDropTarget(null);
+
+    if (
+      projectOrderDropTarget?.projectId !== anchorProjectId
+      || projectOrderDropTarget.position !== position
+    ) {
+      setProjectOrderDropTarget({ projectId: anchorProjectId, position });
     }
   };
 
-  const handleRootDrop = (event: React.DragEvent<HTMLDivElement>) => {
-    if (!draggingProjectId) return;
+  const handleProjectReorderDrop = (
+    event: React.DragEvent<HTMLDivElement>,
+    anchorProjectId: string,
+    anchorFolderId: string,
+    position: "before" | "after",
+  ) => {
+    const sourceProjectId = getDraggedProjectId(event);
+    if (!sourceProjectId || sourceProjectId === anchorProjectId) return;
     event.preventDefault();
-    moveProjectToFolder(draggingProjectId, null);
+    event.stopPropagation();
+    moveProjectToPosition(sourceProjectId, anchorFolderId, anchorProjectId, position);
     setDraggingProjectId(null);
     setDropTarget(null);
+    setProjectOrderDropTarget(null);
   };
 
   const handleFolderDragOver = (
@@ -379,6 +409,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     if (dropTarget?.type !== "folder" || dropTarget.folderId !== folderId) {
       setDropTarget({ type: "folder", folderId });
     }
+    if (projectOrderDropTarget) setProjectOrderDropTarget(null);
   };
 
   const handleFolderDrop = (
@@ -447,16 +478,27 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     setFolderOrderDropTarget(null);
   };
 
-  const renderProjectItem = (project: Project, className?: string) => {
+  const renderProjectItem = (
+    project: Project,
+    folderId: string | null,
+    className?: string,
+  ) => {
     const parsed = project.url ? parseProjectOwnerRepo(project.url) : null;
     const displayLabel = parsed ? (
       <><span className="text-muted-foreground">{parsed.owner}/</span>{parsed.repo}</>
     ) : project.name;
     const displayLabelPlain = parsed ? `${parsed.owner}/${parsed.repo}` : project.name;
     const isDragged = draggingProjectId === project.id;
+    const showReorderZones =
+      folderId !== null
+      && draggingProjectId !== null
+      && draggingProjectId !== project.id;
+    const projectInsertIndicator = projectOrderDropTarget?.projectId === project.id
+      ? projectOrderDropTarget.position
+      : null;
 
     return (
-      <div key={project.id} className={className}>
+      <div key={project.id} className={cn("relative", className)} data-sidebar-project={project.id}>
         <Collapsible
           open={isProjectExpanded(project.id)}
           onOpenChange={(open) =>
@@ -585,6 +627,30 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
             </div>
           </CollapsibleContent>
         </Collapsible>
+        {showReorderZones && folderId !== null && (
+          <>
+            <div
+              data-project-reorder="before"
+              className="absolute inset-x-0 top-0 z-20 h-2.5"
+              onDragOver={(event) => handleProjectReorderDragOver(event, project.id, "before")}
+              onDrop={(event) => handleProjectReorderDrop(event, project.id, folderId, "before")}
+            />
+            <div
+              data-project-reorder="after"
+              className="absolute inset-x-0 bottom-0 z-20 h-2.5"
+              onDragOver={(event) => handleProjectReorderDragOver(event, project.id, "after")}
+              onDrop={(event) => handleProjectReorderDrop(event, project.id, folderId, "after")}
+            />
+          </>
+        )}
+        {projectInsertIndicator && (
+          <div
+            className={cn(
+              "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
+              projectInsertIndicator === "before" ? "top-0" : "bottom-0",
+            )}
+          />
+        )}
       </div>
     );
   };
@@ -675,22 +741,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                 </form>
               )}
 
-              {draggedProjectFolderId !== null && (
-                <div
-                  data-testid="sidebar-root-drop-zone"
-                  onDragOver={handleRootDragOver}
-                  onDrop={handleRootDrop}
-                  className={cn(
-                    "mb-2 rounded-md border border-dashed px-2 py-1.5 text-[11px] font-medium transition-colors",
-                    dropTarget?.type === "root"
-                      ? "border-primary/45 bg-primary/10 text-primary"
-                      : "border-sidebar-border/80 text-muted-foreground",
-                  )}
-                >
-                  Move to top level
-                </div>
-              )}
-
               {folders.length > 0 && (
                 <div className="space-y-1.5">
                   {folders.map((folder) => {
@@ -769,7 +819,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                             <div className="ml-3 mt-1 border-l border-sidebar-border/70 pl-2.5">
                               {folder.projects.length > 0 ? (
                                 <div className="space-y-1.5 py-0.5">
-                                  {folder.projects.map((project) => renderProjectItem(project))}
+                                  {folder.projects.map((project) => renderProjectItem(project, folder.id))}
                                 </div>
                               ) : (
                                 <div
@@ -792,7 +842,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
 
               {rootProjects.length > 0 && (
                 <div className={cn("space-y-1.5", folders.length > 0 && "mt-2")}>
-                  {rootProjects.map((project) => renderProjectItem(project))}
+                  {rootProjects.map((project) => renderProjectItem(project, null))}
                 </div>
               )}
 
@@ -863,7 +913,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
-
     </SidebarShell>
   );
 }

--- a/frontend/src/components/sidebar/SidebarFolderComposer.tsx
+++ b/frontend/src/components/sidebar/SidebarFolderComposer.tsx
@@ -1,0 +1,69 @@
+import { Check, FolderPlus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface SidebarFolderComposerProps {
+  isOpen: boolean;
+  name: string;
+  onNameChange: (value: string) => void;
+  onSubmit: () => void;
+  onCancel: () => void;
+}
+
+export function SidebarFolderComposer({
+  isOpen,
+  name,
+  onNameChange,
+  onSubmit,
+  onCancel,
+}: SidebarFolderComposerProps) {
+  if (!isOpen) return null;
+
+  return (
+    <form
+      className="mb-2 rounded-lg border border-sidebar-border/80 bg-sidebar-accent/25 p-2"
+      onSubmit={(event) => {
+        event.preventDefault();
+        onSubmit();
+      }}
+    >
+      <div className="flex items-center gap-2">
+        <FolderPlus className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <Input
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Escape") {
+              event.preventDefault();
+              onCancel();
+            }
+          }}
+          placeholder="Folder name"
+          aria-label="Folder name"
+          autoFocus
+          className="h-8 bg-background/80 text-sm"
+        />
+        <Button
+          type="submit"
+          variant="ghost"
+          size="icon-xs"
+          disabled={name.trim().length === 0}
+          aria-label="Create folder"
+          title="Create folder"
+        >
+          <Check />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          onClick={onCancel}
+          aria-label="Cancel folder creation"
+          title="Cancel folder creation"
+        >
+          <X />
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/frontend/src/components/sidebar/SidebarFolderItem.tsx
+++ b/frontend/src/components/sidebar/SidebarFolderItem.tsx
@@ -8,6 +8,7 @@ import type { Project } from "@/types";
 interface SidebarFolderItemProps {
   folder: SidebarProjectFolderView;
   expanded: boolean;
+  canInteract: boolean;
   isActiveDropTarget: boolean;
   containsActiveProject: boolean;
   isDraggedFolder: boolean;
@@ -42,6 +43,7 @@ interface SidebarFolderItemProps {
 export function SidebarFolderItem({
   folder,
   expanded,
+  canInteract,
   isActiveDropTarget,
   containsActiveProject,
   isDraggedFolder,
@@ -72,11 +74,11 @@ export function SidebarFolderItem({
     >
       <div
         data-sidebar-folder={folder.id}
-        onDragOver={(event) => onFolderDragOver(event, folder.id)}
-        onDrop={(event) => onFolderDrop(event, folder.id)}
+        onDragOver={canInteract ? (event) => onFolderDragOver(event, folder.id) : undefined}
+        onDrop={canInteract ? (event) => onFolderDrop(event, folder.id) : undefined}
         className="relative rounded-lg"
       >
-        {draggingFolderId !== null && draggingFolderId !== folder.id && (
+        {canInteract && draggingFolderId !== null && draggingFolderId !== folder.id && (
           <>
             <div
               data-folder-reorder="before"
@@ -136,9 +138,9 @@ export function SidebarFolderItem({
             <CollapsibleTrigger asChild>
               <button
                 type="button"
-                draggable
-                onDragStart={(event) => onFolderDragStart(event, folder.id)}
-                onDragEnd={onFolderDragEnd}
+                draggable={canInteract}
+                onDragStart={canInteract ? (event) => onFolderDragStart(event, folder.id) : undefined}
+                onDragEnd={canInteract ? onFolderDragEnd : undefined}
                 aria-grabbed={isDraggedFolder}
                 className={cn(
                   "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-12 text-left transition-colors hover:bg-sidebar-accent/40",
@@ -159,7 +161,8 @@ export function SidebarFolderItem({
               </button>
             </CollapsibleTrigger>
 
-            <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+            {canInteract && (
+              <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
               <button
                 type="button"
                 onClick={(event) => {
@@ -186,7 +189,8 @@ export function SidebarFolderItem({
                   <Trash2 className="h-3 w-3" />
                 </button>
               )}
-            </div>
+              </div>
+            )}
           </div>
         )}
 

--- a/frontend/src/components/sidebar/SidebarFolderItem.tsx
+++ b/frontend/src/components/sidebar/SidebarFolderItem.tsx
@@ -1,0 +1,214 @@
+import { ChevronRight, Folder, FolderOpen, Pencil, Trash2 } from "lucide-react";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import type { SidebarProjectFolderView } from "@/hooks/useSidebarProjectFolders";
+import type { Project } from "@/types";
+
+interface SidebarFolderItemProps {
+  folder: SidebarProjectFolderView;
+  expanded: boolean;
+  isActiveDropTarget: boolean;
+  containsActiveProject: boolean;
+  isDraggedFolder: boolean;
+  isRenaming: boolean;
+  isEmptyFolder: boolean;
+  draggingFolderId: string | null;
+  folderInsertIndicator: "before" | "after" | null;
+  renameDraft: string;
+  onOpenChange: (open: boolean) => void;
+  onFolderDragOver: (event: React.DragEvent<HTMLDivElement>, folderId: string) => void;
+  onFolderDrop: (event: React.DragEvent<HTMLDivElement>, folderId: string) => void;
+  onFolderDragStart: (event: React.DragEvent<HTMLButtonElement>, folderId: string) => void;
+  onFolderDragEnd: () => void;
+  onFolderReorderDragOver: (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+    position: "before" | "after",
+  ) => void;
+  onFolderReorderDrop: (
+    event: React.DragEvent<HTMLDivElement>,
+    folderId: string,
+    position: "before" | "after",
+  ) => void;
+  onStartRenaming: (folderId: string, currentName: string) => void;
+  onDeleteRequest: (folderId: string, folderName: string) => void;
+  onRenameDraftChange: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  renderProjectItem: (project: Project, folderId: string) => React.ReactNode;
+}
+
+export function SidebarFolderItem({
+  folder,
+  expanded,
+  isActiveDropTarget,
+  containsActiveProject,
+  isDraggedFolder,
+  isRenaming,
+  isEmptyFolder,
+  draggingFolderId,
+  folderInsertIndicator,
+  renameDraft,
+  onOpenChange,
+  onFolderDragOver,
+  onFolderDrop,
+  onFolderDragStart,
+  onFolderDragEnd,
+  onFolderReorderDragOver,
+  onFolderReorderDrop,
+  onStartRenaming,
+  onDeleteRequest,
+  onRenameDraftChange,
+  onCommitRename,
+  onCancelRename,
+  renderProjectItem,
+}: SidebarFolderItemProps) {
+  return (
+    <Collapsible
+      key={folder.id}
+      open={expanded}
+      onOpenChange={onOpenChange}
+    >
+      <div
+        data-sidebar-folder={folder.id}
+        onDragOver={(event) => onFolderDragOver(event, folder.id)}
+        onDrop={(event) => onFolderDrop(event, folder.id)}
+        className="relative rounded-lg"
+      >
+        {draggingFolderId !== null && draggingFolderId !== folder.id && (
+          <>
+            <div
+              data-folder-reorder="before"
+              className="absolute inset-x-0 top-0 z-20 h-3"
+              onDragOver={(event) => onFolderReorderDragOver(event, folder.id, "before")}
+              onDrop={(event) => onFolderReorderDrop(event, folder.id, "before")}
+            />
+            <div
+              data-folder-reorder="after"
+              className="absolute inset-x-0 bottom-0 z-20 h-3"
+              onDragOver={(event) => onFolderReorderDragOver(event, folder.id, "after")}
+              onDrop={(event) => onFolderReorderDrop(event, folder.id, "after")}
+            />
+          </>
+        )}
+        {folderInsertIndicator && (
+          <div
+            className={cn(
+              "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
+              folderInsertIndicator === "before" ? "top-0" : "bottom-0",
+            )}
+          />
+        )}
+
+        {isRenaming ? (
+          <form
+            className="flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-1.5"
+            onSubmit={(event) => {
+              event.preventDefault();
+              onCommitRename();
+            }}
+          >
+            <ChevronRight className={cn("h-3.5 w-3.5 shrink-0", expanded && "rotate-90")} />
+            {expanded ? (
+              <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
+            <Input
+              value={renameDraft}
+              onChange={(event) => onRenameDraftChange(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Escape") {
+                  event.preventDefault();
+                  onCancelRename();
+                }
+              }}
+              onFocus={(event) => event.currentTarget.select()}
+              onBlur={onCommitRename}
+              autoFocus
+              aria-label="Rename folder"
+              className="h-6 min-w-0 flex-1 bg-background/80 px-1.5 py-0 text-[12px] font-medium"
+            />
+          </form>
+        ) : (
+          <div className="group/folder relative flex w-full items-center">
+            <CollapsibleTrigger asChild>
+              <button
+                type="button"
+                draggable
+                onDragStart={(event) => onFolderDragStart(event, folder.id)}
+                onDragEnd={onFolderDragEnd}
+                aria-grabbed={isDraggedFolder}
+                className={cn(
+                  "flex w-full items-center gap-1.5 rounded py-1 pl-0 pr-12 text-left transition-colors hover:bg-sidebar-accent/40",
+                  containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
+                  isActiveDropTarget && "bg-primary/10 text-sidebar-foreground ring-1 ring-primary/20",
+                  isDraggedFolder && "cursor-grabbing opacity-45",
+                )}
+              >
+                <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
+                {expanded ? (
+                  <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                ) : (
+                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
+                <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+                  {folder.name}
+                </span>
+              </button>
+            </CollapsibleTrigger>
+
+            <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                  onStartRenaming(folder.id, folder.name);
+                }}
+                className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50"
+                aria-label={`Rename folder ${folder.name}`}
+              >
+                <Pencil className="h-3 w-3" />
+              </button>
+              {isEmptyFolder && (
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    onDeleteRequest(folder.id, folder.name);
+                  }}
+                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/60"
+                  aria-label={`Delete folder ${folder.name}`}
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        <CollapsibleContent>
+          <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
+            {folder.projects.length > 0 ? (
+              <div className="space-y-px py-0.5">
+                {folder.projects.map((project) => renderProjectItem(project, folder.id))}
+              </div>
+            ) : (
+              <div
+                className={cn(
+                  "py-1.5 text-xs text-muted-foreground/70 transition-colors",
+                  isActiveDropTarget && "text-primary",
+                )}
+              >
+                Drop repositories here
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -91,6 +91,7 @@ interface SidebarSectionHeaderProps {
   isLoading?: boolean;
   onAdd?: () => void;
   addLabel?: string;
+  addDisabled?: boolean;
   className?: string;
   addIcon?: React.ReactNode;
   addButtonClassName?: string;
@@ -101,6 +102,7 @@ export function SidebarSectionHeader({
   isLoading = false,
   onAdd,
   addLabel,
+  addDisabled = false,
   className,
   addIcon,
   addButtonClassName,
@@ -117,10 +119,11 @@ export function SidebarSectionHeader({
           <button
             type="button"
             className={cn(
-              "flex items-center justify-center text-muted-foreground/70 transition-colors hover:text-sidebar-foreground",
+              "flex items-center justify-center text-muted-foreground/70 transition-colors hover:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-40",
               addButtonClassName,
             )}
             onClick={onAdd}
+            disabled={addDisabled}
             aria-label={addLabel}
             title={addLabel}
           >

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -1,0 +1,133 @@
+import { Loader2, Plus } from "lucide-react";
+import { CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+interface SidebarGroupHeaderProps {
+  icon: React.ReactNode;
+  label: React.ReactNode;
+  badge?: React.ReactNode;
+  count?: number;
+  isLoading?: boolean;
+  onAdd?: (e: React.MouseEvent) => void;
+  addLabel?: string;
+  variant?: "default" | "plain";
+  buttonClassName?: string;
+  buttonProps?: React.ComponentProps<"button">;
+}
+
+export function SidebarGroupHeader({
+  icon,
+  label,
+  badge,
+  count,
+  isLoading,
+  onAdd,
+  addLabel,
+  variant = "default",
+  buttonClassName,
+  buttonProps,
+}: SidebarGroupHeaderProps) {
+  const isPlain = variant === "plain";
+  const { className: buttonPropsClassName, ...restButtonProps } = buttonProps ?? {};
+
+  return (
+    <div className="group relative flex w-full items-center">
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            "flex w-full min-w-0 items-center overflow-hidden text-left transition-colors",
+            isPlain
+              ? "gap-1.5 px-0 py-0.5"
+              : "gap-2 rounded px-2 py-1 hover:bg-sidebar-accent/40",
+            count !== undefined && "pr-7",
+            buttonClassName,
+            buttonPropsClassName,
+          )}
+          {...restButtonProps}
+        >
+          {icon}
+          <span className="min-w-0 flex-1 truncate text-xs font-semibold lowercase tracking-wider text-sidebar-foreground">
+            {label}
+          </span>
+          {badge}
+        </button>
+      </CollapsibleTrigger>
+      {count !== undefined && (
+        <div className={cn("absolute inset-y-0 flex items-center", isPlain ? "right-0" : "right-2")}>
+          <div className="relative flex h-5 w-5 items-center justify-center">
+            {isLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+            ) : (
+              <>
+                <span className="text-xs tabular-nums text-muted-foreground/60 transition-opacity group-hover:opacity-0">
+                  {count}
+                </span>
+                {onAdd && (
+                  <button
+                    type="button"
+                    className="absolute inset-0 flex items-center justify-center text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover:opacity-100"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      onAdd(e);
+                    }}
+                    aria-label={addLabel}
+                    title={addLabel}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </button>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface SidebarSectionHeaderProps {
+  label: string;
+  isLoading?: boolean;
+  onAdd?: () => void;
+  addLabel?: string;
+  className?: string;
+  addIcon?: React.ReactNode;
+  addButtonClassName?: string;
+}
+
+export function SidebarSectionHeader({
+  label,
+  isLoading = false,
+  onAdd,
+  addLabel,
+  className,
+  addIcon,
+  addButtonClassName,
+}: SidebarSectionHeaderProps) {
+  return (
+    <div className={cn("group relative flex w-full items-center", className)}>
+      <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
+        {label}
+      </span>
+      <div className="relative flex h-5 w-5 items-center justify-center">
+        {isLoading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
+        ) : onAdd ? (
+          <button
+            type="button"
+            className={cn(
+              "flex items-center justify-center text-muted-foreground/70 transition-colors hover:text-sidebar-foreground",
+              addButtonClassName,
+            )}
+            onClick={onAdd}
+            aria-label={addLabel}
+            title={addLabel}
+          >
+            {addIcon ?? <Plus className="h-4 w-4" />}
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -51,25 +51,6 @@ interface SidebarProjectItemProps {
   ) => void;
 }
 
-export function parseProjectOwnerRepo(
-  url: string,
-): { owner: string; repo: string } | null {
-  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
-
-  try {
-    const parsed = new URL(url);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    if (segments.length >= 2) {
-      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
-    }
-  } catch {
-    // not a valid URL
-  }
-
-  return null;
-}
-
 export function SidebarProjectItem({
   project,
   folderId,

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -21,6 +21,7 @@ type ProjectInsertIndicator = "before" | "after" | null;
 interface SidebarProjectItemProps {
   project: Project;
   folderId: string | null;
+  canReorder: boolean;
   className?: string;
   displayLabel: React.ReactNode;
   displayLabelPlain: string;
@@ -54,6 +55,7 @@ interface SidebarProjectItemProps {
 export function SidebarProjectItem({
   project,
   folderId,
+  canReorder,
   className,
   displayLabel,
   displayLabelPlain,
@@ -76,7 +78,8 @@ export function SidebarProjectItem({
 }: SidebarProjectItemProps) {
   const isDragged = draggingProjectId === project.id;
   const showReorderZones =
-    folderId !== null
+    canReorder
+    && folderId !== null
     && draggingProjectId !== null
     && draggingProjectId !== project.id;
 
@@ -103,9 +106,9 @@ export function SidebarProjectItem({
             isDragged && "cursor-grabbing opacity-45",
           )}
           buttonProps={{
-            draggable: true,
-            onDragStart: (event) => onProjectDragStart(event, project.id),
-            onDragEnd: onProjectDragEnd,
+            draggable: canReorder,
+            onDragStart: canReorder ? (event) => onProjectDragStart(event, project.id) : undefined,
+            onDragEnd: canReorder ? onProjectDragEnd : undefined,
             "aria-grabbed": isDragged,
           }}
         />

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -1,0 +1,259 @@
+import { Link } from "react-router-dom";
+import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { SidebarGroupHeader } from "@/components/sidebar/SidebarHeaders";
+import { BranchLabel } from "@/components/BranchLabel";
+import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
+import { ActivityWave } from "@/components/ui/activity-wave";
+import { ProjectAvatar } from "@/components/ProjectAvatar";
+import { computePrDisplayCompact } from "@/lib/pr-display";
+import { cn } from "@/lib/utils";
+import type { WorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
+import type { PrStatusResponse, Project } from "@/types";
+import { ArchiveIcon, Loader2 } from "lucide-react";
+
+type ProjectInsertIndicator = "before" | "after" | null;
+
+interface SidebarProjectItemProps {
+  project: Project;
+  folderId: string | null;
+  className?: string;
+  displayLabel: React.ReactNode;
+  displayLabelPlain: string;
+  isExpanded: boolean;
+  setExpanded: (open: boolean) => void;
+  activeWsId?: string;
+  liveData: Record<string, WorkspaceLiveData>;
+  prStatuses: Record<string, PrStatusResponse>;
+  prLoading: boolean;
+  creatingProjectId: string | null;
+  archivingWsId: string | null;
+  draggingProjectId: string | null;
+  projectInsertIndicator: ProjectInsertIndicator;
+  onAddWorkspace: (projectId: string) => void;
+  onArchiveWorkspace: (wsId: string) => void;
+  onProjectDragStart: (event: React.DragEvent<HTMLButtonElement>, projectId: string) => void;
+  onProjectDragEnd: () => void;
+  onProjectReorderDragOver: (
+    event: React.DragEvent<HTMLDivElement>,
+    projectId: string,
+    position: "before" | "after",
+  ) => void;
+  onProjectReorderDrop: (
+    event: React.DragEvent<HTMLDivElement>,
+    projectId: string,
+    folderId: string,
+    position: "before" | "after",
+  ) => void;
+}
+
+export function parseProjectOwnerRepo(
+  url: string,
+): { owner: string; repo: string } | null {
+  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
+
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length >= 2) {
+      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
+    }
+  } catch {
+    // not a valid URL
+  }
+
+  return null;
+}
+
+export function SidebarProjectItem({
+  project,
+  folderId,
+  className,
+  displayLabel,
+  displayLabelPlain,
+  isExpanded,
+  setExpanded,
+  activeWsId,
+  liveData,
+  prStatuses,
+  prLoading,
+  creatingProjectId,
+  archivingWsId,
+  draggingProjectId,
+  projectInsertIndicator,
+  onAddWorkspace,
+  onArchiveWorkspace,
+  onProjectDragStart,
+  onProjectDragEnd,
+  onProjectReorderDragOver,
+  onProjectReorderDrop,
+}: SidebarProjectItemProps) {
+  const isDragged = draggingProjectId === project.id;
+  const showReorderZones =
+    folderId !== null
+    && draggingProjectId !== null
+    && draggingProjectId !== project.id;
+
+  return (
+    <div key={project.id} className={cn("relative", className)} data-sidebar-project={project.id}>
+      <Collapsible open={isExpanded} onOpenChange={setExpanded}>
+        <SidebarGroupHeader
+          icon={
+            <ProjectAvatar
+              name={project.name}
+              projectId={project.id}
+              hasFavicon={project.hasFavicon}
+              className="h-[18px] w-[18px]"
+            />
+          }
+          label={displayLabel}
+          count={(project.workspaces ?? []).length}
+          isLoading={creatingProjectId === project.id}
+          onAdd={() => { onAddWorkspace(project.id); }}
+          addLabel={`Add workspace to ${displayLabelPlain}`}
+          variant="plain"
+          buttonClassName={cn(
+            "rounded py-1 pl-0 pr-1.5 hover:bg-sidebar-accent/35",
+            isDragged && "cursor-grabbing opacity-45",
+          )}
+          buttonProps={{
+            draggable: true,
+            onDragStart: (event) => onProjectDragStart(event, project.id),
+            onDragEnd: onProjectDragEnd,
+            "aria-grabbed": isDragged,
+          }}
+        />
+
+        <CollapsibleContent>
+          <div className="mt-1 space-y-1.5">
+            {(project.workspaces ?? []).map((ws) => {
+              const wsLive = liveData[ws.id];
+              const wsStreaming = wsLive?.streaming ?? false;
+              const wsScriptRunning = wsLive?.scriptRunning ?? false;
+              const displayBranch = wsLive?.branch ?? ws.branch;
+              const wsUnread = !wsStreaming && Object.keys(wsLive?.unreadSessions ?? {}).length > 0;
+              const prStatus = prStatuses[ws.id];
+              const wsArchiving = archivingWsId === ws.id;
+
+              return (
+                <div
+                  key={ws.id}
+                  className={cn(
+                    "group/ws relative transition-opacity",
+                    wsArchiving && "pointer-events-none opacity-40",
+                  )}
+                >
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Link
+                        to={`/workspaces/${ws.id}`}
+                        className={cn(
+                          "sidebar-card block rounded-md border py-1.5 pl-2 pr-2",
+                          activeWsId === ws.id && "sidebar-card-active",
+                        )}
+                      >
+                        <div className="flex items-center gap-1.5">
+                          <div className="flex h-3.5 w-3.5 shrink-0 items-center justify-center overflow-visible">
+                            {wsStreaming ? (
+                              <AgentActivityPreview size="small" />
+                            ) : wsUnread ? (
+                              <span className="h-1.5 w-1.5 rounded-full bg-primary" />
+                            ) : null}
+                          </div>
+                          <BranchLabel
+                            branch={displayBranch}
+                            showIcon={false}
+                            className={cn(
+                              "min-w-0 flex-1 text-sm",
+                              activeWsId === ws.id || wsUnread
+                                ? "text-sidebar-foreground"
+                                : "text-muted-foreground",
+                            )}
+                          />
+                          {wsScriptRunning && (
+                            <ActivityWave size="small" decorative className="shrink-0" />
+                          )}
+                        </div>
+
+                        <div className="mt-0.5 flex items-center gap-1 pl-5 text-[11px]">
+                          {prStatus?.pr ? (
+                            (() => {
+                              const display = computePrDisplayCompact(prStatus.pr);
+                              return (
+                                <span className={cn("truncate", display.textClass)}>
+                                  #{prStatus.pr.number} {display.label}
+                                </span>
+                              );
+                            })()
+                          ) : prLoading ? (
+                            <span className="text-muted-foreground">Loading…</span>
+                          ) : prStatus?.error ? (
+                            <span className="text-muted-foreground">Error fetching PR</span>
+                          ) : (
+                            <span className="text-muted-foreground">No PR</span>
+                          )}
+                        </div>
+                      </Link>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="text-xs">
+                      {ws.name}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  {wsArchiving ? (
+                    <div className="absolute right-1.5 top-1.5 p-0.5">
+                      <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+                    </div>
+                  ) : !wsScriptRunning && (
+                    <button
+                      type="button"
+                      className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
+                      onClick={(event) => {
+                        event.preventDefault();
+                        event.stopPropagation();
+                        onArchiveWorkspace(ws.id);
+                      }}
+                      aria-label={`Archive workspace ${ws.name}`}
+                      title="Archive workspace"
+                    >
+                      <ArchiveIcon className="h-3 w-3" />
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+      {showReorderZones && folderId !== null && (
+        <>
+          <div
+            data-project-reorder="before"
+            className="absolute inset-x-0 top-0 z-20 h-2.5"
+            onDragOver={(event) => onProjectReorderDragOver(event, project.id, "before")}
+            onDrop={(event) => onProjectReorderDrop(event, project.id, folderId, "before")}
+          />
+          <div
+            data-project-reorder="after"
+            className="absolute inset-x-0 bottom-0 z-20 h-2.5"
+            onDragOver={(event) => onProjectReorderDragOver(event, project.id, "after")}
+            onDrop={(event) => onProjectReorderDrop(event, project.id, folderId, "after")}
+          />
+        </>
+      )}
+      {projectInsertIndicator && (
+        <div
+          className={cn(
+            "pointer-events-none absolute inset-x-1 z-10 h-0.5 rounded-full bg-primary",
+            projectInsertIndicator === "before" ? "top-0" : "bottom-0",
+          )}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import type { Project } from "@/types";
+
+export interface SidebarProjectFolder {
+  id: string;
+  name: string;
+  projectIds: string[];
+}
+
+interface SidebarProjectFoldersState {
+  folders: SidebarProjectFolder[];
+  folderOpenState: Record<string, boolean>;
+}
+
+export interface SidebarProjectFolderView extends SidebarProjectFolder {
+  projects: Project[];
+}
+
+const STORAGE_KEY = "hive:sidebar-project-folders:v1";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function readStoredState(): SidebarProjectFoldersState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) {
+      return { folders: [], folderOpenState: {} };
+    }
+
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) {
+      return { folders: [], folderOpenState: {} };
+    }
+
+    const folders = Array.isArray(parsed.folders) ? parsed.folders : [];
+    const folderOpenState = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
+
+    return {
+      folders: folders.flatMap((folder): SidebarProjectFolder[] => {
+        if (!isRecord(folder)) return [];
+        if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
+
+        const projectIds = Array.isArray(folder.projectIds)
+          ? folder.projectIds.filter((projectId): projectId is string => typeof projectId === "string")
+          : [];
+
+        return [{
+          id: folder.id,
+          name: folder.name,
+          projectIds,
+        }];
+      }),
+      folderOpenState: Object.fromEntries(
+        Object.entries(folderOpenState).flatMap(([key, value]) =>
+          typeof value === "boolean" ? [[key, value] as const] : [],
+        ),
+      ),
+    };
+  } catch {
+    return { folders: [], folderOpenState: {} };
+  }
+}
+
+function sanitizeState(
+  state: SidebarProjectFoldersState,
+  projectIds: string[],
+): SidebarProjectFoldersState {
+  const knownProjectIds = new Set(projectIds);
+  const usedProjectIds = new Set<string>();
+  const seenFolderIds = new Set<string>();
+
+  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
+    const name = folder.name.trim();
+    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
+    seenFolderIds.add(folder.id);
+
+    const seenProjectIds = new Set<string>();
+    const projectIds = folder.projectIds.filter((projectId) => {
+      if (!knownProjectIds.has(projectId)) return false;
+      if (usedProjectIds.has(projectId)) return false;
+      if (seenProjectIds.has(projectId)) return false;
+      usedProjectIds.add(projectId);
+      seenProjectIds.add(projectId);
+      return true;
+    });
+
+    return [{
+      id: folder.id,
+      name,
+      projectIds,
+    }];
+  });
+
+  const folderOpenState = Object.fromEntries(
+    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
+      seenFolderIds.has(folderId) && typeof value === "boolean",
+    ),
+  );
+
+  return { folders, folderOpenState };
+}
+
+function moveProject(
+  state: SidebarProjectFoldersState,
+  projectId: string,
+  targetFolderId: string | null,
+): SidebarProjectFoldersState {
+  const currentFolderId = state.folders.find((folder) => folder.projectIds.includes(projectId))?.id ?? null;
+
+  if (currentFolderId === targetFolderId) return state;
+  if (targetFolderId && !state.folders.some((folder) => folder.id === targetFolderId)) return state;
+
+  const folders = state.folders.map((folder) => ({
+    ...folder,
+    projectIds: folder.projectIds.filter((id) => id !== projectId),
+  }));
+
+  if (!targetFolderId) {
+    return { ...state, folders };
+  }
+
+  return {
+    folders: folders.map((folder) =>
+      folder.id !== targetFolderId
+        ? folder
+        : { ...folder, projectIds: [...folder.projectIds, projectId] },
+    ),
+    folderOpenState: {
+      ...state.folderOpenState,
+      [targetFolderId]: true,
+    },
+  };
+}
+
+function createId(): string {
+  return self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+}
+
+function areStatesEqual(
+  left: SidebarProjectFoldersState,
+  right: SidebarProjectFoldersState,
+): boolean {
+  if (left.folders.length !== right.folders.length) return false;
+
+  for (let i = 0; i < left.folders.length; i += 1) {
+    const leftFolder = left.folders[i];
+    const rightFolder = right.folders[i];
+
+    if (leftFolder.id !== rightFolder.id || leftFolder.name !== rightFolder.name) return false;
+    if (leftFolder.projectIds.length !== rightFolder.projectIds.length) return false;
+    for (let j = 0; j < leftFolder.projectIds.length; j += 1) {
+      if (leftFolder.projectIds[j] !== rightFolder.projectIds[j]) return false;
+    }
+  }
+
+  const leftEntries = Object.entries(left.folderOpenState);
+  const rightEntries = Object.entries(right.folderOpenState);
+  if (leftEntries.length !== rightEntries.length) return false;
+
+  for (const [folderId, expanded] of leftEntries) {
+    if (right.folderOpenState[folderId] !== expanded) return false;
+  }
+
+  return true;
+}
+
+export function useSidebarProjectFolders(projects: Project[]) {
+  const projectIds = useMemo(
+    () => projects.map((project) => project.id),
+    [projects],
+  );
+
+  const [state, setState] = useState<SidebarProjectFoldersState>(() =>
+    sanitizeState(readStoredState(), projectIds),
+  );
+
+  const projectIdsKey = useMemo(
+    () => [...projectIds].sort().join(","),
+    [projectIds],
+  );
+
+  useEffect(() => {
+    setState((prev) => {
+      const next = sanitizeState(prev, projectIds);
+      return areStatesEqual(prev, next) ? prev : next;
+    });
+  }, [projectIds, projectIdsKey]);
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state]);
+
+  const projectMap = useMemo(
+    () => new Map(projects.map((project) => [project.id, project])),
+    [projects],
+  );
+
+  const folders = useMemo<SidebarProjectFolderView[]>(
+    () =>
+      state.folders.map((folder) => ({
+        ...folder,
+        projects: folder.projectIds
+          .map((projectId) => projectMap.get(projectId))
+          .filter((project): project is Project => project !== undefined),
+      })),
+    [projectMap, state.folders],
+  );
+
+  const projectFolderMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const folder of state.folders) {
+      for (const projectId of folder.projectIds) {
+        map.set(projectId, folder.id);
+      }
+    }
+    return map;
+  }, [state.folders]);
+
+  const rootProjects = useMemo(
+    () => projects.filter((project) => !projectFolderMap.has(project.id)),
+    [projectFolderMap, projects],
+  );
+
+  const createFolder = useCallback((name: string) => {
+    const trimmedName = name.trim();
+    if (!trimmedName) return null;
+
+    const folderId = createId();
+    setState((prev) => ({
+      folders: [
+        ...prev.folders,
+        { id: folderId, name: trimmedName, projectIds: [] },
+      ],
+      folderOpenState: {
+        ...prev.folderOpenState,
+        [folderId]: true,
+      },
+    }));
+
+    return folderId;
+  }, []);
+
+  const moveProjectToFolder = useCallback((projectId: string, targetFolderId: string | null) => {
+    setState((prev) => moveProject(prev, projectId, targetFolderId));
+  }, []);
+
+  const setFolderExpanded = useCallback((folderId: string, expanded: boolean) => {
+    setState((prev) => {
+      if (!prev.folders.some((folder) => folder.id === folderId)) return prev;
+      if ((prev.folderOpenState[folderId] ?? true) === expanded) return prev;
+      return {
+        ...prev,
+        folderOpenState: {
+          ...prev.folderOpenState,
+          [folderId]: expanded,
+        },
+      };
+    });
+  }, []);
+
+  const isFolderExpanded = useCallback(
+    (folderId: string) => state.folderOpenState[folderId] ?? true,
+    [state.folderOpenState],
+  );
+
+  const getFolderIdForProject = useCallback(
+    (projectId: string) => projectFolderMap.get(projectId) ?? null,
+    [projectFolderMap],
+  );
+
+  return {
+    folders,
+    rootProjects,
+    createFolder,
+    moveProjectToFolder,
+    isFolderExpanded,
+    setFolderExpanded,
+    getFolderIdForProject,
+  };
+}

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -43,6 +43,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
 
   const initialLocalSeedRef = useRef(readSidebarPreferencesLocalSeed());
   const bootstrappedRef = useRef(false);
+  const [hasInitialHydration, setHasInitialHydration] = useState(false);
   const [state, setState] = useState<SidebarProjectFoldersState>(
     EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
   );
@@ -53,9 +54,15 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   );
 
   // Remote fetch (single source of truth after first hydration).
-  const { data: preferencesData, refetch: refetchPreferences } = useQuery({
+  const {
+    data: preferencesData,
+    error: preferencesError,
+    isFetched: preferencesFetched,
+    refetch: refetchPreferences,
+  } = useQuery({
     queryKey: ["ui-preferences"],
     queryFn: () => api.get<UiPreferencesPayload>("/api/ui-preferences"),
+    retry: false,
     staleTime: 60_000,
   });
 
@@ -93,6 +100,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
         const sanitized = sanitizeSidebarPreferencesState(legacy, projectIds);
         if (!isEmptySidebarPreferencesState(sanitized)) {
           hydratedRef.current = true;
+          setHasInitialHydration(true);
           lastFlushedRef.current = serverState;
           bootstrappedRef.current = true;
           pendingLegacyRemovalRef.current = true;
@@ -103,12 +111,23 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     }
 
     hydratedRef.current = true;
+    setHasInitialHydration(true);
     lastFlushedRef.current = serverState;
     bootstrappedRef.current = true;
     setState((prev) => {
       return areSidebarPreferencesStatesEqual(prev, serverState) ? prev : serverState;
     });
   }, [preferencesData, projectIds, projectIdsKey, projectsReady]);
+
+  useEffect(() => {
+    if (!projectsReady) return;
+    if (hydratedRef.current) return;
+    if (!preferencesFetched || !preferencesError) return;
+
+    hydratedRef.current = true;
+    setHasInitialHydration(true);
+    bootstrappedRef.current = true;
+  }, [preferencesError, preferencesFetched, projectsReady]);
 
   // Re-sanitize when the list of projects changes (e.g. project deleted).
   useEffect(() => {
@@ -218,6 +237,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   );
 
   const createFolder = useCallback((name: string) => {
+    if (!hydratedRef.current) return null;
     const trimmedName = name.trim();
     if (!trimmedName) return null;
 
@@ -237,6 +257,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   }, []);
 
   const renameFolder = useCallback((folderId: string, nextName: string) => {
+    if (!hydratedRef.current) return false;
     const trimmed = nextName.trim();
     if (!trimmed) return false;
     setState((prev) => {
@@ -253,6 +274,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   }, []);
 
   const deleteFolder = useCallback((folderId: string) => {
+    if (!hydratedRef.current) return false;
     let deleted = false;
     setState((prev) => {
       const target = prev.folders.find((folder) => folder.id === folderId);
@@ -268,6 +290,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   }, []);
 
   const moveProjectToFolder = useCallback((projectId: string, targetFolderId: string | null) => {
+    if (!hydratedRef.current) return;
     setState((prev) => moveProjectBetweenSidebarFolders(prev, projectId, targetFolderId));
   }, []);
 
@@ -277,6 +300,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     anchorProjectId: string,
     position: ProjectInsertPosition,
   ) => {
+    if (!hydratedRef.current) return;
     setState((prev) =>
       moveProjectWithinSidebarFolders(prev, projectId, targetFolderId, anchorProjectId, position)
     );
@@ -287,10 +311,12 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     targetFolderId: string,
     position: FolderInsertPosition,
   ) => {
+    if (!hydratedRef.current) return;
     setState((prev) => moveSidebarFolder(prev, folderId, targetFolderId, position));
   }, []);
 
   const setFolderExpanded = useCallback((folderId: string, expanded: boolean) => {
+    if (!hydratedRef.current) return;
     setState((prev) => {
       if (!prev.folders.some((folder) => folder.id === folderId)) return prev;
       if ((prev.folderOpenState[folderId] ?? true) === expanded) return prev;
@@ -317,6 +343,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
   return {
     folders,
     rootProjects,
+    hasInitialHydration,
     createFolder,
     renameFolder,
     deleteFolder,

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -2,264 +2,48 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import type { Project } from "@/types";
-
-export interface SidebarProjectFolder {
-  id: string;
-  name: string;
-  projectIds: string[];
-}
-
-interface SidebarProjectFoldersState {
-  folders: SidebarProjectFolder[];
-  folderOpenState: Record<string, boolean>;
-}
-
-interface UiPreferencesPayload {
-  sidebar: SidebarProjectFoldersState;
-}
-
-type FolderInsertPosition = "before" | "after";
-type ProjectInsertPosition = "before" | "after";
+import {
+  EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+  areSidebarPreferencesStatesEqual,
+  createSidebarFolderProjectMap,
+  mapSidebarFolderProjects,
+  moveProjectBetweenSidebarFolders,
+  moveProjectWithinSidebarFolders,
+  moveSidebarFolder,
+  payloadToSidebarPreferencesState,
+  readLegacySidebarPreferences,
+  readSidebarPreferencesLocalSeed,
+  removeLegacySidebarPreferences,
+  sanitizeSidebarPreferencesState,
+  writeSidebarPreferencesLocalCache,
+  isEmptySidebarPreferencesState,
+  type FolderInsertPosition,
+  type ProjectInsertPosition,
+  type SidebarProjectFolder,
+  type SidebarProjectFoldersState,
+  type UiPreferencesPayload,
+} from "@/lib/sidebar-preferences";
 
 export interface SidebarProjectFolderView extends SidebarProjectFolder {
   projects: Project[];
 }
 
-const LEGACY_STORAGE_KEY = "hive:sidebar-project-folders:v1";
-const CACHE_STORAGE_KEY = "hive:sidebar-project-folders:cache:v1";
 const FLUSH_DEBOUNCE_MS = 300;
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseStoredState(raw: string | null): SidebarProjectFoldersState | null {
-  if (!raw) return null;
-  try {
-    const parsed = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
-
-    const foldersRaw = Array.isArray(parsed.folders) ? parsed.folders : [];
-    const folders = foldersRaw.flatMap((folder): SidebarProjectFolder[] => {
-      if (!isRecord(folder)) return [];
-      if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
-      const projectIds = Array.isArray(folder.projectIds)
-        ? folder.projectIds.filter((id): id is string => typeof id === "string")
-        : [];
-      return [{ id: folder.id, name: folder.name, projectIds }];
-    });
-
-    const openStateRaw = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
-    const folderOpenState = Object.fromEntries(
-      Object.entries(openStateRaw).flatMap(([key, value]) =>
-        typeof value === "boolean" ? [[key, value] as const] : [],
-      ),
-    );
-
-    return { folders, folderOpenState };
-  } catch {
-    return null;
-  }
-}
-
-function readLocalCache(): SidebarProjectFoldersState {
-  if (typeof localStorage === "undefined") return { folders: [], folderOpenState: {} };
-  return (
-    parseStoredState(localStorage.getItem(CACHE_STORAGE_KEY)) ??
-    parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY)) ??
-    { folders: [], folderOpenState: {} }
-  );
-}
-
-function readLegacyStorage(): SidebarProjectFoldersState | null {
-  if (typeof localStorage === "undefined") return null;
-  return parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
-}
-
-function writeLocalCache(state: SidebarProjectFoldersState): void {
-  if (typeof localStorage === "undefined") return;
-  try {
-    localStorage.setItem(CACHE_STORAGE_KEY, JSON.stringify(state));
-  } catch {
-    // Storage may be full or disabled; ignore.
-  }
-}
-
-function isEmptyState(state: SidebarProjectFoldersState): boolean {
-  return state.folders.length === 0 && Object.keys(state.folderOpenState).length === 0;
-}
-
-function sanitizeState(
-  state: SidebarProjectFoldersState,
-  projectIds: string[],
-): SidebarProjectFoldersState {
-  const knownProjectIds = new Set(projectIds);
-  const usedProjectIds = new Set<string>();
-  const seenFolderIds = new Set<string>();
-
-  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
-    const name = folder.name.trim();
-    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
-    seenFolderIds.add(folder.id);
-
-    const seenProjectIds = new Set<string>();
-    const projectIds = folder.projectIds.filter((projectId) => {
-      if (!knownProjectIds.has(projectId)) return false;
-      if (usedProjectIds.has(projectId)) return false;
-      if (seenProjectIds.has(projectId)) return false;
-      usedProjectIds.add(projectId);
-      seenProjectIds.add(projectId);
-      return true;
-    });
-
-    return [{
-      id: folder.id,
-      name,
-      projectIds,
-    }];
-  });
-
-  const folderOpenState = Object.fromEntries(
-    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
-      seenFolderIds.has(folderId) && typeof value === "boolean",
-    ),
-  );
-
-  return { folders, folderOpenState };
-}
-
-function moveProject(
-  state: SidebarProjectFoldersState,
-  projectId: string,
-  targetFolderId: string | null,
-): SidebarProjectFoldersState {
-  const currentFolderId = state.folders.find((folder) => folder.projectIds.includes(projectId))?.id ?? null;
-
-  if (currentFolderId === targetFolderId) return state;
-  if (targetFolderId && !state.folders.some((folder) => folder.id === targetFolderId)) return state;
-
-  const folders = state.folders.map((folder) => ({
-    ...folder,
-    projectIds: folder.projectIds.filter((id) => id !== projectId),
-  }));
-
-  if (!targetFolderId) {
-    return { ...state, folders };
-  }
-
-  return {
-    folders: folders.map((folder) =>
-      folder.id !== targetFolderId
-        ? folder
-        : { ...folder, projectIds: [...folder.projectIds, projectId] },
-    ),
-    folderOpenState: {
-      ...state.folderOpenState,
-      [targetFolderId]: true,
-    },
-  };
-}
-
-function moveProjectToPositionImpl(
-  state: SidebarProjectFoldersState,
-  projectId: string,
-  targetFolderId: string,
-  anchorProjectId: string,
-  position: ProjectInsertPosition,
-): SidebarProjectFoldersState {
-  if (projectId === anchorProjectId) return state;
-
-  const targetFolder = state.folders.find((folder) => folder.id === targetFolderId);
-  if (!targetFolder) return state;
-  if (!targetFolder.projectIds.includes(anchorProjectId)) return state;
-
-  const folders = state.folders.map((folder) => ({
-    ...folder,
-    projectIds: folder.projectIds.filter((id) => id !== projectId),
-  }));
-
-  const nextFolders = folders.map((folder) => {
-    if (folder.id !== targetFolderId) return folder;
-    const anchorIndex = folder.projectIds.findIndex((id) => id === anchorProjectId);
-    if (anchorIndex === -1) return folder;
-    const insertIndex = position === "before" ? anchorIndex : anchorIndex + 1;
-    const projectIds = [...folder.projectIds];
-    projectIds.splice(insertIndex, 0, projectId);
-    return { ...folder, projectIds };
-  });
-
-  return {
-    folders: nextFolders,
-    folderOpenState: {
-      ...state.folderOpenState,
-      [targetFolderId]: true,
-    },
-  };
-}
-
-function moveFolder(
-  state: SidebarProjectFoldersState,
-  folderId: string,
-  targetFolderId: string,
-  position: FolderInsertPosition,
-): SidebarProjectFoldersState {
-  if (folderId === targetFolderId) return state;
-
-  const sourceIndex = state.folders.findIndex((folder) => folder.id === folderId);
-  const targetIndex = state.folders.findIndex((folder) => folder.id === targetFolderId);
-  if (sourceIndex === -1 || targetIndex === -1) return state;
-
-  const folders = [...state.folders];
-  const [movedFolder] = folders.splice(sourceIndex, 1);
-  const currentTargetIndex = folders.findIndex((folder) => folder.id === targetFolderId);
-  if (currentTargetIndex === -1) return state;
-
-  const insertionIndex = position === "before" ? currentTargetIndex : currentTargetIndex + 1;
-  folders.splice(insertionIndex, 0, movedFolder);
-
-  return { ...state, folders };
-}
 
 function createId(): string {
   return self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
 }
 
-function areStatesEqual(
-  left: SidebarProjectFoldersState,
-  right: SidebarProjectFoldersState,
-): boolean {
-  if (left.folders.length !== right.folders.length) return false;
-
-  for (let i = 0; i < left.folders.length; i += 1) {
-    const leftFolder = left.folders[i];
-    const rightFolder = right.folders[i];
-
-    if (leftFolder.id !== rightFolder.id || leftFolder.name !== rightFolder.name) return false;
-    if (leftFolder.projectIds.length !== rightFolder.projectIds.length) return false;
-    for (let j = 0; j < leftFolder.projectIds.length; j += 1) {
-      if (leftFolder.projectIds[j] !== rightFolder.projectIds[j]) return false;
-    }
-  }
-
-  const leftEntries = Object.entries(left.folderOpenState);
-  const rightEntries = Object.entries(right.folderOpenState);
-  if (leftEntries.length !== rightEntries.length) return false;
-
-  for (const [folderId, expanded] of leftEntries) {
-    if (right.folderOpenState[folderId] !== expanded) return false;
-  }
-
-  return true;
-}
-
-export function useSidebarProjectFolders(projects: Project[]) {
+export function useSidebarProjectFolders(projects: Project[], projectsReady = true) {
   const projectIds = useMemo(
     () => projects.map((project) => project.id),
     [projects],
   );
 
-  const [state, setState] = useState<SidebarProjectFoldersState>(() =>
-    sanitizeState(readLocalCache(), projectIds),
+  const initialLocalSeedRef = useRef(readSidebarPreferencesLocalSeed());
+  const bootstrappedRef = useRef(false);
+  const [state, setState] = useState<SidebarProjectFoldersState>(
+    EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
   );
 
   const projectIdsKey = useMemo(
@@ -268,7 +52,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
   );
 
   // Remote fetch (single source of truth after first hydration).
-  const query = useQuery({
+  const { data: preferencesData, refetch: refetchPreferences } = useQuery({
     queryKey: ["ui-preferences"],
     queryFn: () => api.get<UiPreferencesPayload>("/api/ui-preferences"),
     staleTime: 60_000,
@@ -280,71 +64,126 @@ export function useSidebarProjectFolders(projects: Project[]) {
   const hydratedRef = useRef(false);
   const lastFlushedRef = useRef<SidebarProjectFoldersState | null>(null);
   const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const latestStartedSaveRef = useRef(0);
+  const latestSuccessfulSaveRef = useRef(0);
+  const pendingLegacyRemovalRef = useRef(false);
+
+  useEffect(() => {
+    if (!projectsReady) return;
+    if (bootstrappedRef.current || hydratedRef.current) return;
+
+    bootstrappedRef.current = true;
+    const next = sanitizeSidebarPreferencesState(initialLocalSeedRef.current.state, projectIds);
+    setState((prev) => (areSidebarPreferencesStatesEqual(prev, next) ? prev : next));
+  }, [projectIds, projectIdsKey, projectsReady]);
 
   // Hydrate from server when data arrives.
   useEffect(() => {
-    if (!query.data) return;
-    const serverState: SidebarProjectFoldersState = {
-      folders: query.data.sidebar.folders,
-      folderOpenState: query.data.sidebar.folderOpenState,
-    };
+    if (!projectsReady || !preferencesData) return;
+    const serverState = sanitizeSidebarPreferencesState(
+      payloadToSidebarPreferencesState(preferencesData),
+      projectIds,
+    );
 
     // One-shot migration: empty server + legacy localStorage -> push legacy up.
-    if (!hydratedRef.current && isEmptyState(serverState)) {
-      const legacy = readLegacyStorage();
-      if (legacy && !isEmptyState(legacy)) {
-        const sanitized = sanitizeState(legacy, projectIds);
-        hydratedRef.current = true;
-        lastFlushedRef.current = serverState;
-        setState(sanitized);
-        try {
-          localStorage.removeItem(LEGACY_STORAGE_KEY);
-        } catch {
-          // ignore
+    if (!hydratedRef.current && isEmptySidebarPreferencesState(serverState)) {
+      const legacy = readLegacySidebarPreferences();
+      if (legacy && !isEmptySidebarPreferencesState(legacy)) {
+        const sanitized = sanitizeSidebarPreferencesState(legacy, projectIds);
+        if (!isEmptySidebarPreferencesState(sanitized)) {
+          hydratedRef.current = true;
+          lastFlushedRef.current = serverState;
+          bootstrappedRef.current = true;
+          pendingLegacyRemovalRef.current = true;
+          setState(sanitized);
+          return;
         }
-        return;
       }
     }
 
     hydratedRef.current = true;
     lastFlushedRef.current = serverState;
+    bootstrappedRef.current = true;
     setState((prev) => {
-      const next = sanitizeState(serverState, projectIds);
-      return areStatesEqual(prev, next) ? prev : next;
+      return areSidebarPreferencesStatesEqual(prev, serverState) ? prev : serverState;
     });
-  }, [query.data, projectIds, projectIdsKey]);
+  }, [preferencesData, projectIds, projectIdsKey, projectsReady]);
 
   // Re-sanitize when the list of projects changes (e.g. project deleted).
   useEffect(() => {
+    if (!projectsReady || !bootstrappedRef.current) return;
     setState((prev) => {
-      const next = sanitizeState(prev, projectIds);
-      return areStatesEqual(prev, next) ? prev : next;
+      const next = sanitizeSidebarPreferencesState(prev, projectIds);
+      return areSidebarPreferencesStatesEqual(prev, next) ? prev : next;
     });
-  }, [projectIds, projectIdsKey]);
+  }, [projectIds, projectIdsKey, projectsReady]);
 
   // Persist local cache immediately + schedule a debounced PUT to the backend.
   useEffect(() => {
-    writeLocalCache(state);
+    const canWriteLocalCache =
+      bootstrappedRef.current
+      && (hydratedRef.current || initialLocalSeedRef.current.source !== "legacy");
+
+    if (canWriteLocalCache) {
+      writeSidebarPreferencesLocalCache(state);
+    }
 
     if (!hydratedRef.current) return;
-    if (lastFlushedRef.current && areStatesEqual(lastFlushedRef.current, state)) return;
+    if (
+      lastFlushedRef.current
+      && areSidebarPreferencesStatesEqual(lastFlushedRef.current, state)
+    ) {
+      return;
+    }
 
     if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
     flushTimerRef.current = setTimeout(() => {
       const snapshot = state;
+      const requestId = latestStartedSaveRef.current + 1;
+      latestStartedSaveRef.current = requestId;
+
       api
         .put<UiPreferencesPayload>("/api/ui-preferences", { sidebar: snapshot })
         .then((payload) => {
-          const applied: SidebarProjectFoldersState = {
-            folders: payload.sidebar.folders,
-            folderOpenState: payload.sidebar.folderOpenState,
-          };
-          lastFlushedRef.current = applied;
+          const applied = sanitizeSidebarPreferencesState(
+            payloadToSidebarPreferencesState(payload),
+            projectIds,
+          );
+          if (requestId > latestSuccessfulSaveRef.current) {
+            latestSuccessfulSaveRef.current = requestId;
+            lastFlushedRef.current = applied;
+          }
+
+          if (pendingLegacyRemovalRef.current) {
+            removeLegacySidebarPreferences();
+            pendingLegacyRemovalRef.current = false;
+          }
         })
-        .catch(() => {
-          // Revert to last-known server state on failure.
+        .catch(async () => {
+          if (requestId !== latestStartedSaveRef.current) return;
+
+          try {
+            const result = await refetchPreferences();
+            if (result.data) {
+              const canonical = sanitizeSidebarPreferencesState(
+                payloadToSidebarPreferencesState(result.data),
+                projectIds,
+              );
+              lastFlushedRef.current = canonical;
+              setState((prev) => (
+                areSidebarPreferencesStatesEqual(prev, canonical) ? prev : canonical
+              ));
+              return;
+            }
+          } catch {
+            // Fall back to the last known server state below.
+          }
+
           if (lastFlushedRef.current) {
-            setState(lastFlushedRef.current);
+            const fallback = lastFlushedRef.current;
+            setState((prev) => (
+              areSidebarPreferencesStatesEqual(prev, fallback) ? prev : fallback
+            ));
           }
         });
     }, FLUSH_DEBOUNCE_MS);
@@ -355,33 +194,17 @@ export function useSidebarProjectFolders(projects: Project[]) {
         flushTimerRef.current = null;
       }
     };
-  }, [state]);
-
-  const projectMap = useMemo(
-    () => new Map(projects.map((project) => [project.id, project])),
-    [projects],
-  );
+  }, [projectIds, projectIdsKey, refetchPreferences, state]);
 
   const folders = useMemo<SidebarProjectFolderView[]>(
-    () =>
-      state.folders.map((folder) => ({
-        ...folder,
-        projects: folder.projectIds
-          .map((projectId) => projectMap.get(projectId))
-          .filter((project): project is Project => project !== undefined),
-      })),
-    [projectMap, state.folders],
+    () => mapSidebarFolderProjects(state.folders, projects),
+    [projects, state.folders],
   );
 
-  const projectFolderMap = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const folder of state.folders) {
-      for (const projectId of folder.projectIds) {
-        map.set(projectId, folder.id);
-      }
-    }
-    return map;
-  }, [state.folders]);
+  const projectFolderMap = useMemo(
+    () => createSidebarFolderProjectMap(state.folders),
+    [state.folders],
+  );
 
   const rootProjects = useMemo(
     () => projects.filter((project) => !projectFolderMap.has(project.id)),
@@ -439,7 +262,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
   }, []);
 
   const moveProjectToFolder = useCallback((projectId: string, targetFolderId: string | null) => {
-    setState((prev) => moveProject(prev, projectId, targetFolderId));
+    setState((prev) => moveProjectBetweenSidebarFolders(prev, projectId, targetFolderId));
   }, []);
 
   const moveProjectToPosition = useCallback((
@@ -448,7 +271,9 @@ export function useSidebarProjectFolders(projects: Project[]) {
     anchorProjectId: string,
     position: ProjectInsertPosition,
   ) => {
-    setState((prev) => moveProjectToPositionImpl(prev, projectId, targetFolderId, anchorProjectId, position));
+    setState((prev) =>
+      moveProjectWithinSidebarFolders(prev, projectId, targetFolderId, anchorProjectId, position)
+    );
   }, []);
 
   const moveFolderById = useCallback((
@@ -456,7 +281,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
     targetFolderId: string,
     position: FolderInsertPosition,
   ) => {
-    setState((prev) => moveFolder(prev, folderId, targetFolderId, position));
+    setState((prev) => moveSidebarFolder(prev, folderId, targetFolderId, position));
   }, []);
 
   const setFolderExpanded = useCallback((folderId: string, expanded: boolean) => {

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import type { Project } from "@/types";
 import {
@@ -35,6 +35,7 @@ function createId(): string {
 }
 
 export function useSidebarProjectFolders(projects: Project[], projectsReady = true) {
+  const queryClient = useQueryClient();
   const projectIds = useMemo(
     () => projects.map((project) => project.id),
     [projects],
@@ -149,6 +150,11 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
             payloadToSidebarPreferencesState(payload),
             projectIds,
           );
+          queryClient.setQueryData<UiPreferencesPayload>(
+            ["ui-preferences"],
+            { sidebar: applied },
+          );
+
           if (requestId > latestSuccessfulSaveRef.current) {
             latestSuccessfulSaveRef.current = requestId;
             lastFlushedRef.current = applied;
@@ -194,7 +200,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
         flushTimerRef.current = null;
       }
     };
-  }, [projectIds, projectIdsKey, refetchPreferences, state]);
+  }, [projectIds, projectIdsKey, queryClient, refetchPreferences, state]);
 
   const folders = useMemo<SidebarProjectFolderView[]>(
     () => mapSidebarFolderProjects(state.folders, projects),

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -19,6 +19,7 @@ interface UiPreferencesPayload {
 }
 
 type FolderInsertPosition = "before" | "after";
+type ProjectInsertPosition = "before" | "after";
 
 export interface SidebarProjectFolderView extends SidebarProjectFolder {
   projects: Project[];
@@ -152,6 +153,43 @@ function moveProject(
         ? folder
         : { ...folder, projectIds: [...folder.projectIds, projectId] },
     ),
+    folderOpenState: {
+      ...state.folderOpenState,
+      [targetFolderId]: true,
+    },
+  };
+}
+
+function moveProjectToPositionImpl(
+  state: SidebarProjectFoldersState,
+  projectId: string,
+  targetFolderId: string,
+  anchorProjectId: string,
+  position: ProjectInsertPosition,
+): SidebarProjectFoldersState {
+  if (projectId === anchorProjectId) return state;
+
+  const targetFolder = state.folders.find((folder) => folder.id === targetFolderId);
+  if (!targetFolder) return state;
+  if (!targetFolder.projectIds.includes(anchorProjectId)) return state;
+
+  const folders = state.folders.map((folder) => ({
+    ...folder,
+    projectIds: folder.projectIds.filter((id) => id !== projectId),
+  }));
+
+  const nextFolders = folders.map((folder) => {
+    if (folder.id !== targetFolderId) return folder;
+    const anchorIndex = folder.projectIds.findIndex((id) => id === anchorProjectId);
+    if (anchorIndex === -1) return folder;
+    const insertIndex = position === "before" ? anchorIndex : anchorIndex + 1;
+    const projectIds = [...folder.projectIds];
+    projectIds.splice(insertIndex, 0, projectId);
+    return { ...folder, projectIds };
+  });
+
+  return {
+    folders: nextFolders,
     folderOpenState: {
       ...state.folderOpenState,
       [targetFolderId]: true,
@@ -373,6 +411,15 @@ export function useSidebarProjectFolders(projects: Project[]) {
     setState((prev) => moveProject(prev, projectId, targetFolderId));
   }, []);
 
+  const moveProjectToPosition = useCallback((
+    projectId: string,
+    targetFolderId: string,
+    anchorProjectId: string,
+    position: ProjectInsertPosition,
+  ) => {
+    setState((prev) => moveProjectToPositionImpl(prev, projectId, targetFolderId, anchorProjectId, position));
+  }, []);
+
   const moveFolderById = useCallback((
     folderId: string,
     targetFolderId: string,
@@ -410,6 +457,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
     rootProjects,
     createFolder,
     moveProjectToFolder,
+    moveProjectToPosition,
     moveFolderById,
     isFolderExpanded,
     setFolderExpanded,

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -407,6 +407,37 @@ export function useSidebarProjectFolders(projects: Project[]) {
     return folderId;
   }, []);
 
+  const renameFolder = useCallback((folderId: string, nextName: string) => {
+    const trimmed = nextName.trim();
+    if (!trimmed) return false;
+    setState((prev) => {
+      const target = prev.folders.find((folder) => folder.id === folderId);
+      if (!target || target.name === trimmed) return prev;
+      return {
+        ...prev,
+        folders: prev.folders.map((folder) =>
+          folder.id === folderId ? { ...folder, name: trimmed } : folder,
+        ),
+      };
+    });
+    return true;
+  }, []);
+
+  const deleteFolder = useCallback((folderId: string) => {
+    let deleted = false;
+    setState((prev) => {
+      const target = prev.folders.find((folder) => folder.id === folderId);
+      if (!target || target.projectIds.length > 0) return prev;
+      deleted = true;
+      const { [folderId]: _removed, ...folderOpenState } = prev.folderOpenState;
+      return {
+        folders: prev.folders.filter((folder) => folder.id !== folderId),
+        folderOpenState,
+      };
+    });
+    return deleted;
+  }, []);
+
   const moveProjectToFolder = useCallback((projectId: string, targetFolderId: string | null) => {
     setState((prev) => moveProject(prev, projectId, targetFolderId));
   }, []);
@@ -456,6 +487,8 @@ export function useSidebarProjectFolders(projects: Project[]) {
     folders,
     rootProjects,
     createFolder,
+    renameFolder,
+    deleteFolder,
     moveProjectToFolder,
     moveProjectToPosition,
     moveFolderById,

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -1,4 +1,6 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/hooks/useApi";
 import type { Project } from "@/types";
 
 export interface SidebarProjectFolder {
@@ -12,55 +14,78 @@ interface SidebarProjectFoldersState {
   folderOpenState: Record<string, boolean>;
 }
 
+interface UiPreferencesPayload {
+  sidebar: SidebarProjectFoldersState;
+}
+
+type FolderInsertPosition = "before" | "after";
+
 export interface SidebarProjectFolderView extends SidebarProjectFolder {
   projects: Project[];
 }
 
-const STORAGE_KEY = "hive:sidebar-project-folders:v1";
+const LEGACY_STORAGE_KEY = "hive:sidebar-project-folders:v1";
+const CACHE_STORAGE_KEY = "hive:sidebar-project-folders:cache:v1";
+const FLUSH_DEBOUNCE_MS = 300;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function readStoredState(): SidebarProjectFoldersState {
+function parseStoredState(raw: string | null): SidebarProjectFoldersState | null {
+  if (!raw) return null;
   try {
-    const raw = localStorage.getItem(STORAGE_KEY);
-    if (!raw) {
-      return { folders: [], folderOpenState: {} };
-    }
-
     const parsed = JSON.parse(raw);
-    if (!isRecord(parsed)) {
-      return { folders: [], folderOpenState: {} };
-    }
+    if (!isRecord(parsed)) return null;
 
-    const folders = Array.isArray(parsed.folders) ? parsed.folders : [];
-    const folderOpenState = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
+    const foldersRaw = Array.isArray(parsed.folders) ? parsed.folders : [];
+    const folders = foldersRaw.flatMap((folder): SidebarProjectFolder[] => {
+      if (!isRecord(folder)) return [];
+      if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
+      const projectIds = Array.isArray(folder.projectIds)
+        ? folder.projectIds.filter((id): id is string => typeof id === "string")
+        : [];
+      return [{ id: folder.id, name: folder.name, projectIds }];
+    });
 
-    return {
-      folders: folders.flatMap((folder): SidebarProjectFolder[] => {
-        if (!isRecord(folder)) return [];
-        if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
-
-        const projectIds = Array.isArray(folder.projectIds)
-          ? folder.projectIds.filter((projectId): projectId is string => typeof projectId === "string")
-          : [];
-
-        return [{
-          id: folder.id,
-          name: folder.name,
-          projectIds,
-        }];
-      }),
-      folderOpenState: Object.fromEntries(
-        Object.entries(folderOpenState).flatMap(([key, value]) =>
-          typeof value === "boolean" ? [[key, value] as const] : [],
-        ),
+    const openStateRaw = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
+    const folderOpenState = Object.fromEntries(
+      Object.entries(openStateRaw).flatMap(([key, value]) =>
+        typeof value === "boolean" ? [[key, value] as const] : [],
       ),
-    };
+    );
+
+    return { folders, folderOpenState };
   } catch {
-    return { folders: [], folderOpenState: {} };
+    return null;
   }
+}
+
+function readLocalCache(): SidebarProjectFoldersState {
+  if (typeof localStorage === "undefined") return { folders: [], folderOpenState: {} };
+  return (
+    parseStoredState(localStorage.getItem(CACHE_STORAGE_KEY)) ??
+    parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY)) ??
+    { folders: [], folderOpenState: {} }
+  );
+}
+
+function readLegacyStorage(): SidebarProjectFoldersState | null {
+  if (typeof localStorage === "undefined") return null;
+  return parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
+}
+
+function writeLocalCache(state: SidebarProjectFoldersState): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(CACHE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage may be full or disabled; ignore.
+  }
+}
+
+function isEmptyState(state: SidebarProjectFoldersState): boolean {
+  return state.folders.length === 0 && Object.keys(state.folderOpenState).length === 0;
 }
 
 function sanitizeState(
@@ -134,6 +159,29 @@ function moveProject(
   };
 }
 
+function moveFolder(
+  state: SidebarProjectFoldersState,
+  folderId: string,
+  targetFolderId: string,
+  position: FolderInsertPosition,
+): SidebarProjectFoldersState {
+  if (folderId === targetFolderId) return state;
+
+  const sourceIndex = state.folders.findIndex((folder) => folder.id === folderId);
+  const targetIndex = state.folders.findIndex((folder) => folder.id === targetFolderId);
+  if (sourceIndex === -1 || targetIndex === -1) return state;
+
+  const folders = [...state.folders];
+  const [movedFolder] = folders.splice(sourceIndex, 1);
+  const currentTargetIndex = folders.findIndex((folder) => folder.id === targetFolderId);
+  if (currentTargetIndex === -1) return state;
+
+  const insertionIndex = position === "before" ? currentTargetIndex : currentTargetIndex + 1;
+  folders.splice(insertionIndex, 0, movedFolder);
+
+  return { ...state, folders };
+}
+
 function createId(): string {
   return self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
 }
@@ -173,7 +221,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
   );
 
   const [state, setState] = useState<SidebarProjectFoldersState>(() =>
-    sanitizeState(readStoredState(), projectIds),
+    sanitizeState(readLocalCache(), projectIds),
   );
 
   const projectIdsKey = useMemo(
@@ -181,6 +229,54 @@ export function useSidebarProjectFolders(projects: Project[]) {
     [projectIds],
   );
 
+  // Remote fetch (single source of truth after first hydration).
+  const query = useQuery({
+    queryKey: ["ui-preferences"],
+    queryFn: () => api.get<UiPreferencesPayload>("/api/ui-preferences"),
+    staleTime: 60_000,
+  });
+
+  // Track whether the first server response has been applied. Before that,
+  // we don't PUT anything (the user hasn't seen the server state yet, and
+  // flushing cached/legacy data would clobber it).
+  const hydratedRef = useRef(false);
+  const lastFlushedRef = useRef<SidebarProjectFoldersState | null>(null);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Hydrate from server when data arrives.
+  useEffect(() => {
+    if (!query.data) return;
+    const serverState: SidebarProjectFoldersState = {
+      folders: query.data.sidebar.folders,
+      folderOpenState: query.data.sidebar.folderOpenState,
+    };
+
+    // One-shot migration: empty server + legacy localStorage -> push legacy up.
+    if (!hydratedRef.current && isEmptyState(serverState)) {
+      const legacy = readLegacyStorage();
+      if (legacy && !isEmptyState(legacy)) {
+        const sanitized = sanitizeState(legacy, projectIds);
+        hydratedRef.current = true;
+        lastFlushedRef.current = serverState;
+        setState(sanitized);
+        try {
+          localStorage.removeItem(LEGACY_STORAGE_KEY);
+        } catch {
+          // ignore
+        }
+        return;
+      }
+    }
+
+    hydratedRef.current = true;
+    lastFlushedRef.current = serverState;
+    setState((prev) => {
+      const next = sanitizeState(serverState, projectIds);
+      return areStatesEqual(prev, next) ? prev : next;
+    });
+  }, [query.data, projectIds, projectIdsKey]);
+
+  // Re-sanitize when the list of projects changes (e.g. project deleted).
   useEffect(() => {
     setState((prev) => {
       const next = sanitizeState(prev, projectIds);
@@ -188,8 +284,39 @@ export function useSidebarProjectFolders(projects: Project[]) {
     });
   }, [projectIds, projectIdsKey]);
 
+  // Persist local cache immediately + schedule a debounced PUT to the backend.
   useEffect(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    writeLocalCache(state);
+
+    if (!hydratedRef.current) return;
+    if (lastFlushedRef.current && areStatesEqual(lastFlushedRef.current, state)) return;
+
+    if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+    flushTimerRef.current = setTimeout(() => {
+      const snapshot = state;
+      api
+        .put<UiPreferencesPayload>("/api/ui-preferences", { sidebar: snapshot })
+        .then((payload) => {
+          const applied: SidebarProjectFoldersState = {
+            folders: payload.sidebar.folders,
+            folderOpenState: payload.sidebar.folderOpenState,
+          };
+          lastFlushedRef.current = applied;
+        })
+        .catch(() => {
+          // Revert to last-known server state on failure.
+          if (lastFlushedRef.current) {
+            setState(lastFlushedRef.current);
+          }
+        });
+    }, FLUSH_DEBOUNCE_MS);
+
+    return () => {
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+    };
   }, [state]);
 
   const projectMap = useMemo(
@@ -246,6 +373,14 @@ export function useSidebarProjectFolders(projects: Project[]) {
     setState((prev) => moveProject(prev, projectId, targetFolderId));
   }, []);
 
+  const moveFolderById = useCallback((
+    folderId: string,
+    targetFolderId: string,
+    position: FolderInsertPosition,
+  ) => {
+    setState((prev) => moveFolder(prev, folderId, targetFolderId, position));
+  }, []);
+
   const setFolderExpanded = useCallback((folderId: string, expanded: boolean) => {
     setState((prev) => {
       if (!prev.folders.some((folder) => folder.id === folderId)) return prev;
@@ -275,6 +410,7 @@ export function useSidebarProjectFolders(projects: Project[]) {
     rootProjects,
     createFolder,
     moveProjectToFolder,
+    moveFolderById,
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,

--- a/frontend/src/lib/sidebar-helpers.ts
+++ b/frontend/src/lib/sidebar-helpers.ts
@@ -1,0 +1,40 @@
+import type { Automation } from "@/types";
+
+export function parseProjectOwnerRepo(
+  url: string,
+): { owner: string; repo: string } | null {
+  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
+
+  try {
+    const parsed = new URL(url);
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (segments.length >= 2) {
+      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
+    }
+  } catch {
+    // not a valid URL
+  }
+
+  return null;
+}
+
+export function automationSortKey(automation: Automation): number {
+  if (automation.lastRunStatus === "running") return 0;
+  if (automation.enabled) return 1;
+  return 2;
+}
+
+export function describeSchedule(expression: string): string {
+  const presets: Record<string, string> = {
+    "0 * * * *": "Hourly",
+    "0 */6 * * *": "Every 6h",
+    "0 2 * * *": "Daily 2am",
+    "0 8 * * *": "Daily 8am",
+    "0 0 * * *": "Daily midnight",
+    "0 9 * * 1-5": "Weekdays 9am",
+    "0 9 * * 1": "Weekly Mon",
+  };
+
+  return presets[expression] ?? expression;
+}

--- a/frontend/src/lib/sidebar-helpers.ts
+++ b/frontend/src/lib/sidebar-helpers.ts
@@ -1,17 +1,25 @@
 import type { Automation } from "@/types";
 
+function parseRepoPath(path: string): { owner: string; repo: string } | null {
+  const segments = path.split("/").filter(Boolean);
+  if (segments.length < 2) return null;
+
+  const owner = segments[segments.length - 2];
+  const repo = segments[segments.length - 1]?.replace(/\.git$/, "");
+  if (!owner || !repo) return null;
+
+  return { owner, repo };
+}
+
 export function parseProjectOwnerRepo(
   url: string,
 ): { owner: string; repo: string } | null {
-  const scpMatch = url.match(/^[^@]+@[^:]+:([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (scpMatch) return { owner: scpMatch[1], repo: scpMatch[2] };
+  const scpMatch = url.match(/^[^@]+@[^:]+:(.+)$/);
+  if (scpMatch) return parseRepoPath(scpMatch[1]);
 
   try {
     const parsed = new URL(url);
-    const segments = parsed.pathname.split("/").filter(Boolean);
-    if (segments.length >= 2) {
-      return { owner: segments[0], repo: segments[1].replace(/\.git$/, "") };
-    }
+    return parseRepoPath(parsed.pathname);
   } catch {
     // not a valid URL
   }

--- a/frontend/src/lib/sidebar-preferences.ts
+++ b/frontend/src/lib/sidebar-preferences.ts
@@ -6,7 +6,7 @@ import {
   type SidebarProjectFolder,
   type SidebarProjectFoldersState,
   type UiPreferencesPayload,
-} from "../../../shared/sidebar-preferences";
+} from "@hive/shared/sidebar-preferences";
 
 export {
   EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,

--- a/frontend/src/lib/sidebar-preferences.ts
+++ b/frontend/src/lib/sidebar-preferences.ts
@@ -33,26 +33,30 @@ function parseStoredState(raw: string | null): SidebarProjectFoldersState | null
   }
 }
 
+function readStorageItem(key: string): string | null {
+  if (typeof localStorage === "undefined") return null;
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
 export function readSidebarPreferencesLocalSeed(): {
   source: LocalSeedSource;
   state: SidebarProjectFoldersState;
 } {
-  if (typeof localStorage === "undefined") {
-    return { source: "empty", state: EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE };
-  }
-
-  const cached = parseStoredState(localStorage.getItem(CACHE_STORAGE_KEY));
+  const cached = parseStoredState(readStorageItem(CACHE_STORAGE_KEY));
   if (cached) return { source: "cache", state: cached };
 
-  const legacy = parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
+  const legacy = parseStoredState(readStorageItem(LEGACY_STORAGE_KEY));
   if (legacy) return { source: "legacy", state: legacy };
 
   return { source: "empty", state: EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE };
 }
 
 export function readLegacySidebarPreferences(): SidebarProjectFoldersState | null {
-  if (typeof localStorage === "undefined") return null;
-  return parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
+  return parseStoredState(readStorageItem(LEGACY_STORAGE_KEY));
 }
 
 export function writeSidebarPreferencesLocalCache(state: SidebarProjectFoldersState): void {

--- a/frontend/src/lib/sidebar-preferences.ts
+++ b/frontend/src/lib/sidebar-preferences.ts
@@ -1,0 +1,300 @@
+import type { Project } from "@/types";
+
+export interface SidebarProjectFolder {
+  id: string;
+  name: string;
+  projectIds: string[];
+}
+
+export interface SidebarProjectFoldersState {
+  folders: SidebarProjectFolder[];
+  folderOpenState: Record<string, boolean>;
+}
+
+export interface UiPreferencesPayload {
+  sidebar: SidebarProjectFoldersState;
+}
+
+export type FolderInsertPosition = "before" | "after";
+export type ProjectInsertPosition = "before" | "after";
+
+type LocalSeedSource = "cache" | "legacy" | "empty";
+
+const LEGACY_STORAGE_KEY = "hive:sidebar-project-folders:v1";
+const CACHE_STORAGE_KEY = "hive:sidebar-project-folders:cache:v1";
+
+export const EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE: SidebarProjectFoldersState = {
+  folders: [],
+  folderOpenState: {},
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseStoredState(raw: string | null): SidebarProjectFoldersState | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!isRecord(parsed)) return null;
+
+    const foldersRaw = Array.isArray(parsed.folders) ? parsed.folders : [];
+    const folders = foldersRaw.flatMap((folder): SidebarProjectFolder[] => {
+      if (!isRecord(folder)) return [];
+      if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
+      const projectIds = Array.isArray(folder.projectIds)
+        ? folder.projectIds.filter((id): id is string => typeof id === "string")
+        : [];
+      return [{ id: folder.id, name: folder.name, projectIds }];
+    });
+
+    const openStateRaw = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
+    const folderOpenState = Object.fromEntries(
+      Object.entries(openStateRaw).flatMap(([key, value]) =>
+        typeof value === "boolean" ? [[key, value] as const] : [],
+      ),
+    );
+
+    return { folders, folderOpenState };
+  } catch {
+    return null;
+  }
+}
+
+export function readSidebarPreferencesLocalSeed(): {
+  source: LocalSeedSource;
+  state: SidebarProjectFoldersState;
+} {
+  if (typeof localStorage === "undefined") {
+    return { source: "empty", state: EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE };
+  }
+
+  const cached = parseStoredState(localStorage.getItem(CACHE_STORAGE_KEY));
+  if (cached) return { source: "cache", state: cached };
+
+  const legacy = parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
+  if (legacy) return { source: "legacy", state: legacy };
+
+  return { source: "empty", state: EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE };
+}
+
+export function readLegacySidebarPreferences(): SidebarProjectFoldersState | null {
+  if (typeof localStorage === "undefined") return null;
+  return parseStoredState(localStorage.getItem(LEGACY_STORAGE_KEY));
+}
+
+export function writeSidebarPreferencesLocalCache(state: SidebarProjectFoldersState): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(CACHE_STORAGE_KEY, JSON.stringify(state));
+  } catch {
+    // Storage may be full or disabled; ignore.
+  }
+}
+
+export function removeLegacySidebarPreferences(): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.removeItem(LEGACY_STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}
+
+export function isEmptySidebarPreferencesState(state: SidebarProjectFoldersState): boolean {
+  return state.folders.length === 0 && Object.keys(state.folderOpenState).length === 0;
+}
+
+export function payloadToSidebarPreferencesState(
+  payload: UiPreferencesPayload,
+): SidebarProjectFoldersState {
+  return {
+    folders: payload.sidebar.folders,
+    folderOpenState: payload.sidebar.folderOpenState,
+  };
+}
+
+export function sanitizeSidebarPreferencesState(
+  state: SidebarProjectFoldersState,
+  projectIds: string[],
+): SidebarProjectFoldersState {
+  const knownProjectIds = new Set(projectIds);
+  const usedProjectIds = new Set<string>();
+  const seenFolderIds = new Set<string>();
+
+  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
+    const name = folder.name.trim();
+    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
+    seenFolderIds.add(folder.id);
+
+    const seenProjectIds = new Set<string>();
+    const nextProjectIds = folder.projectIds.filter((projectId) => {
+      if (!knownProjectIds.has(projectId)) return false;
+      if (usedProjectIds.has(projectId)) return false;
+      if (seenProjectIds.has(projectId)) return false;
+      usedProjectIds.add(projectId);
+      seenProjectIds.add(projectId);
+      return true;
+    });
+
+    return [{
+      id: folder.id,
+      name,
+      projectIds: nextProjectIds,
+    }];
+  });
+
+  const folderOpenState = Object.fromEntries(
+    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
+      seenFolderIds.has(folderId) && typeof value === "boolean",
+    ),
+  );
+
+  return { folders, folderOpenState };
+}
+
+export function areSidebarPreferencesStatesEqual(
+  left: SidebarProjectFoldersState,
+  right: SidebarProjectFoldersState,
+): boolean {
+  if (left.folders.length !== right.folders.length) return false;
+
+  for (let i = 0; i < left.folders.length; i += 1) {
+    const leftFolder = left.folders[i];
+    const rightFolder = right.folders[i];
+
+    if (leftFolder.id !== rightFolder.id || leftFolder.name !== rightFolder.name) return false;
+    if (leftFolder.projectIds.length !== rightFolder.projectIds.length) return false;
+    for (let j = 0; j < leftFolder.projectIds.length; j += 1) {
+      if (leftFolder.projectIds[j] !== rightFolder.projectIds[j]) return false;
+    }
+  }
+
+  const leftEntries = Object.entries(left.folderOpenState);
+  const rightEntries = Object.entries(right.folderOpenState);
+  if (leftEntries.length !== rightEntries.length) return false;
+
+  for (const [folderId, expanded] of leftEntries) {
+    if (right.folderOpenState[folderId] !== expanded) return false;
+  }
+
+  return true;
+}
+
+export function moveProjectBetweenSidebarFolders(
+  state: SidebarProjectFoldersState,
+  projectId: string,
+  targetFolderId: string | null,
+): SidebarProjectFoldersState {
+  const currentFolderId = state.folders.find((folder) => folder.projectIds.includes(projectId))?.id ?? null;
+
+  if (currentFolderId === targetFolderId) return state;
+  if (targetFolderId && !state.folders.some((folder) => folder.id === targetFolderId)) return state;
+
+  const folders = state.folders.map((folder) => ({
+    ...folder,
+    projectIds: folder.projectIds.filter((id) => id !== projectId),
+  }));
+
+  if (!targetFolderId) {
+    return { ...state, folders };
+  }
+
+  return {
+    folders: folders.map((folder) =>
+      folder.id !== targetFolderId
+        ? folder
+        : { ...folder, projectIds: [...folder.projectIds, projectId] },
+    ),
+    folderOpenState: {
+      ...state.folderOpenState,
+      [targetFolderId]: true,
+    },
+  };
+}
+
+export function moveProjectWithinSidebarFolders(
+  state: SidebarProjectFoldersState,
+  projectId: string,
+  targetFolderId: string,
+  anchorProjectId: string,
+  position: ProjectInsertPosition,
+): SidebarProjectFoldersState {
+  if (projectId === anchorProjectId) return state;
+
+  const targetFolder = state.folders.find((folder) => folder.id === targetFolderId);
+  if (!targetFolder) return state;
+  if (!targetFolder.projectIds.includes(anchorProjectId)) return state;
+
+  const folders = state.folders.map((folder) => ({
+    ...folder,
+    projectIds: folder.projectIds.filter((id) => id !== projectId),
+  }));
+
+  const nextFolders = folders.map((folder) => {
+    if (folder.id !== targetFolderId) return folder;
+    const anchorIndex = folder.projectIds.findIndex((id) => id === anchorProjectId);
+    if (anchorIndex === -1) return folder;
+    const insertIndex = position === "before" ? anchorIndex : anchorIndex + 1;
+    const projectIds = [...folder.projectIds];
+    projectIds.splice(insertIndex, 0, projectId);
+    return { ...folder, projectIds };
+  });
+
+  return {
+    folders: nextFolders,
+    folderOpenState: {
+      ...state.folderOpenState,
+      [targetFolderId]: true,
+    },
+  };
+}
+
+export function moveSidebarFolder(
+  state: SidebarProjectFoldersState,
+  folderId: string,
+  targetFolderId: string,
+  position: FolderInsertPosition,
+): SidebarProjectFoldersState {
+  if (folderId === targetFolderId) return state;
+
+  const sourceIndex = state.folders.findIndex((folder) => folder.id === folderId);
+  const targetIndex = state.folders.findIndex((folder) => folder.id === targetFolderId);
+  if (sourceIndex === -1 || targetIndex === -1) return state;
+
+  const folders = [...state.folders];
+  const [movedFolder] = folders.splice(sourceIndex, 1);
+  const currentTargetIndex = folders.findIndex((folder) => folder.id === targetFolderId);
+  if (currentTargetIndex === -1) return state;
+
+  const insertionIndex = position === "before" ? currentTargetIndex : currentTargetIndex + 1;
+  folders.splice(insertionIndex, 0, movedFolder);
+
+  return { ...state, folders };
+}
+
+export function mapSidebarFolderProjects(
+  folders: SidebarProjectFoldersState["folders"],
+  projects: Project[],
+): Array<SidebarProjectFolder & { projects: Project[] }> {
+  const projectMap = new Map(projects.map((project) => [project.id, project]));
+
+  return folders.map((folder) => ({
+    ...folder,
+    projects: folder.projectIds
+      .map((projectId) => projectMap.get(projectId))
+      .filter((project): project is Project => project !== undefined),
+  }));
+}
+
+export function createSidebarFolderProjectMap(
+  folders: SidebarProjectFoldersState["folders"],
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const folder of folders) {
+    for (const projectId of folder.projectIds) {
+      map.set(projectId, folder.id);
+    }
+  }
+  return map;
+}

--- a/frontend/src/lib/sidebar-preferences.ts
+++ b/frontend/src/lib/sidebar-preferences.ts
@@ -1,19 +1,20 @@
 import type { Project } from "@/types";
+import {
+  EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+  parseSidebarProjectFoldersState,
+  sanitizeSidebarPreferencesState,
+  type SidebarProjectFolder,
+  type SidebarProjectFoldersState,
+  type UiPreferencesPayload,
+} from "../../../shared/sidebar-preferences";
 
-export interface SidebarProjectFolder {
-  id: string;
-  name: string;
-  projectIds: string[];
-}
-
-export interface SidebarProjectFoldersState {
-  folders: SidebarProjectFolder[];
-  folderOpenState: Record<string, boolean>;
-}
-
-export interface UiPreferencesPayload {
-  sidebar: SidebarProjectFoldersState;
-}
+export {
+  EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+  sanitizeSidebarPreferencesState,
+  type SidebarProjectFolder,
+  type SidebarProjectFoldersState,
+  type UiPreferencesPayload,
+};
 
 export type FolderInsertPosition = "before" | "after";
 export type ProjectInsertPosition = "before" | "after";
@@ -23,39 +24,10 @@ type LocalSeedSource = "cache" | "legacy" | "empty";
 const LEGACY_STORAGE_KEY = "hive:sidebar-project-folders:v1";
 const CACHE_STORAGE_KEY = "hive:sidebar-project-folders:cache:v1";
 
-export const EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE: SidebarProjectFoldersState = {
-  folders: [],
-  folderOpenState: {},
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
 function parseStoredState(raw: string | null): SidebarProjectFoldersState | null {
   if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw);
-    if (!isRecord(parsed)) return null;
-
-    const foldersRaw = Array.isArray(parsed.folders) ? parsed.folders : [];
-    const folders = foldersRaw.flatMap((folder): SidebarProjectFolder[] => {
-      if (!isRecord(folder)) return [];
-      if (typeof folder.id !== "string" || typeof folder.name !== "string") return [];
-      const projectIds = Array.isArray(folder.projectIds)
-        ? folder.projectIds.filter((id): id is string => typeof id === "string")
-        : [];
-      return [{ id: folder.id, name: folder.name, projectIds }];
-    });
-
-    const openStateRaw = isRecord(parsed.folderOpenState) ? parsed.folderOpenState : {};
-    const folderOpenState = Object.fromEntries(
-      Object.entries(openStateRaw).flatMap(([key, value]) =>
-        typeof value === "boolean" ? [[key, value] as const] : [],
-      ),
-    );
-
-    return { folders, folderOpenState };
+    return parseSidebarProjectFoldersState(JSON.parse(raw), { mode: "permissive" });
   } catch {
     return null;
   }
@@ -108,49 +80,7 @@ export function isEmptySidebarPreferencesState(state: SidebarProjectFoldersState
 export function payloadToSidebarPreferencesState(
   payload: UiPreferencesPayload,
 ): SidebarProjectFoldersState {
-  return {
-    folders: payload.sidebar.folders,
-    folderOpenState: payload.sidebar.folderOpenState,
-  };
-}
-
-export function sanitizeSidebarPreferencesState(
-  state: SidebarProjectFoldersState,
-  projectIds: string[],
-): SidebarProjectFoldersState {
-  const knownProjectIds = new Set(projectIds);
-  const usedProjectIds = new Set<string>();
-  const seenFolderIds = new Set<string>();
-
-  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
-    const name = folder.name.trim();
-    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
-    seenFolderIds.add(folder.id);
-
-    const seenProjectIds = new Set<string>();
-    const nextProjectIds = folder.projectIds.filter((projectId) => {
-      if (!knownProjectIds.has(projectId)) return false;
-      if (usedProjectIds.has(projectId)) return false;
-      if (seenProjectIds.has(projectId)) return false;
-      usedProjectIds.add(projectId);
-      seenProjectIds.add(projectId);
-      return true;
-    });
-
-    return [{
-      id: folder.id,
-      name,
-      projectIds: nextProjectIds,
-    }];
-  });
-
-  const folderOpenState = Object.fromEntries(
-    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
-      seenFolderIds.has(folderId) && typeof value === "boolean",
-    ),
-  );
-
-  return { folders, folderOpenState };
+  return payload.sidebar;
 }
 
 export function areSidebarPreferencesStatesEqual(

--- a/frontend/tests/components/Sidebar.helpers.test.ts
+++ b/frontend/tests/components/Sidebar.helpers.test.ts
@@ -3,7 +3,7 @@ import {
   parseProjectOwnerRepo,
   automationSortKey,
   describeSchedule,
-} from "@/components/Sidebar";
+} from "@/lib/sidebar-helpers";
 import type { Automation } from "@/types";
 
 // ── parseProjectOwnerRepo ───────────────────────────────────────────

--- a/frontend/tests/components/Sidebar.helpers.test.ts
+++ b/frontend/tests/components/Sidebar.helpers.test.ts
@@ -44,10 +44,17 @@ describe("parseProjectOwnerRepo", () => {
     });
   });
 
-  it("parses GitLab URL with nested path (uses first two segments)", () => {
+  it("parses GitLab URL with nested path using the last two segments", () => {
     expect(parseProjectOwnerRepo("https://gitlab.com/org/subgroup/repo.git")).toEqual({
-      owner: "org",
-      repo: "subgroup",
+      owner: "subgroup",
+      repo: "repo",
+    });
+  });
+
+  it("parses nested SCP-style SSH URL using the last two segments", () => {
+    expect(parseProjectOwnerRepo("git@gitlab.com:org/subgroup/repo.git")).toEqual({
+      owner: "subgroup",
+      repo: "repo",
     });
   });
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -419,45 +419,6 @@ describe("Sidebar", () => {
     });
   });
 
-  it("moves a project back to top level via drag and drop", async () => {
-    const user = userEvent.setup();
-    renderSidebar("/projects", projects);
-
-    await screen.findByText(withTextContent("acme/alpha"));
-    await user.click(screen.getByRole("button", { name: "New folder" }));
-    await user.type(screen.getByLabelText("Folder name"), "Client work");
-    await user.click(screen.getByRole("button", { name: "Create folder" }));
-
-    const folder = screen.getByText("Client work").closest("[data-sidebar-folder]");
-    expect(folder).not.toBeNull();
-
-    const firstTransfer = createDataTransfer();
-    const initialBetaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
-    expect(initialBetaButton).not.toBeNull();
-    fireEvent.dragStart(initialBetaButton!, { dataTransfer: firstTransfer });
-    fireEvent.dragOver(folder!, { dataTransfer: firstTransfer });
-    fireEvent.drop(folder!, { dataTransfer: firstTransfer });
-    fireEvent.dragEnd(initialBetaButton!, { dataTransfer: firstTransfer });
-
-    await waitFor(() => {
-      expect(screen.getByText(withTextContent("acme/beta")).closest("[data-sidebar-folder]")).toBe(folder);
-    });
-
-    const secondTransfer = createDataTransfer();
-    const movedBetaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
-    expect(movedBetaButton).not.toBeNull();
-    fireEvent.dragStart(movedBetaButton!, { dataTransfer: secondTransfer });
-
-    const rootDropZone = await screen.findByTestId("sidebar-root-drop-zone");
-    fireEvent.dragOver(rootDropZone, { dataTransfer: secondTransfer });
-    fireEvent.drop(rootDropZone, { dataTransfer: secondTransfer });
-    fireEvent.dragEnd(movedBetaButton!, { dataTransfer: secondTransfer });
-
-    await waitFor(() => {
-      expect(screen.getByText(withTextContent("acme/beta")).closest("[data-sidebar-folder]")).toBeNull();
-    });
-  });
-
   it("collapses folders and hides their projects", async () => {
     const user = userEvent.setup();
     renderSidebar("/projects", projects);
@@ -483,6 +444,140 @@ describe("Sidebar", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(withTextContent("acme/beta"))).not.toBeInTheDocument();
+    });
+  });
+
+  it("reorders projects within a folder via drag and drop", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return {
+          sidebar: {
+            folders: [{ id: "f-client", name: "Client", projectIds: ["p1", "p2"] }],
+            folderOpenState: { "f-client": true },
+          },
+        };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockImplementation(async (_url: string, body?: unknown) => body);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByRole("button", { name: "Client" });
+
+    const folderContainer = screen.getByText("Client").closest("[data-sidebar-folder]")!;
+    const projectItems = () =>
+      Array.from(folderContainer.querySelectorAll("[data-sidebar-project]")).map(
+        (el) => el.getAttribute("data-sidebar-project"),
+      );
+
+    expect(projectItems()).toEqual(["p1", "p2"]);
+
+    const betaButton = screen.getByText(withTextContent("acme/beta")).closest("button")!;
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(betaButton, { dataTransfer });
+
+    const alphaItem = folderContainer.querySelector("[data-sidebar-project='p1']")!;
+    const beforeZone = alphaItem.querySelector("[data-project-reorder='before']")!;
+    expect(beforeZone).not.toBeNull();
+
+    fireEvent.dragOver(beforeZone, { dataTransfer });
+    fireEvent.drop(beforeZone, { dataTransfer });
+    fireEvent.dragEnd(betaButton, { dataTransfer });
+
+    await waitFor(() => {
+      expect(projectItems()).toEqual(["p2", "p1"]);
+    });
+  });
+
+  it("moves a project between folders at a specific position via drag and drop", async () => {
+    const multiProjects: Project[] = [
+      ...projects,
+      {
+        id: "p3",
+        name: "Gamma",
+        url: "https://github.com/acme/gamma.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return multiProjects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return {
+          sidebar: {
+            folders: [
+              { id: "f-a", name: "Folder A", projectIds: ["p1", "p2"] },
+              { id: "f-b", name: "Folder B", projectIds: ["p3"] },
+            ],
+            folderOpenState: { "f-a": true, "f-b": true },
+          },
+        };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockImplementation(async (_url: string, body?: unknown) => body);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByRole("button", { name: "Folder B" });
+
+    const folderB = screen.getByText("Folder B").closest("[data-sidebar-folder]")!;
+    const folderBProjectIds = () =>
+      Array.from(folderB.querySelectorAll("[data-sidebar-project]")).map(
+        (el) => el.getAttribute("data-sidebar-project"),
+      );
+
+    expect(folderBProjectIds()).toEqual(["p3"]);
+
+    const alphaButton = screen.getByText(withTextContent("acme/alpha")).closest("button")!;
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(alphaButton, { dataTransfer });
+
+    const gammaItem = folderB.querySelector("[data-sidebar-project='p3']")!;
+    const beforeZone = gammaItem.querySelector("[data-project-reorder='before']")!;
+    expect(beforeZone).not.toBeNull();
+
+    fireEvent.dragOver(beforeZone, { dataTransfer });
+    fireEvent.drop(beforeZone, { dataTransfer });
+    fireEvent.dragEnd(alphaButton, { dataTransfer });
+
+    await waitFor(() => {
+      expect(folderBProjectIds()).toEqual(["p1", "p3"]);
     });
   });
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -217,7 +217,7 @@ function createDataTransfer(): DataTransfer {
 }
 
 function expectFolderOrder(labels: string[]) {
-  const actual = Array.from(document.querySelectorAll("[data-sidebar-folder] > button")).map(
+  const actual = Array.from(document.querySelectorAll("[data-sidebar-folder] > div > button")).map(
     (button) => button.textContent?.trim() ?? "",
   );
   expect(actual).toEqual(labels);
@@ -611,6 +611,106 @@ describe("Sidebar", () => {
     await waitFor(() => {
       expectFolderOrder(["Infra", "Client work"]);
     });
+  });
+
+  it("renames a folder via the inline rename input", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Old name");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await screen.findByRole("button", { name: "Old name" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename folder Old name" }));
+
+    const input = await screen.findByLabelText("Rename folder");
+    await user.clear(input);
+    await user.type(input, "Renamed folder{Enter}");
+
+    expect(await screen.findByRole("button", { name: "Renamed folder" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Old name" })).not.toBeInTheDocument();
+  });
+
+  it("cancels folder rename when Escape is pressed", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Keep me");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await screen.findByRole("button", { name: "Keep me" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Rename folder Keep me" }));
+
+    const input = await screen.findByLabelText("Rename folder");
+    await user.clear(input);
+    await user.type(input, "Discarded{Escape}");
+
+    expect(await screen.findByRole("button", { name: "Keep me" })).toBeInTheDocument();
+    expect(screen.queryByLabelText("Rename folder")).not.toBeInTheDocument();
+  });
+
+  it("deletes an empty folder after confirmation", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Temporary");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await screen.findByRole("button", { name: "Temporary" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete folder Temporary" }));
+
+    const confirm = await screen.findByRole("button", { name: "Delete" });
+    await user.click(confirm);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Temporary" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("hides the delete button for non-empty folders", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return {
+          sidebar: {
+            folders: [{ id: "f-client", name: "Client", projectIds: ["p1"] }],
+            folderOpenState: { "f-client": true },
+          },
+        };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByRole("button", { name: "Client" });
+
+    expect(screen.queryByRole("button", { name: "Delete folder Client" })).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Rename folder Client" })).toBeInTheDocument();
   });
 
   it("expands the active project's workspaces on workspace route", async () => {

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -327,6 +327,83 @@ describe("Sidebar", () => {
     );
   });
 
+  it("keeps the latest folder state in react-query cache after saving", async () => {
+    const user = userEvent.setup();
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return { sidebar: { folders: [], folderOpenState: {} } };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockImplementation(async (url: string, body?: unknown) => {
+      if (url === "/api/ui-preferences") return body;
+      throw new Error(`Unexpected PUT: ${url}`);
+    });
+
+    const workspaceIds = projects.flatMap((project) => (
+      (project.workspaces ?? []).map((workspace) => workspace.id)
+    ));
+
+    const firstRender = render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        "/api/ui-preferences",
+        expect.objectContaining({
+          sidebar: expect.objectContaining({
+            folders: expect.arrayContaining([
+              expect.objectContaining({ name: "Client work" }),
+            ]),
+          }),
+        }),
+      );
+    });
+
+    firstRender.unmount();
+    localStorage.removeItem("hive:sidebar-project-folders:cache:v1");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: "Client work" })).toBeInTheDocument();
+  });
+
   it("hydrates folders from the server response", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
@@ -176,6 +176,34 @@ function mockPostWithBulkFallback(overrides: Record<string, unknown | Error>) {
   });
 }
 
+function createDataTransfer(): DataTransfer {
+  const data = new Map<string, string>();
+  const types = new Set<string>();
+
+  return {
+    dropEffect: "move",
+    effectAllowed: "move",
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    clearData: (format?: string) => {
+      if (format) {
+        data.delete(format);
+        types.delete(format);
+      } else {
+        data.clear();
+        types.clear();
+      }
+    },
+    getData: (format: string) => data.get(format) ?? "",
+    setData: (format: string, value: string) => {
+      data.set(format, value);
+      types.add(format);
+    },
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
 describe("Sidebar", () => {
   const projects: Project[] = [
     {
@@ -206,6 +234,7 @@ describe("Sidebar", () => {
     vi.mocked(api.get).mockReset();
     vi.mocked(api.post).mockReset();
     vi.mocked(api.delete).mockReset();
+    localStorage.removeItem("hive:sidebar-project-folders:v1");
     mockPostWithBulkFallback({});
     const { __wsMock } = await getWsMock();
     __wsMock.reset();
@@ -236,6 +265,111 @@ describe("Sidebar", () => {
     expect(alphaHeader.querySelector("[class*='tabular-nums']")).toHaveTextContent("1");
     // Beta has 0 workspaces → count "0" visible in project header
     expect(betaHeader.querySelector("[class*='tabular-nums']")).toHaveTextContent("0");
+  });
+
+  it("creates collapsible folders from the workspaces header", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    expect(await screen.findByRole("button", { name: "Client work" })).toBeInTheDocument();
+    expect(screen.getByText("Drop repositories here")).toBeInTheDocument();
+  });
+
+  it("moves a project into a folder via drag and drop", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    const betaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
+    const folder = screen.getByText("Client work").closest("[data-sidebar-folder]");
+    expect(betaButton).not.toBeNull();
+    expect(folder).not.toBeNull();
+
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(betaButton!, { dataTransfer });
+    fireEvent.dragOver(folder!, { dataTransfer });
+    fireEvent.drop(folder!, { dataTransfer });
+    fireEvent.dragEnd(betaButton!, { dataTransfer });
+
+    await waitFor(() => {
+      expect(screen.getByText(withTextContent("acme/beta")).closest("[data-sidebar-folder]")).toBe(folder);
+    });
+  });
+
+  it("moves a project back to top level via drag and drop", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    const folder = screen.getByText("Client work").closest("[data-sidebar-folder]");
+    expect(folder).not.toBeNull();
+
+    const firstTransfer = createDataTransfer();
+    const initialBetaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
+    expect(initialBetaButton).not.toBeNull();
+    fireEvent.dragStart(initialBetaButton!, { dataTransfer: firstTransfer });
+    fireEvent.dragOver(folder!, { dataTransfer: firstTransfer });
+    fireEvent.drop(folder!, { dataTransfer: firstTransfer });
+    fireEvent.dragEnd(initialBetaButton!, { dataTransfer: firstTransfer });
+
+    await waitFor(() => {
+      expect(screen.getByText(withTextContent("acme/beta")).closest("[data-sidebar-folder]")).toBe(folder);
+    });
+
+    const secondTransfer = createDataTransfer();
+    const movedBetaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
+    expect(movedBetaButton).not.toBeNull();
+    fireEvent.dragStart(movedBetaButton!, { dataTransfer: secondTransfer });
+
+    const rootDropZone = await screen.findByTestId("sidebar-root-drop-zone");
+    fireEvent.dragOver(rootDropZone, { dataTransfer: secondTransfer });
+    fireEvent.drop(rootDropZone, { dataTransfer: secondTransfer });
+    fireEvent.dragEnd(movedBetaButton!, { dataTransfer: secondTransfer });
+
+    await waitFor(() => {
+      expect(screen.getByText(withTextContent("acme/beta")).closest("[data-sidebar-folder]")).toBeNull();
+    });
+  });
+
+  it("collapses folders and hides their projects", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    const folder = screen.getByText("Client work").closest("[data-sidebar-folder]");
+    expect(folder).not.toBeNull();
+
+    const dataTransfer = createDataTransfer();
+    const betaButton = screen.getByText(withTextContent("acme/beta")).closest("button");
+    expect(betaButton).not.toBeNull();
+    fireEvent.dragStart(betaButton!, { dataTransfer });
+    fireEvent.dragOver(folder!, { dataTransfer });
+    fireEvent.drop(folder!, { dataTransfer });
+    fireEvent.dragEnd(betaButton!, { dataTransfer });
+
+    expect(await screen.findByText(withTextContent("acme/beta"))).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Client work" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(withTextContent("acme/beta"))).not.toBeInTheDocument();
+    });
   });
 
   it("expands the active project's workspaces on workspace route", async () => {

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -394,6 +394,123 @@ describe("Sidebar", () => {
     expect(localStorage.getItem("hive:sidebar-project-folders:v1")).toBeNull();
   });
 
+  it("waits for projects before migrating legacy folders and does not shadow legacy storage early", async () => {
+    localStorage.setItem(
+      "hive:sidebar-project-folders:v1",
+      JSON.stringify({
+        folders: [{ id: "legacy", name: "Migrated", projectIds: ["p1"] }],
+        folderOpenState: { legacy: true },
+      }),
+    );
+
+    let resolveProjects!: (value: Project[]) => void;
+    const pendingProjects = new Promise<Project[]>((resolve) => {
+      resolveProjects = resolve;
+    });
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return pendingProjects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return { sidebar: { folders: [], folderOpenState: {} } };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockImplementation(async (_url: string, body?: unknown) => body);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(localStorage.getItem("hive:sidebar-project-folders:v1")).not.toBeNull();
+    expect(localStorage.getItem("hive:sidebar-project-folders:cache:v1")).toBeNull();
+    expect(api.put).not.toHaveBeenCalled();
+
+    await act(async () => {
+      resolveProjects(projects);
+    });
+
+    expect(await screen.findByRole("button", { name: "Migrated" })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        "/api/ui-preferences",
+        expect.objectContaining({
+          sidebar: expect.objectContaining({
+            folders: expect.arrayContaining([
+              expect.objectContaining({ name: "Migrated", projectIds: ["p1"] }),
+            ]),
+          }),
+        }),
+      );
+    });
+    expect(localStorage.getItem("hive:sidebar-project-folders:v1")).toBeNull();
+  });
+
+  it("keeps legacy storage when the migration save fails", async () => {
+    localStorage.setItem(
+      "hive:sidebar-project-folders:v1",
+      JSON.stringify({
+        folders: [{ id: "legacy", name: "Migrated", projectIds: ["p1"] }],
+        folderOpenState: { legacy: true },
+      }),
+    );
+
+    let uiPreferencesReads = 0;
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        uiPreferencesReads += 1;
+        return { sidebar: { folders: [], folderOpenState: {} } };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockRejectedValue(new Error("save failed"));
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalled();
+    });
+    await waitFor(() => {
+      expect(uiPreferencesReads).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(localStorage.getItem("hive:sidebar-project-folders:v1")).not.toBeNull();
+  });
+
   it("moves a project into a folder via drag and drop", async () => {
     const user = userEvent.setup();
     renderSidebar("/projects", projects);

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -6,6 +6,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import Sidebar from "@/components/Sidebar";
 import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { api } from "@/hooks/useApi";
+import type { UiPreferencesPayload } from "@/lib/sidebar-preferences";
 import type { Project, PullRequestInfo, WsOutgoing } from "@/types";
 
 /** Match elements whose full textContent equals `text` (handles text split across child spans). */
@@ -402,6 +403,84 @@ describe("Sidebar", () => {
     });
 
     expect(screen.getByRole("button", { name: "Client work" })).toBeInTheDocument();
+  });
+
+  it("disables folder creation until the first ui-preferences hydration completes", async () => {
+    let resolvePreferences!: (value: UiPreferencesPayload) => void;
+    const pendingPreferences = new Promise<UiPreferencesPayload>((resolve) => {
+      resolvePreferences = resolve;
+    });
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") return pendingPreferences;
+      return { committed: [], uncommitted: [] };
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    expect(screen.getByRole("button", { name: "New folder" })).toBeDisabled();
+
+    resolvePreferences({ sidebar: { folders: [], folderOpenState: {} } });
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "New folder" })).toBeEnabled();
+    });
+  });
+
+  it("falls back to local hydration when the initial ui-preferences request fails", async () => {
+    const user = userEvent.setup();
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") throw new Error("ui-preferences unavailable");
+      return { committed: [], uncommitted: [] };
+    });
+
+    vi.mocked(api.put).mockImplementation(async (url: string, body?: unknown) => {
+      if (url === "/api/ui-preferences") return body;
+      throw new Error(`Unexpected PUT: ${url}`);
+    });
+
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "New folder" })).toBeEnabled();
+    });
+
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Recovered");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        "/api/ui-preferences",
+        expect.objectContaining({
+          sidebar: expect.objectContaining({
+            folders: expect.arrayContaining([
+              expect.objectContaining({ name: "Recovered" }),
+            ]),
+          }),
+        }),
+      );
+    });
   });
 
   it("hydrates folders from the server response", async () => {

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -20,6 +20,7 @@ vi.mock("@/hooks/useApi", () => ({
   api: {
     get: vi.fn(),
     post: vi.fn(),
+    put: vi.fn(),
     delete: vi.fn(),
   },
 }));
@@ -102,6 +103,9 @@ function renderSidebar(
       if (override instanceof Error) throw override;
       return override ?? [];
     }
+    if (url === "/api/ui-preferences") {
+      return { sidebar: { folders: [], folderOpenState: {} } };
+    }
     const diffMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
     if (diffMatch) {
       const override = apiOverrides?.diffStat;
@@ -110,6 +114,11 @@ function renderSidebar(
       return { committed: [], uncommitted: [] };
     }
     throw new Error(`Unexpected GET: ${url}`);
+  });
+
+  vi.mocked(api.put).mockImplementation(async (url: string, body?: unknown) => {
+    if (url === "/api/ui-preferences") return body;
+    throw new Error(`Unexpected PUT: ${url}`);
   });
 
   const workspaceIds = projects.flatMap((p) => (p.workspaces ?? []).map((ws) => ws.id));
@@ -179,13 +188,12 @@ function mockPostWithBulkFallback(overrides: Record<string, unknown | Error>) {
 function createDataTransfer(): DataTransfer {
   const data = new Map<string, string>();
   const types = new Set<string>();
-
-  return {
+  const transfer = {
     dropEffect: "move",
     effectAllowed: "move",
     files: [] as unknown as FileList,
     items: [] as unknown as DataTransferItemList,
-    types: [],
+    types: [] as string[],
     clearData: (format?: string) => {
       if (format) {
         data.delete(format);
@@ -194,14 +202,25 @@ function createDataTransfer(): DataTransfer {
         data.clear();
         types.clear();
       }
+      transfer.types = [...types];
     },
     getData: (format: string) => data.get(format) ?? "",
     setData: (format: string, value: string) => {
       data.set(format, value);
       types.add(format);
+      transfer.types = [...types];
     },
     setDragImage: vi.fn(),
-  } as unknown as DataTransfer;
+  };
+
+  return transfer as unknown as DataTransfer;
+}
+
+function expectFolderOrder(labels: string[]) {
+  const actual = Array.from(document.querySelectorAll("[data-sidebar-folder] > button")).map(
+    (button) => button.textContent?.trim() ?? "",
+  );
+  expect(actual).toEqual(labels);
 }
 
 describe("Sidebar", () => {
@@ -233,8 +252,10 @@ describe("Sidebar", () => {
   beforeEach(async () => {
     vi.mocked(api.get).mockReset();
     vi.mocked(api.post).mockReset();
+    vi.mocked(api.put).mockReset();
     vi.mocked(api.delete).mockReset();
     localStorage.removeItem("hive:sidebar-project-folders:v1");
+    localStorage.removeItem("hive:sidebar-project-folders:cache:v1");
     mockPostWithBulkFallback({});
     const { __wsMock } = await getWsMock();
     __wsMock.reset();
@@ -278,6 +299,99 @@ describe("Sidebar", () => {
 
     expect(await screen.findByRole("button", { name: "Client work" })).toBeInTheDocument();
     expect(screen.getByText("Drop repositories here")).toBeInTheDocument();
+  });
+
+  it("persists folder changes to /api/ui-preferences", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await waitFor(
+      () => {
+        expect(api.put).toHaveBeenCalledWith(
+          "/api/ui-preferences",
+          expect.objectContaining({
+            sidebar: expect.objectContaining({
+              folders: expect.arrayContaining([
+                expect.objectContaining({ name: "Client work" }),
+              ]),
+            }),
+          }),
+        );
+      },
+      { timeout: 2000 },
+    );
+  });
+
+  it("hydrates folders from the server response", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    vi.mocked(api.get).mockImplementation(async (url: string) => {
+      if (url === "/api/projects") return projects;
+      if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return {
+          sidebar: {
+            folders: [{ id: "remote-folder", name: "Server Folder", projectIds: ["p2"] }],
+            folderOpenState: { "remote-folder": true },
+          },
+        };
+      }
+      return { committed: [], uncommitted: [] };
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <WorkspaceLiveDataProvider workspaceIds={["w1"]}>
+          <MemoryRouter initialEntries={["/projects"]}>
+            <Routes>
+              <Route path="/projects" element={<SidebarRoute />} />
+            </Routes>
+          </MemoryRouter>
+        </WorkspaceLiveDataProvider>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByRole("button", { name: "Server Folder" })).toBeInTheDocument();
+    const folder = screen.getByText("Server Folder").closest("[data-sidebar-folder]");
+    expect(folder).not.toBeNull();
+    expect(folder!.textContent).toContain("acme/beta");
+  });
+
+  it("migrates legacy localStorage to the backend on first hydration", async () => {
+    localStorage.setItem(
+      "hive:sidebar-project-folders:v1",
+      JSON.stringify({
+        folders: [{ id: "legacy", name: "Migrated", projectIds: ["p1"] }],
+        folderOpenState: { legacy: true },
+      }),
+    );
+
+    renderSidebar("/projects", projects);
+
+    await waitFor(
+      () => {
+        expect(api.put).toHaveBeenCalledWith(
+          "/api/ui-preferences",
+          expect.objectContaining({
+            sidebar: expect.objectContaining({
+              folders: expect.arrayContaining([
+                expect.objectContaining({ name: "Migrated", projectIds: ["p1"] }),
+              ]),
+            }),
+          }),
+        );
+      },
+      { timeout: 2000 },
+    );
+
+    expect(localStorage.getItem("hive:sidebar-project-folders:v1")).toBeNull();
   });
 
   it("moves a project into a folder via drag and drop", async () => {
@@ -369,6 +483,38 @@ describe("Sidebar", () => {
 
     await waitFor(() => {
       expect(screen.queryByText(withTextContent("acme/beta"))).not.toBeInTheDocument();
+    });
+  });
+
+  it("reorders folders by dragging one before another", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Client work");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Infra");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    expectFolderOrder(["Client work", "Infra"]);
+
+    const infraButton = screen.getByRole("button", { name: "Infra" });
+    const dataTransfer = createDataTransfer();
+    fireEvent.dragStart(infraButton, { dataTransfer });
+
+    const clientFolder = screen.getByText("Client work").closest("[data-sidebar-folder]");
+    expect(clientFolder).not.toBeNull();
+    const beforeZone = clientFolder!.querySelector("[data-folder-reorder='before']");
+    expect(beforeZone).not.toBeNull();
+
+    fireEvent.dragOver(beforeZone!, { dataTransfer });
+    fireEvent.drop(beforeZone!, { dataTransfer });
+    fireEvent.dragEnd(infraButton, { dataTransfer });
+
+    await waitFor(() => {
+      expectFolderOrder(["Infra", "Client work"]);
     });
   });
 
@@ -954,6 +1100,9 @@ describe("Sidebar", () => {
     vi.mocked(api.get).mockImplementation(async (url: string) => {
       if (url === "/api/projects") return projects;
       if (url === "/api/automations") return pendingAutomations;
+      if (url === "/api/ui-preferences") {
+        return { sidebar: { folders: [], folderOpenState: {} } };
+      }
       return { committed: [], uncommitted: [] };
     });
 
@@ -1156,6 +1305,9 @@ describe("Sidebar", () => {
     vi.mocked(api.get).mockImplementation(async (url: string) => {
       if (url === "/api/projects") return projects;
       if (url === "/api/automations") return [];
+      if (url === "/api/ui-preferences") {
+        return { sidebar: { folders: [], folderOpenState: {} } };
+      }
       return { committed: [], uncommitted: [] };
     });
 

--- a/frontend/tests/lib/sidebar-preferences.test.ts
+++ b/frontend/tests/lib/sidebar-preferences.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  readLegacySidebarPreferences,
+  readSidebarPreferencesLocalSeed,
+} from "@/lib/sidebar-preferences";
+
+const originalWindowLocalStorage = window.localStorage;
+const originalGlobalLocalStorage = globalThis.localStorage;
+
+function installThrowingLocalStorage(): void {
+  const throwingStorage = {
+    getItem: () => {
+      throw new Error("storage disabled");
+    },
+    setItem: () => {},
+    removeItem: () => {},
+    clear: () => {},
+    key: () => null,
+    length: 0,
+  } as Storage;
+
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: throwingStorage,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: throwingStorage,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    value: originalWindowLocalStorage,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: originalGlobalLocalStorage,
+  });
+});
+
+describe("sidebar local storage reads", () => {
+  it("falls back to an empty seed when localStorage.getItem throws", () => {
+    installThrowingLocalStorage();
+
+    expect(readSidebarPreferencesLocalSeed()).toEqual({
+      source: "empty",
+      state: { folders: [], folderOpenState: {} },
+    });
+  });
+
+  it("returns null for legacy preferences when localStorage.getItem throws", () => {
+    installThrowingLocalStorage();
+
+    expect(readLegacySidebarPreferences()).toBeNull();
+  });
+});

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -8,6 +8,40 @@ class ResizeObserverMock {
 
 vi.stubGlobal("ResizeObserver", ResizeObserverMock);
 
+// Node 22+ ships a native experimental `localStorage` that shadows jsdom's
+// Storage implementation and lacks methods like `removeItem`. Force a
+// jsdom-compatible stub so tests work regardless of the host Node version.
+if (typeof window !== "undefined") {
+  const needsShim =
+    typeof window.localStorage?.removeItem !== "function" ||
+    typeof window.localStorage?.getItem !== "function";
+  if (needsShim) {
+    const store = new Map<string, string>();
+    const storage: Storage = {
+      get length() {
+        return store.size;
+      },
+      clear: () => store.clear(),
+      getItem: (key: string) => (store.has(key) ? store.get(key)! : null),
+      setItem: (key: string, value: string) => {
+        store.set(key, String(value));
+      },
+      removeItem: (key: string) => {
+        store.delete(key);
+      },
+      key: (index: number) => Array.from(store.keys())[index] ?? null,
+    };
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get: () => storage,
+    });
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      get: () => storage,
+    });
+  }
+}
+
 // jsdom does not implement matchMedia
 if (typeof window !== "undefined" && !window.matchMedia) {
   Object.defineProperty(window, "matchMedia", {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "outDir": "dist",
-    "rootDir": "src",
+    "rootDir": "..",
     "declaration": false,
     "declarationMap": false,
     "baseUrl": ".",
@@ -13,5 +13,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src"]
+  "include": ["src", "../shared/**/*.ts"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -5,7 +5,7 @@
     "moduleResolution": "bundler",
     "jsx": "react-jsx",
     "outDir": "dist",
-    "rootDir": "..",
+    "rootDir": "src",
     "declaration": false,
     "declarationMap": false,
     "baseUrl": ".",
@@ -13,5 +13,5 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "../shared/**/*.ts"]
+  "include": ["src"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
       "name": "hive",
       "workspaces": [
         "backend",
-        "frontend"
+        "frontend",
+        "shared"
       ],
       "devDependencies": {
         "@eslint/js": "^9.21.0",
@@ -25,6 +26,7 @@
       "dependencies": {
         "@fastify/cors": "^11.2.0",
         "@fastify/websocket": "^11.2.0",
+        "@hive/shared": "^0.1.0",
         "croner": "^10.0.1",
         "fastify": "^5.7.4",
         "nanoid": "^3.3.11",
@@ -47,6 +49,7 @@
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language-data": "^6.5.2",
         "@codemirror/theme-one-dark": "^6.1.3",
+        "@hive/shared": "^0.1.0",
         "@pierre/diffs": "^1.0.10",
         "@react-symbols/icons": "^1.3.0",
         "@streamdown/cjk": "^1.0.2",
@@ -2379,6 +2382,10 @@
     },
     "node_modules/@hive/frontend": {
       "resolved": "frontend",
+      "link": true
+    },
+    "node_modules/@hive/shared": {
+      "resolved": "shared",
       "link": true
     },
     "node_modules/@hono/node-server": {
@@ -17412,6 +17419,13 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "shared": {
+      "name": "@hive/shared",
+      "version": "0.1.0",
+      "devDependencies": {
+        "typescript": "^5.9.3"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "workspaces": [
     "backend",
-    "frontend"
+    "frontend",
+    "shared"
   ],
   "scripts": {
     "lint": "npm run lint --workspace @hive/backend --workspace @hive/frontend",

--- a/shared/package.json
+++ b/shared/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@hive/shared",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    "./sidebar-preferences": "./dist/sidebar-preferences.js"
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  }
+}

--- a/shared/sidebar-preferences.ts
+++ b/shared/sidebar-preferences.ts
@@ -33,6 +33,11 @@ interface ParseUiPreferencesOptions {
   mode?: ParseMode;
 }
 
+interface NormalizedFoldersResult {
+  folders: SidebarProjectFolder[];
+  folderIds: Set<string>;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -123,21 +128,48 @@ export function parseUiPreferencesPayload(
   return { sidebar };
 }
 
+function normalizeFolders(
+  folders: SidebarProjectFoldersState["folders"],
+  mapProjectIds: (folder: SidebarProjectFolder) => string[],
+): NormalizedFoldersResult {
+  const folderIds = new Set<string>();
+
+  return {
+    folders: folders.flatMap((folder): SidebarProjectFolder[] => {
+      const name = folder.name.trim();
+      if (!folder.id || !name || folderIds.has(folder.id)) return [];
+      folderIds.add(folder.id);
+
+      return [{
+        id: folder.id,
+        name,
+        projectIds: mapProjectIds(folder),
+      }];
+    }),
+    folderIds,
+  };
+}
+
+function normalizeFolderOpenState(
+  folderOpenState: SidebarProjectFoldersState["folderOpenState"],
+  folderIds: Set<string>,
+): Record<string, boolean> {
+  return Object.fromEntries(
+    Object.entries(folderOpenState).filter(([folderId, value]) =>
+      folderIds.has(folderId) && typeof value === "boolean",
+    ),
+  );
+}
+
 export function sanitizeSidebarPreferencesState(
   state: SidebarProjectFoldersState,
   projectIds: string[],
 ): SidebarProjectFoldersState {
   const knownProjectIds = new Set(projectIds);
   const usedProjectIds = new Set<string>();
-  const seenFolderIds = new Set<string>();
-
-  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
-    const name = folder.name.trim();
-    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
-    seenFolderIds.add(folder.id);
-
+  const { folders, folderIds } = normalizeFolders(state.folders, (folder) => {
     const seenProjectIds = new Set<string>();
-    const nextProjectIds = folder.projectIds.filter((projectId) => {
+    return folder.projectIds.filter((projectId) => {
       if (!knownProjectIds.has(projectId)) return false;
       if (usedProjectIds.has(projectId)) return false;
       if (seenProjectIds.has(projectId)) return false;
@@ -145,19 +177,9 @@ export function sanitizeSidebarPreferencesState(
       seenProjectIds.add(projectId);
       return true;
     });
-
-    return [{
-      id: folder.id,
-      name,
-      projectIds: nextProjectIds,
-    }];
   });
 
-  const folderOpenState = Object.fromEntries(
-    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
-      seenFolderIds.has(folderId) && typeof value === "boolean",
-    ),
-  );
+  const folderOpenState = normalizeFolderOpenState(state.folderOpenState, folderIds);
 
   return { folders, folderOpenState };
 }
@@ -165,23 +187,11 @@ export function sanitizeSidebarPreferencesState(
 export function normalizeSidebarPreferencesState(
   state: SidebarProjectFoldersState,
 ): SidebarProjectFoldersState {
-  const seenFolderIds = new Set<string>();
-  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
-    const name = folder.name.trim();
-    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
-    seenFolderIds.add(folder.id);
-    return [{
-      id: folder.id,
-      name,
-      projectIds: folder.projectIds,
-    }];
-  });
-
-  const folderOpenState = Object.fromEntries(
-    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
-      seenFolderIds.has(folderId) && typeof value === "boolean",
-    ),
+  const { folders, folderIds } = normalizeFolders(
+    state.folders,
+    (folder) => folder.projectIds,
   );
+  const folderOpenState = normalizeFolderOpenState(state.folderOpenState, folderIds);
 
   return { folders, folderOpenState };
 }

--- a/shared/sidebar-preferences.ts
+++ b/shared/sidebar-preferences.ts
@@ -1,0 +1,196 @@
+export interface SidebarProjectFolder {
+  id: string;
+  name: string;
+  projectIds: string[];
+}
+
+export interface SidebarProjectFoldersState {
+  folders: SidebarProjectFolder[];
+  folderOpenState: Record<string, boolean>;
+}
+
+export interface UiPreferencesPayload {
+  sidebar: SidebarProjectFoldersState;
+}
+
+export const EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE: SidebarProjectFoldersState = {
+  folders: [],
+  folderOpenState: {},
+};
+
+export const EMPTY_UI_PREFERENCES_PAYLOAD: UiPreferencesPayload = {
+  sidebar: EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+};
+
+type ParseMode = "strict" | "permissive";
+
+interface ParseSidebarStateOptions {
+  mode?: ParseMode;
+  requireFoldersArray?: boolean;
+}
+
+interface ParseUiPreferencesOptions {
+  mode?: ParseMode;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseProjectIds(raw: unknown, mode: ParseMode): string[] | null {
+  if (!Array.isArray(raw)) {
+    return mode === "strict" ? null : [];
+  }
+
+  const projectIds = raw.filter((id): id is string => typeof id === "string");
+  if (mode === "strict" && projectIds.length !== raw.length) return null;
+  return projectIds;
+}
+
+function parseFolder(raw: unknown, mode: ParseMode): SidebarProjectFolder | null {
+  if (!isRecord(raw)) return null;
+  if (typeof raw.id !== "string" || typeof raw.name !== "string") return null;
+
+  const projectIds = parseProjectIds(raw.projectIds, mode);
+  if (projectIds === null) return null;
+
+  return {
+    id: raw.id,
+    name: raw.name,
+    projectIds,
+  };
+}
+
+export function parseSidebarProjectFoldersState(
+  raw: unknown,
+  options: ParseSidebarStateOptions = {},
+): SidebarProjectFoldersState | null {
+  const mode = options.mode ?? "permissive";
+  if (!isRecord(raw)) {
+    return mode === "strict" ? null : EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE;
+  }
+
+  const foldersValue = raw.folders;
+  if (!Array.isArray(foldersValue) && (mode === "strict" || options.requireFoldersArray)) {
+    return null;
+  }
+
+  const foldersRaw = Array.isArray(foldersValue) ? foldersValue : [];
+  const folders: SidebarProjectFolder[] = [];
+  for (const entry of foldersRaw) {
+    const folder = parseFolder(entry, mode);
+    if (!folder) {
+      if (mode === "strict") return null;
+      continue;
+    }
+    folders.push(folder);
+  }
+
+  const openStateValue = raw.folderOpenState;
+  if (openStateValue !== undefined && !isRecord(openStateValue)) {
+    return mode === "strict" ? null : { folders, folderOpenState: {} };
+  }
+
+  const openStateRaw = isRecord(openStateValue) ? openStateValue : {};
+  const folderOpenState: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(openStateRaw)) {
+    if (typeof value !== "boolean") {
+      if (mode === "strict") return null;
+      continue;
+    }
+    folderOpenState[key] = value;
+  }
+
+  const parsedState = { folders, folderOpenState };
+  return mode === "permissive"
+    ? normalizeSidebarPreferencesState(parsedState)
+    : parsedState;
+}
+
+export function parseUiPreferencesPayload(
+  raw: unknown,
+  options: ParseUiPreferencesOptions = {},
+): UiPreferencesPayload | null {
+  const mode = options.mode ?? "strict";
+  if (!isRecord(raw) || !isRecord(raw.sidebar)) return null;
+
+  const sidebar = parseSidebarProjectFoldersState(raw.sidebar, {
+    mode,
+    requireFoldersArray: true,
+  });
+  if (!sidebar) return null;
+
+  return { sidebar };
+}
+
+export function sanitizeSidebarPreferencesState(
+  state: SidebarProjectFoldersState,
+  projectIds: string[],
+): SidebarProjectFoldersState {
+  const knownProjectIds = new Set(projectIds);
+  const usedProjectIds = new Set<string>();
+  const seenFolderIds = new Set<string>();
+
+  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
+    const name = folder.name.trim();
+    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
+    seenFolderIds.add(folder.id);
+
+    const seenProjectIds = new Set<string>();
+    const nextProjectIds = folder.projectIds.filter((projectId) => {
+      if (!knownProjectIds.has(projectId)) return false;
+      if (usedProjectIds.has(projectId)) return false;
+      if (seenProjectIds.has(projectId)) return false;
+      usedProjectIds.add(projectId);
+      seenProjectIds.add(projectId);
+      return true;
+    });
+
+    return [{
+      id: folder.id,
+      name,
+      projectIds: nextProjectIds,
+    }];
+  });
+
+  const folderOpenState = Object.fromEntries(
+    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
+      seenFolderIds.has(folderId) && typeof value === "boolean",
+    ),
+  );
+
+  return { folders, folderOpenState };
+}
+
+export function normalizeSidebarPreferencesState(
+  state: SidebarProjectFoldersState,
+): SidebarProjectFoldersState {
+  const seenFolderIds = new Set<string>();
+  const folders = state.folders.flatMap((folder): SidebarProjectFolder[] => {
+    const name = folder.name.trim();
+    if (!folder.id || !name || seenFolderIds.has(folder.id)) return [];
+    seenFolderIds.add(folder.id);
+    return [{
+      id: folder.id,
+      name,
+      projectIds: folder.projectIds,
+    }];
+  });
+
+  const folderOpenState = Object.fromEntries(
+    Object.entries(state.folderOpenState).filter(([folderId, value]) =>
+      seenFolderIds.has(folderId) && typeof value === "boolean",
+    ),
+  );
+
+  return { folders, folderOpenState };
+}
+
+export function sanitizeUiPreferencesPayload(
+  payload: UiPreferencesPayload,
+  projectIds: string[],
+): UiPreferencesPayload {
+  return {
+    sidebar: sanitizeSidebarPreferencesState(payload.sidebar, projectIds),
+  };
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "src"
+    "rootDir": "."
   },
-  "include": ["src"]
+  "include": ["sidebar-preferences.ts"]
 }


### PR DESCRIPTION
## Summary
- Introduces sidebar project folders with drag-to-reorder across folders, inline rename, and delete-with-confirmation.
- Persists folder layout + open state through a new `/api/ui-preferences` endpoint, with a shared schema package, local seed cache, and sanitize-on-read/write.
- Hardens mutations behind initial ui-preferences hydration so an empty local state can't clobber server folders, with a local fallback when the fetch fails.
- Tightens sidebar layout (left-aligned top rows, flattened automations) and fixes repo owner/repo parsing for nested GitLab paths + SCP-style URLs.

## Test plan
- [ ] `npm run typecheck` from repo root
- [ ] `npm test` from repo root
- [ ] Create / rename / delete a folder and reload — layout persists
- [ ] Drag a project between folders and between root and folder
- [ ] Reorder folders via drag
- [ ] Block network on `/api/ui-preferences` GET, reload — UI falls back to local seed and still lets you create folders
- [ ] Initial page load: folder controls are disabled until hydration completes
- [ ] Delete a project referenced by a folder — entry is removed on next hydration