### PR TITLE
Sidebar: roll-up activity indicators + hierarchy polish

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - Icons are compiled into the Rust binary; after changing icons run `cargo clean` in `src-tauri/` then rebuild.
 - Vite config (`frontend/vite.config.ts`) includes Tauri-specific settings (fixed port, HMR, build targets).
 - Sidebar collapse: CSS var `--traffic-light-clearance` (76px) provides clearance for macOS traffic lights. Tauri fullscreen detection resets to 0.
+- **HTML5 drag & drop inside the webview**: `dragDropEnabled` is set to `false` on the window in `tauri.conf.json`. When left at its default (`true`), Tauri's OS-level file-drop handler intercepts drag events before they reach the DOM — `dragstart` still fires but `dragover`/`drop` never do, which breaks in-app DnD (e.g. sidebar project folders reordering). The tradeoff: dropping files from Finder/Explorer onto the Hive window is disabled. If we later need OS file-drop for a feature, options are: (a) re-enable `dragDropEnabled` and migrate in-app DnD to pointer-event-based libs like `@dnd-kit/core` which aren't affected by the OS handler, or (b) keep it disabled and use a Tauri dialog / OS picker for file selection instead.
 
 ## Known Gaps (Current)
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -17,7 +17,8 @@
         "fullscreen": false,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 12, "y": 24 }
+        "trafficLightPosition": { "x": 12, "y": 24 },
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
   parseProjectOwnerRepo,
 } from "@/lib/sidebar-helpers";
 import { cn } from "@/lib/utils";
+import { aggregateWorkspaceActivity } from "@/lib/workspace-activity";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
 import { SidebarFolderComposer } from "@/components/sidebar/SidebarFolderComposer";
@@ -455,6 +456,10 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
 
                     const isRenaming = renamingFolderId === folder.id;
                     const isEmptyFolder = folder.projects.length === 0;
