### PR TITLE
Fix nonfatal Codex stderr banners

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -605,6 +605,49 @@ describe("ConversationSession", () => {
     }
   });
 
+  it("sends Codex prompt through stdin", () => {
+    const session = createSession({ sessionId: "codex-stdin" });
+
+    session.sendMessage("Hi Codex", { model: "codex:gpt-5.5" });
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      "codex",
+      expect.arrayContaining(["exec", "--json", "-"]),
+      expect.any(Object),
+    );
+    expect(mockProc._stdinEnd).toHaveBeenCalledWith("Hi Codex");
+  });
+
+  it("suppresses known Codex stderr diagnostics", () => {
+    const session = createSession({ sessionId: "codex-stderr-noise" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi", { model: "codex:gpt-5.5" });
+    mockProc._stderr.push("Reading additional input from stdin...");
+    mockProc._stderr.push("2026-04-24T08:34:25.714940Z ERROR codex_core::tools::router: error=resources/templates/list failed: unknown MCP server 'openaiDeveloperDocs'");
+    mockProc._stderr.push("2026-04-24T08:34:25.714946Z ERROR codex_core::tools::router: error=resources/list failed: unknown MCP server 'openaiDeveloperDocs'");
+
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(0);
+  });
+
+  it("still emits Codex stderr errors when message is not known noise", () => {
+    const session = createSession({ sessionId: "codex-stderr-real" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi", { model: "codex:gpt-5.5" });
+    mockProc._stderr.push("permission denied");
+
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(1);
+    if (errors[0].type === "error") {
+      expect(errors[0].message).toContain("stderr:");
+      expect(errors[0].message).toContain("permission denied");
+    }
+  });
+
   it("defaults command to claude", () => {
     const session = createSession();
     session.sendMessage("Hi");

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -34,6 +34,28 @@ const GEMINI_STDERR_NOISE = [
   "GaxiosError",
 ];
 
+/** Codex CLI writes non-fatal operational diagnostics to stderr. */
+const CODEX_STDERR_NOISE = [
+  "Reading additional input from stdin",
+];
+
+const CODEX_STDERR_NOISE_PATTERNS = [
+  /\bERROR\s+codex_core::tools::router:\s+error=resources\/(?:templates\/)?list failed: unknown MCP server '[^']+'/,
+];
+
+function isKnownStderrNoise(providerId: string | undefined, text: string): boolean {
+  if (providerId === "gemini") {
+    return GEMINI_STDERR_NOISE.some((n) => text.includes(n));
+  }
+
+  if (providerId === "codex") {
+    return CODEX_STDERR_NOISE.some((n) => text.includes(n))
+      || CODEX_STDERR_NOISE_PATTERNS.some((pattern) => pattern.test(text));
+  }
+
+  return false;
+}
+
 /** Map Anthropic server_tool_use names to their Claude Code display names. */
 const serverToolNameMap: Record<string, string> = {
   web_search: "WebSearch",
@@ -356,6 +378,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let command: string;
     let args: string[];
     let env: Record<string, string> | undefined;
+    let stdinContent: string | undefined;
 
     if (this.testCommand) {
       // Test mode: use raw command (e.g. "bash") — no provider
@@ -378,6 +401,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         systemPrompt: this.systemPrompt,
         skipPermissions: this.skipPermissions,
       });
+      if (provider!.id === "codex") {
+        stdinContent = cliContent;
+      }
       env = provider!.buildEnv({ ...msgOptions, model: modelId });
     }
 
@@ -569,7 +595,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       ...(this.testCommand ? {} : { env: buildWorkspaceEnv(env) }),
     });
 
-    this.process.stdin?.end();
+    this.process.stdin?.end(stdinContent);
 
     this.process.stdout?.on("data", (chunk: Buffer) => {
       this.parser?.write(chunk.toString("utf-8"));
@@ -578,8 +604,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.process.stderr?.on("data", (chunk: Buffer) => {
       const text = chunk.toString("utf-8").trim();
       if (!text) return;
-      // Skip known informational stderr noise from Gemini CLI
-      if (GEMINI_STDERR_NOISE.some((n) => text.includes(n))) return;
+      if (isKnownStderrNoise(provider?.id, text)) return;
       const stderrLine = `stderr: ${sanitizeErrorDetail(text)}`;
       lastStderr = stderrLine;
       this.emit("message", { type: "error", message: stderrLine, sessionId: this.sessionId } as WsOutgoing);

--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -118,15 +118,17 @@ describe("CodexProvider", () => {
     expect(args).toContain("model_reasoning_effort=low");
   });
 
-  it("puts content as last positional arg on first message", () => {
+  it("uses stdin marker as prompt arg on first message", () => {
     const args = provider.buildArgs("Do something", {}, baseSession({ isFirstMessage: true }));
-    expect(args[args.length - 1]).toBe("Do something");
+    expect(args[args.length - 1]).toBe("-");
+    expect(args).not.toContain("Do something");
   });
 
-  it("puts session ID and content as last args on resume", () => {
+  it("puts session ID and stdin marker as last args on resume", () => {
     const args = provider.buildArgs("Do something", {}, baseSession({ isFirstMessage: false, sessionId: "thread-xyz" }));
     expect(args[args.length - 2]).toBe("thread-xyz");
-    expect(args[args.length - 1]).toBe("Do something");
+    expect(args[args.length - 1]).toBe("-");
+    expect(args).not.toContain("Do something");
   });
 
   it("does NOT use -p flag for content", () => {

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -38,8 +38,9 @@ export class CodexProvider implements AgentProvider {
     const thinkingLevel = options.thinkingLevel ?? DEFAULT_THINKING_LEVEL;
 
     // Codex uses `codex exec` for non-interactive mode with `--json` for JSONL streaming.
-    // Session continuity: `codex exec resume <thread_id> "msg"` on subsequent turns.
-    // NOTE: The prompt is a positional arg (not -p, which is --profile in codex CLI).
+    // Session continuity: `codex exec resume <thread_id> -` on subsequent turns.
+    // NOTE: The prompt is provided on stdin via "-" because Codex also reads from
+    // piped stdin when a positional prompt is present, which creates noisy stderr.
     const flags = [
       "--json",
       ...(model ? ["--model", model.cliValue] : []),
@@ -48,9 +49,9 @@ export class CodexProvider implements AgentProvider {
     ];
 
     if (session.isFirstMessage) {
-      return ["exec", ...flags, content];
+      return ["exec", ...flags, "-"];
     }
-    return ["exec", "resume", ...flags, session.sessionId, content];
+    return ["exec", "resume", ...flags, session.sessionId, "-"];
   }
 
   buildEnv(_options: ProviderMessageOptions): Record<string, string> | undefined {


### PR DESCRIPTION
## Summary
- Send Codex prompts through stdin using the "-" marker to avoid the extra stdin warning.
- Suppress known nonfatal Codex stderr diagnostics from surfacing as chat error banners.
- Add regression coverage for Codex stdin handling and stderr filtering.

## Tests
- npm --prefix backend test -- --run src/agents/providers/codex.test.ts src/agents/conversation-session.test.ts
- npm --prefix backend run typecheck
- npm --prefix backend run lint -- src/agents/conversation-session.ts src/agents/providers/codex.ts src/agents/conversation-session.test.ts src/agents/providers/codex.test.ts

Lint passes with one existing unrelated warning in backend/src/api/ui-preferences.ts.