### PR TITLE
fix(ios): mark app as iPhone-only to unblock TestFlight upload

### DIFF
--- a/ios/HiveMobile.xcodeproj/project.pbxproj
+++ b/ios/HiveMobile.xcodeproj/project.pbxproj
@@ -266,7 +266,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Hive;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -277,7 +276,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -295,7 +294,6 @@
 				INFOPLIST_KEY_CFBundleDisplayName = Hive;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -306,7 +304,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Release;
 		};

--- a/ios/HiveMobile.xcodeproj/project.pbxproj
+++ b/ios/HiveMobile.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hive.mobile-agent";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -299,7 +299,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 0.3.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.hive.mobile-agent";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary
- App Store validation was rejecting TestFlight uploads: the bundle declared `TARGETED_DEVICE_FAMILY = "1,2"` (iPhone + iPad) but only listed portrait orientations on iPad. Apple requires iPad apps to support all four orientations for multitasking.
- The UI isn't optimized for iPad, so restrict the target to iPhone (`TARGETED_DEVICE_FAMILY = 1`) and drop `INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad` in both Debug and Release configs.

## Test plan
- [ ] Bump `CURRENT_PROJECT_VERSION` (build number)
- [ ] Archive in Xcode and upload to App Store Connect
- [ ] Verify validation passes (no orientation error)
- [ ] Confirm the build appears in TestFlight as iPhone-only