### PR TITLE
feat(codex): switch default model to gpt-5.5

### DIFF
--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -36,9 +36,19 @@ describe("CodexProvider", () => {
     expect(defaults).toHaveLength(1);
   });
 
-  it("includes gpt-5.4 as default", () => {
+  it("includes gpt-5.5 as default", () => {
     const defaultModel = provider.models.find((m) => m.isDefault);
-    expect(defaultModel?.id).toBe("gpt-5.4");
+    expect(defaultModel?.id).toBe("gpt-5.5");
+  });
+
+  it("tracks the verified 400K context window for gpt-5.5", () => {
+    const defaultModel = provider.models.find((m) => m.isDefault);
+    expect(defaultModel?.contextWindow).toBe(400_000);
+  });
+
+  it("tracks the verified 400K context window for gpt-5.3-codex", () => {
+    const legacyModel = provider.models.find((m) => m.id === "gpt-5.3-codex");
+    expect(legacyModel?.contextWindow).toBe(400_000);
   });
 
   // ── Capabilities ───────────────────────────────────────────────────

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -10,8 +10,8 @@ import type {
 } from "./types.js";
 
 const CODEX_MODELS: ModelDefinition[] = [
-  { id: "gpt-5.4", label: "GPT-5.4", cliValue: "gpt-5.4", isDefault: true, isNew: true },
-  { id: "gpt-5.3-codex", label: "GPT-5.3-Codex", cliValue: "gpt-5.3-codex" },
+  { id: "gpt-5.5", label: "GPT-5.5", cliValue: "gpt-5.5", isDefault: true, isNew: true, contextWindow: 400_000 },
+  { id: "gpt-5.3-codex", label: "GPT-5.3-Codex", cliValue: "gpt-5.3-codex", contextWindow: 400_000 },
 ];
 
 const CODEX_CAPABILITIES: ProviderCapabilities = {

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -225,7 +225,7 @@ describe("getModelCatalog", () => {
 
     const newModels = catalog.models.filter((m) => m.isNew);
     expect(newModels.length).toBeGreaterThan(0);
-    expect(newModels[0].id).toBe("codex:gpt-5.4");
+    expect(newModels[0].id).toBe("codex:gpt-5.5");
   });
 });
 
@@ -312,7 +312,7 @@ describe("contextWindow in catalog", () => {
     expect(haiku?.contextWindow).toBe(200_000);
   });
 
-  it("omits contextWindow for Codex models (cumulative turn usage not reliable for context ring)", () => {
+  it("omits contextWindow for Codex models even when the provider knows the raw window size", () => {
     markProviderAvailable("codex");
     const catalog = getModelCatalog();
     const codexModels = catalog.models.filter((m) => m.provider === "codex");

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -123,7 +123,11 @@ export function getModelCatalog(): ModelCatalogResponse {
         isDefault: model.isDefault,
         isNew: model.isNew,
         capabilities: provider.capabilities,
-        contextWindow: model.contextWindow,
+        // This is keyed off provider.id ("codex"), not model.id. Catalog IDs are compound
+        // values like "codex:gpt-5.5". We still hide Codex context windows here because
+        // the CLI only exposes turn-level usage via turn.completed today, which can be
+        // cumulative across sub-calls and would make the context ring misleading.
+        contextWindow: provider.id === "codex" ? undefined : model.contextWindow,
       });
       if (provider.id === "claude" && model.isDefault) {
         defaultModelId = compoundId;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -277,7 +277,7 @@ export interface QuestionInput {
 /** Per-message options that control agent CLI behavior. */
 export interface MessageOptions {
   planMode?: boolean;
-  /** Compound model ID: "provider:model", e.g. "claude:opus-4-7" or "codex:gpt-5.3-codex" */
+  /** Compound model ID: "provider:model", e.g. "claude:opus-4-7" or "codex:gpt-5.5" */
   model?: string;
   /** Reasoning effort level for providers that support it (Claude `--effort`, Codex `model_reasoning_effort`). */
   thinkingLevel?: ThinkingLevel;

--- a/frontend/tests/components/ChatInput.autocomplete.test.tsx
+++ b/frontend/tests/components/ChatInput.autocomplete.test.tsx
@@ -206,7 +206,7 @@ describe("ChatInput autocomplete", () => {
     vi.mocked(useModels).mockReturnValue({
       models: [],
       defaultModelId: "",
-      selectedModelId: "codex:gpt-5.3-codex",
+      selectedModelId: "codex:gpt-5.5",
       selectedModel: undefined,
       capabilities: { thinkingLevels: ["none", "minimal", "low", "medium", "high", "xhigh"], planMode: false, blockingTools: false, completions: false },
       setSelectedModelId: vi.fn(),

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -24,8 +24,8 @@ const CLAUDE_MODELS: ModelCatalogEntry[] = [
 
 const CODEX_MODELS: ModelCatalogEntry[] = [
   {
-    id: "codex:gpt-5.3-codex",
-    label: "GPT-5.3-Codex",
+    id: "codex:gpt-5.5",
+    label: "GPT-5.5",
     provider: "codex",
     providerLabel: "Codex",
     isDefault: true,
@@ -93,7 +93,7 @@ describe("ModelSelector", () => {
 
     // Model labels
     expect(screen.getByText("Sonnet 4.6")).toBeInTheDocument();
-    expect(screen.getByText("GPT-5.3-Codex")).toBeInTheDocument();
+    expect(screen.getByText("GPT-5.5")).toBeInTheDocument();
     expect(screen.getByText("Gemini 3.1 Pro")).toBeInTheDocument();
   });
 
@@ -150,7 +150,7 @@ describe("ModelSelector", () => {
     await user.click(screen.getByRole("button", { name: /Model: Opus 4.7/i }));
 
     // Codex models should be visually disabled (opacity-30, cursor-not-allowed)
-    const codexModelElement = screen.getByText("GPT-5.3-Codex");
+    const codexModelElement = screen.getByText("GPT-5.5");
     const container = codexModelElement.closest("div");
     expect(container?.className).toContain("opacity-30");
     expect(container?.className).toContain("cursor-not-allowed");
@@ -173,11 +173,11 @@ describe("ModelSelector", () => {
 
     // The codex model is rendered as a plain div (not a DropdownMenuItem),
     // so clicking it should NOT trigger onSelect
-    const codexModelElement = screen.getByText("GPT-5.3-Codex");
+    const codexModelElement = screen.getByText("GPT-5.5");
     await user.click(codexModelElement);
 
     // Should not have been called with the codex model
-    expect(onSelect).not.toHaveBeenCalledWith("codex:gpt-5.3-codex");
+    expect(onSelect).not.toHaveBeenCalledWith("codex:gpt-5.5");
   });
 
   it("allows clicking same-provider models when provider is locked", async () => {
@@ -212,9 +212,9 @@ describe("ModelSelector", () => {
     );
 
     await user.click(screen.getByRole("button", { name: /Model: Opus 4.7/i }));
-    await user.click(screen.getByText("GPT-5.3-Codex"));
+    await user.click(screen.getByText("GPT-5.5"));
 
-    expect(onSelect).toHaveBeenCalledWith("codex:gpt-5.3-codex");
+    expect(onSelect).toHaveBeenCalledWith("codex:gpt-5.5");
   });
 
   it("has correct aria-label on trigger button", () => {

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -31,8 +31,8 @@ const MOCK_CATALOG: ModelCatalogResponse = {
       capabilities: { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true },
     },
     {
-      id: "codex:gpt-5.3-codex",
-      label: "GPT-5.3-Codex",
+      id: "codex:gpt-5.5",
+      label: "GPT-5.5",
       provider: "codex",
       providerLabel: "Codex",
       isDefault: true,
@@ -125,7 +125,7 @@ describe("useModels", () => {
     });
 
     act(() => {
-      result.current.setSelectedModelId("codex:gpt-5.3-codex");
+      result.current.setSelectedModelId("codex:gpt-5.5");
     });
 
     expect(result.current.capabilities).toEqual({
@@ -193,7 +193,7 @@ describe("useModels", () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(result.current.selectedModelId).toBe("codex:gpt-5.3-codex");
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
     expect(result.current.selectedModel?.provider).toBe("codex");
   });
 


### PR DESCRIPTION
## Summary
- switch the default Codex model from `gpt-5.4` to `gpt-5.5`
- record the verified `400,000` context window for both `gpt-5.5` and `gpt-5.3-codex`
- keep Codex context windows hidden from the frontend catalog because Codex CLI token usage is still reported at `turn.completed` and can be cumulative across sub-calls
- update backend and frontend tests/mocks to match the new default model

## Verification
- `npm run test --workspace @hive/backend -- src/agents/providers/codex.test.ts src/agents/providers/registry.test.ts`
- `npm run test --workspace @hive/frontend -- tests/hooks/useModels.test.ts tests/components/ModelSelector.test.tsx tests/components/ChatInput.autocomplete.test.tsx`

## Sources
- OpenAI announcement: https://openai.com/index/introducing-gpt-5-5/
- OpenAI model page for `gpt-5.3-codex`: https://developers.openai.com/api/docs/models/gpt-5.3-codex
