### PR TITLE
fix(sidebar): stop wiping folder contents on transient project-list failures

### DIFF
--- a/backend/src/api/ui-preferences.test.ts
+++ b/backend/src/api/ui-preferences.test.ts
@@ -43,21 +43,38 @@ describe("GET /api/ui-preferences", () => {
     expect(res.json()).toEqual({ sidebar: { folders: [], folderOpenState: {} } });
   });
 
-  it("prunes folders referencing deleted projects at read time", async () => {
-    await seedProject("p-alive");
-    const res = await app.inject({
-      method: "PUT",
-      url: "/api/ui-preferences",
-      payload: {
+  // Regression: the read path used to sanitize against listProjects(), which
+  // meant any transient read failure (empty readdir, corrupt state.json) wiped
+  // every folder.projectIds from the response — and the client then flushed
+  // that empty state back on the next interaction. Reads must now be raw.
+  it("preserves folder refs on read even when no projects are listed", async () => {
+    const { writeFile, mkdir } = await import("node:fs/promises");
+    await mkdir(dataDir, { recursive: true });
+    await writeFile(
+      join(dataDir, "ui-preferences.json"),
+      JSON.stringify({
         sidebar: {
-          folders: [{ id: "f1", name: "Work", projectIds: ["p-alive"] }],
-          folderOpenState: { f1: true },
+          folders: [
+            { id: "f1", name: "Work", projectIds: ["p-a", "p-b"] },
+            { id: "f2", name: "Perso", projectIds: ["p-c"] },
+          ],
+          folderOpenState: { f1: true, f2: false },
         },
-      },
-    });
-    expect(res.statusCode).toBe(200);
+      }),
+      "utf-8",
+    );
 
-    // Now write a raw file that references a dead project — simulate a project deletion
+    // No seedProject() — simulates the transient-empty listProjects() case
+    const getRes = await app.inject({ method: "GET", url: "/api/ui-preferences" });
+    expect(getRes.statusCode).toBe(200);
+    expect(getRes.json().sidebar.folders).toEqual([
+      { id: "f1", name: "Work", projectIds: ["p-a", "p-b"] },
+      { id: "f2", name: "Perso", projectIds: ["p-c"] },
+    ]);
+  });
+
+  it("returns raw stored payload without any server-side filtering", async () => {
+    await seedProject("p-alive");
     const { writeFile } = await import("node:fs/promises");
     await writeFile(
       join(dataDir, "ui-preferences.json"),
@@ -72,8 +89,10 @@ describe("GET /api/ui-preferences", () => {
       "utf-8",
     );
 
+    // Unknown IDs survive the read — the client filters at display time via
+    // mapSidebarFolderProjects, and deletion prunes explicitly.
     const getRes = await app.inject({ method: "GET", url: "/api/ui-preferences" });
-    expect(getRes.json().sidebar.folders[0].projectIds).toEqual(["p-alive"]);
+    expect(getRes.json().sidebar.folders[0].projectIds).toEqual(["p-alive", "p-dead"]);
   });
 });
 
@@ -116,6 +135,47 @@ describe("PUT /api/ui-preferences", () => {
     });
     expect(res.statusCode).toBe(200);
     expect(res.json().sidebar.folders[0].projectIds).toEqual(["p1"]);
+  });
+
+  // Regression: a transient-empty listProjects() at write time used to drop
+  // every ref from the payload. Guard: when no projects are listed but the
+  // payload still references some, treat listProjects as unreliable and
+  // persist the payload verbatim rather than wiping it.
+  it("preserves payload refs when listProjects() is transiently empty", async () => {
+    // No seedProject() — simulates listProjects failing/returning empty
+    const payload = {
+      sidebar: {
+        folders: [
+          { id: "f1", name: "Work", projectIds: ["p-a", "p-b"] },
+          { id: "f2", name: "Perso", projectIds: ["p-c"] },
+        ],
+        folderOpenState: { f1: true, f2: true },
+      },
+    };
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(payload);
+
+    const onDisk = JSON.parse(
+      await readFile(join(dataDir, "ui-preferences.json"), "utf-8"),
+    );
+    expect(onDisk).toEqual(payload);
+  });
+
+  // The guard only kicks in when we have refs to preserve: a genuinely empty
+  // write (e.g. user cleared everything) should still round-trip as empty.
+  it("still persists an empty payload when listProjects() is empty", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/ui-preferences",
+      payload: { sidebar: { folders: [], folderOpenState: {} } },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ sidebar: { folders: [], folderOpenState: {} } });
   });
 
   it("rejects payload missing sidebar (400)", async () => {

--- a/backend/src/api/ui-preferences.ts
+++ b/backend/src/api/ui-preferences.ts
@@ -19,12 +19,14 @@ export async function uiPreferencesRoutes(
 ): Promise<void> {
   const dataDir = opts.dataDir ?? getDataDir();
 
+  // Reads never sanitize: the persisted file is the source of truth. Running
+  // sanitize here would let a transient `listProjects()` failure (empty readdir,
+  // unreadable state.json) feed emptied folder.projectIds to the client, which
+  // then flushes them back on the next user interaction — permanently wiping
+  // the sort order. Display-time filtering (mapSidebarFolderProjects) handles
+  // stale refs safely, and project deletion prunes refs explicitly.
   app.get("/api/ui-preferences", async () => {
-    const [prefs, projects] = await Promise.all([
-      loadUiPreferences(dataDir),
-      listProjects(dataDir),
-    ]);
-    return sanitizeUiPreferences(prefs, projects.map((p) => p.id));
+    return loadUiPreferences(dataDir);
   });
 
   app.put<{ Body: unknown }>("/api/ui-preferences", async (req, reply) => {
@@ -34,6 +36,17 @@ export async function uiPreferencesRoutes(
     }
 
     const projects = await listProjects(dataDir);
+    const payloadHasRefs = parsed.sidebar.folders.some((f) => f.projectIds.length > 0);
+
+    // Safety: listProjects returning [] while the payload references real
+    // project IDs almost always means a transient read failure, not that every
+    // project was just deleted. Persist the payload verbatim rather than
+    // sanitizing every ref out of existence.
+    if (projects.length === 0 && payloadHasRefs) {
+      await saveUiPreferences(parsed, dataDir);
+      return parsed;
+    }
+
     const sanitized = sanitizeUiPreferences(parsed, projects.map((p) => p.id));
     await saveUiPreferences(sanitized, dataDir);
     return sanitized;

--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -86,6 +86,30 @@ describe("deleteProject", () => {
     await deleteProject(state.id, dataDir);
     expect(existsSync(projDir)).toBe(false);
   });
+
+  it("prunes the deleted project from sidebar folder refs", async () => {
+    const state = await createProject(fixtureRepoUrl, dataDir);
+    const { writeFile, readFile } = await import("node:fs/promises");
+    await writeFile(
+      join(dataDir, "ui-preferences.json"),
+      JSON.stringify({
+        sidebar: {
+          folders: [
+            { id: "f1", name: "Work", projectIds: [state.id, "other"] },
+          ],
+          folderOpenState: { f1: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    await deleteProject(state.id, dataDir);
+
+    const onDisk = JSON.parse(
+      await readFile(join(dataDir, "ui-preferences.json"), "utf-8"),
+    );
+    expect(onDisk.sidebar.folders[0].projectIds).toEqual(["other"]);
+  });
 });
 
 describe("initProject", () => {

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -6,6 +6,7 @@ import { gh } from "../utils/github.js";
 import { bareRepoPath } from "../utils/paths.js";
 import { saveProject, loadProject, loadAllProjects, getDataDir } from "../state/state.js";
 import { notifyProjectDeleted } from "../state/workspace-index.js";
+import { pruneProjectFromUiPreferences } from "../state/ui-preferences.js";
 import { validateRepositoryUrl } from "../utils/repo-url.js";
 import { NotFoundError } from "../utils/errors.js";
 import type { ProjectState } from "../types.js";
@@ -194,6 +195,7 @@ export async function deleteProject(
   const projectDir = join(dataDir, projectId);
   await rm(projectDir, { recursive: true, force: true });
   notifyProjectDeleted(projectId);
+  await pruneProjectFromUiPreferences(projectId, dataDir);
 }
 
 export async function fetchProject(

--- a/backend/src/state/ui-preferences.ts
+++ b/backend/src/state/ui-preferences.ts
@@ -50,3 +50,26 @@ export function sanitizeUiPreferences(
 ): UiPreferences {
   return sanitizeUiPreferencesPayload(prefs, knownProjectIds);
 }
+
+/**
+ * Remove a project's id from every folder and persist. Call this from
+ * project deletion — it's the only moment we know for sure the project is gone.
+ * No-op when the project isn't referenced anywhere.
+ */
+export async function pruneProjectFromUiPreferences(
+  projectId: string,
+  dataDir = getDataDir(),
+): Promise<void> {
+  const prefs = await loadUiPreferences(dataDir);
+  let changed = false;
+  const folders = prefs.sidebar.folders.map((folder) => {
+    const filtered = folder.projectIds.filter((id) => id !== projectId);
+    if (filtered.length !== folder.projectIds.length) changed = true;
+    return { ...folder, projectIds: filtered };
+  });
+  if (!changed) return;
+  await saveUiPreferences(
+    { sidebar: { folders, folderOpenState: prefs.sidebar.folderOpenState } },
+    dataDir,
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,9 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { getNextRun, formatTimeUntil } from "@/lib/cron";
 import {
+  AlertCircle,
   FolderPlus,
+  Loader2,
   Settings,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
@@ -18,6 +20,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
 import { useQueryClient } from "@tanstack/react-query";
 import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
 import { useProjects } from "@/hooks/useProjects";
@@ -61,7 +64,17 @@ type ProjectOrderDropTarget = {
 };
 
 export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps) {
-  const { projects, loading, ready: projectsReady, createWorkspace, archiveWorkspace } = useProjects();
+  const {
+    projects,
+    loading,
+    recovering: projectsRecovering,
+    unavailable: projectsUnavailable,
+    ready: projectsReady,
+    errorMessage: projectsErrorMessage,
+    retryProjects,
+    createWorkspace,
+    archiveWorkspace,
+  } = useProjects();
   const { data: automations, isLoading: automationsLoading } = useAutomations();
   const queryClient = useQueryClient();
   const { wsId: activeWsId } = useParams();
@@ -111,6 +124,17 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     setFolderExpanded,
     getFolderIdForProject,
   } = useSidebarProjectFolders(projects, projectsReady);
+  const projectsAppearIncomplete = projectsReady
+    && projects.length === 0
+    && folders.some((folder) => folder.projectIds.length > folder.projects.length);
+
+  useEffect(() => {
+    if (!projectsAppearIncomplete) return;
+    const intervalId = setInterval(() => {
+      void retryProjects();
+    }, 5_000);
+    return () => clearInterval(intervalId);
+  }, [projectsAppearIncomplete, retryProjects]);
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];
@@ -420,6 +444,44 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
             </div>
           ) : (
             <TooltipProvider delayDuration={400}>
+              {(projectsUnavailable || projectsAppearIncomplete) && (
+                <div
+                  className="mb-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3"
+                  role="alert"
+                >
+                  <div className="flex items-start gap-2.5">
+                    {projectsRecovering ? (
+                      <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-amber-500" />
+                    ) : (
+                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <p className="text-xs font-medium text-sidebar-foreground">
+                        {projectsAppearIncomplete
+                          ? "Repository list looks incomplete"
+                          : "Unable to load repositories"}
+                      </p>
+                      <p className="mt-1 text-xs text-muted-foreground">
+                        {projectsAppearIncomplete
+                          ? "Folders were restored, but the repository list is empty. Hive is retrying automatically."
+                          : `${projectsErrorMessage ?? "The repository list is unavailable."} Hive will keep retrying automatically.`}
+                      </p>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="xs"
+                        className="mt-3"
+                        onClick={() => { void retryProjects(); }}
+                        disabled={projectsRecovering}
+                      >
+                        {projectsRecovering && <Loader2 className="h-3 w-3 animate-spin" />}
+                        {projectsRecovering ? "Retrying..." : "Retry now"}
+                      </Button>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <SidebarSectionHeader
                 label="Workspaces"
                 className="mb-1"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -61,7 +61,7 @@ type ProjectOrderDropTarget = {
 };
 
 export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps) {
-  const { projects, loading, createWorkspace, archiveWorkspace } = useProjects();
+  const { projects, loading, ready: projectsReady, createWorkspace, archiveWorkspace } = useProjects();
   const { data: automations, isLoading: automationsLoading } = useAutomations();
   const queryClient = useQueryClient();
   const { wsId: activeWsId } = useParams();
@@ -110,7 +110,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,
-  } = useSidebarProjectFolders(projects, !loading);
+  } = useSidebarProjectFolders(projects, projectsReady);
 
   const isProjectExpanded = (projectId: string) => {
     const expanded = expandedProjects[projectId];

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -43,10 +43,19 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
 }
 
 export const api = {
-  get: <T>(url: string) => request<T>(url),
-  post: <T>(url: string, body?: unknown) =>
-    request<T>(url, { method: "POST", body: body ? JSON.stringify(body) : undefined }),
-  put: <T>(url: string, body?: unknown) =>
-    request<T>(url, { method: "PUT", body: body ? JSON.stringify(body) : undefined }),
-  delete: <T>(url: string) => request<T>(url, { method: "DELETE" }),
+  get: <T>(url: string, options?: RequestInit) => request<T>(url, options),
+  post: <T>(url: string, body?: unknown, options?: RequestInit) =>
+    request<T>(url, {
+      ...options,
+      method: "POST",
+      body: body ? JSON.stringify(body) : options?.body,
+    }),
+  put: <T>(url: string, body?: unknown, options?: RequestInit) =>
+    request<T>(url, {
+      ...options,
+      method: "PUT",
+      body: body ? JSON.stringify(body) : options?.body,
+    }),
+  delete: <T>(url: string, options?: RequestInit) =>
+    request<T>(url, { ...options, method: "DELETE" }),
 };

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,14 +1,104 @@
+import { useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "./useApi";
 import type { Project, Workspace } from "@/types";
+
+const PROJECTS_FETCH_TIMEOUT_MS = 10_000;
+const PROJECTS_RECOVERY_INTERVAL_MS = 5_000;
+
+function makeTimeoutError(message: string): Error {
+  if (typeof DOMException === "function") {
+    return new DOMException(message, "TimeoutError");
+  }
+  const error = new Error(message);
+  error.name = "TimeoutError";
+  return error;
+}
+
+function createLinkedAbortSignal(parentSignal?: AbortSignal): {
+  abort: (reason?: unknown) => void;
+  cleanup: () => void;
+  signal: AbortSignal;
+} {
+  const controller = new AbortController();
+
+  const abortFromParent = () => {
+    controller.abort(parentSignal?.reason);
+  };
+
+  if (parentSignal?.aborted) {
+    abortFromParent();
+  } else if (parentSignal) {
+    parentSignal.addEventListener("abort", abortFromParent, { once: true });
+  }
+
+  return {
+    abort: (reason?: unknown) => controller.abort(reason),
+    signal: controller.signal,
+    cleanup: () => {
+      parentSignal?.removeEventListener("abort", abortFromParent);
+    },
+  };
+}
+
+async function fetchProjects(signal?: AbortSignal): Promise<Project[]> {
+  const {
+    abort,
+    signal: requestSignal,
+    cleanup,
+  } = createLinkedAbortSignal(signal);
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timeoutId = setTimeout(() => {
+      const timeoutError = makeTimeoutError("Loading repositories timed out.");
+      abort(timeoutError);
+      reject(timeoutError);
+    }, PROJECTS_FETCH_TIMEOUT_MS);
+  });
+
+  try {
+    return await Promise.race([
+      api.get<Project[]>("/api/projects", { signal: requestSignal }),
+      timeoutPromise,
+    ]);
+  } catch (error) {
+    if (!signal?.aborted && requestSignal.aborted && requestSignal.reason instanceof Error) {
+      throw requestSignal.reason;
+    }
+    throw error;
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+    cleanup();
+  }
+}
+
+function formatProjectsError(error: unknown): string {
+  if (error instanceof DOMException && error.name === "TimeoutError") {
+    return "The server took too long to respond.";
+  }
+  if (error instanceof Error && error.message.trim().length > 0) {
+    return error.message;
+  }
+  return "Unable to load repositories.";
+}
 
 export function useProjects() {
   const queryClient = useQueryClient();
 
   const query = useQuery({
     queryKey: ["projects"],
-    queryFn: () => api.get<Project[]>("/api/projects"),
+    queryFn: ({ signal }) => fetchProjects(signal),
+    refetchInterval: (currentQuery) =>
+      currentQuery.state.error && !currentQuery.state.data
+        ? PROJECTS_RECOVERY_INTERVAL_MS
+        : false,
+    refetchIntervalInBackground: true,
   });
+
+  const retryProjects = useCallback(
+    () => query.refetch(),
+    [query.refetch],
+  );
 
   /** Shared logic: create project → optimistic cache → create workspace → rollback on error. */
   async function createProjectThenWorkspace(
@@ -93,12 +183,16 @@ export function useProjects() {
   return {
     projects: query.data ?? [],
     loading: query.isLoading,
+    recovering: query.isFetching && query.isError && !query.data,
+    unavailable: query.isError && !query.data,
     // True only after a successful fetch — guards destructive UI logic that
     // must not run on an empty/failed project list (e.g. sidebar-folder sanitize).
     ready: query.isSuccess,
     error: query.error,
+    errorMessage: query.error ? formatProjectsError(query.error) : null,
     fetchProjects: () =>
       queryClient.invalidateQueries({ queryKey: ["projects"] }),
+    retryProjects,
     createProjectWithWorkspace: (url: string) =>
       createProjectWithWorkspace.mutateAsync(url),
     createNewProjectWithWorkspace: (params: { name: string; visibility?: "public" | "private" }) =>

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -93,6 +93,9 @@ export function useProjects() {
   return {
     projects: query.data ?? [],
     loading: query.isLoading,
+    // True only after a successful fetch — guards destructive UI logic that
+    // must not run on an empty/failed project list (e.g. sidebar-folder sanitize).
+    ready: query.isSuccess,
     error: query.error,
     fetchProjects: () =>
       queryClient.invalidateQueries({ queryKey: ["projects"] }),

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -10,11 +10,11 @@ import {
   moveProjectBetweenSidebarFolders,
   moveProjectWithinSidebarFolders,
   moveSidebarFolder,
+  normalizeSidebarPreferencesState,
   payloadToSidebarPreferencesState,
   readLegacySidebarPreferences,
   readSidebarPreferencesLocalSeed,
   removeLegacySidebarPreferences,
-  sanitizeSidebarPreferencesState,
   writeSidebarPreferencesLocalCache,
   isEmptySidebarPreferencesState,
   type FolderInsertPosition,
@@ -36,21 +36,12 @@ function createId(): string {
 
 export function useSidebarProjectFolders(projects: Project[], projectsReady = true) {
   const queryClient = useQueryClient();
-  const projectIds = useMemo(
-    () => projects.map((project) => project.id),
-    [projects],
-  );
 
   const initialLocalSeedRef = useRef(readSidebarPreferencesLocalSeed());
   const bootstrappedRef = useRef(false);
   const [hasInitialHydration, setHasInitialHydration] = useState(false);
   const [state, setState] = useState<SidebarProjectFoldersState>(
     EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
-  );
-
-  const projectIdsKey = useMemo(
-    () => [...projectIds].sort().join(","),
-    [projectIds],
   );
 
   // Remote fetch (single source of truth after first hydration).
@@ -81,30 +72,32 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     if (bootstrappedRef.current || hydratedRef.current) return;
 
     bootstrappedRef.current = true;
-    const next = sanitizeSidebarPreferencesState(initialLocalSeedRef.current.state, projectIds);
+    // Non-destructive: normalize folder shape only. Filtering projectIds against
+    // the known project list is reserved for explicit project deletion; running
+    // it here would wipe refs whenever projects are transiently incomplete.
+    const next = normalizeSidebarPreferencesState(initialLocalSeedRef.current.state);
     setState((prev) => (areSidebarPreferencesStatesEqual(prev, next) ? prev : next));
-  }, [projectIds, projectIdsKey, projectsReady]);
+  }, [projectsReady]);
 
   // Hydrate from server when data arrives.
   useEffect(() => {
     if (!projectsReady || !preferencesData) return;
-    const serverState = sanitizeSidebarPreferencesState(
+    const serverState = normalizeSidebarPreferencesState(
       payloadToSidebarPreferencesState(preferencesData),
-      projectIds,
     );
 
     // One-shot migration: empty server + legacy localStorage -> push legacy up.
     if (!hydratedRef.current && isEmptySidebarPreferencesState(serverState)) {
       const legacy = readLegacySidebarPreferences();
       if (legacy && !isEmptySidebarPreferencesState(legacy)) {
-        const sanitized = sanitizeSidebarPreferencesState(legacy, projectIds);
-        if (!isEmptySidebarPreferencesState(sanitized)) {
+        const normalizedLegacy = normalizeSidebarPreferencesState(legacy);
+        if (!isEmptySidebarPreferencesState(normalizedLegacy)) {
           hydratedRef.current = true;
           setHasInitialHydration(true);
           lastFlushedRef.current = serverState;
           bootstrappedRef.current = true;
           pendingLegacyRemovalRef.current = true;
-          setState(sanitized);
+          setState(normalizedLegacy);
           return;
         }
       }
@@ -117,7 +110,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     setState((prev) => {
       return areSidebarPreferencesStatesEqual(prev, serverState) ? prev : serverState;
     });
-  }, [preferencesData, projectIds, projectIdsKey, projectsReady]);
+  }, [preferencesData, projectsReady]);
 
   useEffect(() => {
     if (!projectsReady) return;
@@ -129,14 +122,10 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     bootstrappedRef.current = true;
   }, [preferencesError, preferencesFetched, projectsReady]);
 
-  // Re-sanitize when the list of projects changes (e.g. project deleted).
-  useEffect(() => {
-    if (!projectsReady || !bootstrappedRef.current) return;
-    setState((prev) => {
-      const next = sanitizeSidebarPreferencesState(prev, projectIds);
-      return areSidebarPreferencesStatesEqual(prev, next) ? prev : next;
-    });
-  }, [projectIds, projectIdsKey, projectsReady]);
+  // Project deletion prunes folder refs server-side (see pruneProjectFromUiPreferences),
+  // and mapSidebarFolderProjects hides any stale refs at render. A client-side
+  // sanitize here would add nothing but one more way to clobber state when the
+  // project list is transiently incomplete.
 
   // Persist local cache immediately + schedule a debounced PUT to the backend.
   useEffect(() => {
@@ -165,9 +154,8 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
       api
         .put<UiPreferencesPayload>("/api/ui-preferences", { sidebar: snapshot })
         .then((payload) => {
-          const applied = sanitizeSidebarPreferencesState(
+          const applied = normalizeSidebarPreferencesState(
             payloadToSidebarPreferencesState(payload),
-            projectIds,
           );
           queryClient.setQueryData<UiPreferencesPayload>(
             ["ui-preferences"],
@@ -190,9 +178,8 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
           try {
             const result = await refetchPreferences();
             if (result.data) {
-              const canonical = sanitizeSidebarPreferencesState(
+              const canonical = normalizeSidebarPreferencesState(
                 payloadToSidebarPreferencesState(result.data),
-                projectIds,
               );
               lastFlushedRef.current = canonical;
               setState((prev) => (
@@ -219,7 +206,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
         flushTimerRef.current = null;
       }
     };
-  }, [projectIds, projectIdsKey, queryClient, refetchPreferences, state]);
+  }, [queryClient, refetchPreferences, state]);
 
   const folders = useMemo<SidebarProjectFolderView[]>(
     () => mapSidebarFolderProjects(state.folders, projects),

--- a/frontend/src/lib/sidebar-preferences.ts
+++ b/frontend/src/lib/sidebar-preferences.ts
@@ -1,6 +1,7 @@
 import type { Project } from "@/types";
 import {
   EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+  normalizeSidebarPreferencesState,
   parseSidebarProjectFoldersState,
   sanitizeSidebarPreferencesState,
   type SidebarProjectFolder,
@@ -10,6 +11,7 @@ import {
 
 export {
   EMPTY_SIDEBAR_PROJECT_FOLDERS_STATE,
+  normalizeSidebarPreferencesState,
   sanitizeSidebarPreferencesState,
   type SidebarProjectFolder,
   type SidebarProjectFoldersState,

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -89,8 +89,10 @@ function renderSidebar(
   path: string,
   projects: Project[],
   apiOverrides?: {
+    projects?: Project[] | Error | (() => Promise<Project[]>);
     diffStat?: Record<string, unknown> | Error;
     automations?: Record<string, unknown>[] | Error;
+    uiPreferences?: UiPreferencesPayload;
   },
 ) {
   const queryClient = new QueryClient({
@@ -98,14 +100,19 @@ function renderSidebar(
   });
 
   vi.mocked(api.get).mockImplementation(async (url: string) => {
-    if (url === "/api/projects") return projects;
+    if (url === "/api/projects") {
+      const override = apiOverrides?.projects;
+      if (override instanceof Error) throw override;
+      if (typeof override === "function") return override();
+      return override ?? projects;
+    }
     if (url === "/api/automations") {
       const override = apiOverrides?.automations;
       if (override instanceof Error) throw override;
       return override ?? [];
     }
     if (url === "/api/ui-preferences") {
-      return { sidebar: { folders: [], folderOpenState: {} } };
+      return apiOverrides?.uiPreferences ?? { sidebar: { folders: [], folderOpenState: {} } };
     }
     const diffMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
     if (diffMatch) {
@@ -287,6 +294,46 @@ describe("Sidebar", () => {
     expect(alphaHeader.querySelector("[class*='tabular-nums']")).toHaveTextContent("1");
     // Beta has 0 workspaces → count "0" visible in project header
     expect(betaHeader.querySelector("[class*='tabular-nums']")).toHaveTextContent("0");
+  });
+
+  it("shows a retry banner when projects fail to load and can recover manually", async () => {
+    const user = userEvent.setup();
+    let attempts = 0;
+
+    renderSidebar("/projects", projects, {
+      projects: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("backend unreachable");
+        return projects;
+      },
+    });
+
+    expect(await screen.findByText("Unable to load repositories")).toBeInTheDocument();
+    expect(screen.getByText(/backend unreachable/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Retry now" }));
+
+    expect(await screen.findByText(withTextContent("acme/alpha"))).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByText("Unable to load repositories")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows a recovery banner when folders load before any repositories", async () => {
+    renderSidebar("/projects", [], {
+      uiPreferences: {
+        sidebar: {
+          folders: [{ id: "f1", name: "Recovered", projectIds: ["p1"] }],
+          folderOpenState: { f1: true },
+        },
+      },
+    });
+
+    expect(await screen.findByText("Repository list looks incomplete")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Folders were restored, but the repository list is empty/i),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Retry now" })).toBeInTheDocument();
   });
 
   it("creates collapsible folders from the workspaces header", async () => {

--- a/frontend/tests/hooks/useProjects.test.ts
+++ b/frontend/tests/hooks/useProjects.test.ts
@@ -46,7 +46,23 @@ describe("useProjects", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.projects).toEqual([makeProject("p1")]);
+    expect(result.current.ready).toBe(true);
     expect(api.get).toHaveBeenCalledWith("/api/projects");
+  });
+
+  // Regression: consumers that do destructive work against `projects` (e.g.
+  // sidebar-folder sanitize) must gate on `ready`, not on `!loading`. A failed
+  // first fetch leaves `loading=false` with `projects=[]` — treating that as
+  // "ready" wipes every folder.projectIds downstream.
+  it("ready stays false when the initial fetch fails", async () => {
+    vi.mocked(api.get).mockRejectedValueOnce(new Error("boom"));
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.projects).toEqual([]);
+    expect(result.current.ready).toBe(false);
   });
 
   it("creates workspace and appends it to the project cache", async () => {

--- a/frontend/tests/hooks/useProjects.test.ts
+++ b/frontend/tests/hooks/useProjects.test.ts
@@ -35,6 +35,7 @@ function makeWorkspace(id: string): Workspace {
 
 describe("useProjects", () => {
   beforeEach(() => {
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -47,7 +48,10 @@ describe("useProjects", () => {
 
     expect(result.current.projects).toEqual([makeProject("p1")]);
     expect(result.current.ready).toBe(true);
-    expect(api.get).toHaveBeenCalledWith("/api/projects");
+    expect(api.get).toHaveBeenCalledWith(
+      "/api/projects",
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   // Regression: consumers that do destructive work against `projects` (e.g.
@@ -62,6 +66,54 @@ describe("useProjects", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.projects).toEqual([]);
+    expect(result.current.ready).toBe(false);
+  });
+
+  it("retries automatically after an initial fetch failure", async () => {
+    vi.useFakeTimers();
+    vi.mocked(api.get)
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce([makeProject("p1")]);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+
+    expect(result.current.errorMessage).toBe("boom");
+    expect(result.current.unavailable).toBe(true);
+
+    await act(async () => {
+      for (let i = 0; i < 5 && !result.current.ready; i += 1) {
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
+    });
+
+    expect(result.current.ready).toBe(true);
+    expect(result.current.projects).toEqual([makeProject("p1")]);
+  });
+
+  it("times out a hung initial fetch and marks projects as unavailable", async () => {
+    vi.useFakeTimers();
+    vi.mocked(api.get).mockImplementation(
+      () => new Promise<Project[]>(() => {}),
+    );
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+      for (let i = 0; i < 12 && !result.current.unavailable; i += 1) {
+        await vi.advanceTimersByTimeAsync(1_000);
+      }
+    });
+
+    vi.useRealTimers();
+    await waitFor(() => expect(result.current.unavailable).toBe(true));
+    expect(result.current.errorMessage).toBe("The server took too long to respond.");
     expect(result.current.ready).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

Occasionally at startup, sidebar folders would appear empty with every project reset to the root — forcing users to re-sort. Root cause: `sanitizeSidebarPreferencesState` drops any `projectId` not in the "known projects" set, and it ran on **every** read/write. Whenever `listProjects()` returned empty or partial data (transient `readdir` failure, slow backend boot, failed initial `/api/projects` fetch), the GET response came back with emptied `folder.projectIds`. The client hydrated with that, and the first user interaction flushed it back via the debounced PUT — permanent loss.

- **Backend GET** returns the raw persisted payload; display-time filtering (`mapSidebarFolderProjects`) already hides stale refs safely.
- **Backend PUT** keeps the sanitize, but skips it when `listProjects()` returns `[]` while the payload still references real IDs (treat as unreliable read rather than mass deletion).
- **Project deletion** prunes folder refs explicitly via `pruneProjectFromUiPreferences` — the only moment we can be sure a project is gone.
- **Frontend** gates destructive hydration on `query.isSuccess` (exposed as `ready`) instead of `!isLoading`, and normalizes rather than sanitizes on hydration and PUT echo.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm test` passes (backend 1216/1216, frontend 1108/1108)
- [x] New backend tests: GET preserves refs on empty project list; PUT preserves refs on transient empty; PUT still persists legitimately-empty payloads; `deleteProject` prunes folder refs on disk
- [x] New frontend test: `useProjects.ready` stays `false` when the initial fetch fails
- [ ] Manual: restart Hive with a populated `ui-preferences.json` and verify folder contents survive across restarts