### PR TITLE
feat: add agent browser live panel

### DIFF
--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -12,6 +12,7 @@ import type { ChatMessage, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
 import { TelegramChannel } from "../notifications/telegram.js";
 import { ApnsChannel } from "../notifications/apns.js";
+import { browserSessionManager } from "../services/browser-session-manager.js";
 import type { AppConfig } from "../state/config.js";
 import { loadConfig, saveConfig } from "../state/config.js";
 
@@ -381,6 +382,7 @@ export async function endSession(
         session.stop("park");
       }
     }
+    browserSessionManager.closeWorkspace(wsId);
 
     const result = await getWorkspace(wsId, dataDir);
     if (!result) throw new NotFoundError(`Workspace ${wsId} not found`);
@@ -487,6 +489,16 @@ function attachNotificationListener(
   });
 }
 
+async function attachBrowserEnv(
+  session: ConversationSession,
+  workspaceId: string,
+  options?: SessionOptions,
+): Promise<void> {
+  if (options?.command) return;
+  await browserSessionManager.ensureSession(workspaceId, session.sessionId);
+  session.setBrowserEnv(browserSessionManager.getEnv(workspaceId, session.sessionId));
+}
+
 async function createSession(
   ctx: Awaited<ReturnType<typeof resolveWorkspaceContext>>,
   dataDir: string,
@@ -508,6 +520,7 @@ async function createSession(
     systemPrompt,
     skipPermissions: options?.skipPermissions,
   });
+  await attachBrowserEnv(session, ctx.workspace.id, options);
   await session.persistMetadata();
   attachNotificationListener(session, ctx);
 
@@ -571,6 +584,7 @@ async function loadSessionFromDisk(
     systemPrompt,
     skipPermissions: options?.skipPermissions,
   });
+  await attachBrowserEnv(session, ctx.workspace.id, options);
   attachNotificationListener(session, ctx);
   rememberLoadedSession(ctx.workspace.id, session);
   return session;