+                    const folderWorkspaceIds = folder.projects.flatMap((project) =>
+                      (project.workspaces ?? []).map((ws) => ws.id),
+                    );
+                    const folderActivity = aggregateWorkspaceActivity(folderWorkspaceIds, liveData);
 
                     return (
                       <SidebarFolderItem
@@ -469,6 +474,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                         isEmptyFolder={isEmptyFolder}
                         draggingFolderId={draggingFolderId}
                         folderInsertIndicator={folderInsertIndicator}
+                        activityState={folderActivity}
                         renameDraft={renameDraft}
                         onOpenChange={(open) => setFolderExpanded(folder.id, open)}
                         onFolderDragOver={handleFolderDragOver}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -524,7 +524,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                     <p className="text-xs text-muted-foreground/60">no automations</p>
                   </div>
                 ) : (
-                  <div className="mt-1 space-y-px">
+                  <div className="mt-2 space-y-1.5">
                     {sortedAutomations.map((auto) => (
                       <AutomationRow key={auto.id} auto={auto} pathname={pathname} />
                     ))}
@@ -619,51 +619,43 @@ function AutomationRow({ auto, pathname }: { auto: Automation; pathname: string 
   })();
 
   return (
-    <div className="relative">
-      {isActive && (
-        <span
-          aria-hidden
-          className="pointer-events-none absolute left-0 top-1 bottom-1 w-0.5 rounded-full bg-primary"
-        />
+    <Link
+      to={`/automations/${auto.id}`}
+      className={cn(
+        "sidebar-card block rounded-md border px-2.5 py-1.5",
+        isActive && "sidebar-card-active",
       )}
-      <Link
-        to={`/automations/${auto.id}`}
-        className={cn(
-          "sidebar-card block rounded px-2 py-1 transition-colors hover:bg-sidebar-accent/50",
-          isActive && "sidebar-card-active bg-sidebar-accent/70",
-        )}
-      >
-        <div className="flex items-center gap-2">
-          <span
-            className={cn(
-              "h-1.5 w-1.5 shrink-0 rounded-full",
-              isRunning
-                ? "bg-green-500 animate-pulse"
-                : auto.enabled
-                  ? "bg-green-500"
-                  : "bg-muted-foreground/40",
-            )}
-          />
-          <span
-            className={cn(
-              "min-w-0 flex-1 truncate text-[13px]",
-              isActive || auto.enabled
-                ? "text-sidebar-foreground"
-                : "text-muted-foreground",
-            )}
-          >
-            {auto.name}
-          </span>
-          <span
-            className={cn(
-              "shrink-0 text-[11px]",
-              isActive ? "text-sidebar-foreground/70" : "text-muted-foreground",
-            )}
-          >
-            {rightLabel}
-          </span>
-        </div>
-      </Link>
-    </div>
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            isRunning
+              ? "bg-green-500 animate-pulse"
+              : auto.enabled
+                ? "bg-green-500"
+                : "bg-muted-foreground/40",
+          )}
+        />
+        <span
+          className={cn(
+            "min-w-0 flex-1 truncate text-sm",
+            isActive || auto.enabled
+              ? "text-sidebar-foreground"
+              : "text-muted-foreground",
+          )}
+        >
+          {auto.name}
+        </span>
+        <span
+          className={cn(
+            "shrink-0 text-[11px]",
+            isActive ? "text-sidebar-foreground/70" : "text-muted-foreground",
+          )}
+        >
+          {rightLabel}
+        </span>
+      </div>
+    </Link>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -30,7 +30,7 @@ import {
   parseProjectOwnerRepo,
 } from "@/lib/sidebar-helpers";
 import { cn } from "@/lib/utils";
-import { aggregateWorkspaceActivity } from "@/lib/workspace-activity";
+import { aggregateScriptRunning, aggregateWorkspaceActivity } from "@/lib/workspace-activity";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
 import { SidebarFolderComposer } from "@/components/sidebar/SidebarFolderComposer";
@@ -460,6 +460,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                       (project.workspaces ?? []).map((ws) => ws.id),
                     );
                     const folderActivity = aggregateWorkspaceActivity(folderWorkspaceIds, liveData);
+                    const folderScriptRunning = aggregateScriptRunning(folderWorkspaceIds, liveData);
 
                     return (
                       <SidebarFolderItem
@@ -475,6 +476,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
                         draggingFolderId={draggingFolderId}
                         folderInsertIndicator={folderInsertIndicator}
                         activityState={folderActivity}
+                        scriptRunning={folderScriptRunning}
                         renameDraft={renameDraft}
                         onOpenChange={(open) => setFolderExpanded(folder.id, open)}
                         onFolderDragOver={handleFolderDragOver}

--- a/frontend/src/components/sidebar/SidebarActivityDot.tsx
+++ b/frontend/src/components/sidebar/SidebarActivityDot.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/lib/utils";
+import type { ActivityState } from "@/lib/workspace-activity";
+
+interface SidebarActivityDotProps {
+  state: ActivityState;
+  dimmed?: boolean;
+  className?: string;
+}
+
+export function SidebarActivityDot({ state, dimmed, className }: SidebarActivityDotProps) {
+  if (state === "idle") return null;
+
+  const label =
+    state === "streaming" ? "Agent is working" : "Unread activity";
+
+  return (
+    <span
+      className={cn(
+        "pointer-events-none absolute -top-1 -right-1 flex h-2.5 w-2.5 items-center justify-center",
+        dimmed && "opacity-60",
+        className,
+      )}
+      aria-label={label}
+      role="status"
+    >
+      {state === "streaming" && (
+        <span className="absolute inset-0 animate-ping rounded-full bg-primary/70" />
+      )}
+      <span className="relative h-2 w-2 rounded-full bg-primary shadow-[0_0_0_2px_var(--sidebar)]" />
+    </span>
+  );
+}

--- a/frontend/src/components/sidebar/SidebarFolderItem.tsx
+++ b/frontend/src/components/sidebar/SidebarFolderItem.tsx
@@ -2,6 +2,8 @@ import { ChevronRight, Folder, FolderOpen, Pencil, Trash2 } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { SidebarActivityDot } from "@/components/sidebar/SidebarActivityDot";
+import type { ActivityState } from "@/lib/workspace-activity";
 import type { SidebarProjectFolderView } from "@/hooks/useSidebarProjectFolders";
 import type { Project } from "@/types";
 
@@ -16,6 +18,7 @@ interface SidebarFolderItemProps {
   isEmptyFolder: boolean;
   draggingFolderId: string | null;
   folderInsertIndicator: "before" | "after" | null;
+  activityState: ActivityState;
   renameDraft: string;
   onOpenChange: (open: boolean) => void;
   onFolderDragOver: (event: React.DragEvent<HTMLDivElement>, folderId: string) => void;
@@ -51,6 +54,7 @@ export function SidebarFolderItem({
   isEmptyFolder,
   draggingFolderId,
   folderInsertIndicator,
+  activityState,
   renameDraft,
   onOpenChange,
   onFolderDragOver,
@@ -112,11 +116,14 @@ export function SidebarFolderItem({
             }}
           >
             <ChevronRight className={cn("h-3.5 w-3.5 shrink-0", expanded && "rotate-90")} />
-            {expanded ? (
-              <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-            ) : (
-              <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-            )}
+            <span className="relative inline-flex shrink-0">
+              {expanded ? (
+                <FolderOpen className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <Folder className="h-4 w-4 text-muted-foreground" />
+              )}
+              <SidebarActivityDot state={activityState} dimmed={expanded} />
+            </span>
             <Input
               value={renameDraft}
               onChange={(event) => onRenameDraftChange(event.target.value)}
@@ -150,11 +157,14 @@ export function SidebarFolderItem({
                 )}
               >
                 <ChevronRight className={cn("h-3.5 w-3.5 shrink-0 transition-transform", expanded && "rotate-90")} />
-                {expanded ? (
-                  <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
-                ) : (
-                  <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
-                )}
+                <span className="relative inline-flex shrink-0">
+                  {expanded ? (
+                    <FolderOpen className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <Folder className="h-4 w-4 text-muted-foreground" />
+                  )}
+                  <SidebarActivityDot state={activityState} dimmed={expanded} />
+                </span>
                 <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
                   {folder.name}
                 </span>

--- a/frontend/src/components/sidebar/SidebarFolderItem.tsx
+++ b/frontend/src/components/sidebar/SidebarFolderItem.tsx
@@ -2,6 +2,7 @@ import { ChevronRight, Folder, FolderOpen, Pencil, Trash2 } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
+import { ActivityWave } from "@/components/ui/activity-wave";
 import { SidebarActivityDot } from "@/components/sidebar/SidebarActivityDot";
 import type { ActivityState } from "@/lib/workspace-activity";
 import type { SidebarProjectFolderView } from "@/hooks/useSidebarProjectFolders";
@@ -19,6 +20,7 @@ interface SidebarFolderItemProps {
   draggingFolderId: string | null;
   folderInsertIndicator: "before" | "after" | null;
   activityState: ActivityState;
+  scriptRunning: boolean;
   renameDraft: string;
   onOpenChange: (open: boolean) => void;
   onFolderDragOver: (event: React.DragEvent<HTMLDivElement>, folderId: string) => void;
@@ -55,6 +57,7 @@ export function SidebarFolderItem({
   draggingFolderId,
   folderInsertIndicator,
   activityState,
+  scriptRunning,
   renameDraft,
   onOpenChange,
   onFolderDragOver,
@@ -171,8 +174,19 @@ export function SidebarFolderItem({
               </button>
             </CollapsibleTrigger>
 
+            {scriptRunning && !expanded && (
+              <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center">
+                <div className="flex h-5 w-5 items-center justify-center">
+                  <ActivityWave size="small" decorative className="shrink-0" />
+                </div>
+              </div>
+            )}
+
             {canInteract && (
-              <div className="pointer-events-none absolute inset-y-0 right-1 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100">
+              <div className={cn(
+                "pointer-events-none absolute inset-y-0 flex items-center gap-0.5 opacity-0 transition-opacity group-hover/folder:pointer-events-auto group-hover/folder:opacity-100 focus-within:pointer-events-auto focus-within:opacity-100",
+                scriptRunning && !expanded ? "right-6" : "right-0",
+              )}>
               <button
                 type="button"
                 onClick={(event) => {
@@ -180,7 +194,7 @@ export function SidebarFolderItem({
                   event.stopPropagation();
                   onStartRenaming(folder.id, folder.name);
                 }}
-                className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50"
+                className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-sidebar-accent/60 hover:text-sidebar-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/50"
                 aria-label={`Rename folder ${folder.name}`}
               >
                 <Pencil className="h-3 w-3" />
@@ -193,7 +207,7 @@ export function SidebarFolderItem({
                     event.stopPropagation();
                     onDeleteRequest(folder.id, folder.name);
                   }}
-                  className="rounded p-0.5 text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/60"
+                  className="flex h-5 w-5 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-destructive/15 hover:text-destructive focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-destructive/60"
                   aria-label={`Delete folder ${folder.name}`}
                 >
                   <Trash2 className="h-3 w-3" />

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -36,7 +36,7 @@ export function SidebarGroupHeader({
         <button
           type="button"
           className={cn(
-            "flex w-full min-w-0 items-center overflow-hidden text-left transition-colors",
+            "flex w-full min-w-0 items-center text-left transition-colors",
             isPlain
               ? "gap-1.5 px-0 py-0.5"
               : "gap-2 rounded px-2 py-1 hover:bg-sidebar-accent/40",

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -6,6 +6,7 @@ interface SidebarGroupHeaderProps {
   icon: React.ReactNode;
   label: React.ReactNode;
   badge?: React.ReactNode;
+  activityIndicator?: React.ReactNode;
   count?: number;
   isLoading?: boolean;
   onAdd?: (e: React.MouseEvent) => void;
@@ -19,6 +20,7 @@ export function SidebarGroupHeader({
   icon,
   label,
   badge,
+  activityIndicator,
   count,
   isLoading,
   onAdd,
@@ -29,6 +31,17 @@ export function SidebarGroupHeader({
 }: SidebarGroupHeaderProps) {
   const isPlain = variant === "plain";
   const { className: buttonPropsClassName, ...restButtonProps } = buttonProps ?? {};
+  const hasActivity = activityIndicator !== undefined && activityIndicator !== null && activityIndicator !== false;
+  const hasCount = count !== undefined;
+  // When both count and activity are shown, count takes the rightmost rail
+  // and the activity indicator sits to its left. When only one is shown,
+  // it takes the rightmost rail.
+  const activitySlotRight = hasCount ? "right-6" : "right-0";
+  const buttonRightPad = hasActivity && hasCount
+    ? "pr-12"
+    : hasCount || hasActivity
+      ? "pr-6"
+      : undefined;
 
   return (
     <div className="group relative flex w-full items-center">
@@ -40,7 +53,7 @@ export function SidebarGroupHeader({
             isPlain
               ? "gap-1.5 px-0 py-0.5"
               : "gap-2 rounded px-2 py-1 hover:bg-sidebar-accent/40",
-            count !== undefined && "pr-7",
+            buttonRightPad,
             buttonClassName,
             buttonPropsClassName,
           )}
@@ -53,8 +66,15 @@ export function SidebarGroupHeader({
           {badge}
         </button>
       </CollapsibleTrigger>
-      {count !== undefined && (
-        <div className={cn("absolute inset-y-0 flex items-center", isPlain ? "right-0" : "right-2")}>
+      {hasActivity && (
+        <div className={cn("pointer-events-none absolute inset-y-0 flex items-center", activitySlotRight)}>
+          <div className="flex h-5 w-5 items-center justify-center">
+            {activityIndicator}
+          </div>
+        </div>
+      )}
+      {hasCount && (
+        <div className="absolute inset-y-0 right-0 flex items-center">
           <div className="relative flex h-5 w-5 items-center justify-center">
             {isLoading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -6,6 +6,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { SidebarGroupHeader } from "@/components/sidebar/SidebarHeaders";
+import { SidebarActivityDot } from "@/components/sidebar/SidebarActivityDot";
 import { BranchLabel } from "@/components/BranchLabel";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
 import { ActivityWave } from "@/components/ui/activity-wave";
@@ -13,6 +14,7 @@ import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { computePrDisplayCompact } from "@/lib/pr-display";
 import { cn } from "@/lib/utils";
 import type { WorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
+import { aggregateWorkspaceActivity } from "@/lib/workspace-activity";
 import type { PrStatusResponse, Project } from "@/types";
 import { ArchiveIcon, Loader2 } from "lucide-react";
 
@@ -83,17 +85,23 @@ export function SidebarProjectItem({
     && draggingProjectId !== null
     && draggingProjectId !== project.id;
 
+  const workspaceIds = (project.workspaces ?? []).map((ws) => ws.id);
+  const projectActivity = aggregateWorkspaceActivity(workspaceIds, liveData);
+
   return (
     <div key={project.id} className={cn("relative", className)} data-sidebar-project={project.id}>
       <Collapsible open={isExpanded} onOpenChange={setExpanded}>
         <SidebarGroupHeader
           icon={
-            <ProjectAvatar
-              name={project.name}
-              projectId={project.id}
-              hasFavicon={project.hasFavicon}
-              className="h-[18px] w-[18px]"
-            />
+            <span className="relative inline-flex shrink-0">
+              <ProjectAvatar
+                name={project.name}
+                projectId={project.id}
+                hasFavicon={project.hasFavicon}
+                className="h-[18px] w-[18px]"
+              />
+              <SidebarActivityDot state={projectActivity} dimmed={isExpanded} />
+            </span>
           }
           label={displayLabel}
           count={(project.workspaces ?? []).length}

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -127,7 +127,7 @@ export function SidebarProjectItem({
           }}
         />
 
-        <CollapsibleContent>
+        <CollapsibleContent className="mb-2">
           <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
             <div className="mt-1 space-y-1.5">
               {(project.workspaces ?? []).map((ws) => {

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -128,8 +128,9 @@ export function SidebarProjectItem({
         />
 
         <CollapsibleContent>
-          <div className="mt-1 space-y-1.5">
-            {(project.workspaces ?? []).map((ws) => {
+          <div className="ml-2 mt-px border-l border-sidebar-border/40 pl-2">
+            <div className="mt-1 space-y-1.5">
+              {(project.workspaces ?? []).map((ws) => {
               const wsLive = liveData[ws.id];
               const wsStreaming = wsLive?.streaming ?? false;
               const wsScriptRunning = wsLive?.scriptRunning ?? false;
@@ -228,6 +229,7 @@ export function SidebarProjectItem({
                 </div>
               );
             })}
+            </div>
           </div>
         </CollapsibleContent>
       </Collapsible>

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -14,7 +14,7 @@ import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { computePrDisplayCompact } from "@/lib/pr-display";
 import { cn } from "@/lib/utils";
 import type { WorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
-import { aggregateWorkspaceActivity } from "@/lib/workspace-activity";
+import { aggregateScriptRunning, aggregateWorkspaceActivity } from "@/lib/workspace-activity";
 import type { PrStatusResponse, Project } from "@/types";
 import { ArchiveIcon, Loader2 } from "lucide-react";
 
@@ -87,6 +87,7 @@ export function SidebarProjectItem({
 
   const workspaceIds = (project.workspaces ?? []).map((ws) => ws.id);
   const projectActivity = aggregateWorkspaceActivity(workspaceIds, liveData);
+  const projectScriptRunning = aggregateScriptRunning(workspaceIds, liveData);
 
   return (
     <div key={project.id} className={cn("relative", className)} data-sidebar-project={project.id}>
@@ -104,6 +105,11 @@ export function SidebarProjectItem({
             </span>
           }
           label={displayLabel}
+          activityIndicator={
+            projectScriptRunning && !isExpanded ? (
+              <ActivityWave size="small" decorative className="shrink-0" />
+            ) : undefined
+          }
           count={(project.workspaces ?? []).length}
           isLoading={creatingProjectId === project.id}
           onAdd={() => { onAddWorkspace(project.id); }}
@@ -161,15 +167,12 @@ export function SidebarProjectItem({
                             branch={displayBranch}
                             showIcon={false}
                             className={cn(
-                              "min-w-0 flex-1 text-sm",
+                              "min-w-0 flex-1 pr-5 text-sm",
                               activeWsId === ws.id || wsUnread
                                 ? "text-sidebar-foreground"
                                 : "text-muted-foreground",
                             )}
                           />
-                          {wsScriptRunning && (
-                            <ActivityWave size="small" decorative className="shrink-0" />
-                          )}
                         </div>
 
                         <div className="mt-0.5 flex items-center gap-1 pl-5 text-[11px]">
@@ -197,14 +200,20 @@ export function SidebarProjectItem({
                     </TooltipContent>
                   </Tooltip>
 
+                  {wsScriptRunning && !wsArchiving && (
+                    <div className="pointer-events-none absolute right-2 top-1.5">
+                      <ActivityWave size="small" decorative className="shrink-0" />
+                    </div>
+                  )}
+
                   {wsArchiving ? (
-                    <div className="absolute right-1.5 top-1.5 p-0.5">
+                    <div className="absolute right-2 top-1.5 p-0.5">
                       <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
                     </div>
                   ) : !wsScriptRunning && (
                     <button
                       type="button"
-                      className="absolute right-1.5 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
+                      className="absolute right-2 top-1.5 rounded p-0.5 text-muted-foreground opacity-0 transition-opacity hover:text-sidebar-foreground group-hover/ws:opacity-100"
                       onClick={(event) => {
                         event.preventDefault();
                         event.stopPropagation();

--- a/frontend/src/lib/workspace-activity.ts
+++ b/frontend/src/lib/workspace-activity.ts
@@ -1,0 +1,31 @@
+import type { WorkspaceLiveData } from "@/hooks/useWorkspaceLiveData";
+
+export type ActivityState = "streaming" | "unread" | "idle";
+
+export function workspaceActivityState(data: WorkspaceLiveData | undefined): ActivityState {
+  if (!data) return "idle";
+  if (data.streaming) return "streaming";
+  if (data.unreadSessions && Object.keys(data.unreadSessions).length > 0) return "unread";
+  return "idle";
+}
+
+const PRIORITY: Record<ActivityState, number> = {
+  streaming: 2,
+  unread: 1,
+  idle: 0,
+};
+
+export function aggregateActivityState(states: ActivityState[]): ActivityState {
+  let best: ActivityState = "idle";
+  for (const s of states) {
+    if (PRIORITY[s] > PRIORITY[best]) best = s;
+  }
+  return best;
+}
+
+export function aggregateWorkspaceActivity(
+  workspaceIds: string[],
+  liveData: Record<string, WorkspaceLiveData>,
+): ActivityState {
+  return aggregateActivityState(workspaceIds.map((id) => workspaceActivityState(liveData[id])));
+}

--- a/frontend/src/lib/workspace-activity.ts
+++ b/frontend/src/lib/workspace-activity.ts
@@ -29,3 +29,10 @@ export function aggregateWorkspaceActivity(
 ): ActivityState {
   return aggregateActivityState(workspaceIds.map((id) => workspaceActivityState(liveData[id])));
 }
+
+export function aggregateScriptRunning(
+  workspaceIds: string[],
+  liveData: Record<string, WorkspaceLiveData>,
+): boolean {
+  return workspaceIds.some((id) => liveData[id]?.scriptRunning === true);
+}

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -1230,17 +1230,16 @@ describe("Sidebar", () => {
 
     await screen.findByText("workspace/tokyo");
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
-    // No wave indicator initially (no SVGs — GitBranch icon is always hidden)
-    const svgsBefore = workspaceLink.querySelectorAll("svg");
-    expect(svgsBefore).toHaveLength(0);
+    const workspaceRow = workspaceLink.closest('[class*="group/ws"]') as HTMLElement;
+    // No wave indicator initially
+    expect(workspaceRow.querySelectorAll('svg[viewBox="0 0 12 12"]')).toHaveLength(0);
 
     act(() => {
       __wsMock.emit("w1", { type: "script_status", scriptType: "run", state: "running" });
     });
 
     // Wave indicator SVG should appear (the inline SVG with viewBox="0 0 12 12")
-    const svgsAfter = workspaceLink.querySelectorAll("svg");
-    expect(svgsAfter.length).toBeGreaterThan(0);
+    expect(workspaceRow.querySelectorAll('svg[viewBox="0 0 12 12"]').length).toBeGreaterThan(0);
   });
 
   it("hides wave indicator when script finishes", async () => {
@@ -1254,13 +1253,14 @@ describe("Sidebar", () => {
     });
 
     const workspaceLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
-    expect(workspaceLink.querySelectorAll("svg").length).toBeGreaterThan(0);
+    const workspaceRow = workspaceLink.closest('[class*="group/ws"]') as HTMLElement;
+    expect(workspaceRow.querySelectorAll('svg[viewBox="0 0 12 12"]').length).toBeGreaterThan(0);
 
     act(() => {
       __wsMock.emit("w1", { type: "script_status", scriptType: "run", state: "done", exitCode: 0 });
     });
 
-    expect(workspaceLink.querySelectorAll("svg")).toHaveLength(0); // no SVGs at rest
+    expect(workspaceRow.querySelectorAll('svg[viewBox="0 0 12 12"]')).toHaveLength(0);
   });
 
   it("hides archive button when script is running", async () => {


### PR DESCRIPTION
## Summary

- **Rollup activity dot** on projects and folders that aggregates the streaming / unread state of all descendant workspaces — so in-progress agents stay visible when those levels are collapsed.
- **Rollup activity wave** on collapsed projects and folders when any descendant has a running script (dev server, long-running process). Workspace-level wave still wins when the row is expanded.
- **Aligned right rail**: section header add button, project count, folder rename/delete actions and the activity wave all sit in a uniform 20×20 slot at the same x so nothing feels off-grid. Count stays rightmost on projects; the wave lands to its left when both are present.
- **Indent + vertical line** from project → workspace, mirroring the existing folder → project treatment, so the tree reads consistently at all three depths. Small `mb-2` below an expanded project keeps sibling projects from feeling glued together.
- **Tauri**: disable OS-level drag-drop on the webview so HTML5 DnD (folder reordering from the last PR) actually fires `dragover`/`drop` events. Tradeoff documented in CLAUDE.md — Finder/Explorer file drop onto the window is disabled for now.

## Test plan

- [ ] Agent streaming in a workspace → pulsing dot appears on its project (collapsed) and on its folder (collapsed)
- [ ] Unread state after a `done` event → static dot shows at both rollup levels; clears on visit
- [ ] Script running (setup / run / terminal) → wave appears on collapsed project + folder, not when expanded
- [ ] Right rail: section header `+`, project count, folder pencil/trash, wave all line up vertically
- [ ] Project expanded → workspaces render with left border + indent matching folder → project
- [ ] Small gap between last workspace of an expanded project and the next sibling project
- [ ] Tauri desktop: drag a project into / out of a folder, reorder projects, reorder folders — DnD events fire correctly
- [ ] `npm run typecheck` and `npm test` pass (1107 tests)