@@ -676,6 +690,7 @@ export async function hardDeleteSession(
     const ctx = await resolveWorkspaceContext(wsId, dataDir);
     const loaded = getLoadedSessionById(wsId, sessionId);
     const wasActive = activeSessionIds.get(wsId) === sessionId;
+    browserSessionManager.closeSession(wsId, sessionId);
 
     if (loaded) {
       removeLoadedSession(wsId, sessionId);

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -124,6 +124,7 @@ export interface ConversationSessionConfig {
   command?: string;
   systemPrompt?: string;
   skipPermissions?: boolean;
+  browserEnv?: Record<string, string>;
 }
 
 export type ConversationSessionEvent = {
@@ -139,6 +140,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private readonly testCommand: string | undefined;
   private readonly systemPrompt: string | undefined;
   private readonly skipPermissions: boolean;
+  private browserEnv: Record<string, string> | undefined;
   private readonly sessionDir: string;
   private readonly workspaceId: string;
   private process: ChildProcess | null = null;
@@ -167,6 +169,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.testCommand = config.command !== undefined && config.command !== "claude" ? config.command : undefined;
     this.systemPrompt = config.systemPrompt;
     this.skipPermissions = config.skipPermissions ?? true;
+    this.browserEnv = config.browserEnv;
     this.workspaceId = config.workspaceId;
     this.sessionDir = join(config.dataDir, "sessions", this.sessionId);
 
@@ -189,6 +192,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
   get metadata(): SessionMetadata {
     return { ...this._metadata };
+  }
+
+  setBrowserEnv(env: Record<string, string> | undefined): void {
+    this.browserEnv = env;
   }
 
   /** Return a snapshot of in-progress streaming content (text, thinking, tool calls).
@@ -404,7 +411,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       if (provider!.id === "codex") {
         stdinContent = cliContent;
       }
-      env = provider!.buildEnv({ ...msgOptions, model: modelId });
+      env = {
+        ...(provider!.buildEnv({ ...msgOptions, model: modelId }) ?? {}),
+        ...(this.browserEnv ?? {}),
+      };
     }
 
     const supportsBlockingTools = provider?.capabilities.blockingTools ?? false;

--- a/backend/src/agents/system-prompt.ts
+++ b/backend/src/agents/system-prompt.ts
@@ -117,6 +117,16 @@ export function formatGitContextBlock(
   return gitLines.join("\n");
 }
 
+export function formatBrowserContextBlock(): string {
+  return [
+    "# Browser Context",
+    "",
+    "Hive provides a read-only live browser panel when you use the `agent-browser` CLI.",
+    "For frontend or UI verification, use `agent-browser` to inspect the running app instead of relying only on static reasoning.",
+    "Use the existing `AGENT_BROWSER_STREAM_PORT` environment variable for the stream; do not start a separate browser dashboard or streaming server.",
+  ].join("\n");
+}
+
 /** Replace prompt placeholders with concrete workspace/project values. */
 export function interpolatePromptVariables(
   prompt: string,
@@ -154,6 +164,7 @@ export async function buildSystemPrompt(opts: SystemPromptOptions): Promise<stri
 
   const sections: string[] = [basePrompt];
   sections.push(formatGitContextBlock(ctx, { projectName, workspaceName }));
+  sections.push(formatBrowserContextBlock());
 
   return sections.join("\n\n");
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { agentSettingsRoutes } from "./api/agents-settings.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
+import { browserWsRoutes } from "./ws/browser.js";
 import { automationRoutes } from "./api/automations.js";
 import { promptTemplateRoutes } from "./api/prompt-templates.js";
 import { basePromptRoutes } from "./api/base-prompt.js";
@@ -315,6 +316,9 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   await app.register((instance: FastifyInstance) => scriptRoutes(instance));
   await app.register((instance: FastifyInstance) =>
     scriptWsRoutes(instance, { authToken }),
+  );
+  await app.register((instance: FastifyInstance) =>
+    browserWsRoutes(instance, { authToken }),
   );
   await app.register((instance: FastifyInstance) =>
     automationRoutes(instance, { scheduler: opts.scheduler }),

--- a/backend/src/services/browser-session-manager.test.ts
+++ b/backend/src/services/browser-session-manager.test.ts
@@ -22,7 +22,7 @@ describe("BrowserSessionManager", () => {
     });
   });
 
-  it("marks sessions active when an agent-browser command is observed", async () => {
+  it("marks sessions streaming when an agent-browser command is observed", async () => {
     await manager.ensureSession("ws-1", "session-1");
     const payload = manager.maybeMarkToolActivity(
       "ws-1",
@@ -34,7 +34,7 @@ describe("BrowserSessionManager", () => {
     expect(payload).toMatchObject({
       sessionId: "session-1",
       state: "active",
-      streaming: false,
+      streaming: true,
       streamPath: "/ws/browser/ws-1/session-1",
     });
     expect(manager.getVisibleStatuses("ws-1")).toHaveLength(1);
@@ -109,5 +109,24 @@ describe("BrowserSessionManager", () => {
     expect(statuses).toHaveLength(2);
     expect(statuses[0]).toMatchObject({ state: "active", streaming: true });
     expect(statuses[1]).toMatchObject({ state: "active", streaming: false });
+  });
+
+  it("keeps streaming true during the upstream screencast startup status", async () => {
+    const statuses: unknown[] = [];
+    await manager.ensureSession("ws-1", "session-1");
+    manager.markStreaming("ws-1", "session-1", true);
+    manager.on("status", (_workspaceId, status) => statuses.push(status));
+
+    manager.ingestStreamMessage("ws-1", "session-1", JSON.stringify({
+      type: "status",
+      connected: true,
+      screencasting: false,
+    }));
+
+    expect(manager.getVisibleStatuses("ws-1")[0]).toMatchObject({
+      state: "active",
+      streaming: true,
+    });
+    expect(statuses).toHaveLength(0);
   });
 });

--- a/backend/src/services/browser-session-manager.test.ts
+++ b/backend/src/services/browser-session-manager.test.ts
@@ -34,6 +34,7 @@ describe("BrowserSessionManager", () => {
     expect(payload).toMatchObject({
       sessionId: "session-1",
       state: "active",
+      streaming: false,
       streamPath: "/ws/browser/ws-1/session-1",
     });
     expect(manager.getVisibleStatuses("ws-1")).toHaveLength(1);
@@ -52,6 +53,24 @@ describe("BrowserSessionManager", () => {
     expect(manager.getVisibleStatuses("ws-1")).toHaveLength(0);
   });
 
+  it("marks the browser as not streaming when a close command is observed", async () => {
+    await manager.ensureSession("ws-1", "session-1");
+    manager.markStreaming("ws-1", "session-1", true);
+
+    const payload = manager.maybeMarkToolActivity(
+      "ws-1",
+      "session-1",
+      "Bash",
+      JSON.stringify({ command: "agent-browser close" }),
+    );
+
+    expect(payload).toMatchObject({
+      sessionId: "session-1",
+      state: "active",
+      streaming: false,
+    });
+  });
+
   it("ingests stream tab metadata without emitting frame traffic", async () => {
     const statuses: unknown[] = [];
     await manager.ensureSession("ws-1", "session-1");
@@ -65,8 +84,30 @@ describe("BrowserSessionManager", () => {
     expect(statuses).toHaveLength(1);
     expect(statuses[0]).toMatchObject({
       state: "active",
+      streaming: false,
       url: "http://localhost:5173",
       title: "Hive",
     });
+  });
+
+  it("tracks stream status and frame activity", async () => {
+    const statuses: unknown[] = [];
+    await manager.ensureSession("ws-1", "session-1");
+    manager.on("status", (_workspaceId, status) => statuses.push(status));
+
+    manager.ingestStreamMessage("ws-1", "session-1", JSON.stringify({
+      type: "status",
+      connected: true,
+      screencasting: true,
+    }));
+    manager.ingestStreamMessage("ws-1", "session-1", JSON.stringify({
+      type: "status",
+      connected: false,
+      screencasting: false,
+    }));
+
+    expect(statuses).toHaveLength(2);
+    expect(statuses[0]).toMatchObject({ state: "active", streaming: true });
+    expect(statuses[1]).toMatchObject({ state: "active", streaming: false });
   });
 });

--- a/backend/src/services/browser-session-manager.test.ts
+++ b/backend/src/services/browser-session-manager.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { BrowserSessionManager } from "./browser-session-manager.js";
+
+let manager: BrowserSessionManager;
+
+beforeEach(() => {
+  manager = new BrowserSessionManager();
+});
+
+describe("BrowserSessionManager", () => {
+  it("allocates stable browser env for a session", async () => {
+    const first = await manager.ensureSession("ws-1", "session-1");
+    const second = await manager.ensureSession("ws-1", "session-1");
+    const env = manager.getEnv("ws-1", "session-1");
+
+    expect(second.port).toBe(first.port);
+    expect(env).toMatchObject({
+      AGENT_BROWSER_STREAM_PORT: String(first.port),
+      AGENT_BROWSER_HIVE_WORKSPACE_ID: "ws-1",
+      AGENT_BROWSER_HIVE_SESSION_ID: "session-1",
+    });
+  });
+
+  it("marks sessions active when an agent-browser command is observed", async () => {
+    await manager.ensureSession("ws-1", "session-1");
+    const payload = manager.maybeMarkToolActivity(
+      "ws-1",
+      "session-1",
+      "Bash",
+      JSON.stringify({ command: "agent-browser open http://localhost:5173" }),
+    );
+
+    expect(payload).toMatchObject({
+      sessionId: "session-1",
+      state: "active",
+      streamPath: "/ws/browser/ws-1/session-1",
+    });
+    expect(manager.getVisibleStatuses("ws-1")).toHaveLength(1);
+  });
+
+  it("ignores unrelated tool activity", async () => {
+    await manager.ensureSession("ws-1", "session-1");
+    const payload = manager.maybeMarkToolActivity(
+      "ws-1",
+      "session-1",
+      "Bash",
+      JSON.stringify({ command: "npm test" }),
+    );
+
+    expect(payload).toBeNull();
+    expect(manager.getVisibleStatuses("ws-1")).toHaveLength(0);
+  });
+
+  it("ingests stream tab metadata without emitting frame traffic", async () => {
+    const statuses: unknown[] = [];
+    await manager.ensureSession("ws-1", "session-1");
+    manager.on("status", (_workspaceId, status) => statuses.push(status));
+
+    manager.ingestStreamMessage("ws-1", "session-1", JSON.stringify({
+      type: "tabs",
+      tabs: [{ url: "http://localhost:5173", title: "Hive", active: true }],
+    }));
+
+    expect(statuses).toHaveLength(1);
+    expect(statuses[0]).toMatchObject({
+      state: "active",
+      url: "http://localhost:5173",
+      title: "Hive",
+    });
+  });
+});

--- a/backend/src/services/browser-session-manager.test.ts
+++ b/backend/src/services/browser-session-manager.test.ts
@@ -16,6 +16,7 @@ describe("BrowserSessionManager", () => {
     expect(second.port).toBe(first.port);
     expect(env).toMatchObject({
       AGENT_BROWSER_STREAM_PORT: String(first.port),
+      AGENT_BROWSER_SESSION: "hive-ws-1-session-1",
       AGENT_BROWSER_HIVE_WORKSPACE_ID: "ws-1",
       AGENT_BROWSER_HIVE_SESSION_ID: "session-1",
     });

--- a/backend/src/services/browser-session-manager.ts
+++ b/backend/src/services/browser-session-manager.ts
@@ -151,7 +151,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     if (AGENT_BROWSER_STOP_PATTERN.test(commandText)) {
       return this.markStreaming(workspaceId, sessionId, false);
     }
-    return this.markActive(workspaceId, sessionId);
+    return this.markStreaming(workspaceId, sessionId, true);
   }
 
   markActive(workspaceId: string, sessionId: string): BrowserStatusPayload | null {
@@ -212,8 +212,10 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     } else if (parsed.type === "status") {
       const connected = typeof parsed.connected === "boolean" ? parsed.connected : undefined;
       const screencasting = typeof parsed.screencasting === "boolean" ? parsed.screencasting : undefined;
-      if (connected !== undefined || screencasting !== undefined) {
-        nextStreaming = Boolean(connected && screencasting);
+      if (connected === false) {
+        nextStreaming = false;
+      } else if (connected === true && screencasting === true) {
+        nextStreaming = true;
       }
     } else if (parsed.type === "frame") {
       nextStreaming = true;

--- a/backend/src/services/browser-session-manager.ts
+++ b/backend/src/services/browser-session-manager.ts
@@ -6,6 +6,7 @@ import type { BrowserSessionState, BrowserStatusPayload } from "../types.js";
 export interface BrowserSessionRecord {
   workspaceId: string;
   sessionId: string;
+  agentBrowserSession: string;
   port: number;
   state: BrowserSessionState;
   createdAt: number;
@@ -29,6 +30,18 @@ function keyFor(workspaceId: string, sessionId: string): string {
 
 function buildStreamPath(workspaceId: string, sessionId: string): string {
   return `/ws/browser/${encodeURIComponent(workspaceId)}/${encodeURIComponent(sessionId)}`;
+}
+
+function sanitizeAgentBrowserSessionPart(value: string): string {
+  const sanitized = value
+    .trim()
+    .replace(/[^a-zA-Z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return sanitized.slice(0, 48) || "session";
+}
+
+function buildAgentBrowserSession(workspaceId: string, sessionId: string): string {
+  return `hive-${sanitizeAgentBrowserSessionPart(workspaceId)}-${sanitizeAgentBrowserSessionPart(sessionId)}`.slice(0, 120);
 }
 
 function isObject(value: unknown): value is Record<string, unknown> {
@@ -89,6 +102,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     const created: BrowserSessionRecord = {
       workspaceId,
       sessionId,
+      agentBrowserSession: buildAgentBrowserSession(workspaceId, sessionId),
       port: await allocateLoopbackPort(),
       state: "registered",
       createdAt: now,
@@ -109,6 +123,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     if (!session) return undefined;
     return {
       AGENT_BROWSER_STREAM_PORT: String(session.port),
+      AGENT_BROWSER_SESSION: session.agentBrowserSession,
       AGENT_BROWSER_HIVE_WORKSPACE_ID: workspaceId,
       AGENT_BROWSER_HIVE_SESSION_ID: sessionId,
     };
@@ -224,6 +239,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     const session: BrowserSessionRecord = {
       workspaceId,
       sessionId,
+      agentBrowserSession: buildAgentBrowserSession(workspaceId, sessionId),
       port,
       state,
       createdAt: now,

--- a/backend/src/services/browser-session-manager.ts
+++ b/backend/src/services/browser-session-manager.ts
@@ -1,0 +1,256 @@
+import { EventEmitter } from "node:events";
+import { createServer } from "node:net";
+import type { AddressInfo } from "node:net";
+import type { BrowserSessionState, BrowserStatusPayload } from "../types.js";
+
+export interface BrowserSessionRecord {
+  workspaceId: string;
+  sessionId: string;
+  port: number;
+  state: BrowserSessionState;
+  createdAt: number;
+  updatedAt: number;
+  lastActiveAt?: number;
+  url?: string;
+  title?: string;
+  error?: string;
+}
+
+export type BrowserSessionManagerEvent = {
+  status: [workspaceId: string, status: BrowserStatusPayload];
+};
+
+const AGENT_BROWSER_COMMAND_PATTERN = /(^|[\s"'`;&|()])(?:npx\s+|pnpm\s+dlx\s+|bunx\s+)?agent-browser(?=$|[\s"'`;&|()])/i;
+const AGENT_BROWSER_ENV_PATTERN = /\bAGENT_BROWSER_STREAM_PORT\b/;
+
+function keyFor(workspaceId: string, sessionId: string): string {
+  return `${workspaceId}:${sessionId}`;
+}
+
+function buildStreamPath(workspaceId: string, sessionId: string): string {
+  return `/ws/browser/${encodeURIComponent(workspaceId)}/${encodeURIComponent(sessionId)}`;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function extractCommandText(input: string): string {
+  try {
+    const parsed = JSON.parse(input) as unknown;
+    if (isObject(parsed) && typeof parsed.command === "string") {
+      return parsed.command;
+    }
+  } catch {
+    // Tool inputs are not guaranteed to be JSON.
+  }
+  return input;
+}
+
+function extractString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function extractActiveTab(tabs: unknown): { url?: string; title?: string } {
+  if (!Array.isArray(tabs)) return {};
+  const objects = tabs.filter(isObject);
+  const active = objects.find((tab) => tab.active === true || tab.selected === true) ?? objects[0];
+  if (!active) return {};
+  return {
+    url: extractString(active.url),
+    title: extractString(active.title),
+  };
+}
+
+async function allocateLoopbackPort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? (address as AddressInfo).port : 0;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => err ? reject(err) : resolve());
+  });
+  if (!port) throw new Error("Failed to allocate browser stream port");
+  return port;
+}
+
+export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEvent> {
+  private readonly sessions = new Map<string, BrowserSessionRecord>();
+
+  async ensureSession(workspaceId: string, sessionId: string): Promise<BrowserSessionRecord> {
+    const key = keyFor(workspaceId, sessionId);
+    const existing = this.sessions.get(key);
+    if (existing && existing.state !== "closed") return existing;
+
+    const now = Date.now();
+    const created: BrowserSessionRecord = {
+      workspaceId,
+      sessionId,
+      port: await allocateLoopbackPort(),
+      state: "registered",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.sessions.set(key, created);
+    return created;
+  }
+
+  getSession(workspaceId: string, sessionId: string): BrowserSessionRecord | undefined {
+    const session = this.sessions.get(keyFor(workspaceId, sessionId));
+    if (!session || session.state === "closed") return undefined;
+    return session;
+  }
+
+  getEnv(workspaceId: string, sessionId: string): Record<string, string> | undefined {
+    const session = this.getSession(workspaceId, sessionId);
+    if (!session) return undefined;
+    return {
+      AGENT_BROWSER_STREAM_PORT: String(session.port),
+      AGENT_BROWSER_HIVE_WORKSPACE_ID: workspaceId,
+      AGENT_BROWSER_HIVE_SESSION_ID: sessionId,
+    };
+  }
+
+  getVisibleStatuses(workspaceId: string): BrowserStatusPayload[] {
+    return Array.from(this.sessions.values())
+      .filter((session) => session.workspaceId === workspaceId && session.state !== "registered" && session.state !== "closed")
+      .map((session) => this.toPayload(session));
+  }
+
+  maybeMarkToolActivity(workspaceId: string, sessionId: string, toolName: string, input: string): BrowserStatusPayload | null {
+    const normalizedName = toolName.toLowerCase();
+    const commandText = extractCommandText(input);
+    const isBrowserTool =
+      normalizedName.includes("agent-browser") ||
+      normalizedName.includes("agent_browser") ||
+      AGENT_BROWSER_COMMAND_PATTERN.test(commandText) ||
+      AGENT_BROWSER_ENV_PATTERN.test(commandText);
+
+    if (!isBrowserTool) return null;
+    return this.markActive(workspaceId, sessionId);
+  }
+
+  markActive(workspaceId: string, sessionId: string): BrowserStatusPayload | null {
+    const session = this.getSession(workspaceId, sessionId);
+    if (!session) return null;
+    const now = Date.now();
+    session.state = "active";
+    session.lastActiveAt = now;
+    session.updatedAt = now;
+    session.error = undefined;
+    const payload = this.toPayload(session);
+    this.emit("status", workspaceId, payload);
+    return payload;
+  }
+
+  markError(workspaceId: string, sessionId: string, error: string): BrowserStatusPayload | null {
+    const session = this.getSession(workspaceId, sessionId);
+    if (!session) return null;
+    session.state = "error";
+    session.error = error;
+    session.updatedAt = Date.now();
+    const payload = this.toPayload(session);
+    this.emit("status", workspaceId, payload);
+    return payload;
+  }
+
+  ingestStreamMessage(workspaceId: string, sessionId: string, raw: string): void {
+    const session = this.getSession(workspaceId, sessionId);
+    if (!session) return;
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw) as unknown;
+    } catch {
+      return;
+    }
+    if (!isObject(parsed)) return;
+
+    const beforeUrl = session.url;
+    const beforeTitle = session.title;
+    let nextUrl: string | undefined;
+    let nextTitle: string | undefined;
+
+    if (parsed.type === "url") {
+      nextUrl = extractString(parsed.url) ?? extractString(parsed.value);
+      nextTitle = extractString(parsed.title);
+    } else if (parsed.type === "tabs") {
+      const active = extractActiveTab(parsed.tabs);
+      nextUrl = active.url;
+      nextTitle = active.title;
+    } else if (isObject(parsed.tab)) {
+      nextUrl = extractString(parsed.tab.url);
+      nextTitle = extractString(parsed.tab.title);
+    }
+
+    if (nextUrl) session.url = nextUrl;
+    if (nextTitle) session.title = nextTitle;
+
+    if (session.state !== "active") {
+      this.markActive(workspaceId, sessionId);
+      return;
+    }
+
+    if (beforeUrl !== session.url || beforeTitle !== session.title) {
+      session.updatedAt = Date.now();
+      this.emit("status", workspaceId, this.toPayload(session));
+    }
+  }
+
+  closeSession(workspaceId: string, sessionId: string): BrowserStatusPayload | null {
+    const session = this.sessions.get(keyFor(workspaceId, sessionId));
+    if (!session || session.state === "closed") return null;
+    session.state = "closed";
+    session.updatedAt = Date.now();
+    const payload = this.toPayload(session);
+    this.emit("status", workspaceId, payload);
+    this.sessions.delete(keyFor(workspaceId, sessionId));
+    return payload;
+  }
+
+  closeWorkspace(workspaceId: string): void {
+    for (const session of Array.from(this.sessions.values())) {
+      if (session.workspaceId === workspaceId) {
+        this.closeSession(session.workspaceId, session.sessionId);
+      }
+    }
+  }
+
+  _registerForTests(workspaceId: string, sessionId: string, port: number, state: BrowserSessionState = "registered"): BrowserStatusPayload {
+    const now = Date.now();
+    const session: BrowserSessionRecord = {
+      workspaceId,
+      sessionId,
+      port,
+      state,
+      createdAt: now,
+      updatedAt: now,
+      ...(state === "active" ? { lastActiveAt: now } : {}),
+    };
+    this.sessions.set(keyFor(workspaceId, sessionId), session);
+    return this.toPayload(session);
+  }
+
+  _clearForTests(): void {
+    this.sessions.clear();
+    this.removeAllListeners();
+  }
+
+  private toPayload(session: BrowserSessionRecord): BrowserStatusPayload {
+    return {
+      sessionId: session.sessionId,
+      state: session.state,
+      streamPath: buildStreamPath(session.workspaceId, session.sessionId),
+      updatedAt: session.updatedAt,
+      ...(session.lastActiveAt ? { lastActiveAt: session.lastActiveAt } : {}),
+      ...(session.url ? { url: session.url } : {}),
+      ...(session.title ? { title: session.title } : {}),
+      ...(session.error ? { error: session.error } : {}),
+    };
+  }
+}
+
+export const browserSessionManager = new BrowserSessionManager();

--- a/backend/src/services/browser-session-manager.ts
+++ b/backend/src/services/browser-session-manager.ts
@@ -9,6 +9,7 @@ export interface BrowserSessionRecord {
   agentBrowserSession: string;
   port: number;
   state: BrowserSessionState;
+  streaming: boolean;
   createdAt: number;
   updatedAt: number;
   lastActiveAt?: number;
@@ -23,6 +24,7 @@ export type BrowserSessionManagerEvent = {
 
 const AGENT_BROWSER_COMMAND_PATTERN = /(^|[\s"'`;&|()])(?:npx\s+|pnpm\s+dlx\s+|bunx\s+)?agent-browser(?=$|[\s"'`;&|()])/i;
 const AGENT_BROWSER_ENV_PATTERN = /\bAGENT_BROWSER_STREAM_PORT\b/;
+const AGENT_BROWSER_STOP_PATTERN = /\bagent-browser\b(?:\s+--?[^\s]+(?:\s+\S+)?)*\s+(?:close|stream\s+disable)\b/i;
 
 function keyFor(workspaceId: string, sessionId: string): string {
   return `${workspaceId}:${sessionId}`;
@@ -105,6 +107,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
       agentBrowserSession: buildAgentBrowserSession(workspaceId, sessionId),
       port: await allocateLoopbackPort(),
       state: "registered",
+      streaming: false,
       createdAt: now,
       updatedAt: now,
     };
@@ -145,6 +148,9 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
       AGENT_BROWSER_ENV_PATTERN.test(commandText);
 
     if (!isBrowserTool) return null;
+    if (AGENT_BROWSER_STOP_PATTERN.test(commandText)) {
+      return this.markStreaming(workspaceId, sessionId, false);
+    }
     return this.markActive(workspaceId, sessionId);
   }
 
@@ -153,6 +159,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     if (!session) return null;
     const now = Date.now();
     session.state = "active";
+    if (session.streaming === undefined) session.streaming = false;
     session.lastActiveAt = now;
     session.updatedAt = now;
     session.error = undefined;
@@ -165,6 +172,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     const session = this.getSession(workspaceId, sessionId);
     if (!session) return null;
     session.state = "error";
+    session.streaming = false;
     session.error = error;
     session.updatedAt = Date.now();
     const payload = this.toPayload(session);
@@ -186,8 +194,10 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
 
     const beforeUrl = session.url;
     const beforeTitle = session.title;
+    const beforeStreaming = session.streaming;
     let nextUrl: string | undefined;
     let nextTitle: string | undefined;
+    let nextStreaming: boolean | undefined;
 
     if (parsed.type === "url") {
       nextUrl = extractString(parsed.url) ?? extractString(parsed.value);
@@ -199,26 +209,54 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     } else if (isObject(parsed.tab)) {
       nextUrl = extractString(parsed.tab.url);
       nextTitle = extractString(parsed.tab.title);
+    } else if (parsed.type === "status") {
+      const connected = typeof parsed.connected === "boolean" ? parsed.connected : undefined;
+      const screencasting = typeof parsed.screencasting === "boolean" ? parsed.screencasting : undefined;
+      if (connected !== undefined || screencasting !== undefined) {
+        nextStreaming = Boolean(connected && screencasting);
+      }
+    } else if (parsed.type === "frame") {
+      nextStreaming = true;
     }
 
     if (nextUrl) session.url = nextUrl;
     if (nextTitle) session.title = nextTitle;
+    if (nextStreaming !== undefined) session.streaming = nextStreaming;
 
     if (session.state !== "active") {
       this.markActive(workspaceId, sessionId);
       return;
     }
 
-    if (beforeUrl !== session.url || beforeTitle !== session.title) {
+    if (beforeUrl !== session.url || beforeTitle !== session.title || beforeStreaming !== session.streaming) {
       session.updatedAt = Date.now();
       this.emit("status", workspaceId, this.toPayload(session));
     }
+  }
+
+  markStreaming(workspaceId: string, sessionId: string, streaming: boolean): BrowserStatusPayload | null {
+    const session = this.getSession(workspaceId, sessionId);
+    if (!session) return null;
+    const now = Date.now();
+    const changed = session.streaming !== streaming || session.state !== "active" || Boolean(session.error);
+    session.state = "active";
+    session.streaming = streaming;
+    session.updatedAt = now;
+    if (streaming) {
+      session.lastActiveAt = now;
+      session.error = undefined;
+    }
+    if (!changed) return this.toPayload(session);
+    const payload = this.toPayload(session);
+    this.emit("status", workspaceId, payload);
+    return payload;
   }
 
   closeSession(workspaceId: string, sessionId: string): BrowserStatusPayload | null {
     const session = this.sessions.get(keyFor(workspaceId, sessionId));
     if (!session || session.state === "closed") return null;
     session.state = "closed";
+    session.streaming = false;
     session.updatedAt = Date.now();
     const payload = this.toPayload(session);
     this.emit("status", workspaceId, payload);
@@ -242,6 +280,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
       agentBrowserSession: buildAgentBrowserSession(workspaceId, sessionId),
       port,
       state,
+      streaming: false,
       createdAt: now,
       updatedAt: now,
       ...(state === "active" ? { lastActiveAt: now } : {}),
@@ -259,6 +298,7 @@ export class BrowserSessionManager extends EventEmitter<BrowserSessionManagerEve
     return {
       sessionId: session.sessionId,
       state: session.state,
+      streaming: session.streaming,
       streamPath: buildStreamPath(session.workspaceId, session.sessionId),
       updatedAt: session.updatedAt,
       ...(session.lastActiveAt ? { lastActiveAt: session.lastActiveAt } : {}),

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -290,6 +290,7 @@ export type BrowserSessionState = "registered" | "active" | "closed" | "error";
 export interface BrowserStatusPayload {
   sessionId: string;
   state: BrowserSessionState;
+  streaming?: boolean;
   streamPath?: string;
   url?: string;
   title?: string;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -285,6 +285,19 @@ export interface MessageOptions {
 
 export type ThinkingLevel = "none" | "minimal" | "low" | "medium" | "high" | "xhigh" | "max";
 
+export type BrowserSessionState = "registered" | "active" | "closed" | "error";
+
+export interface BrowserStatusPayload {
+  sessionId: string;
+  state: BrowserSessionState;
+  streamPath?: string;
+  url?: string;
+  title?: string;
+  updatedAt: number;
+  lastActiveAt?: number;
+  error?: string;
+}
+
 /** Frontend -> Backend */
 export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
@@ -308,6 +321,7 @@ export type WsOutgoing =
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
   | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }
+  | { type: "browser_status"; status: BrowserStatusPayload }
   | { type: "plan_mode_changed"; sessionId: string; active: boolean };
 
 // ── Automation types ─────────────────────────────────────────────────

--- a/backend/src/ws/browser.test.ts
+++ b/backend/src/ws/browser.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import websocket from "@fastify/websocket";
+import WebSocket, { WebSocketServer } from "ws";
+import { browserSessionManager } from "../services/browser-session-manager.js";
+import { browserWsRoutes } from "./browser.js";
+
+let app: FastifyInstance;
+let upstream: WebSocketServer | undefined;
+
+beforeEach(async () => {
+  browserSessionManager._clearForTests();
+  app = Fastify();
+  await app.register(websocket, { options: { maxPayload: 10 * 1024 * 1024 } });
+  await app.register((instance: FastifyInstance) => browserWsRoutes(instance, { authToken: "secret" }));
+  await app.ready();
+});
+
+afterEach(async () => {
+  upstream?.close();
+  upstream = undefined;
+  browserSessionManager._clearForTests();
+  await app.close();
+});
+
+function waitForCondition(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error("Timed out waiting for condition"));
+    }, timeoutMs);
+    const interval = setInterval(() => {
+      if (!predicate()) return;
+      clearTimeout(timer);
+      clearInterval(interval);
+      resolve();
+    }, 10);
+  });
+}
+
+async function startUpstream(): Promise<{ port: number; messages: string[] }> {
+  const messages: string[] = [];
+  upstream = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  await new Promise<void>((resolve) => upstream?.once("listening", resolve));
+  upstream.on("connection", (socket) => {
+    socket.on("message", (data) => {
+      messages.push(data.toString());
+    });
+  });
+  const address = upstream.address();
+  if (typeof address !== "object" || !address) throw new Error("Missing upstream address");
+  return { port: address.port, messages };
+}
+
+async function connectBrowserWs(path: string): Promise<{
+  ws: WebSocket;
+  jsonMessages: Array<Record<string, unknown>>;
+  closed: Promise<{ code: number; reason: Buffer }>;
+}> {
+  const jsonMessages: Array<Record<string, unknown>> = [];
+  const ws = await app.injectWS(path, {}, {
+    onInit: (clientWs) => {
+      clientWs.on("message", (data: Buffer) => {
+        jsonMessages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+      });
+    },
+  });
+  const closed = new Promise<{ code: number; reason: Buffer }>((resolve) => {
+    ws.once("close", (code, reason) => resolve({ code, reason }));
+  });
+  return { ws, jsonMessages, closed };
+}
+
+describe("browser WS route", () => {
+  it("rejects unauthorized websocket connections", async () => {
+    browserSessionManager._registerForTests("ws-1", "session-1", 1234, "active");
+    const { ws, jsonMessages, closed } = await connectBrowserWs("/ws/browser/ws-1/session-1");
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({ type: "error", message: "Unauthorized" });
+    expect(result.code).toBe(1008);
+    ws.terminate();
+  });
+
+  it("rejects unknown browser sessions", async () => {
+    const { ws, jsonMessages, closed } = await connectBrowserWs("/ws/browser/ws-1/missing?token=secret");
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({ type: "error", message: "Browser session not found" });
+    expect(result.code).toBe(1008);
+    ws.terminate();
+  });
+
+  it("proxies upstream stream messages and ignores client input", async () => {
+    const upstreamInfo = await startUpstream();
+    browserSessionManager._registerForTests("ws-1", "session-1", upstreamInfo.port, "active");
+
+    const { ws, jsonMessages } = await connectBrowserWs("/ws/browser/ws-1/session-1?token=secret");
+    await waitForCondition(() => (upstream?.clients.size ?? 0) === 1);
+    const upstreamClient = Array.from(upstream!.clients)[0];
+    upstreamClient.send(JSON.stringify({ type: "url", url: "http://localhost:5173" }));
+    ws.send(JSON.stringify({ type: "click", x: 10, y: 10 }));
+
+    await waitForCondition(() => jsonMessages.length > 0);
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(jsonMessages[0]).toEqual({ type: "url", url: "http://localhost:5173" });
+    expect(upstreamInfo.messages).toHaveLength(0);
+    ws.terminate();
+  });
+});

--- a/backend/src/ws/browser.test.ts
+++ b/backend/src/ws/browser.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
 import websocket from "@fastify/websocket";
+import { createServer } from "node:net";
 import WebSocket, { WebSocketServer } from "ws";
 import { browserSessionManager } from "../services/browser-session-manager.js";
 import { browserWsRoutes, type BrowserViewportSetter } from "./browser.js";
@@ -41,9 +42,24 @@ function waitForCondition(predicate: () => boolean, timeoutMs = 3000): Promise<v
   });
 }
 
-async function startUpstream(): Promise<{ port: number; messages: string[] }> {
+async function allocatePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address();
+  const port = typeof address === "object" && address ? address.port : 0;
+  await new Promise<void>((resolve, reject) => {
+    server.close((err) => err ? reject(err) : resolve());
+  });
+  if (!port) throw new Error("Failed to allocate port");
+  return port;
+}
+
+async function startUpstream(port = 0): Promise<{ port: number; messages: string[] }> {
   const messages: string[] = [];
-  upstream = new WebSocketServer({ host: "127.0.0.1", port: 0 });
+  upstream = new WebSocketServer({ host: "127.0.0.1", port });
   await new Promise<void>((resolve) => upstream?.once("listening", resolve));
   upstream.on("connection", (socket) => {
     socket.on("message", (data) => {
@@ -142,6 +158,65 @@ describe("browser WS route", () => {
       state: "active",
       streaming: false,
     });
+    ws.terminate();
+  });
+
+  it("waits for the agent-browser upstream to become ready before marking the stream stopped", async () => {
+    const port = await allocatePort();
+    browserSessionManager._registerForTests("ws-1", "session-1", port, "active");
+    browserSessionManager.markStreaming("ws-1", "session-1", true);
+    const statuses: BrowserStatusPayload[] = [];
+    browserSessionManager.on("status", (_workspaceId, status) => statuses.push(status));
+
+    const { ws, jsonMessages } = await connectBrowserWs("/ws/browser/ws-1/session-1?token=secret");
+    await new Promise((resolve) => setTimeout(resolve, 75));
+    expect(statuses.some((status) => status.streaming === false)).toBe(false);
+
+    await startUpstream(port);
+    await waitForCondition(() => (upstream?.clients.size ?? 0) === 1);
+    const upstreamClient = Array.from(upstream!.clients)[0];
+    upstreamClient.send(JSON.stringify({
+      type: "status",
+      connected: true,
+      screencasting: false,
+    }));
+    upstreamClient.send(JSON.stringify({
+      type: "frame",
+      data: "abc123",
+    }));
+
+    await waitForCondition(() => jsonMessages.some((message) => message.type === "frame"));
+    expect(statuses.some((status) => status.streaming === false)).toBe(false);
+    expect(statuses.at(-1)).toMatchObject({
+      sessionId: "session-1",
+      state: "active",
+      streaming: true,
+    });
+    ws.terminate();
+  });
+
+  it("reconnects when upstream accepts before the browser has launched", async () => {
+    const upstreamInfo = await startUpstream();
+    browserSessionManager._registerForTests("ws-1", "session-1", upstreamInfo.port, "active");
+    browserSessionManager.markStreaming("ws-1", "session-1", true);
+    const statuses: BrowserStatusPayload[] = [];
+    browserSessionManager.on("status", (_workspaceId, status) => statuses.push(status));
+    let connectionCount = 0;
+    upstream!.on("connection", (socket) => {
+      connectionCount += 1;
+      if (connectionCount === 1) {
+        socket.send(JSON.stringify({ type: "error", message: "Browser not launched" }));
+        return;
+      }
+      socket.send(JSON.stringify({ type: "frame", data: "ready" }));
+    });
+
+    const { ws, jsonMessages } = await connectBrowserWs("/ws/browser/ws-1/session-1?token=secret");
+
+    await waitForCondition(() => jsonMessages.some((message) => message.type === "frame"));
+    expect(connectionCount).toBeGreaterThanOrEqual(2);
+    expect(jsonMessages.some((message) => message.type === "error")).toBe(false);
+    expect(statuses.some((status) => status.streaming === false)).toBe(false);
     ws.terminate();
   });
 });

--- a/backend/src/ws/browser.test.ts
+++ b/backend/src/ws/browser.test.ts
@@ -4,6 +4,7 @@ import websocket from "@fastify/websocket";
 import WebSocket, { WebSocketServer } from "ws";
 import { browserSessionManager } from "../services/browser-session-manager.js";
 import { browserWsRoutes, type BrowserViewportSetter } from "./browser.js";
+import type { BrowserStatusPayload } from "../types.js";
 
 let app: FastifyInstance;
 let upstream: WebSocketServer | undefined;
@@ -121,6 +122,26 @@ describe("browser WS route", () => {
     await waitForCondition(() => setViewport.mock.calls.length === 1);
     expect(setViewport).toHaveBeenCalledWith("ws-1", "session-1", { width: 420, height: 260 });
     expect(upstreamInfo.messages).toHaveLength(0);
+    ws.terminate();
+  });
+
+  it("marks the browser stream as stopped when the upstream stream closes", async () => {
+    const upstreamInfo = await startUpstream();
+    browserSessionManager._registerForTests("ws-1", "session-1", upstreamInfo.port, "active");
+    browserSessionManager.markStreaming("ws-1", "session-1", true);
+    const statuses: BrowserStatusPayload[] = [];
+    browserSessionManager.on("status", (_workspaceId, status) => statuses.push(status));
+
+    const { ws } = await connectBrowserWs("/ws/browser/ws-1/session-1?token=secret");
+    await waitForCondition(() => (upstream?.clients.size ?? 0) === 1);
+    Array.from(upstream!.clients)[0].close();
+
+    await waitForCondition(() => statuses.some((status) => status.streaming === false));
+    expect(statuses.at(-1)).toMatchObject({
+      sessionId: "session-1",
+      state: "active",
+      streaming: false,
+    });
     ws.terminate();
   });
 });

--- a/backend/src/ws/browser.test.ts
+++ b/backend/src/ws/browser.test.ts
@@ -1,18 +1,20 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
 import websocket from "@fastify/websocket";
 import WebSocket, { WebSocketServer } from "ws";
 import { browserSessionManager } from "../services/browser-session-manager.js";
-import { browserWsRoutes } from "./browser.js";
+import { browserWsRoutes, type BrowserViewportSetter } from "./browser.js";
 
 let app: FastifyInstance;
 let upstream: WebSocketServer | undefined;
+let setViewport: Mock<BrowserViewportSetter>;
 
 beforeEach(async () => {
   browserSessionManager._clearForTests();
+  setViewport = vi.fn<BrowserViewportSetter>().mockResolvedValue(undefined);
   app = Fastify();
   await app.register(websocket, { options: { maxPayload: 10 * 1024 * 1024 } });
-  await app.register((instance: FastifyInstance) => browserWsRoutes(instance, { authToken: "secret" }));
+  await app.register((instance: FastifyInstance) => browserWsRoutes(instance, { authToken: "secret", setViewport }));
   await app.ready();
 });
 
@@ -104,6 +106,20 @@ describe("browser WS route", () => {
     await waitForCondition(() => jsonMessages.length > 0);
     await new Promise((resolve) => setTimeout(resolve, 25));
     expect(jsonMessages[0]).toEqual({ type: "url", url: "http://localhost:5173" });
+    expect(upstreamInfo.messages).toHaveLength(0);
+    ws.terminate();
+  });
+
+  it("handles viewport resize messages without forwarding them upstream", async () => {
+    const upstreamInfo = await startUpstream();
+    browserSessionManager._registerForTests("ws-1", "session-1", upstreamInfo.port, "active");
+
+    const { ws } = await connectBrowserWs("/ws/browser/ws-1/session-1?token=secret");
+    await waitForCondition(() => (upstream?.clients.size ?? 0) === 1);
+    ws.send(JSON.stringify({ type: "viewport_resize", width: 420.4, height: 260.2 }));
+
+    await waitForCondition(() => setViewport.mock.calls.length === 1);
+    expect(setViewport).toHaveBeenCalledWith("ws-1", "session-1", { width: 420, height: 260 });
     expect(upstreamInfo.messages).toHaveLength(0);
     ws.terminate();
   });

--- a/backend/src/ws/browser.ts
+++ b/backend/src/ws/browser.ts
@@ -1,0 +1,105 @@
+import type { FastifyInstance } from "fastify";
+import WebSocket from "ws";
+import { browserSessionManager } from "../services/browser-session-manager.js";
+import { isAuthorized } from "../utils/auth.js";
+
+const PING_INTERVAL_MS = 30_000;
+
+export interface BrowserWsRoutesOptions {
+  authToken?: string;
+}
+
+export async function browserWsRoutes(
+  app: FastifyInstance,
+  opts: BrowserWsRoutesOptions = {},
+) {
+  const { authToken } = opts;
+
+  app.get<{
+    Params: { wsId: string; sessionId: string };
+    Querystring: { token?: string };
+  }>(
+    "/ws/browser/:wsId/:sessionId",
+    { websocket: true },
+    async (client, req) => {
+      const queryToken = typeof req.query.token === "string" ? req.query.token : undefined;
+      if (!isAuthorized(req.headers, authToken, queryToken)) {
+        client.send(JSON.stringify({ type: "error", message: "Unauthorized" }));
+        client.close(1008, "Unauthorized");
+        return;
+      }
+
+      const { wsId, sessionId } = req.params;
+      const session = browserSessionManager.getSession(wsId, sessionId);
+      if (!session) {
+        client.send(JSON.stringify({ type: "error", message: "Browser session not found" }));
+        client.close(1008, "Browser session not found");
+        return;
+      }
+
+      const upstream = new WebSocket(`ws://127.0.0.1:${session.port}`);
+      let upstreamOpen = false;
+
+      const closeBoth = (code = 1000, reason?: string) => {
+        if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+          upstream.close();
+        }
+        if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
+          client.close(code, reason);
+        }
+      };
+
+      const pingTimer = setInterval(() => {
+        if (client.readyState === client.OPEN) client.ping();
+        if (upstream.readyState === upstream.OPEN) upstream.ping();
+      }, PING_INTERVAL_MS);
+
+      upstream.on("open", () => {
+        upstreamOpen = true;
+        browserSessionManager.markActive(wsId, sessionId);
+      });
+
+      upstream.on("message", (data, isBinary) => {
+        if (client.readyState !== client.OPEN) return;
+        if (!isBinary) {
+          const text = data.toString();
+          browserSessionManager.ingestStreamMessage(wsId, sessionId, text);
+          client.send(text);
+          return;
+        }
+        client.send(data, { binary: true });
+      });
+
+      upstream.on("error", () => {
+        if (!upstreamOpen) {
+          browserSessionManager.markError(wsId, sessionId, "Browser stream is not ready");
+          if (client.readyState === client.OPEN) {
+            client.send(JSON.stringify({ type: "error", message: "Browser stream is not ready" }));
+          }
+        }
+      });
+
+      upstream.on("close", () => {
+        clearInterval(pingTimer);
+        if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
+          client.close(1000, "Browser stream closed");
+        }
+      });
+
+      // The Hive browser panel is intentionally read-only. Client messages are
+      // ignored so keyboard/mouse input cannot reach the agent-owned browser.
+      client.on("message", () => {});
+
+      client.on("close", () => {
+        clearInterval(pingTimer);
+        if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+          upstream.close();
+        }
+      });
+
+      client.on("error", () => {
+        closeBoth(1011, "Browser client error");
+      });
+    },
+  );
+}

--- a/backend/src/ws/browser.ts
+++ b/backend/src/ws/browser.ts
@@ -1,12 +1,78 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { FastifyInstance } from "fastify";
 import WebSocket from "ws";
 import { browserSessionManager } from "../services/browser-session-manager.js";
 import { isAuthorized } from "../utils/auth.js";
+import { buildWorkspaceEnv } from "../utils/env.js";
 
 const PING_INTERVAL_MS = 30_000;
+const MIN_VIEWPORT_WIDTH = 160;
+const MIN_VIEWPORT_HEIGHT = 120;
+const MAX_VIEWPORT_WIDTH = 4096;
+const MAX_VIEWPORT_HEIGHT = 4096;
+const execFileAsync = promisify(execFile);
+
+export interface BrowserViewportSize {
+  width: number;
+  height: number;
+}
+
+export type BrowserViewportSetter = (
+  workspaceId: string,
+  sessionId: string,
+  viewport: BrowserViewportSize,
+) => Promise<void>;
 
 export interface BrowserWsRoutesOptions {
   authToken?: string;
+  setViewport?: BrowserViewportSetter;
+}
+
+function parseViewportDimension(value: unknown, min: number, max: number): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  const rounded = Math.round(value);
+  if (rounded < min || rounded > max) return null;
+  return rounded;
+}
+
+function parseViewportResizeMessage(data: WebSocket.RawData, isBinary: boolean): BrowserViewportSize | null {
+  if (isBinary) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(data.toString()) as unknown;
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const message = parsed as Record<string, unknown>;
+  if (message.type !== "viewport_resize") return null;
+
+  const width = parseViewportDimension(message.width, MIN_VIEWPORT_WIDTH, MAX_VIEWPORT_WIDTH);
+  const height = parseViewportDimension(message.height, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
+  if (!width || !height) return null;
+  return { width, height };
+}
+
+async function setAgentBrowserViewport(
+  workspaceId: string,
+  sessionId: string,
+  viewport: BrowserViewportSize,
+): Promise<void> {
+  const env = browserSessionManager.getEnv(workspaceId, sessionId);
+  if (!env) throw new Error("Browser session not found");
+
+  await execFileAsync(
+    "agent-browser",
+    ["set", "viewport", String(viewport.width), String(viewport.height)],
+    {
+      env: buildWorkspaceEnv(env),
+      timeout: 5_000,
+      windowsHide: true,
+    },
+  );
 }
 
 export async function browserWsRoutes(
@@ -14,6 +80,7 @@ export async function browserWsRoutes(
   opts: BrowserWsRoutesOptions = {},
 ) {
   const { authToken } = opts;
+  const setViewport = opts.setViewport ?? setAgentBrowserViewport;
 
   app.get<{
     Params: { wsId: string; sessionId: string };
@@ -39,6 +106,7 @@ export async function browserWsRoutes(
 
       const upstream = new WebSocket(`ws://127.0.0.1:${session.port}`);
       let upstreamOpen = false;
+      let lastViewport: BrowserViewportSize | null = null;
 
       const closeBoth = (code = 1000, reason?: string) => {
         if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
@@ -86,9 +154,18 @@ export async function browserWsRoutes(
         }
       });
 
-      // The Hive browser panel is intentionally read-only. Client messages are
-      // ignored so keyboard/mouse input cannot reach the agent-owned browser.
-      client.on("message", () => {});
+      // The Hive browser panel is intentionally read-only for page input.
+      // Only viewport resize messages are handled locally by Hive and are not
+      // forwarded to agent-browser's input WebSocket.
+      client.on("message", (data, isBinary) => {
+        const viewport = parseViewportResizeMessage(data, isBinary);
+        if (!viewport) return;
+        if (lastViewport?.width === viewport.width && lastViewport.height === viewport.height) return;
+        lastViewport = viewport;
+        void setViewport(wsId, sessionId, viewport).catch((err: unknown) => {
+          app.log.debug({ err, wsId, sessionId, viewport }, "Failed to resize agent browser viewport");
+        });
+      });
 
       client.on("close", () => {
         clearInterval(pingTimer);

--- a/backend/src/ws/browser.ts
+++ b/backend/src/ws/browser.ts
@@ -106,10 +106,12 @@ export async function browserWsRoutes(
 
       const upstream = new WebSocket(`ws://127.0.0.1:${session.port}`);
       let upstreamOpen = false;
+      let closingFromClient = false;
       let lastViewport: BrowserViewportSize | null = null;
 
       const closeBoth = (code = 1000, reason?: string) => {
         if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+          closingFromClient = true;
           upstream.close();
         }
         if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
@@ -140,7 +142,7 @@ export async function browserWsRoutes(
 
       upstream.on("error", () => {
         if (!upstreamOpen) {
-          browserSessionManager.markError(wsId, sessionId, "Browser stream is not ready");
+          browserSessionManager.markStreaming(wsId, sessionId, false);
           if (client.readyState === client.OPEN) {
             client.send(JSON.stringify({ type: "error", message: "Browser stream is not ready" }));
           }
@@ -149,6 +151,9 @@ export async function browserWsRoutes(
 
       upstream.on("close", () => {
         clearInterval(pingTimer);
+        if (!closingFromClient) {
+          browserSessionManager.markStreaming(wsId, sessionId, false);
+        }
         if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
           client.close(1000, "Browser stream closed");
         }
@@ -170,6 +175,7 @@ export async function browserWsRoutes(
       client.on("close", () => {
         clearInterval(pingTimer);
         if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+          closingFromClient = true;
           upstream.close();
         }
       });

--- a/backend/src/ws/browser.ts
+++ b/backend/src/ws/browser.ts
@@ -7,6 +7,8 @@ import { isAuthorized } from "../utils/auth.js";
 import { buildWorkspaceEnv } from "../utils/env.js";
 
 const PING_INTERVAL_MS = 30_000;
+const UPSTREAM_RETRY_INTERVAL_MS = 250;
+const UPSTREAM_CONNECT_TIMEOUT_MS = 12_000;
 const MIN_VIEWPORT_WIDTH = 160;
 const MIN_VIEWPORT_HEIGHT = 120;
 const MAX_VIEWPORT_WIDTH = 4096;
@@ -54,6 +56,22 @@ function parseViewportResizeMessage(data: WebSocket.RawData, isBinary: boolean):
   const height = parseViewportDimension(message.height, MIN_VIEWPORT_HEIGHT, MAX_VIEWPORT_HEIGHT);
   if (!width || !height) return null;
   return { width, height };
+}
+
+function isRetryableUpstreamMessage(raw: string): boolean {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return false;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return false;
+  const message = parsed as Record<string, unknown>;
+  if (message.type !== "error" || typeof message.message !== "string") return false;
+
+  const text = message.message.toLowerCase();
+  return text.includes("browser not launched") || text.includes("screencast");
 }
 
 async function setAgentBrowserViewport(
@@ -104,13 +122,18 @@ export async function browserWsRoutes(
         return;
       }
 
-      const upstream = new WebSocket(`ws://127.0.0.1:${session.port}`);
-      let upstreamOpen = false;
+      let upstream: WebSocket | null = null;
       let closingFromClient = false;
       let lastViewport: BrowserViewportSize | null = null;
+      let upstreamRetryTimer: NodeJS.Timeout | null = null;
+      const upstreamConnectDeadline = Date.now() + UPSTREAM_CONNECT_TIMEOUT_MS;
 
       const closeBoth = (code = 1000, reason?: string) => {
-        if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+        if (upstreamRetryTimer) {
+          clearTimeout(upstreamRetryTimer);
+          upstreamRetryTimer = null;
+        }
+        if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
           closingFromClient = true;
           upstream.close();
         }
@@ -121,43 +144,83 @@ export async function browserWsRoutes(
 
       const pingTimer = setInterval(() => {
         if (client.readyState === client.OPEN) client.ping();
-        if (upstream.readyState === upstream.OPEN) upstream.ping();
+        if (upstream?.readyState === WebSocket.OPEN) upstream.ping();
       }, PING_INTERVAL_MS);
 
-      upstream.on("open", () => {
-        upstreamOpen = true;
-        browserSessionManager.markActive(wsId, sessionId);
-      });
+      const markUpstreamUnavailable = () => {
+        browserSessionManager.markStreaming(wsId, sessionId, false);
+        if (client.readyState === client.OPEN) {
+          client.send(JSON.stringify({ type: "error", message: "Browser stream is not ready" }));
+        }
+      };
 
-      upstream.on("message", (data, isBinary) => {
-        if (client.readyState !== client.OPEN) return;
-        if (!isBinary) {
-          const text = data.toString();
-          browserSessionManager.ingestStreamMessage(wsId, sessionId, text);
-          client.send(text);
+      const scheduleUpstreamConnect = () => {
+        if (closingFromClient || client.readyState !== client.OPEN) return;
+        if (upstreamRetryTimer) return;
+        if (Date.now() >= upstreamConnectDeadline) {
+          markUpstreamUnavailable();
+          closeBoth(1000, "Browser stream unavailable");
           return;
         }
-        client.send(data, { binary: true });
-      });
+        upstreamRetryTimer = setTimeout(() => {
+          upstreamRetryTimer = null;
+          connectUpstream();
+        }, UPSTREAM_RETRY_INTERVAL_MS);
+      };
 
-      upstream.on("error", () => {
-        if (!upstreamOpen) {
-          browserSessionManager.markStreaming(wsId, sessionId, false);
-          if (client.readyState === client.OPEN) {
-            client.send(JSON.stringify({ type: "error", message: "Browser stream is not ready" }));
+      const connectUpstream = () => {
+        if (closingFromClient || client.readyState !== client.OPEN) return;
+        if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) return;
+
+        let opened = false;
+        let retryingUpstream = false;
+        const ws = new WebSocket(`ws://127.0.0.1:${session.port}`);
+        upstream = ws;
+
+        ws.on("open", () => {
+          opened = true;
+          browserSessionManager.markActive(wsId, sessionId);
+        });
+
+        ws.on("message", (data, isBinary) => {
+          if (client.readyState !== client.OPEN) return;
+          if (!isBinary) {
+            const text = data.toString();
+            if (isRetryableUpstreamMessage(text)) {
+              retryingUpstream = true;
+              ws.close();
+              return;
+            }
+            browserSessionManager.ingestStreamMessage(wsId, sessionId, text);
+            client.send(text);
+            return;
           }
-        }
-      });
+          client.send(data, { binary: true });
+        });
 
-      upstream.on("close", () => {
-        clearInterval(pingTimer);
-        if (!closingFromClient) {
-          browserSessionManager.markStreaming(wsId, sessionId, false);
-        }
-        if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
-          client.close(1000, "Browser stream closed");
-        }
-      });
+        ws.on("error", () => {
+          if (!opened) {
+            scheduleUpstreamConnect();
+          }
+        });
+
+        ws.on("close", () => {
+          if (upstream === ws) upstream = null;
+          if ((!opened || retryingUpstream) && !closingFromClient) {
+            scheduleUpstreamConnect();
+            return;
+          }
+          clearInterval(pingTimer);
+          if (!closingFromClient) {
+            browserSessionManager.markStreaming(wsId, sessionId, false);
+          }
+          if (client.readyState === client.OPEN || client.readyState === client.CONNECTING) {
+            client.close(1000, "Browser stream closed");
+          }
+        });
+      };
+
+      connectUpstream();
 
       // The Hive browser panel is intentionally read-only for page input.
       // Only viewport resize messages are handled locally by Hive and are not
@@ -174,7 +237,11 @@ export async function browserWsRoutes(
 
       client.on("close", () => {
         clearInterval(pingTimer);
-        if (upstream.readyState === upstream.OPEN || upstream.readyState === upstream.CONNECTING) {
+        if (upstreamRetryTimer) {
+          clearTimeout(upstreamRetryTimer);
+          upstreamRetryTimer = null;
+        }
+        if (upstream && (upstream.readyState === WebSocket.OPEN || upstream.readyState === WebSocket.CONNECTING)) {
           closingFromClient = true;
           upstream.close();
         }

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -17,6 +17,7 @@ import { getScriptStatus } from "../services/script-runner.js";
 import { getWorkspace } from "../workspaces/workspace-manager.js";
 import { workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
+import { browserSessionManager } from "../services/browser-session-manager.js";
 import { join, resolve, sep } from "node:path";
 
 interface GitSyncSnapshotProvider {
@@ -121,6 +122,15 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     authToken,
     gitSyncSnapshotProvider,
   } = opts;
+
+  const onBrowserStatus = (workspaceId: string, status: Extract<WsOutgoing, { type: "browser_status" }>["status"]) => {
+    broadcastToWorkspace(workspaceId, { type: "browser_status", status });
+  };
+  browserSessionManager.on("status", onBrowserStatus);
+  app.addHook("onClose", (_instance, done) => {
+    browserSessionManager.removeListener("status", onBrowserStatus);
+    done();
+  });
 
   // ── Channel helpers ───────────────────────────────────────────────
 
@@ -237,6 +247,9 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       if (msg.type === "tool_input_required") {
         channel.pendingToolRequests.set(msg.requestId, session.sessionId);
       }
+      if (msg.type === "tool_use") {
+        browserSessionManager.maybeMarkToolActivity(workspaceId, session.sessionId, msg.name, msg.input);
+      }
       broadcastToChannel(channel, workspaceId, msg);
     };
     const onError = (err: Error) => {
@@ -344,6 +357,10 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           ...(info.exitCode !== undefined ? { exitCode: info.exitCode } : {}),
         });
       }
+    }
+
+    for (const status of browserSessionManager.getVisibleStatuses(wsId)) {
+      sendToHub(hub, wsId, { type: "browser_status", status });
     }
   };
 

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Maximize2Icon, PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
+import { ChevronDownIcon, ChevronUpIcon, Maximize2Icon, MonitorIcon, PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -16,6 +17,8 @@ const MIN_VIEWPORT_HEIGHT = 120;
 
 interface BrowserPanelProps {
   status: BrowserStatusPayload;
+  collapsed?: boolean;
+  onToggleCollapsed?: () => void;
 }
 
 function connectionLabel(status: BrowserStreamConnectionStatus): string {
@@ -31,7 +34,7 @@ function connectionLabel(status: BrowserStreamConnectionStatus): string {
   }
 }
 
-export function BrowserPanel({ status }: BrowserPanelProps) {
+export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: BrowserPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const objectUrlRef = useRef<string | null>(null);
   const pausedRef = useRef(false);
@@ -50,8 +53,8 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
   pausedRef.current = paused;
 
   const streamUrl = useMemo(
-    () => status.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
-    [status.streamPath],
+    () => !collapsed && status.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
+    [collapsed, status.streamPath],
   );
 
   useEffect(() => {
@@ -183,83 +186,121 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
 
   const displayUrl = url ?? title ?? "Browser";
   const isLive = connectionStatus === "connected" && !paused;
+  const statusBadge = status.state === "error" ? "Error" : "Live";
 
   return (
     <TooltipProvider>
       <div className="flex h-full min-h-0 flex-col bg-background">
-        <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
-          {frameSrc ? (
-            <img
-              src={frameSrc}
-              alt="Agent browser"
-              className="h-full w-full object-fill"
-              draggable={false}
-            />
-          ) : (
-            <div className="px-4 text-center text-xs text-zinc-400">
-              {error ?? (status.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
+        <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
+          <MonitorIcon className="size-3.5 text-muted-foreground" />
+          <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
+          <Badge
+            variant={status.state === "error" ? "destructive" : "secondary"}
+            className="px-1.5 py-0 text-[10px]"
+          >
+            {statusBadge}
+          </Badge>
+
+          {!collapsed && (
+            <div className="flex min-w-0 items-center gap-2 text-xs">
+              <span
+                className={cn(
+                  "size-1.5 shrink-0 rounded-full",
+                  isLive ? "bg-emerald-400" : connectionStatus === "error" ? "bg-red-400" : "bg-muted-foreground/60",
+                )}
+              />
+              <span className="shrink-0 text-muted-foreground">{connectionLabel(connectionStatus)}</span>
+              <span className="truncate text-muted-foreground">{displayUrl}</span>
             </div>
           )}
 
-          <div className="absolute left-3 top-3 flex min-w-0 max-w-[calc(100%-7rem)] items-center gap-2 rounded-md border border-white/10 bg-black/70 px-2 py-1 text-xs text-white shadow-sm backdrop-blur">
-            <span
-              className={cn(
-                "size-1.5 rounded-full",
-                isLive ? "bg-emerald-400" : connectionStatus === "error" ? "bg-red-400" : "bg-zinc-400",
-              )}
-            />
-            <span className="shrink-0 text-white/70">{connectionLabel(connectionStatus)}</span>
-            <span className="truncate text-white/90">{displayUrl}</span>
-          </div>
+          <div className="ml-auto" />
 
-          <div className="absolute right-3 top-3 flex items-center gap-1 rounded-md border border-white/10 bg-black/70 p-1 shadow-sm backdrop-blur">
+          {!collapsed && (
+            <div className="flex items-center gap-1">
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={() => setPaused((value) => !value)}
+                    aria-label={paused ? "Resume browser stream" : "Pause browser stream"}
+                  >
+                    {paused ? <PlayIcon className="size-3" /> : <PauseIcon className="size-3" />}
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>{paused ? "Resume" : "Pause"}</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={() => setRetryNonce((value) => value + 1)}
+                    aria-label="Reconnect browser stream"
+                  >
+                    <RotateCcwIcon className="size-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Reconnect</TooltipContent>
+              </Tooltip>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={handleFullscreen}
+                    aria-label="Fullscreen browser stream"
+                  >
+                    <Maximize2Icon className="size-3" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Fullscreen</TooltipContent>
+              </Tooltip>
+            </div>
+          )}
+
+          {onToggleCollapsed && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
                   type="button"
                   variant="ghost"
                   size="icon-xs"
-                  className="text-white/80 hover:bg-white/10 hover:text-white"
-                  onClick={() => setPaused((value) => !value)}
-                  aria-label={paused ? "Resume browser stream" : "Pause browser stream"}
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={onToggleCollapsed}
+                  aria-label={collapsed ? "Expand browser panel" : "Collapse browser panel"}
                 >
-                  {paused ? <PlayIcon className="size-3" /> : <PauseIcon className="size-3" />}
+                  {collapsed ? <ChevronUpIcon className="size-3" /> : <ChevronDownIcon className="size-3" />}
                 </Button>
               </TooltipTrigger>
-              <TooltipContent>{paused ? "Resume" : "Pause"}</TooltipContent>
+              <TooltipContent>{collapsed ? "Expand" : "Collapse"}</TooltipContent>
             </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-white/80 hover:bg-white/10 hover:text-white"
-                  onClick={() => setRetryNonce((value) => value + 1)}
-                  aria-label="Reconnect browser stream"
-                >
-                  <RotateCcwIcon className="size-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Reconnect</TooltipContent>
-            </Tooltip>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  className="text-white/80 hover:bg-white/10 hover:text-white"
-                  onClick={handleFullscreen}
-                  aria-label="Fullscreen browser stream"
-                >
-                  <Maximize2Icon className="size-3" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Fullscreen</TooltipContent>
-            </Tooltip>
-          </div>
+          )}
         </div>
+
+        {!collapsed && (
+          <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
+            {frameSrc ? (
+              <img
+                src={frameSrc}
+                alt="Agent browser"
+                className="h-full w-full object-fill"
+                draggable={false}
+              />
+            ) : (
+              <div className="px-4 text-center text-xs text-zinc-400">
+                {error ?? (status.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </TooltipProvider>
   );

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -6,9 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/comp
 import {
   buildBrowserStreamUrl,
   parseBrowserStreamMessage,
-  type BrowserStreamConnectionStatus,
 } from "@/lib/browser-stream";
-import { cn } from "@/lib/utils";
 import type { BrowserStatusPayload } from "@/types";
 
 const VIEWPORT_RESIZE_DEBOUNCE_MS = 250;
@@ -16,22 +14,9 @@ const MIN_VIEWPORT_WIDTH = 160;
 const MIN_VIEWPORT_HEIGHT = 120;
 
 interface BrowserPanelProps {
-  status: BrowserStatusPayload;
+  status?: BrowserStatusPayload;
   collapsed?: boolean;
   onToggleCollapsed?: () => void;
-}
-
-function connectionLabel(status: BrowserStreamConnectionStatus): string {
-  switch (status) {
-    case "connecting":
-      return "Connecting";
-    case "connected":
-      return "Live";
-    case "error":
-      return "Error";
-    case "disconnected":
-      return "Disconnected";
-  }
 }
 
 export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: BrowserPanelProps) {
@@ -43,25 +28,21 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
   const lastSentViewportRef = useRef<{ width: number; height: number } | null>(null);
 
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
-  const [connectionStatus, setConnectionStatus] = useState<BrowserStreamConnectionStatus>("connecting");
+  const [connectionError, setConnectionError] = useState(false);
   const [paused, setPaused] = useState(false);
   const [retryNonce, setRetryNonce] = useState(0);
-  const [url, setUrl] = useState(status.url);
-  const [title, setTitle] = useState(status.title);
-  const [error, setError] = useState(status.error);
+  const [error, setError] = useState(status?.error);
 
   pausedRef.current = paused;
 
   const streamUrl = useMemo(
-    () => !collapsed && status.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
-    [collapsed, status.streamPath],
+    () => !collapsed && status?.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
+    [collapsed, status?.streamPath],
   );
 
   useEffect(() => {
-    setUrl(status.url);
-    setTitle(status.title);
-    setError(status.error);
-  }, [status.url, status.title, status.error]);
+    setError(status?.error);
+  }, [status?.error]);
 
   const sendViewportResize = useCallback(() => {
     const element = containerRef.current;
@@ -80,9 +61,13 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
   }, []);
 
   useEffect(() => {
-    if (!streamUrl) return undefined;
+    if (!streamUrl) {
+      setConnectionError(false);
+      setFrameSrc(null);
+      return undefined;
+    }
     lastSentViewportRef.current = null;
-    setConnectionStatus("connecting");
+    setConnectionError(false);
     setError(undefined);
 
     const ws = new WebSocket(streamUrl);
@@ -90,7 +75,6 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
     ws.binaryType = "blob";
 
     ws.onopen = () => {
-      setConnectionStatus("connected");
       sendViewportResize();
     };
 
@@ -110,22 +94,16 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
 
       if ("error" in parsed && parsed.error) {
         setError(parsed.error);
-        setConnectionStatus("error");
+        setConnectionError(true);
       }
-      if ("url" in parsed && parsed.url) setUrl(parsed.url);
-      if ("title" in parsed && parsed.title) setTitle(parsed.title);
       if ("src" in parsed && parsed.src && !pausedRef.current) {
         setFrameSrc(parsed.src);
       }
     };
 
     ws.onerror = () => {
-      setConnectionStatus("error");
+      setConnectionError(true);
       setError("Browser stream unavailable");
-    };
-
-    ws.onclose = () => {
-      setConnectionStatus((current) => current === "error" ? current : "disconnected");
     };
 
     return () => {
@@ -184,9 +162,9 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
     void containerRef.current?.requestFullscreen?.();
   }, []);
 
-  const displayUrl = url ?? title ?? "Browser";
-  const isLive = connectionStatus === "connected" && !paused;
-  const statusBadge = status.state === "error" ? "Error" : "Live";
+  const isActive = Boolean(status);
+  const isError = isActive && (status?.state === "error" || connectionError);
+  const statusBadge = !isActive ? "Idle" : isError ? "Error" : "Live";
 
   return (
     <TooltipProvider>
@@ -195,28 +173,15 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
           <MonitorIcon className="size-3.5 text-muted-foreground" />
           <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
           <Badge
-            variant={status.state === "error" ? "destructive" : "secondary"}
+            variant={isError ? "destructive" : "secondary"}
             className="px-1.5 py-0 text-[10px]"
           >
             {statusBadge}
           </Badge>
 
-          {!collapsed && (
-            <div className="flex min-w-0 items-center gap-2 text-xs">
-              <span
-                className={cn(
-                  "size-1.5 shrink-0 rounded-full",
-                  isLive ? "bg-emerald-400" : connectionStatus === "error" ? "bg-red-400" : "bg-muted-foreground/60",
-                )}
-              />
-              <span className="shrink-0 text-muted-foreground">{connectionLabel(connectionStatus)}</span>
-              <span className="truncate text-muted-foreground">{displayUrl}</span>
-            </div>
-          )}
-
           <div className="ml-auto" />
 
-          {!collapsed && (
+          {isActive && !collapsed && (
             <div className="flex items-center gap-1">
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -266,7 +231,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
             </div>
           )}
 
-          {onToggleCollapsed && (
+          {isActive && onToggleCollapsed && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
@@ -285,7 +250,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
           )}
         </div>
 
-        {!collapsed && (
+        {isActive && !collapsed && (
           <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
             {frameSrc ? (
               <img
@@ -296,7 +261,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
               />
             ) : (
               <div className="px-4 text-center text-xs text-zinc-400">
-                {error ?? (status.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
+                {error ?? (status?.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
               </div>
             )}
           </div>

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDownIcon, ChevronUpIcon, Maximize2Icon, MonitorIcon, PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -163,8 +162,8 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
   }, []);
 
   const isActive = Boolean(status);
-  const isError = isActive && (status?.state === "error" || connectionError);
-  const statusBadge = !isActive ? "Idle" : isError ? "Error" : "Live";
+  const isStreaming = Boolean(status?.streaming) && !connectionError;
+  const statusLabel = isStreaming ? "streaming" : "not streaming";
 
   return (
     <TooltipProvider>
@@ -172,12 +171,10 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
         <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
           <MonitorIcon className="size-3.5 text-muted-foreground" />
           <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
-          <Badge
-            variant={isError ? "destructive" : "secondary"}
-            className="px-1.5 py-0 text-[10px]"
-          >
-            {statusBadge}
-          </Badge>
+          <span className="flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+            <span className={isStreaming ? "size-1.5 rounded-full bg-emerald-400" : "size-1.5 rounded-full bg-muted-foreground/50"} />
+            {statusLabel}
+          </span>
 
           <div className="ml-auto" />
 

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { ChevronDownIcon, ChevronUpIcon, Maximize2Icon, MonitorIcon, PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDownIcon, ChevronUpIcon, MonitorIcon, RotateCcwIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
@@ -230,14 +230,12 @@ interface BrowserPanelProps {
 }
 
 export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: BrowserPanelProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
   const connectionRef = useRef<BrowserStreamConnection | null>(null);
 
   const [streamSnapshot, setStreamSnapshot] = useState<BrowserStreamSnapshot>(emptySnapshot);
   const [displayFrameSrc, setDisplayFrameSrc] = useState<string | null>(null);
   const [statusStoppedAt, setStatusStoppedAt] = useState(0);
   const [statusStartedAt, setStatusStartedAt] = useState(0);
-  const [paused, setPaused] = useState(false);
 
   const streamUrl = useMemo(
     () => status?.streamPath && status.streaming !== false
@@ -276,10 +274,10 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
       setDisplayFrameSrc(null);
       return;
     }
-    if (!paused && streamSnapshot.frameSrc) {
+    if (streamSnapshot.frameSrc) {
       setDisplayFrameSrc(streamSnapshot.frameSrc);
     }
-  }, [paused, streamSnapshot.closedAt, streamSnapshot.frameSrc, streamUrl]);
+  }, [streamSnapshot.closedAt, streamSnapshot.frameSrc, streamUrl]);
 
   useEffect(() => {
     if (status?.streaming === false) {
@@ -301,10 +299,6 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
     }
   }, [status?.streaming, statusStoppedAt, streamSnapshot.frameReceivedAt]);
 
-  const handleFullscreen = useCallback(() => {
-    void containerRef.current?.requestFullscreen?.();
-  }, []);
-
   const isActive = Boolean(status);
   const localFrameAfterStop = statusStoppedAt > 0 && streamSnapshot.frameReceivedAt > statusStoppedAt;
   const localStreamAllowed = status?.streaming !== false || localFrameAfterStop;
@@ -322,11 +316,13 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
 
   return (
     <TooltipProvider>
-      <div className="flex h-full min-h-0 flex-col bg-background">
-        <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
-          <MonitorIcon className="size-3.5 text-muted-foreground" />
-          <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
-          <span className="flex items-center gap-1 rounded-full bg-muted/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+      <div className="flex h-full min-h-0 flex-col bg-sidebar text-sidebar-foreground">
+        <div className="flex h-9 shrink-0 items-center gap-3 border-t border-border/50 px-3">
+          <div className="flex min-w-0 items-center gap-1.5">
+            <MonitorIcon className="size-3.5 shrink-0 text-muted-foreground" />
+            <span className="text-xs uppercase tracking-wide text-foreground">Browser</span>
+          </div>
+          <span className="flex items-center gap-1 rounded-full bg-sidebar-accent/60 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
             <span className={isStreaming ? "size-1.5 rounded-full bg-emerald-400" : "size-1.5 rounded-full bg-muted-foreground/50"} />
             {statusLabel}
           </span>
@@ -334,53 +330,21 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
           <div className="ml-auto" />
 
           {isActive && !collapsed && (
-            <div className="flex items-center gap-1">
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={() => setPaused((value) => !value)}
-                    aria-label={paused ? "Resume browser stream" : "Pause browser stream"}
-                  >
-                    {paused ? <PlayIcon className="size-3" /> : <PauseIcon className="size-3" />}
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>{paused ? "Resume" : "Pause"}</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={() => connectionRef.current?.reconnect()}
-                    aria-label="Reconnect browser stream"
-                  >
-                    <RotateCcwIcon className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Reconnect</TooltipContent>
-              </Tooltip>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={handleFullscreen}
-                    aria-label="Fullscreen browser stream"
-                  >
-                    <Maximize2Icon className="size-3" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent>Fullscreen</TooltipContent>
-              </Tooltip>
-            </div>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-muted-foreground hover:text-foreground"
+                  onClick={() => connectionRef.current?.reconnect()}
+                  aria-label="Reconnect browser stream"
+                >
+                  <RotateCcwIcon className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Reconnect</TooltipContent>
+            </Tooltip>
           )}
 
           {isActive && onToggleCollapsed && (
@@ -403,7 +367,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
         </div>
 
         {isActive && !collapsed && (
-          <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
+          <div className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-sidebar">
             {displayFrameSrc ? (
               <img
                 src={displayFrameSrc}
@@ -412,7 +376,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
                 draggable={false}
               />
             ) : (
-              <div className="px-4 text-center text-xs text-zinc-400">
+              <div className="px-4 text-center text-xs text-muted-foreground">
                 {error ?? (status?.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
               </div>
             )}

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -10,6 +10,10 @@ import {
 import { cn } from "@/lib/utils";
 import type { BrowserStatusPayload } from "@/types";
 
+const VIEWPORT_RESIZE_DEBOUNCE_MS = 250;
+const MIN_VIEWPORT_WIDTH = 160;
+const MIN_VIEWPORT_HEIGHT = 120;
+
 interface BrowserPanelProps {
   status: BrowserStatusPayload;
 }
@@ -31,6 +35,9 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const objectUrlRef = useRef<string | null>(null);
   const pausedRef = useRef(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const resizeTimerRef = useRef<number | null>(null);
+  const lastSentViewportRef = useRef<{ width: number; height: number } | null>(null);
 
   const [frameSrc, setFrameSrc] = useState<string | null>(null);
   const [connectionStatus, setConnectionStatus] = useState<BrowserStreamConnectionStatus>("connecting");
@@ -53,16 +60,35 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
     setError(status.error);
   }, [status.url, status.title, status.error]);
 
+  const sendViewportResize = useCallback(() => {
+    const element = containerRef.current;
+    const ws = wsRef.current;
+    if (!element || !ws || ws.readyState !== WebSocket.OPEN) return;
+
+    const rect = element.getBoundingClientRect();
+    const width = Math.round(rect.width);
+    const height = Math.round(rect.height);
+    if (width < MIN_VIEWPORT_WIDTH || height < MIN_VIEWPORT_HEIGHT) return;
+
+    const last = lastSentViewportRef.current;
+    if (last?.width === width && last.height === height) return;
+    lastSentViewportRef.current = { width, height };
+    ws.send(JSON.stringify({ type: "viewport_resize", width, height }));
+  }, []);
+
   useEffect(() => {
     if (!streamUrl) return undefined;
+    lastSentViewportRef.current = null;
     setConnectionStatus("connecting");
     setError(undefined);
 
     const ws = new WebSocket(streamUrl);
+    wsRef.current = ws;
     ws.binaryType = "blob";
 
     ws.onopen = () => {
       setConnectionStatus("connected");
+      sendViewportResize();
     };
 
     ws.onmessage = (event) => {
@@ -100,9 +126,47 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
     };
 
     return () => {
+      if (wsRef.current === ws) wsRef.current = null;
       ws.close();
     };
-  }, [streamUrl, retryNonce]);
+  }, [streamUrl, retryNonce, sendViewportResize]);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element) return undefined;
+
+    const scheduleResize = () => {
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current);
+      }
+      resizeTimerRef.current = window.setTimeout(() => {
+        resizeTimerRef.current = null;
+        sendViewportResize();
+      }, VIEWPORT_RESIZE_DEBOUNCE_MS);
+    };
+
+    if (typeof ResizeObserver === "undefined") {
+      scheduleResize();
+      return () => {
+        if (resizeTimerRef.current !== null) {
+          window.clearTimeout(resizeTimerRef.current);
+          resizeTimerRef.current = null;
+        }
+      };
+    }
+
+    const observer = new ResizeObserver(scheduleResize);
+    observer.observe(element);
+    scheduleResize();
+
+    return () => {
+      observer.disconnect();
+      if (resizeTimerRef.current !== null) {
+        window.clearTimeout(resizeTimerRef.current);
+        resizeTimerRef.current = null;
+      }
+    };
+  }, [sendViewportResize, streamUrl, retryNonce]);
 
   useEffect(() => {
     return () => {
@@ -128,7 +192,7 @@ export function BrowserPanel({ status }: BrowserPanelProps) {
             <img
               src={frameSrc}
               alt="Agent browser"
-              className="h-full w-full object-contain"
+              className="h-full w-full object-fill"
               draggable={false}
             />
           ) : (

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -8,9 +8,220 @@ import {
 } from "@/lib/browser-stream";
 import type { BrowserStatusPayload } from "@/types";
 
-const VIEWPORT_RESIZE_DEBOUNCE_MS = 250;
-const MIN_VIEWPORT_WIDTH = 160;
-const MIN_VIEWPORT_HEIGHT = 120;
+const DESKTOP_VIEWPORT_WIDTH = 1280;
+const DESKTOP_VIEWPORT_HEIGHT = 720;
+const CONNECTION_RELEASE_DELAY_MS = 2_000;
+
+interface BrowserStreamSnapshot {
+  frameSrc: string | null;
+  frameReceivedAt: number;
+  closedAt: number;
+  connectionError: boolean;
+  streamOpen: boolean;
+  error?: string;
+}
+
+const emptySnapshot: BrowserStreamSnapshot = {
+  frameSrc: null,
+  frameReceivedAt: 0,
+  closedAt: 0,
+  connectionError: false,
+  streamOpen: false,
+};
+
+type BrowserStreamSubscriber = (snapshot: BrowserStreamSnapshot) => void;
+
+class BrowserStreamConnection {
+  private ws: WebSocket | null = null;
+  private objectUrl: string | null = null;
+  private lastSentViewport: { width: number; height: number } | null = null;
+  private snapshot: BrowserStreamSnapshot = emptySnapshot;
+  private readonly subscribers = new Set<BrowserStreamSubscriber>();
+  releaseTimer: number | null = null;
+
+  constructor(private readonly streamUrl: string) {
+    this.connect();
+  }
+
+  subscribe(subscriber: BrowserStreamSubscriber): () => void {
+    this.subscribers.add(subscriber);
+    subscriber(this.snapshot);
+    return () => {
+      this.subscribers.delete(subscriber);
+    };
+  }
+
+  reconnect(): void {
+    this.connect();
+  }
+
+  ensureConnected(): void {
+    if (
+      !this.ws ||
+      this.ws.readyState === WebSocket.CLOSED ||
+      this.ws.readyState === WebSocket.CLOSING
+    ) {
+      this.connect();
+    }
+  }
+
+  hasSubscribers(): boolean {
+    return this.subscribers.size > 0;
+  }
+
+  close(): void {
+    if (this.releaseTimer !== null) {
+      window.clearTimeout(this.releaseTimer);
+      this.releaseTimer = null;
+    }
+    const ws = this.ws;
+    this.ws = null;
+    ws?.close();
+    if (this.objectUrl) {
+      URL.revokeObjectURL(this.objectUrl);
+      this.objectUrl = null;
+    }
+    this.lastSentViewport = null;
+    this.setSnapshot(emptySnapshot);
+  }
+
+  private connect(): void {
+    const previous = this.ws;
+    this.ws = null;
+    previous?.close();
+    this.lastSentViewport = null;
+    this.setSnapshot({ ...this.snapshot, connectionError: false, streamOpen: false, error: undefined });
+
+    const ws = new WebSocket(this.streamUrl);
+    this.ws = ws;
+    ws.binaryType = "blob";
+
+    ws.onopen = () => {
+      if (this.ws !== ws) return;
+      this.setSnapshot({
+        ...this.snapshot,
+        closedAt: 0,
+        streamOpen: true,
+        connectionError: false,
+        error: undefined,
+      });
+      this.sendViewportResize();
+    };
+
+    ws.onmessage = (event) => {
+      if (this.ws !== ws) return;
+      if (event.data instanceof Blob) {
+        this.setFrame(URL.createObjectURL(event.data));
+        return;
+      }
+
+      if (typeof event.data !== "string") return;
+      const parsed = parseBrowserStreamMessage(event.data);
+      if (!parsed) return;
+
+      if ("error" in parsed && parsed.error) {
+        this.setSnapshot({ ...this.snapshot, error: parsed.error, connectionError: true });
+      }
+      if ("src" in parsed && parsed.src) {
+        this.setFrame(parsed.src);
+      }
+    };
+
+    ws.onerror = () => {
+      if (this.ws !== ws) return;
+      this.setSnapshot({
+        ...this.snapshot,
+        streamOpen: false,
+        connectionError: true,
+        error: "Browser stream unavailable",
+      });
+    };
+
+    ws.onclose = () => {
+      if (this.ws !== ws) return;
+      this.ws = null;
+      this.setSnapshot({
+        ...this.snapshot,
+        frameSrc: null,
+        frameReceivedAt: 0,
+        closedAt: Date.now(),
+        streamOpen: false,
+      });
+    };
+  }
+
+  private setFrame(frameSrc: string): void {
+    if (this.objectUrl && this.objectUrl !== frameSrc) {
+      URL.revokeObjectURL(this.objectUrl);
+    }
+    this.objectUrl = frameSrc.startsWith("blob:") ? frameSrc : null;
+    this.setSnapshot({
+      ...this.snapshot,
+      frameSrc,
+      frameReceivedAt: Date.now(),
+      closedAt: 0,
+      streamOpen: true,
+      connectionError: false,
+      error: undefined,
+    });
+  }
+
+  private sendViewportResize(): void {
+    const ws = this.ws;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+
+    const width = DESKTOP_VIEWPORT_WIDTH;
+    const height = DESKTOP_VIEWPORT_HEIGHT;
+    const last = this.lastSentViewport;
+    if (last?.width === width && last.height === height) return;
+    this.lastSentViewport = { width, height };
+    ws.send(JSON.stringify({ type: "viewport_resize", width, height }));
+  }
+
+  private setSnapshot(snapshot: BrowserStreamSnapshot): void {
+    this.snapshot = snapshot;
+    for (const subscriber of this.subscribers) {
+      subscriber(snapshot);
+    }
+  }
+}
+
+const browserStreamConnections = new Map<string, BrowserStreamConnection>();
+
+function retainBrowserStreamConnection(streamUrl: string): BrowserStreamConnection {
+  const existing = browserStreamConnections.get(streamUrl);
+  if (existing) {
+    if (existing.releaseTimer !== null) {
+      window.clearTimeout(existing.releaseTimer);
+      existing.releaseTimer = null;
+    }
+    existing.ensureConnected();
+    return existing;
+  }
+
+  const created = new BrowserStreamConnection(streamUrl);
+  browserStreamConnections.set(streamUrl, created);
+  return created;
+}
+
+function releaseBrowserStreamConnection(streamUrl: string, connection: BrowserStreamConnection): void {
+  if (connection.releaseTimer !== null) {
+    window.clearTimeout(connection.releaseTimer);
+  }
+  connection.releaseTimer = window.setTimeout(() => {
+    if (browserStreamConnections.get(streamUrl) !== connection) return;
+    if (connection.hasSubscribers()) return;
+    browserStreamConnections.delete(streamUrl);
+    connection.close();
+  }, CONNECTION_RELEASE_DELAY_MS);
+}
+
+export function __clearBrowserStreamConnectionsForTests(): void {
+  for (const connection of browserStreamConnections.values()) {
+    connection.close();
+  }
+  browserStreamConnections.clear();
+}
 
 interface BrowserPanelProps {
   status?: BrowserStatusPayload;
@@ -20,150 +231,92 @@ interface BrowserPanelProps {
 
 export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: BrowserPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
-  const objectUrlRef = useRef<string | null>(null);
-  const pausedRef = useRef(false);
-  const wsRef = useRef<WebSocket | null>(null);
-  const resizeTimerRef = useRef<number | null>(null);
-  const lastSentViewportRef = useRef<{ width: number; height: number } | null>(null);
+  const connectionRef = useRef<BrowserStreamConnection | null>(null);
 
-  const [frameSrc, setFrameSrc] = useState<string | null>(null);
-  const [connectionError, setConnectionError] = useState(false);
+  const [streamSnapshot, setStreamSnapshot] = useState<BrowserStreamSnapshot>(emptySnapshot);
+  const [displayFrameSrc, setDisplayFrameSrc] = useState<string | null>(null);
+  const [statusStoppedAt, setStatusStoppedAt] = useState(0);
+  const [statusStartedAt, setStatusStartedAt] = useState(0);
   const [paused, setPaused] = useState(false);
-  const [retryNonce, setRetryNonce] = useState(0);
-  const [error, setError] = useState(status?.error);
-
-  pausedRef.current = paused;
 
   const streamUrl = useMemo(
-    () => !collapsed && status?.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
-    [collapsed, status?.streamPath],
+    () => status?.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
+    [status?.streamPath],
   );
 
   useEffect(() => {
-    setError(status?.error);
-  }, [status?.error]);
+    if (!streamUrl) {
+      connectionRef.current = null;
+      setStreamSnapshot(emptySnapshot);
+      setDisplayFrameSrc(null);
+      return undefined;
+    }
 
-  const sendViewportResize = useCallback(() => {
-    const element = containerRef.current;
-    const ws = wsRef.current;
-    if (!element || !ws || ws.readyState !== WebSocket.OPEN) return;
+    const connection = retainBrowserStreamConnection(streamUrl);
+    connectionRef.current = connection;
+    const unsubscribe = connection.subscribe(setStreamSnapshot);
 
-    const rect = element.getBoundingClientRect();
-    const width = Math.round(rect.width);
-    const height = Math.round(rect.height);
-    if (width < MIN_VIEWPORT_WIDTH || height < MIN_VIEWPORT_HEIGHT) return;
-
-    const last = lastSentViewportRef.current;
-    if (last?.width === width && last.height === height) return;
-    lastSentViewportRef.current = { width, height };
-    ws.send(JSON.stringify({ type: "viewport_resize", width, height }));
-  }, []);
+    return () => {
+      unsubscribe();
+      if (connectionRef.current === connection) {
+        connectionRef.current = null;
+      }
+      releaseBrowserStreamConnection(streamUrl, connection);
+    };
+  }, [streamUrl]);
 
   useEffect(() => {
     if (!streamUrl) {
-      setConnectionError(false);
-      setFrameSrc(null);
-      return undefined;
+      setDisplayFrameSrc(null);
+      return;
     }
-    lastSentViewportRef.current = null;
-    setConnectionError(false);
-    setError(undefined);
-
-    const ws = new WebSocket(streamUrl);
-    wsRef.current = ws;
-    ws.binaryType = "blob";
-
-    ws.onopen = () => {
-      sendViewportResize();
-    };
-
-    ws.onmessage = (event) => {
-      if (event.data instanceof Blob) {
-        if (pausedRef.current) return;
-        if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
-        const objectUrl = URL.createObjectURL(event.data);
-        objectUrlRef.current = objectUrl;
-        setFrameSrc(objectUrl);
-        return;
-      }
-
-      if (typeof event.data !== "string") return;
-      const parsed = parseBrowserStreamMessage(event.data);
-      if (!parsed) return;
-
-      if ("error" in parsed && parsed.error) {
-        setError(parsed.error);
-        setConnectionError(true);
-      }
-      if ("src" in parsed && parsed.src && !pausedRef.current) {
-        setFrameSrc(parsed.src);
-      }
-    };
-
-    ws.onerror = () => {
-      setConnectionError(true);
-      setError("Browser stream unavailable");
-    };
-
-    return () => {
-      if (wsRef.current === ws) wsRef.current = null;
-      ws.close();
-    };
-  }, [streamUrl, retryNonce, sendViewportResize]);
+    if (!streamSnapshot.frameSrc && streamSnapshot.closedAt > 0) {
+      setDisplayFrameSrc(null);
+      return;
+    }
+    if (!paused && streamSnapshot.frameSrc) {
+      setDisplayFrameSrc(streamSnapshot.frameSrc);
+    }
+  }, [paused, streamSnapshot.closedAt, streamSnapshot.frameSrc, streamUrl]);
 
   useEffect(() => {
-    const element = containerRef.current;
-    if (!element) return undefined;
-
-    const scheduleResize = () => {
-      if (resizeTimerRef.current !== null) {
-        window.clearTimeout(resizeTimerRef.current);
-      }
-      resizeTimerRef.current = window.setTimeout(() => {
-        resizeTimerRef.current = null;
-        sendViewportResize();
-      }, VIEWPORT_RESIZE_DEBOUNCE_MS);
-    };
-
-    if (typeof ResizeObserver === "undefined") {
-      scheduleResize();
-      return () => {
-        if (resizeTimerRef.current !== null) {
-          window.clearTimeout(resizeTimerRef.current);
-          resizeTimerRef.current = null;
-        }
-      };
+    if (status?.streaming === false) {
+      setStatusStoppedAt(Date.now());
+    } else if (status?.streaming === true) {
+      setStatusStoppedAt(0);
+      setStatusStartedAt(Date.now());
+      connectionRef.current?.ensureConnected();
     }
-
-    const observer = new ResizeObserver(scheduleResize);
-    observer.observe(element);
-    scheduleResize();
-
-    return () => {
-      observer.disconnect();
-      if (resizeTimerRef.current !== null) {
-        window.clearTimeout(resizeTimerRef.current);
-        resizeTimerRef.current = null;
-      }
-    };
-  }, [sendViewportResize, streamUrl, retryNonce]);
+  }, [status?.streaming, status?.updatedAt]);
 
   useEffect(() => {
-    return () => {
-      if (objectUrlRef.current) {
-        URL.revokeObjectURL(objectUrlRef.current);
-        objectUrlRef.current = null;
-      }
-    };
-  }, []);
+    if (
+      status?.streaming === false &&
+      statusStoppedAt > 0 &&
+      streamSnapshot.frameReceivedAt <= statusStoppedAt
+    ) {
+      setDisplayFrameSrc(null);
+    }
+  }, [status?.streaming, statusStoppedAt, streamSnapshot.frameReceivedAt]);
 
   const handleFullscreen = useCallback(() => {
     void containerRef.current?.requestFullscreen?.();
   }, []);
 
   const isActive = Boolean(status);
-  const isStreaming = Boolean(status?.streaming) && !connectionError;
+  const localFrameAfterStop = statusStoppedAt > 0 && streamSnapshot.frameReceivedAt > statusStoppedAt;
+  const localStreamAllowed = status?.streaming !== false || localFrameAfterStop;
+  const statusStreamingActive = Boolean(status?.streaming) && (
+    streamSnapshot.closedAt === 0 ||
+    statusStartedAt > streamSnapshot.closedAt
+  );
+  const hasLiveStream = localStreamAllowed && (
+    Boolean(streamUrl && streamSnapshot.streamOpen) ||
+    Boolean(streamSnapshot.frameSrc)
+  );
+  const isStreaming = isActive && !streamSnapshot.connectionError && (statusStreamingActive || hasLiveStream);
   const statusLabel = isStreaming ? "streaming" : "not streaming";
+  const error = status?.error ?? streamSnapshot.error;
 
   return (
     <TooltipProvider>
@@ -202,7 +355,7 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
                     variant="ghost"
                     size="icon-xs"
                     className="text-muted-foreground hover:text-foreground"
-                    onClick={() => setRetryNonce((value) => value + 1)}
+                    onClick={() => connectionRef.current?.reconnect()}
                     aria-label="Reconnect browser stream"
                   >
                     <RotateCcwIcon className="size-3" />
@@ -249,11 +402,11 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
 
         {isActive && !collapsed && (
           <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
-            {frameSrc ? (
+            {displayFrameSrc ? (
               <img
-                src={frameSrc}
+                src={displayFrameSrc}
                 alt="Agent browser"
-                className="h-full w-full object-fill"
+                className="h-full w-full object-contain"
                 draggable={false}
               />
             ) : (

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Maximize2Icon, PauseIcon, PlayIcon, RotateCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  buildBrowserStreamUrl,
+  parseBrowserStreamMessage,
+  type BrowserStreamConnectionStatus,
+} from "@/lib/browser-stream";
+import { cn } from "@/lib/utils";
+import type { BrowserStatusPayload } from "@/types";
+
+interface BrowserPanelProps {
+  status: BrowserStatusPayload;
+}
+
+function connectionLabel(status: BrowserStreamConnectionStatus): string {
+  switch (status) {
+    case "connecting":
+      return "Connecting";
+    case "connected":
+      return "Live";
+    case "error":
+      return "Error";
+    case "disconnected":
+      return "Disconnected";
+  }
+}
+
+export function BrowserPanel({ status }: BrowserPanelProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const objectUrlRef = useRef<string | null>(null);
+  const pausedRef = useRef(false);
+
+  const [frameSrc, setFrameSrc] = useState<string | null>(null);
+  const [connectionStatus, setConnectionStatus] = useState<BrowserStreamConnectionStatus>("connecting");
+  const [paused, setPaused] = useState(false);
+  const [retryNonce, setRetryNonce] = useState(0);
+  const [url, setUrl] = useState(status.url);
+  const [title, setTitle] = useState(status.title);
+  const [error, setError] = useState(status.error);
+
+  pausedRef.current = paused;
+
+  const streamUrl = useMemo(
+    () => status.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
+    [status.streamPath],
+  );
+
+  useEffect(() => {
+    setUrl(status.url);
+    setTitle(status.title);
+    setError(status.error);
+  }, [status.url, status.title, status.error]);
+
+  useEffect(() => {
+    if (!streamUrl) return undefined;
+    setConnectionStatus("connecting");
+    setError(undefined);
+
+    const ws = new WebSocket(streamUrl);
+    ws.binaryType = "blob";
+
+    ws.onopen = () => {
+      setConnectionStatus("connected");
+    };
+
+    ws.onmessage = (event) => {
+      if (event.data instanceof Blob) {
+        if (pausedRef.current) return;
+        if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+        const objectUrl = URL.createObjectURL(event.data);
+        objectUrlRef.current = objectUrl;
+        setFrameSrc(objectUrl);
+        return;
+      }
+
+      if (typeof event.data !== "string") return;
+      const parsed = parseBrowserStreamMessage(event.data);
+      if (!parsed) return;
+
+      if ("error" in parsed && parsed.error) {
+        setError(parsed.error);
+        setConnectionStatus("error");
+      }
+      if ("url" in parsed && parsed.url) setUrl(parsed.url);
+      if ("title" in parsed && parsed.title) setTitle(parsed.title);
+      if ("src" in parsed && parsed.src && !pausedRef.current) {
+        setFrameSrc(parsed.src);
+      }
+    };
+
+    ws.onerror = () => {
+      setConnectionStatus("error");
+      setError("Browser stream unavailable");
+    };
+
+    ws.onclose = () => {
+      setConnectionStatus((current) => current === "error" ? current : "disconnected");
+    };
+
+    return () => {
+      ws.close();
+    };
+  }, [streamUrl, retryNonce]);
+
+  useEffect(() => {
+    return () => {
+      if (objectUrlRef.current) {
+        URL.revokeObjectURL(objectUrlRef.current);
+        objectUrlRef.current = null;
+      }
+    };
+  }, []);
+
+  const handleFullscreen = useCallback(() => {
+    void containerRef.current?.requestFullscreen?.();
+  }, []);
+
+  const displayUrl = url ?? title ?? "Browser";
+  const isLive = connectionStatus === "connected" && !paused;
+
+  return (
+    <TooltipProvider>
+      <div className="flex h-full min-h-0 flex-col bg-background">
+        <div ref={containerRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden bg-black">
+          {frameSrc ? (
+            <img
+              src={frameSrc}
+              alt="Agent browser"
+              className="h-full w-full object-contain"
+              draggable={false}
+            />
+          ) : (
+            <div className="px-4 text-center text-xs text-zinc-400">
+              {error ?? (status.state === "error" ? "Browser stream unavailable" : "Waiting for browser stream")}
+            </div>
+          )}
+
+          <div className="absolute left-3 top-3 flex min-w-0 max-w-[calc(100%-7rem)] items-center gap-2 rounded-md border border-white/10 bg-black/70 px-2 py-1 text-xs text-white shadow-sm backdrop-blur">
+            <span
+              className={cn(
+                "size-1.5 rounded-full",
+                isLive ? "bg-emerald-400" : connectionStatus === "error" ? "bg-red-400" : "bg-zinc-400",
+              )}
+            />
+            <span className="shrink-0 text-white/70">{connectionLabel(connectionStatus)}</span>
+            <span className="truncate text-white/90">{displayUrl}</span>
+          </div>
+
+          <div className="absolute right-3 top-3 flex items-center gap-1 rounded-md border border-white/10 bg-black/70 p-1 shadow-sm backdrop-blur">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-white/80 hover:bg-white/10 hover:text-white"
+                  onClick={() => setPaused((value) => !value)}
+                  aria-label={paused ? "Resume browser stream" : "Pause browser stream"}
+                >
+                  {paused ? <PlayIcon className="size-3" /> : <PauseIcon className="size-3" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>{paused ? "Resume" : "Pause"}</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-white/80 hover:bg-white/10 hover:text-white"
+                  onClick={() => setRetryNonce((value) => value + 1)}
+                  aria-label="Reconnect browser stream"
+                >
+                  <RotateCcwIcon className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Reconnect</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-xs"
+                  className="text-white/80 hover:bg-white/10 hover:text-white"
+                  onClick={handleFullscreen}
+                  aria-label="Fullscreen browser stream"
+                >
+                  <Maximize2Icon className="size-3" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Fullscreen</TooltipContent>
+            </Tooltip>
+          </div>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/BrowserPanel.tsx
+++ b/frontend/src/components/BrowserPanel.tsx
@@ -240,8 +240,10 @@ export function BrowserPanel({ status, collapsed = false, onToggleCollapsed }: B
   const [paused, setPaused] = useState(false);
 
   const streamUrl = useMemo(
-    () => status?.streamPath ? buildBrowserStreamUrl(status.streamPath) : null,
-    [status?.streamPath],
+    () => status?.streamPath && status.streaming !== false
+      ? buildBrowserStreamUrl(status.streamPath)
+      : null,
+    [status?.streamPath, status?.streaming],
   );
 
   useEffect(() => {

--- a/frontend/src/components/PrStatusSection.tsx
+++ b/frontend/src/components/PrStatusSection.tsx
@@ -16,7 +16,7 @@ export function PrStatusSection({ wsId }: PrStatusSectionProps) {
 
   if (loading) {
     return (
-      <div className="border-t border-border/50 px-4 py-2.5">
+      <div className="border-t border-border/50 px-3 py-2.5">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <GitPullRequest className="size-3.5 shrink-0" />
           <span>Loading…</span>
@@ -28,7 +28,7 @@ export function PrStatusSection({ wsId }: PrStatusSectionProps) {
   // Error state: gh unavailable / not authenticated
   if (error) {
     return (
-      <div className="border-t border-border/50 px-4 py-2.5">
+      <div className="border-t border-border/50 px-3 py-2.5">
         <div className="flex items-center gap-2 text-xs text-destructive">
           <AlertCircle className="size-3.5 shrink-0" />
           <span className="min-w-0 truncate">{error}</span>
@@ -40,7 +40,7 @@ export function PrStatusSection({ wsId }: PrStatusSectionProps) {
   // No PR (non-GitHub repo, or GitHub repo with no PR for this branch)
   if (!pr) {
     return (
-      <div className="border-t border-border/50 px-4 py-2.5">
+      <div className="border-t border-border/50 px-3 py-2.5">
         <div className="flex items-center gap-2 text-xs text-muted-foreground">
           <GitPullRequest className="size-3.5 shrink-0" />
           <span>No pull request</span>
@@ -52,7 +52,7 @@ export function PrStatusSection({ wsId }: PrStatusSectionProps) {
   const { Icon, iconClass, textClass, label } = computePrDisplay(pr);
 
   return (
-    <div className="border-t border-border/50 px-4 py-2.5">
+    <div className="border-t border-border/50 px-3 py-2.5">
       <div className="flex items-center gap-2 text-xs">
         <Icon className={cn("size-3.5 shrink-0", iconClass)} />
         <span className={cn("min-w-0 truncate", textClass)}>

--- a/frontend/src/hooks/useWorkspaceLiveData.ts
+++ b/frontend/src/hooks/useWorkspaceLiveData.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { wsTransport } from "@/lib/ws-transport";
-import type { BranchInfo, DiffStatResponse, ScriptState } from "@/types";
+import type { BranchInfo, BrowserStatusPayload, DiffStatResponse, ScriptState } from "@/types";
 
 export interface WorkspaceLiveData {
   status?: "idle" | "busy";
@@ -11,6 +11,7 @@ export interface WorkspaceLiveData {
   diffStats?: DiffStatResponse;
   scriptRunning?: boolean;
   scriptStates?: Record<string, ScriptState>;
+  browserSessions?: Record<string, BrowserStatusPayload>;
   unreadSessions?: Record<string, boolean>;
 }
 
@@ -122,6 +123,23 @@ export function useWorkspaceLiveData(
               return prev;
             }
             return { ...prev, [wsId]: { ...current, scriptRunning, scriptStates: prevScripts } };
+          });
+        } else if (msg.type === "browser_status") {
+          setLiveData((prev) => {
+            const current = prev[wsId] ?? {};
+            const prevSessions = { ...(current.browserSessions ?? {}) };
+            if (msg.status.state === "closed") {
+              delete prevSessions[msg.status.sessionId];
+            } else {
+              prevSessions[msg.status.sessionId] = msg.status;
+            }
+            return {
+              ...prev,
+              [wsId]: {
+                ...current,
+                browserSessions: Object.keys(prevSessions).length > 0 ? prevSessions : undefined,
+              },
+            };
           });
         }
       }),

--- a/frontend/src/lib/browser-stream.ts
+++ b/frontend/src/lib/browser-stream.ts
@@ -1,0 +1,99 @@
+import { getServerUrl } from "@/hooks/useServerUrl";
+
+export type BrowserStreamConnectionStatus = "connecting" | "connected" | "disconnected" | "error";
+
+export interface BrowserStreamFrame {
+  src: string;
+  url?: string;
+  title?: string;
+}
+
+export interface BrowserStreamMetadata {
+  url?: string;
+  title?: string;
+  error?: string;
+}
+
+export function buildBrowserStreamUrl(streamPath: string): string {
+  const serverUrl = getServerUrl();
+  let wsHost: string;
+  if (serverUrl) {
+    wsHost = serverUrl.replace(/^http/, "ws");
+  } else {
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    wsHost = import.meta.env.VITE_WS_URL || `${protocol}//${window.location.host}`;
+  }
+  const authToken = import.meta.env.VITE_HIVE_AUTH_TOKEN?.trim();
+  const query = authToken ? `?token=${encodeURIComponent(authToken)}` : "";
+  return `${wsHost}${streamPath}${query}`;
+}
+
+function asObject(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null ? value as Record<string, unknown> : null;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function toImageSrc(data: string): string {
+  return data.startsWith("data:") ? data : `data:image/jpeg;base64,${data}`;
+}
+
+function activeTabMetadata(tabs: unknown): BrowserStreamMetadata {
+  if (!Array.isArray(tabs)) return {};
+  const tabObjects = tabs.map(asObject).filter((tab): tab is Record<string, unknown> => tab !== null);
+  const active = tabObjects.find((tab) => tab.active === true || tab.selected === true) ?? tabObjects[0];
+  if (!active) return {};
+  return {
+    url: asString(active.url),
+    title: asString(active.title),
+  };
+}
+
+export function parseBrowserStreamMessage(raw: string): BrowserStreamFrame | BrowserStreamMetadata | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch {
+    return null;
+  }
+  const msg = asObject(parsed);
+  if (!msg) return null;
+
+  if (msg.type === "frame") {
+    const data = asString(msg.data);
+    if (!data) return null;
+    const metadata = asObject(msg.metadata);
+    return {
+      src: toImageSrc(data),
+      url: asString(msg.url) ?? asString(metadata?.url),
+      title: asString(msg.title) ?? asString(metadata?.title),
+    };
+  }
+
+  if (msg.type === "url") {
+    return {
+      url: asString(msg.url) ?? asString(msg.value),
+      title: asString(msg.title),
+    };
+  }
+
+  if (msg.type === "tabs") {
+    return activeTabMetadata(msg.tabs);
+  }
+
+  if (msg.type === "error") {
+    return { error: asString(msg.message) ?? "Browser stream error" };
+  }
+
+  const tab = asObject(msg.tab);
+  if (tab) {
+    return {
+      url: asString(tab.url),
+      title: asString(tab.title),
+    };
+  }
+
+  return null;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -294,13 +294,14 @@ export default function WorkspaceView() {
 
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
+  const browserPanelRef = usePanelRef();
   const [browserPanelCollapsed, setBrowserPanelCollapsed] = useState(false);
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
   });
   const { defaultLayout: splitLayout, onLayoutChanged: onSplitLayoutChanged } = useDefaultLayout({
-    id: "hive-right-split-v2",
+    id: "hive-right-split-v3",
     storage: localStorage,
   });
 
@@ -329,8 +330,8 @@ export default function WorkspaceView() {
     return status;
   }, [wsId, sessionId, liveData]);
 
-  const browserPanelVisible = Boolean(currentBrowserStatus);
-  const browserPanelExpanded = browserPanelVisible && !browserPanelCollapsed;
+  const browserPanelActive = Boolean(currentBrowserStatus);
+  const browserPanelExpanded = browserPanelActive && !browserPanelCollapsed;
 
   const handleToggleBrowserPanel = useCallback(() => {
     setBrowserPanelCollapsed((collapsed) => !collapsed);
@@ -343,6 +344,10 @@ export default function WorkspaceView() {
     }
     rightPanelRef.current?.expand();
   }, [currentBrowserStatus, rightPanelRef]);
+
+  useEffect(() => {
+    browserPanelRef.current?.resize(browserPanelExpanded ? 28 : 7);
+  }, [browserPanelExpanded, browserPanelRef]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -733,7 +738,7 @@ export default function WorkspaceView() {
               onLayoutChanged={onSplitLayoutChanged}
               style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
             >
-              <Panel id="file-tree" defaultSize={browserPanelVisible ? "42%" : "50%"} minSize="15%" maxSize="85%">
+              <Panel id="file-tree" defaultSize={browserPanelExpanded ? "42%" : "50%"} minSize="15%" maxSize="85%">
                 <div className="h-full overflow-auto p-3">
                   {sidebarTab === "modified" && (
                     <ModifiedFileList
@@ -765,7 +770,7 @@ export default function WorkspaceView() {
                 </div>
               </Panel>
               <ResizeHandle orientation="horizontal" />
-              <Panel id="scripts" defaultSize={browserPanelVisible ? "30%" : undefined} minSize="15%">
+              <Panel id="scripts" defaultSize={browserPanelExpanded ? "30%" : undefined} minSize="15%">
                 <ScriptPanel
                   key={wsId}
                   config={scriptsConfig}
@@ -778,25 +783,22 @@ export default function WorkspaceView() {
                   onDisconnectOutput={disconnectScriptOutput}
                 />
               </Panel>
-              {browserPanelVisible && currentBrowserStatus && (
-                <>
-                  <ResizeHandle orientation="horizontal" />
-                  <Panel
-                    id="browser"
-                    defaultSize={browserPanelExpanded ? "28%" : "9%"}
-                    minSize={browserPanelExpanded ? "18%" : "7%"}
-                    maxSize={browserPanelExpanded ? "48%" : "12%"}
-                  >
-                    <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
-                      <BrowserPanel
-                        status={currentBrowserStatus}
-                        collapsed={browserPanelCollapsed}
-                        onToggleCollapsed={handleToggleBrowserPanel}
-                      />
-                    </div>
-                  </Panel>
-                </>
-              )}
+              <ResizeHandle orientation="horizontal" />
+              <Panel
+                id="browser"
+                panelRef={browserPanelRef}
+                defaultSize={browserPanelExpanded ? "28%" : "7%"}
+                minSize={browserPanelExpanded ? "18%" : "7%"}
+                maxSize={browserPanelExpanded ? "48%" : "7%"}
+              >
+                <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
+                  <BrowserPanel
+                    status={currentBrowserStatus}
+                    collapsed={!browserPanelExpanded}
+                    onToggleCollapsed={browserPanelActive ? handleToggleBrowserPanel : undefined}
+                  />
+                </div>
+              </Panel>
             </Group>
             <PrStatusSection wsId={wsId} />
           </div>

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Group, Panel, useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { ChevronDownIcon, MonitorIcon, TerminalIcon, XIcon } from "lucide-react";
+import { ChevronDownIcon, TerminalIcon } from "lucide-react";
 import { VscodeIcon, Iterm2Icon } from "@/components/icons/software-icons";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
@@ -294,7 +294,7 @@ export default function WorkspaceView() {
 
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
-  const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
+  const [browserPanelCollapsed, setBrowserPanelCollapsed] = useState(false);
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
@@ -329,21 +329,20 @@ export default function WorkspaceView() {
     return status;
   }, [wsId, sessionId, liveData]);
 
-  useEffect(() => {
-    if (!currentBrowserStatus && browserPanelOpen) {
-      setBrowserPanelOpen(false);
-    }
-  }, [currentBrowserStatus, browserPanelOpen]);
+  const browserPanelVisible = Boolean(currentBrowserStatus);
+  const browserPanelExpanded = browserPanelVisible && !browserPanelCollapsed;
 
   const handleToggleBrowserPanel = useCallback(() => {
-    setBrowserPanelOpen((open) => {
-      const next = !open;
-      if (next) {
-        rightPanelRef.current?.expand();
-      }
-      return next;
-    });
-  }, [rightPanelRef]);
+    setBrowserPanelCollapsed((collapsed) => !collapsed);
+  }, []);
+
+  useEffect(() => {
+    if (!currentBrowserStatus) {
+      setBrowserPanelCollapsed(false);
+      return;
+    }
+    rightPanelRef.current?.expand();
+  }, [currentBrowserStatus, rightPanelRef]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -510,26 +509,6 @@ export default function WorkspaceView() {
               <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
             )}
             <div className="ml-auto" />
-            {currentBrowserStatus && (
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <Button
-                      type="button"
-                      variant={browserPanelOpen ? "secondary" : "ghost"}
-                      size="icon-xs"
-                      className="relative text-muted-foreground hover:text-foreground"
-                      onClick={handleToggleBrowserPanel}
-                      aria-label="Toggle browser panel"
-                    >
-                      <MonitorIcon className="size-3.5" />
-                      <span className="absolute right-1 top-1 size-1.5 rounded-full bg-emerald-400 ring-1 ring-background" />
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Browser</TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            )}
             {terminalApps.length > 0 ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -754,7 +733,7 @@ export default function WorkspaceView() {
               onLayoutChanged={onSplitLayoutChanged}
               style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
             >
-              <Panel id="file-tree" defaultSize={browserPanelOpen ? "42%" : "50%"} minSize="15%" maxSize="85%">
+              <Panel id="file-tree" defaultSize={browserPanelVisible ? "42%" : "50%"} minSize="15%" maxSize="85%">
                 <div className="h-full overflow-auto p-3">
                   {sidebarTab === "modified" && (
                     <ModifiedFileList
@@ -786,7 +765,7 @@ export default function WorkspaceView() {
                 </div>
               </Panel>
               <ResizeHandle orientation="horizontal" />
-              <Panel id="scripts" defaultSize={browserPanelOpen ? "30%" : undefined} minSize="15%">
+              <Panel id="scripts" defaultSize={browserPanelVisible ? "30%" : undefined} minSize="15%">
                 <ScriptPanel
                   key={wsId}
                   config={scriptsConfig}
@@ -799,35 +778,21 @@ export default function WorkspaceView() {
                   onDisconnectOutput={disconnectScriptOutput}
                 />
               </Panel>
-              {browserPanelOpen && currentBrowserStatus && (
+              {browserPanelVisible && currentBrowserStatus && (
                 <>
                   <ResizeHandle orientation="horizontal" />
-                  <Panel id="browser" defaultSize="28%" minSize="18%" maxSize="48%">
+                  <Panel
+                    id="browser"
+                    defaultSize={browserPanelExpanded ? "28%" : "9%"}
+                    minSize={browserPanelExpanded ? "18%" : "7%"}
+                    maxSize={browserPanelExpanded ? "48%" : "12%"}
+                  >
                     <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
-                      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
-                        <MonitorIcon className="size-3.5 text-muted-foreground" />
-                        <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
-                        <Badge
-                          variant={currentBrowserStatus.state === "error" ? "destructive" : "secondary"}
-                          className="px-1.5 py-0 text-[10px]"
-                        >
-                          {currentBrowserStatus.state === "error" ? "Error" : "Live"}
-                        </Badge>
-                        <div className="ml-auto" />
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="icon-xs"
-                          className="text-muted-foreground hover:text-foreground"
-                          onClick={() => setBrowserPanelOpen(false)}
-                          aria-label="Close browser panel"
-                        >
-                          <XIcon className="size-3" />
-                        </Button>
-                      </div>
-                      <div className="min-h-0 flex-1">
-                        <BrowserPanel status={currentBrowserStatus} />
-                      </div>
+                      <BrowserPanel
+                        status={currentBrowserStatus}
+                        collapsed={browserPanelCollapsed}
+                        onToggleCollapsed={handleToggleBrowserPanel}
+                      />
                     </div>
                   </Panel>
                 </>

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Group, Panel, useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { ChevronDownIcon, TerminalIcon } from "lucide-react";
+import { ChevronDownIcon, MonitorIcon, TerminalIcon, XIcon } from "lucide-react";
 import { VscodeIcon, Iterm2Icon } from "@/components/icons/software-icons";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
@@ -24,6 +24,7 @@ import { BranchLabel } from "@/components/BranchLabel";
 import { InlineDiffViewer, type InlineDiffViewerHandle } from "@/components/diff/InlineDiffViewer";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
 import { PrStatusSection } from "@/components/PrStatusSection";
+import { BrowserPanel } from "@/components/BrowserPanel";
 import ScriptPanel from "@/components/ScriptPanel";
 import TaskTracker from "@/components/TaskTracker";
 import { useTasks } from "@/hooks/useTasks";
@@ -293,6 +294,7 @@ export default function WorkspaceView() {
 
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
+  const [rightPanelMode, setRightPanelMode] = useState<"workspace" | "browser">("workspace");
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
@@ -319,6 +321,29 @@ export default function WorkspaceView() {
       rightPanelRef.current?.expand();
     }
   }, [isLg, rightPanelRef]);
+
+  const currentBrowserStatus = useMemo(() => {
+    if (!wsId || !sessionId) return undefined;
+    const status = liveData[wsId]?.browserSessions?.[sessionId];
+    if (!status || status.state === "registered" || status.state === "closed") return undefined;
+    return status;
+  }, [wsId, sessionId, liveData]);
+
+  useEffect(() => {
+    if (!currentBrowserStatus && rightPanelMode === "browser") {
+      setRightPanelMode("workspace");
+    }
+  }, [currentBrowserStatus, rightPanelMode]);
+
+  const handleToggleBrowserPanel = useCallback(() => {
+    setRightPanelMode((mode) => {
+      const next = mode === "browser" ? "workspace" : "browser";
+      if (next === "browser") {
+        rightPanelRef.current?.expand();
+      }
+      return next;
+    });
+  }, [rightPanelRef]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -485,6 +510,26 @@ export default function WorkspaceView() {
               <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
             )}
             <div className="ml-auto" />
+            {currentBrowserStatus && (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant={rightPanelMode === "browser" ? "secondary" : "ghost"}
+                      size="icon-xs"
+                      className="relative text-muted-foreground hover:text-foreground"
+                      onClick={handleToggleBrowserPanel}
+                      aria-label="Toggle browser panel"
+                    >
+                      <MonitorIcon className="size-3.5" />
+                      <span className="absolute right-1 top-1 size-1.5 rounded-full bg-emerald-400 ring-1 ring-background" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Browser</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            )}
             {terminalApps.length > 0 ? (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -673,89 +718,121 @@ export default function WorkspaceView() {
         >
           <div className="flex h-full flex-col">
             <div className="flex h-12 items-center gap-3 border-b border-border/50 px-4" data-tauri-drag-region>
-              <button
-                type="button"
-                className={cn(
-                  "text-xs uppercase tracking-wide transition-colors",
-                  sidebarTab === "all"
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-                onClick={() => setSidebarTab("all")}
-              >
-                All
-              </button>
-              <button
-                type="button"
-                className={cn(
-                  "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
-                  sidebarTab === "modified"
-                    ? "text-foreground"
-                    : "text-muted-foreground hover:text-foreground",
-                )}
-                onClick={() => setSidebarTab("modified")}
-              >
-                Modified
-                {diffTotalCount > 0 && (
-                  <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                    {diffTotalCount}
+              {rightPanelMode === "browser" && currentBrowserStatus ? (
+                <>
+                  <MonitorIcon className="size-3.5 text-muted-foreground" />
+                  <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
+                  <Badge
+                    variant={currentBrowserStatus.state === "error" ? "destructive" : "secondary"}
+                    className="px-1.5 py-0 text-[10px]"
+                  >
+                    {currentBrowserStatus.state === "error" ? "Error" : "Live"}
                   </Badge>
-                )}
-              </button>
+                  <div className="ml-auto" />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="text-muted-foreground hover:text-foreground"
+                    onClick={() => setRightPanelMode("workspace")}
+                    aria-label="Close browser panel"
+                  >
+                    <XIcon className="size-3" />
+                  </Button>
+                </>
+              ) : (
+                <>
+                  <button
+                    type="button"
+                    className={cn(
+                      "text-xs uppercase tracking-wide transition-colors",
+                      sidebarTab === "all"
+                        ? "text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                    onClick={() => setSidebarTab("all")}
+                  >
+                    All
+                  </button>
+                  <button
+                    type="button"
+                    className={cn(
+                      "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
+                      sidebarTab === "modified"
+                        ? "text-foreground"
+                        : "text-muted-foreground hover:text-foreground",
+                    )}
+                    onClick={() => setSidebarTab("modified")}
+                  >
+                    Modified
+                    {diffTotalCount > 0 && (
+                      <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                        {diffTotalCount}
+                      </Badge>
+                    )}
+                  </button>
+                </>
+              )}
             </div>
-            <Group
-              orientation="vertical"
-              defaultLayout={splitLayout}
-              onLayoutChanged={onSplitLayoutChanged}
-              style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
-            >
-              <Panel id="file-tree" defaultSize="50%" minSize="15%" maxSize="85%">
-                <div className="h-full overflow-auto p-3">
-                  {sidebarTab === "modified" && (
-                    <ModifiedFileList
-                      committed={diffCommitted}
-                      uncommitted={diffUncommitted}
-                      onFileClick={handleModifiedFileClick}
-                      activeFile={isFileTabActive && fileViewMode === "diff" ? openFile ?? undefined : undefined}
-                    />
-                  )}
-                  {sidebarTab === "all" && fileTreeError && (
-                    <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                      {fileTreeError}
-                    </div>
-                  )}
-                  {sidebarTab === "all" && !fileTreeError && (
-                    <FileTree
-                      expanded={expandedPaths}
-                      onExpandedChange={setExpandedPaths}
-                      onPathSelect={handleFileTreeSelect}
-                      selectedPath={selectedPath}
-                    >
-                      {fileTree.length ? (
-                        renderFileTreeNodes(fileTree)
-                      ) : (
-                        <div className="px-2 py-1 text-xs text-muted-foreground">No files found.</div>
+            {rightPanelMode === "browser" && currentBrowserStatus ? (
+              <BrowserPanel status={currentBrowserStatus} />
+            ) : (
+              <>
+                <Group
+                  orientation="vertical"
+                  defaultLayout={splitLayout}
+                  onLayoutChanged={onSplitLayoutChanged}
+                  style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
+                >
+                  <Panel id="file-tree" defaultSize="50%" minSize="15%" maxSize="85%">
+                    <div className="h-full overflow-auto p-3">
+                      {sidebarTab === "modified" && (
+                        <ModifiedFileList
+                          committed={diffCommitted}
+                          uncommitted={diffUncommitted}
+                          onFileClick={handleModifiedFileClick}
+                          activeFile={isFileTabActive && fileViewMode === "diff" ? openFile ?? undefined : undefined}
+                        />
                       )}
-                    </FileTree>
-                  )}
-                </div>
-              </Panel>
-              <ResizeHandle orientation="horizontal" />
-              <Panel id="scripts" minSize="15%">
-                <ScriptPanel
-                  key={wsId}
-                  config={scriptsConfig}
-                  status={scriptsStatus}
-                  onStart={startScript}
-                  onStop={stopScript}
-                  onStartTerminal={startTerminal}
-                  onStopTerminal={stopTerminal}
-                  onConnectOutput={connectScriptOutput}
-                  onDisconnectOutput={disconnectScriptOutput}
-                />
-              </Panel>
-            </Group>
-            <PrStatusSection wsId={wsId} />
+                      {sidebarTab === "all" && fileTreeError && (
+                        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+                          {fileTreeError}
+                        </div>
+                      )}
+                      {sidebarTab === "all" && !fileTreeError && (
+                        <FileTree
+                          expanded={expandedPaths}
+                          onExpandedChange={setExpandedPaths}
+                          onPathSelect={handleFileTreeSelect}
+                          selectedPath={selectedPath}
+                        >
+                          {fileTree.length ? (
+                            renderFileTreeNodes(fileTree)
+                          ) : (
+                            <div className="px-2 py-1 text-xs text-muted-foreground">No files found.</div>
+                          )}
+                        </FileTree>
+                      )}
+                    </div>
+                  </Panel>
+                  <ResizeHandle orientation="horizontal" />
+                  <Panel id="scripts" minSize="15%">
+                    <ScriptPanel
+                      key={wsId}
+                      config={scriptsConfig}
+                      status={scriptsStatus}
+                      onStart={startScript}
+                      onStop={stopScript}
+                      onStartTerminal={startTerminal}
+                      onStopTerminal={stopTerminal}
+                      onConnectOutput={connectScriptOutput}
+                      onDisconnectOutput={disconnectScriptOutput}
+                    />
+                  </Panel>
+                </Group>
+                <PrStatusSection wsId={wsId} />
+              </>
+            )}
           </div>
         </Panel>
       </Group>

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -798,7 +798,7 @@ export default function WorkspaceView() {
                 <>
                   <ResizeHandle orientation="horizontal" />
                   <Panel id="browser" defaultSize="28%" minSize="18%" maxSize="48%">
-                    <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
+                    <div className="flex h-full min-h-0 flex-col bg-sidebar">
                       <BrowserPanel
                         status={currentBrowserStatus}
                         onToggleCollapsed={handleToggleBrowserPanel}
@@ -809,7 +809,7 @@ export default function WorkspaceView() {
               )}
             </Group>
             {!browserPanelExpanded && (
-              <div className="border-t border-border/40 bg-background">
+              <div className="bg-sidebar">
                 <BrowserPanel
                   status={currentBrowserStatus}
                   collapsed

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -294,14 +294,13 @@ export default function WorkspaceView() {
 
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
-  const browserPanelRef = usePanelRef();
   const [browserPanelCollapsed, setBrowserPanelCollapsed] = useState(false);
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
   });
   const { defaultLayout: splitLayout, onLayoutChanged: onSplitLayoutChanged } = useDefaultLayout({
-    id: "hive-right-split-v3",
+    id: "hive-right-split-v4",
     storage: localStorage,
   });
 
@@ -344,10 +343,6 @@ export default function WorkspaceView() {
     }
     rightPanelRef.current?.expand();
   }, [currentBrowserStatus, rightPanelRef]);
-
-  useEffect(() => {
-    browserPanelRef.current?.resize(browserPanelExpanded ? 28 : 7);
-  }, [browserPanelExpanded, browserPanelRef]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();
@@ -783,23 +778,29 @@ export default function WorkspaceView() {
                   onDisconnectOutput={disconnectScriptOutput}
                 />
               </Panel>
-              <ResizeHandle orientation="horizontal" />
-              <Panel
-                id="browser"
-                panelRef={browserPanelRef}
-                defaultSize={browserPanelExpanded ? "28%" : "7%"}
-                minSize={browserPanelExpanded ? "18%" : "7%"}
-                maxSize={browserPanelExpanded ? "48%" : "7%"}
-              >
-                <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
-                  <BrowserPanel
-                    status={currentBrowserStatus}
-                    collapsed={!browserPanelExpanded}
-                    onToggleCollapsed={browserPanelActive ? handleToggleBrowserPanel : undefined}
-                  />
-                </div>
-              </Panel>
+              {browserPanelExpanded && (
+                <>
+                  <ResizeHandle orientation="horizontal" />
+                  <Panel id="browser" defaultSize="28%" minSize="18%" maxSize="48%">
+                    <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
+                      <BrowserPanel
+                        status={currentBrowserStatus}
+                        onToggleCollapsed={handleToggleBrowserPanel}
+                      />
+                    </div>
+                  </Panel>
+                </>
+              )}
             </Group>
+            {!browserPanelExpanded && (
+              <div className="border-t border-border/40 bg-background">
+                <BrowserPanel
+                  status={currentBrowserStatus}
+                  collapsed
+                  onToggleCollapsed={browserPanelActive ? handleToggleBrowserPanel : undefined}
+                />
+              </div>
+            )}
             <PrStatusSection wsId={wsId} />
           </div>
         </Panel>

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -353,9 +353,12 @@ export default function WorkspaceView() {
       return;
     }
     if (currentBrowserStatus.streaming) {
+      if (!browserPanelCollapsed) {
+        setBrowserPanelManualOpen(true);
+      }
       rightPanelRef.current?.expand();
     }
-  }, [currentBrowserStatus, rightPanelRef]);
+  }, [browserPanelCollapsed, currentBrowserStatus, rightPanelRef]);
 
   const handleCreateSession = useCallback(async () => {
     const meta = await createSession();

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -295,6 +295,7 @@ export default function WorkspaceView() {
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
   const [browserPanelCollapsed, setBrowserPanelCollapsed] = useState(false);
+  const [browserPanelManualOpen, setBrowserPanelManualOpen] = useState(false);
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
@@ -330,18 +331,30 @@ export default function WorkspaceView() {
   }, [wsId, sessionId, liveData]);
 
   const browserPanelActive = Boolean(currentBrowserStatus);
-  const browserPanelExpanded = browserPanelActive && !browserPanelCollapsed;
+  const browserPanelStreaming = Boolean(currentBrowserStatus?.streaming);
+  const browserPanelExpanded = browserPanelActive && (
+    browserPanelManualOpen || (browserPanelStreaming && !browserPanelCollapsed)
+  );
 
   const handleToggleBrowserPanel = useCallback(() => {
-    setBrowserPanelCollapsed((collapsed) => !collapsed);
-  }, []);
+    if (browserPanelExpanded) {
+      setBrowserPanelManualOpen(false);
+      setBrowserPanelCollapsed(true);
+      return;
+    }
+    setBrowserPanelCollapsed(false);
+    setBrowserPanelManualOpen(true);
+  }, [browserPanelExpanded]);
 
   useEffect(() => {
     if (!currentBrowserStatus) {
       setBrowserPanelCollapsed(false);
+      setBrowserPanelManualOpen(false);
       return;
     }
-    rightPanelRef.current?.expand();
+    if (currentBrowserStatus.streaming) {
+      rightPanelRef.current?.expand();
+    }
   }, [currentBrowserStatus, rightPanelRef]);
 
   const handleCreateSession = useCallback(async () => {

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -294,13 +294,13 @@ export default function WorkspaceView() {
 
   // ── Resizable panels ──
   const rightPanelRef = usePanelRef();
-  const [rightPanelMode, setRightPanelMode] = useState<"workspace" | "browser">("workspace");
+  const [browserPanelOpen, setBrowserPanelOpen] = useState(false);
   const { defaultLayout: wsLayout, onLayoutChanged: onWsLayoutChanged } = useDefaultLayout({
     id: "hive-workspace",
     storage: localStorage,
   });
   const { defaultLayout: splitLayout, onLayoutChanged: onSplitLayoutChanged } = useDefaultLayout({
-    id: "hive-right-split",
+    id: "hive-right-split-v2",
     storage: localStorage,
   });
 
@@ -330,15 +330,15 @@ export default function WorkspaceView() {
   }, [wsId, sessionId, liveData]);
 
   useEffect(() => {
-    if (!currentBrowserStatus && rightPanelMode === "browser") {
-      setRightPanelMode("workspace");
+    if (!currentBrowserStatus && browserPanelOpen) {
+      setBrowserPanelOpen(false);
     }
-  }, [currentBrowserStatus, rightPanelMode]);
+  }, [currentBrowserStatus, browserPanelOpen]);
 
   const handleToggleBrowserPanel = useCallback(() => {
-    setRightPanelMode((mode) => {
-      const next = mode === "browser" ? "workspace" : "browser";
-      if (next === "browser") {
+    setBrowserPanelOpen((open) => {
+      const next = !open;
+      if (next) {
         rightPanelRef.current?.expand();
       }
       return next;
@@ -516,7 +516,7 @@ export default function WorkspaceView() {
                   <TooltipTrigger asChild>
                     <Button
                       type="button"
-                      variant={rightPanelMode === "browser" ? "secondary" : "ghost"}
+                      variant={browserPanelOpen ? "secondary" : "ghost"}
                       size="icon-xs"
                       className="relative text-muted-foreground hover:text-foreground"
                       onClick={handleToggleBrowserPanel}
@@ -718,121 +718,122 @@ export default function WorkspaceView() {
         >
           <div className="flex h-full flex-col">
             <div className="flex h-12 items-center gap-3 border-b border-border/50 px-4" data-tauri-drag-region>
-              {rightPanelMode === "browser" && currentBrowserStatus ? (
-                <>
-                  <MonitorIcon className="size-3.5 text-muted-foreground" />
-                  <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
-                  <Badge
-                    variant={currentBrowserStatus.state === "error" ? "destructive" : "secondary"}
-                    className="px-1.5 py-0 text-[10px]"
-                  >
-                    {currentBrowserStatus.state === "error" ? "Error" : "Live"}
+              <button
+                type="button"
+                className={cn(
+                  "text-xs uppercase tracking-wide transition-colors",
+                  sidebarTab === "all"
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setSidebarTab("all")}
+              >
+                All
+              </button>
+              <button
+                type="button"
+                className={cn(
+                  "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
+                  sidebarTab === "modified"
+                    ? "text-foreground"
+                    : "text-muted-foreground hover:text-foreground",
+                )}
+                onClick={() => setSidebarTab("modified")}
+              >
+                Modified
+                {diffTotalCount > 0 && (
+                  <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+                    {diffTotalCount}
                   </Badge>
-                  <div className="ml-auto" />
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    className="text-muted-foreground hover:text-foreground"
-                    onClick={() => setRightPanelMode("workspace")}
-                    aria-label="Close browser panel"
-                  >
-                    <XIcon className="size-3" />
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <button
-                    type="button"
-                    className={cn(
-                      "text-xs uppercase tracking-wide transition-colors",
-                      sidebarTab === "all"
-                        ? "text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    onClick={() => setSidebarTab("all")}
-                  >
-                    All
-                  </button>
-                  <button
-                    type="button"
-                    className={cn(
-                      "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
-                      sidebarTab === "modified"
-                        ? "text-foreground"
-                        : "text-muted-foreground hover:text-foreground",
-                    )}
-                    onClick={() => setSidebarTab("modified")}
-                  >
-                    Modified
-                    {diffTotalCount > 0 && (
-                      <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-                        {diffTotalCount}
-                      </Badge>
-                    )}
-                  </button>
-                </>
-              )}
+                )}
+              </button>
             </div>
-            {rightPanelMode === "browser" && currentBrowserStatus ? (
-              <BrowserPanel status={currentBrowserStatus} />
-            ) : (
-              <>
-                <Group
-                  orientation="vertical"
-                  defaultLayout={splitLayout}
-                  onLayoutChanged={onSplitLayoutChanged}
-                  style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
-                >
-                  <Panel id="file-tree" defaultSize="50%" minSize="15%" maxSize="85%">
-                    <div className="h-full overflow-auto p-3">
-                      {sidebarTab === "modified" && (
-                        <ModifiedFileList
-                          committed={diffCommitted}
-                          uncommitted={diffUncommitted}
-                          onFileClick={handleModifiedFileClick}
-                          activeFile={isFileTabActive && fileViewMode === "diff" ? openFile ?? undefined : undefined}
-                        />
+            <Group
+              orientation="vertical"
+              defaultLayout={splitLayout}
+              onLayoutChanged={onSplitLayoutChanged}
+              style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
+            >
+              <Panel id="file-tree" defaultSize={browserPanelOpen ? "42%" : "50%"} minSize="15%" maxSize="85%">
+                <div className="h-full overflow-auto p-3">
+                  {sidebarTab === "modified" && (
+                    <ModifiedFileList
+                      committed={diffCommitted}
+                      uncommitted={diffUncommitted}
+                      onFileClick={handleModifiedFileClick}
+                      activeFile={isFileTabActive && fileViewMode === "diff" ? openFile ?? undefined : undefined}
+                    />
+                  )}
+                  {sidebarTab === "all" && fileTreeError && (
+                    <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
+                      {fileTreeError}
+                    </div>
+                  )}
+                  {sidebarTab === "all" && !fileTreeError && (
+                    <FileTree
+                      expanded={expandedPaths}
+                      onExpandedChange={setExpandedPaths}
+                      onPathSelect={handleFileTreeSelect}
+                      selectedPath={selectedPath}
+                    >
+                      {fileTree.length ? (
+                        renderFileTreeNodes(fileTree)
+                      ) : (
+                        <div className="px-2 py-1 text-xs text-muted-foreground">No files found.</div>
                       )}
-                      {sidebarTab === "all" && fileTreeError && (
-                        <div className="rounded-md border border-destructive/30 bg-destructive/10 p-3 text-xs text-destructive">
-                          {fileTreeError}
-                        </div>
-                      )}
-                      {sidebarTab === "all" && !fileTreeError && (
-                        <FileTree
-                          expanded={expandedPaths}
-                          onExpandedChange={setExpandedPaths}
-                          onPathSelect={handleFileTreeSelect}
-                          selectedPath={selectedPath}
+                    </FileTree>
+                  )}
+                </div>
+              </Panel>
+              <ResizeHandle orientation="horizontal" />
+              <Panel id="scripts" defaultSize={browserPanelOpen ? "30%" : undefined} minSize="15%">
+                <ScriptPanel
+                  key={wsId}
+                  config={scriptsConfig}
+                  status={scriptsStatus}
+                  onStart={startScript}
+                  onStop={stopScript}
+                  onStartTerminal={startTerminal}
+                  onStopTerminal={stopTerminal}
+                  onConnectOutput={connectScriptOutput}
+                  onDisconnectOutput={disconnectScriptOutput}
+                />
+              </Panel>
+              {browserPanelOpen && currentBrowserStatus && (
+                <>
+                  <ResizeHandle orientation="horizontal" />
+                  <Panel id="browser" defaultSize="28%" minSize="18%" maxSize="48%">
+                    <div className="flex h-full min-h-0 flex-col border-t border-border/40 bg-background">
+                      <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border/50 px-3">
+                        <MonitorIcon className="size-3.5 text-muted-foreground" />
+                        <span className="text-xs font-medium uppercase tracking-wide text-foreground">Browser</span>
+                        <Badge
+                          variant={currentBrowserStatus.state === "error" ? "destructive" : "secondary"}
+                          className="px-1.5 py-0 text-[10px]"
                         >
-                          {fileTree.length ? (
-                            renderFileTreeNodes(fileTree)
-                          ) : (
-                            <div className="px-2 py-1 text-xs text-muted-foreground">No files found.</div>
-                          )}
-                        </FileTree>
-                      )}
+                          {currentBrowserStatus.state === "error" ? "Error" : "Live"}
+                        </Badge>
+                        <div className="ml-auto" />
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="icon-xs"
+                          className="text-muted-foreground hover:text-foreground"
+                          onClick={() => setBrowserPanelOpen(false)}
+                          aria-label="Close browser panel"
+                        >
+                          <XIcon className="size-3" />
+                        </Button>
+                      </div>
+                      <div className="min-h-0 flex-1">
+                        <BrowserPanel status={currentBrowserStatus} />
+                      </div>
                     </div>
                   </Panel>
-                  <ResizeHandle orientation="horizontal" />
-                  <Panel id="scripts" minSize="15%">
-                    <ScriptPanel
-                      key={wsId}
-                      config={scriptsConfig}
-                      status={scriptsStatus}
-                      onStart={startScript}
-                      onStop={stopScript}
-                      onStartTerminal={startTerminal}
-                      onStopTerminal={stopTerminal}
-                      onConnectOutput={connectScriptOutput}
-                      onDisconnectOutput={disconnectScriptOutput}
-                    />
-                  </Panel>
-                </Group>
-                <PrStatusSection wsId={wsId} />
-              </>
-            )}
+                </>
+              )}
+            </Group>
+            <PrStatusSection wsId={wsId} />
           </div>
         </Panel>
       </Group>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -326,6 +326,7 @@ export type BrowserSessionState = "registered" | "active" | "closed" | "error";
 export interface BrowserStatusPayload {
   sessionId: string;
   state: BrowserSessionState;
+  streaming?: boolean;
   streamPath?: string;
   url?: string;
   title?: string;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -318,7 +318,21 @@ export type WsOutgoing =
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
   | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }
+  | { type: "browser_status"; status: BrowserStatusPayload }
   | { type: "plan_mode_changed"; sessionId: string; active: boolean };
+
+export type BrowserSessionState = "registered" | "active" | "closed" | "error";
+
+export interface BrowserStatusPayload {
+  sessionId: string;
+  state: BrowserSessionState;
+  streamPath?: string;
+  url?: string;
+  title?: string;
+  updatedAt: number;
+  lastActiveAt?: number;
+  error?: string;
+}
 
 // ── Automation types ─────────────────────────────────────────────────
 

--- a/frontend/tests/browser-stream.test.ts
+++ b/frontend/tests/browser-stream.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { parseBrowserStreamMessage } from "../src/lib/browser-stream";
+
+describe("parseBrowserStreamMessage", () => {
+  it("parses jpeg frame messages", () => {
+    expect(parseBrowserStreamMessage(JSON.stringify({
+      type: "frame",
+      data: "abc123",
+      metadata: { url: "http://localhost:5173", title: "Hive" },
+    }))).toEqual({
+      src: "data:image/jpeg;base64,abc123",
+      url: "http://localhost:5173",
+      title: "Hive",
+    });
+  });
+
+  it("parses active tab metadata", () => {
+    expect(parseBrowserStreamMessage(JSON.stringify({
+      type: "tabs",
+      tabs: [
+        { url: "http://old.local", title: "Old", active: false },
+        { url: "http://localhost:5173", title: "Hive", active: true },
+      ],
+    }))).toEqual({
+      url: "http://localhost:5173",
+      title: "Hive",
+    });
+  });
+
+  it("ignores malformed messages", () => {
+    expect(parseBrowserStreamMessage("not json")).toBeNull();
+  });
+});

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -1,0 +1,99 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { BrowserPanel } from "@/components/BrowserPanel";
+import type { BrowserStatusPayload } from "@/types";
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readyState = MockWebSocket.CONNECTING;
+  binaryType = "";
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    MockWebSocket.instances.push(this);
+    queueMicrotask(() => {
+      this.readyState = MockWebSocket.OPEN;
+      this.onopen?.();
+    });
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+const status: BrowserStatusPayload = {
+  sessionId: "session-1",
+  state: "active",
+  streamPath: "/ws/browser/ws-1/session-1",
+  updatedAt: 1,
+};
+
+const originalWebSocket = globalThis.WebSocket;
+
+describe("BrowserPanel", () => {
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", MockWebSocket);
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      x: 0,
+      y: 0,
+      width: 640,
+      height: 360,
+      top: 0,
+      right: 640,
+      bottom: 360,
+      left: 0,
+      toJSON: () => ({}),
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.defineProperty(globalThis, "WebSocket", {
+      configurable: true,
+      writable: true,
+      value: originalWebSocket,
+    });
+  });
+
+  it("sends the panel dimensions as a viewport resize when the stream opens", async () => {
+    render(<BrowserPanel status={status} />);
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances[0]?.sent).toContain(JSON.stringify({
+        type: "viewport_resize",
+        width: 640,
+        height: 360,
+      }));
+    });
+  });
+
+  it("renders stream frames as a full panel viewport", async () => {
+    render(<BrowserPanel status={status} />);
+
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+    act(() => MockWebSocket.instances[0].onmessage?.({
+      data: JSON.stringify({ type: "frame", data: "abc123" }),
+    }));
+
+    const frame = await screen.findByAltText("Agent browser");
+    expect(frame).toHaveClass("h-full", "w-full", "object-fill");
+  });
+});

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { BrowserPanel } from "@/components/BrowserPanel";
+import { BrowserPanel, __clearBrowserStreamConnectionsForTests } from "@/components/BrowserPanel";
 import type { BrowserStatusPayload } from "@/types";
 
 class MockWebSocket {
@@ -23,8 +23,10 @@ class MockWebSocket {
     this.url = url;
     MockWebSocket.instances.push(this);
     queueMicrotask(() => {
-      this.readyState = MockWebSocket.OPEN;
-      this.onopen?.();
+      act(() => {
+        this.readyState = MockWebSocket.OPEN;
+        this.onopen?.();
+      });
     });
   }
 
@@ -66,6 +68,7 @@ describe("BrowserPanel", () => {
   });
 
   afterEach(() => {
+    act(() => __clearBrowserStreamConnectionsForTests());
     vi.restoreAllMocks();
     Object.defineProperty(globalThis, "WebSocket", {
       configurable: true,
@@ -74,14 +77,14 @@ describe("BrowserPanel", () => {
     });
   });
 
-  it("sends the panel dimensions as a viewport resize when the stream opens", async () => {
+  it("sends a fixed desktop viewport resize when the stream opens", async () => {
     render(<BrowserPanel status={status} />);
 
     await waitFor(() => {
       expect(MockWebSocket.instances[0]?.sent).toContain(JSON.stringify({
         type: "viewport_resize",
-        width: 640,
-        height: 360,
+        width: 1280,
+        height: 720,
       }));
     });
   });
@@ -95,13 +98,13 @@ describe("BrowserPanel", () => {
     expect(MockWebSocket.instances).toHaveLength(0);
   });
 
-  it("uses a small streaming label when the stream is active", () => {
+  it("uses a small streaming label when the stream is active", async () => {
     render(<BrowserPanel status={status} />);
 
-    expect(screen.getByText("streaming")).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("streaming")).toBeInTheDocument());
   });
 
-  it("renders stream frames as a full panel viewport", async () => {
+  it("renders stream frames without distorting the desktop viewport", async () => {
     render(<BrowserPanel status={status} />);
 
     await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
@@ -110,7 +113,62 @@ describe("BrowserPanel", () => {
     }));
 
     const frame = await screen.findByAltText("Agent browser");
-    expect(frame).toHaveClass("h-full", "w-full", "object-fill");
+    expect(frame).toHaveClass("h-full", "w-full", "object-contain");
+  });
+
+  it("keeps the streaming label active when frames arrive before hub status updates", async () => {
+    render(<BrowserPanel status={{ ...status, streaming: false }} />);
+
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+    act(() => MockWebSocket.instances[0].onmessage?.({
+      data: JSON.stringify({ type: "frame", data: "abc123" }),
+    }));
+
+    expect(await screen.findByText("streaming")).toBeInTheDocument();
+  });
+
+  it("stops showing streaming and clears the last frame when a stop status arrives", async () => {
+    const { rerender } = render(<BrowserPanel status={status} />);
+
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+    act(() => MockWebSocket.instances[0].onmessage?.({
+      data: JSON.stringify({ type: "frame", data: "abc123" }),
+    }));
+    expect(await screen.findByAltText("Agent browser")).toBeInTheDocument();
+    expect(screen.getByText("streaming")).toBeInTheDocument();
+
+    rerender(<BrowserPanel status={{ ...status, streaming: false, updatedAt: 2 }} />);
+
+    await waitFor(() => expect(screen.getByText("not streaming")).toBeInTheDocument());
+    expect(screen.queryByAltText("Agent browser")).not.toBeInTheDocument();
+  });
+
+  it("stops showing streaming and clears the frame when the stream socket closes", async () => {
+    render(<BrowserPanel status={status} />);
+
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+    act(() => MockWebSocket.instances[0].onmessage?.({
+      data: JSON.stringify({ type: "frame", data: "abc123" }),
+    }));
+    expect(await screen.findByAltText("Agent browser")).toBeInTheDocument();
+
+    act(() => MockWebSocket.instances[0].close());
+
+    await waitFor(() => expect(screen.getByText("not streaming")).toBeInTheDocument());
+    expect(screen.queryByAltText("Agent browser")).not.toBeInTheDocument();
+  });
+
+  it("reconnects automatically when streaming restarts on the same browser session", async () => {
+    const { rerender } = render(<BrowserPanel status={{ ...status, streaming: false }} />);
+
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+    act(() => MockWebSocket.instances[0].close());
+    await waitFor(() => expect(screen.getByText("not streaming")).toBeInTheDocument());
+
+    rerender(<BrowserPanel status={{ ...status, streaming: true, updatedAt: 2 }} />);
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));
+    await waitFor(() => expect(MockWebSocket.instances[1]?.readyState).toBe(MockWebSocket.OPEN));
   });
 
   it("keeps the viewport closed when collapsed", () => {
@@ -118,6 +176,16 @@ describe("BrowserPanel", () => {
 
     expect(screen.queryByAltText("Agent browser")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Expand browser panel" })).toBeInTheDocument();
-    expect(MockWebSocket.instances).toHaveLength(0);
+    expect(MockWebSocket.instances).toHaveLength(1);
+  });
+
+  it("keeps the browser stream connection alive across panel remounts", async () => {
+    const first = render(<BrowserPanel status={status} />);
+    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
+
+    first.unmount();
+    render(<BrowserPanel status={status} collapsed onToggleCollapsed={() => {}} />);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
   });
 });

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -41,6 +41,7 @@ class MockWebSocket {
 const status: BrowserStatusPayload = {
   sessionId: "session-1",
   state: "active",
+  streaming: true,
   streamPath: "/ws/browser/ws-1/session-1",
   updatedAt: 1,
 };
@@ -89,9 +90,15 @@ describe("BrowserPanel", () => {
     render(<BrowserPanel />);
 
     expect(screen.getByText("Browser")).toBeInTheDocument();
-    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.getByText("not streaming")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Expand browser panel" })).not.toBeInTheDocument();
     expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
+  it("uses a small streaming label when the stream is active", () => {
+    render(<BrowserPanel status={status} />);
+
+    expect(screen.getByText("streaming")).toBeInTheDocument();
   });
 
   it("renders stream frames as a full panel viewport", async () => {

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -96,4 +96,12 @@ describe("BrowserPanel", () => {
     const frame = await screen.findByAltText("Agent browser");
     expect(frame).toHaveClass("h-full", "w-full", "object-fill");
   });
+
+  it("keeps the viewport closed when collapsed", () => {
+    render(<BrowserPanel status={status} collapsed onToggleCollapsed={() => {}} />);
+
+    expect(screen.queryByAltText("Agent browser")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Expand browser panel" })).toBeInTheDocument();
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
 });

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -116,15 +116,12 @@ describe("BrowserPanel", () => {
     expect(frame).toHaveClass("h-full", "w-full", "object-contain");
   });
 
-  it("keeps the streaming label active when frames arrive before hub status updates", async () => {
+  it("does not open a stream socket while the browser status is stopped", () => {
     render(<BrowserPanel status={{ ...status, streaming: false }} />);
 
-    await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
-    act(() => MockWebSocket.instances[0].onmessage?.({
-      data: JSON.stringify({ type: "frame", data: "abc123" }),
-    }));
-
-    expect(await screen.findByText("streaming")).toBeInTheDocument();
+    expect(screen.getByText("not streaming")).toBeInTheDocument();
+    expect(screen.getByText("Waiting for browser stream")).toBeInTheDocument();
+    expect(MockWebSocket.instances).toHaveLength(0);
   });
 
   it("stops showing streaming and clears the last frame when a stop status arrives", async () => {
@@ -159,12 +156,13 @@ describe("BrowserPanel", () => {
   });
 
   it("reconnects automatically when streaming restarts on the same browser session", async () => {
-    const { rerender } = render(<BrowserPanel status={{ ...status, streaming: false }} />);
+    const { rerender } = render(<BrowserPanel status={status} />);
 
     await waitFor(() => expect(MockWebSocket.instances[0]?.readyState).toBe(MockWebSocket.OPEN));
     act(() => MockWebSocket.instances[0].close());
     await waitFor(() => expect(screen.getByText("not streaming")).toBeInTheDocument());
 
+    rerender(<BrowserPanel status={{ ...status, streaming: false, updatedAt: 2 }} />);
     rerender(<BrowserPanel status={{ ...status, streaming: true, updatedAt: 2 }} />);
 
     await waitFor(() => expect(MockWebSocket.instances).toHaveLength(2));

--- a/frontend/tests/components/BrowserPanel.test.tsx
+++ b/frontend/tests/components/BrowserPanel.test.tsx
@@ -85,6 +85,15 @@ describe("BrowserPanel", () => {
     });
   });
 
+  it("renders an idle header without opening a stream", () => {
+    render(<BrowserPanel />);
+
+    expect(screen.getByText("Browser")).toBeInTheDocument();
+    expect(screen.getByText("Idle")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Expand browser panel" })).not.toBeInTheDocument();
+    expect(MockWebSocket.instances).toHaveLength(0);
+  });
+
   it("renders stream frames as a full panel viewport", async () => {
     render(<BrowserPanel status={status} />);
 

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -375,6 +375,7 @@ describe("useWorkspaceLiveData", () => {
         status: {
           sessionId: "sess-a",
           state: "active",
+          streaming: true,
           streamPath: "/ws/browser/ws-1/sess-a",
           updatedAt: 1,
         },
@@ -385,6 +386,7 @@ describe("useWorkspaceLiveData", () => {
       "sess-a": {
         sessionId: "sess-a",
         state: "active",
+        streaming: true,
         streamPath: "/ws/browser/ws-1/sess-a",
         updatedAt: 1,
       },

--- a/frontend/tests/hooks/useWorkspaceLiveData.test.ts
+++ b/frontend/tests/hooks/useWorkspaceLiveData.test.ts
@@ -365,6 +365,45 @@ describe("useWorkspaceLiveData", () => {
     });
   });
 
+  it("tracks and clears browser session status", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "browser_status",
+        status: {
+          sessionId: "sess-a",
+          state: "active",
+          streamPath: "/ws/browser/ws-1/sess-a",
+          updatedAt: 1,
+        },
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.browserSessions).toEqual({
+      "sess-a": {
+        sessionId: "sess-a",
+        state: "active",
+        streamPath: "/ws/browser/ws-1/sess-a",
+        updatedAt: 1,
+      },
+    });
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "browser_status",
+        status: {
+          sessionId: "sess-a",
+          state: "closed",
+          updatedAt: 2,
+        },
+      });
+    });
+
+    expect(result.current.liveData["ws-1"]?.browserSessions).toBeUndefined();
+  });
+
   it("does not re-render when same script_status is emitted twice", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useWorkspaceLiveData(["ws-1"]));

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -114,6 +114,26 @@ vi.mock("@/components/ScriptPanel", () => ({
   },
 }));
 
+vi.mock("@/components/BrowserPanel", () => ({
+  BrowserPanel: ({
+    collapsed,
+    onToggleCollapsed,
+  }: {
+    collapsed?: boolean;
+    onToggleCollapsed?: () => void;
+  }) => (
+    <div data-testid="browser-panel" data-collapsed={collapsed ? "true" : "false"}>
+      <button
+        type="button"
+        aria-label={collapsed ? "Expand browser panel" : "Collapse browser panel"}
+        onClick={onToggleCollapsed}
+      >
+        browser-toggle
+      </button>
+    </div>
+  ),
+}));
+
 vi.mock("@/components/ChatConversation", () => ({
   default: ({
     isStreaming,
@@ -560,6 +580,38 @@ describe("WorkspaceView behavior", () => {
 
     // Should render the simple "VS Code" button, not a dropdown
     expect(screen.getByRole("button", { name: "VS Code" })).toBeInTheDocument();
+  });
+
+  it("automatically shows the browser panel for active browser sessions and keeps local manual collapse", async () => {
+    const user = userEvent.setup();
+    mocks.useConversation.mockReturnValue(buildConversationState({ sessionId: "sess-active" }));
+    mocks.useWorkspaceLiveData.mockReturnValue({
+      clearUnread: vi.fn(),
+      liveData: {
+        "ws-1": {
+          browserSessions: {
+            "sess-active": {
+              sessionId: "sess-active",
+              state: "active",
+              streamPath: "/ws/browser/ws-1/sess-active",
+              updatedAt: 1,
+            },
+          },
+        },
+      },
+    });
+
+    renderWorkspace();
+    await screen.findByText("tokyo");
+
+    expect(screen.queryByRole("button", { name: "Toggle browser panel" })).not.toBeInTheDocument();
+    expect(screen.getByTestId("browser-panel")).toHaveAttribute("data-collapsed", "false");
+
+    await user.click(screen.getByRole("button", { name: "Collapse browser panel" }));
+    expect(screen.getByTestId("browser-panel")).toHaveAttribute("data-collapsed", "true");
+
+    await user.click(screen.getByRole("button", { name: "Expand browser panel" }));
+    expect(screen.getByTestId("browser-panel")).toHaveAttribute("data-collapsed", "false");
   });
 
   it("shows QuestionPanel instead of ChatInput when AskUserQuestion is pending", async () => {

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -603,6 +603,7 @@ describe("WorkspaceView behavior", () => {
             "sess-active": {
               sessionId: "sess-active",
               state: "active",
+              streaming: true,
               streamPath: "/ws/browser/ws-1/sess-active",
               updatedAt: 1,
             },

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -116,20 +116,28 @@ vi.mock("@/components/ScriptPanel", () => ({
 
 vi.mock("@/components/BrowserPanel", () => ({
   BrowserPanel: ({
+    status,
     collapsed,
     onToggleCollapsed,
   }: {
+    status?: unknown;
     collapsed?: boolean;
     onToggleCollapsed?: () => void;
   }) => (
-    <div data-testid="browser-panel" data-collapsed={collapsed ? "true" : "false"}>
-      <button
-        type="button"
-        aria-label={collapsed ? "Expand browser panel" : "Collapse browser panel"}
-        onClick={onToggleCollapsed}
-      >
-        browser-toggle
-      </button>
+    <div
+      data-testid="browser-panel"
+      data-active={status ? "true" : "false"}
+      data-collapsed={collapsed ? "true" : "false"}
+    >
+      {onToggleCollapsed && (
+        <button
+          type="button"
+          aria-label={collapsed ? "Expand browser panel" : "Collapse browser panel"}
+          onClick={onToggleCollapsed}
+        >
+          browser-toggle
+        </button>
+      )}
     </div>
   ),
 }));
@@ -580,6 +588,8 @@ describe("WorkspaceView behavior", () => {
 
     // Should render the simple "VS Code" button, not a dropdown
     expect(screen.getByRole("button", { name: "VS Code" })).toBeInTheDocument();
+    expect(screen.getByTestId("browser-panel")).toHaveAttribute("data-active", "false");
+    expect(screen.getByTestId("browser-panel")).toHaveAttribute("data-collapsed", "true");
   });
 
   it("automatically shows the browser panel for active browser sessions and keeps local manual collapse", async () => {


### PR DESCRIPTION
## Summary
- add backend browser session tracking and a read-only browser WebSocket proxy
- expose browser stream status through workspace live data
- add the frontend browser panel with reconnect/collapse behavior
- cover the manager, WS route, stream parsing, panel, hook, and workspace integration with tests

## Verification
- npm run typecheck
- npm run lint
- npm test
- npm run test --workspace @hive/frontend
- npm run test --workspace @hive/frontend -- browser-stream.test.ts BrowserPanel.test.tsx WorkspaceView.test.tsx useWorkspaceLiveData.test.ts
- git diff --check main...HEAD

Note: the first full npm test run hit an intermittent jsdom/Radix unhandled exception in an unchanged ExternalLinkDialog test after all tests passed. The isolated test and a full frontend rerun both passed.