### PR TITLE
Add workspace path copy action

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,8 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/lib/clipboard.ts`: `copyToClipboard()` with `execCommand` fallback for HTTP contexts
 - `frontend/src/lib/terminal.ts`: SSH command builder + terminal app detection (Tauri)
 - `frontend/src/lib/open-external.ts`: VS Code remote SSH URI builder + external app launcher
-- `frontend/src/components/Sidebar.tsx`: project/workspace nav + org/repo two-tone headers + build/automation tabs + sidebar collapse + bulk PR status + unread badges + dashed active border
+- `frontend/src/components/Sidebar.tsx`: project/workspace nav + org/repo two-tone headers + resizable workspace/automation panels + sidebar collapse + bulk PR status + unread badges + dashed active border
+- `frontend/src/components/WorkspacePathCopyButton.tsx`: workspace header path-copy action with tooltip and transient copied state
 - `frontend/src/components/ChatInput.tsx`: message input with provider-adaptive controls, `#` file autocomplete with `MentionHighlightOverlay`, Commit & Push quick action, context ring, message queue display, `appendText` ref for paste-from-diff
 - `frontend/src/components/ChatConversation.tsx`: conversation display with hydration flash fix (visibility:hidden + double-rAF settle)
 - `frontend/src/components/PrStatusSection.tsx`: enriched PR display (13 states)
@@ -209,6 +210,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/components/chat/PlanActionBar.tsx`: floating action bar above chat input with Copy / Hand-off / Approve buttons
 - `frontend/src/components/chat/SubAgentNode.tsx`: Task tool rendering with type-specific icons, expand/collapse, nested child tool tree, result footer
 - `frontend/src/components/chat/ContextRing.tsx`: SVG ring showing context window usage (green/yellow/red thresholds) with tooltip
+- `frontend/src/hooks/useClipboardCopy.ts`: shared clipboard copy state/timer hook used by copy affordances
 - `frontend/src/components/chat/FileAutocompletePopup.tsx`: dropdown for `#` file mention autocomplete
 - `frontend/src/components/chat/MentionHighlightOverlay.tsx`: overlay highlighting `#file` and `@agent` mentions in chat input
 - `frontend/src/components/chat/QuestionPanel.tsx`: AskUserQuestion card with numbered options, inline text input, multi-question support, CANCELLED badge

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ npm test
 | `GET` | `/api/projects/:id/workspaces` | List project workspaces |
 | `GET` | `/api/workspaces/:wsId` | Get workspace details + default branch |
 | `DELETE` | `/api/workspaces/:wsId` | Delete workspace |
-| `GET` | `/api/workspaces/:wsId/diff` | Unified diff (committed + uncommitted + untracked) |
+| `GET` | `/api/workspaces/:wsId/diff?scope=combined\|committed\|uncommitted` | Unified diff; defaults to combined committed + uncommitted + untracked |
 | `GET` | `/api/workspaces/:wsId/diff/stat` | Diff stats (`committed` + `uncommitted`) |
 | `GET` | `/api/workspaces/:wsId/files` | Workspace file tree |
 | `GET` | `/api/workspaces/:wsId/file?path=<file>` | Read workspace file content |

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ It manages:
 - macOS traffic light positioning, drag regions, and App Transport Security exceptions for Tailscale HTTP.
 - Sidebar collapse toggle (Cmd/Ctrl+B) with CSS transition and fullscreen detection.
 - VS Code remote SSH workspace opening via `vscode://vscode-remote/ssh-remote+` URIs.
+- Workspace header action for copying the current worktree path.
 
 **iOS**
 - Native SwiftUI app with chat, model selection, session switching (max 4), and push notifications (APNs).

--- a/backend/src/api/ui-preferences.ts
+++ b/backend/src/api/ui-preferences.ts
@@ -4,7 +4,6 @@ import {
   loadUiPreferences,
   saveUiPreferences,
   sanitizeUiPreferences,
-  type UiPreferences,
 } from "../state/ui-preferences.js";
 import { getDataDir } from "../state/state.js";
 import { listProjects } from "../projects/project-manager.js";

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -194,6 +194,54 @@ describe("GET /api/workspaces/:wsId/diff", () => {
     expect(res.statusCode).toBe(200);
     expect(res.json().diff).toContain("api-test.txt");
   });
+
+  it("returns scoped diffs", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const ws = createRes.json();
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    await writeFile(join(wsPath, "committed.txt"), "committed\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "api committed change"], wsPath);
+    await writeFile(join(wsPath, "README.md"), "local only\n");
+
+    const committedRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${ws.id}/diff?scope=committed`,
+    });
+    const uncommittedRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${ws.id}/diff?scope=uncommitted`,
+    });
+
+    expect(committedRes.statusCode).toBe(200);
+    expect(committedRes.json().diff).toContain("committed.txt");
+    expect(committedRes.json().diff).not.toContain("README.md");
+    expect(uncommittedRes.statusCode).toBe(200);
+    expect(uncommittedRes.json().diff).not.toContain("committed.txt");
+    expect(uncommittedRes.json().diff).toContain("README.md");
+  });
+
+  it("rejects invalid diff scopes", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const ws = createRes.json();
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${ws.id}/diff?scope=everything`,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toBe("Invalid diff scope");
+  });
 });
 
 describe("GET /api/workspaces/:wsId/diff/stat", () => {

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -16,13 +16,23 @@ import { endSession } from "../agents/agent-manager.js";
 import { join } from "node:path";
 import { bareRepoPath, resolveDefaultBranch, workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
-import { errorMessage, errorStatus } from "../utils/errors.js";
+import { BadRequestError, errorMessage, errorStatus } from "../utils/errors.js";
 import { parseGitHubRepo, fetchPrForBranch } from "../utils/github.js";
 import { getBranchName } from "../services/git-sync.js";
 import { readHiveConfig } from "../utils/hive-config.js";
 import { startScript } from "../services/script-runner.js";
 import { broadcastToWorkspace } from "../ws/stream.js";
-import type { BulkPrStatusResponse, PrStatusResponse } from "../types.js";
+import type { BulkPrStatusResponse, DiffScope, PrStatusResponse } from "../types.js";
+
+const DIFF_SCOPES = new Set<DiffScope>(["combined", "committed", "uncommitted"]);
+
+function parseDiffScope(scope: unknown): DiffScope {
+  if (scope === undefined) return "combined";
+  if (typeof scope === "string" && DIFF_SCOPES.has(scope as DiffScope)) {
+    return scope as DiffScope;
+  }
+  throw new BadRequestError("Invalid diff scope");
+}
 
 export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
   app.post<{ Params: { id: string } }>("/api/projects/:id/workspaces", async (req, reply) => {
@@ -101,9 +111,9 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
     }
   });
 
-  app.get<{ Params: { wsId: string } }>("/api/workspaces/:wsId/diff", async (req, reply) => {
+  app.get<{ Params: { wsId: string }; Querystring: { scope?: string } }>("/api/workspaces/:wsId/diff", async (req, reply) => {
     try {
-      const diff = await getWorkspaceDiff(req.params.wsId, dataDir);
+      const diff = await getWorkspaceDiff(req.params.wsId, dataDir, parseDiffScope(req.query.scope));
       return reply.send({ diff });
     } catch (err: unknown) {
       return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed") });

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -238,6 +238,7 @@ export interface WorkspaceScriptsResponse {
 // ── Diff types ───────────────────────────────────────────────────────
 
 export type DiffFileStatus = "added" | "modified" | "deleted" | "renamed";
+export type DiffScope = "combined" | "committed" | "uncommitted";
 
 export interface DiffFileStat {
   file: string;

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -410,6 +410,67 @@ describe("getWorkspaceDiff", () => {
     expect(diff).toContain("brand-new.txt");
   });
 
+  it("returns only committed changes for the committed diff scope", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    await writeFile(join(wsPath, "committed.txt"), "committed\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "committed file"], wsPath);
+
+    await writeFile(join(wsPath, "README.md"), "local only change\n");
+    await writeFile(join(wsPath, "brand-new.txt"), "untracked\n");
+
+    const diff = await getWorkspaceDiff(ws.id, dataDir, "committed");
+
+    expect(diff).toContain("committed.txt");
+    expect(diff).not.toContain("README.md");
+    expect(diff).not.toContain("brand-new.txt");
+  });
+
+  it("returns only working tree changes for the uncommitted diff scope", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    await writeFile(join(wsPath, "committed.txt"), "committed\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "committed file"], wsPath);
+
+    await writeFile(join(wsPath, "README.md"), "local only change\n");
+    await writeFile(join(wsPath, "brand-new.txt"), "untracked\n");
+
+    const diff = await getWorkspaceDiff(ws.id, dataDir, "uncommitted");
+
+    expect(diff).not.toContain("committed.txt");
+    expect(diff).toContain("README.md");
+    expect(diff).toContain("brand-new.txt");
+  });
+
+  it("separates committed and uncommitted hunks for the same file by scope", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    await writeFile(join(wsPath, "README.md"), "base\ncommitted change\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "modify readme"], wsPath);
+
+    await writeFile(join(wsPath, "README.md"), "base\ncommitted change\nuncommitted extra\n");
+
+    const committedDiff = await getWorkspaceDiff(ws.id, dataDir, "committed");
+    const uncommittedDiff = await getWorkspaceDiff(ws.id, dataDir, "uncommitted");
+
+    expect(committedDiff).toContain("+committed change");
+    expect(committedDiff).not.toContain("+uncommitted extra");
+    expect(uncommittedDiff).not.toContain("+committed change");
+    expect(uncommittedDiff).toContain("+uncommitted extra");
+  });
+
   it("does not duplicate a file modified in both committed and uncommitted changes", async () => {
     const ws = await createWorkspace(projectId, dataDir);
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -12,7 +12,7 @@ import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectState
 import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.js";
 import { stopAllForWorkspace } from "../services/script-runner.js";
-import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffStatResponse } from "../types.js";
+import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffScope, DiffStatResponse } from "../types.js";
 
 const IGNORED_DIRS = new Set([
   ".git",
@@ -329,37 +329,16 @@ async function resolveWorkspacePaths(
   return { bare, wsPath, defaultBranch, workspace };
 }
 
-export async function getWorkspaceDiff(
-  wsId: string,
-  dataDir = getDataDir()
-): Promise<string> {
-  const { wsPath, defaultBranch, workspace } =
-    await resolveWorkspacePaths(wsId, dataDir);
-
-  // Find merge-base so we can compute a single combined diff
-  // (committed + uncommitted) without duplicating files that appear in both.
-  const mergeBase = await git(
-    ["merge-base", defaultBranch, workspace.branch],
-    wsPath,
-  ).then((r) => r.stdout.trim()).catch(() => "");
-
-  // Single diff from merge-base to working directory
-  const [combinedDiff, untrackedResult] = await Promise.all([
-    mergeBase
-      ? git(["diff", mergeBase], wsPath).then((r) => r.stdout).catch(() => "")
-      : git(["diff", "HEAD"], wsPath).then((r) => r.stdout).catch(() => ""),
-    git(["ls-files", "--others", "--exclude-standard"], wsPath)
-      .then((r) => r.stdout)
-      .catch(() => ""),
-  ]);
-
-  // Generate synthetic diffs for untracked files
+async function getUntrackedDiff(wsPath: string): Promise<string> {
+  const untrackedResult = await git(["ls-files", "--others", "--exclude-standard"], wsPath)
+    .then((r) => r.stdout)
+    .catch(() => "");
   const untrackedFiles = untrackedResult.split("\n").filter(Boolean);
   const untrackedPatches: string[] = [];
+
   for (const file of untrackedFiles.slice(0, 100)) {
     try {
       const content = await readFile(join(wsPath, file), "utf-8");
-      // Skip binary files (contains null bytes)
       if (content.includes("\0")) continue;
       const lines = content.endsWith("\n") ? content.slice(0, -1).split("\n") : content.split("\n");
       const lineCount = lines.length;
@@ -371,7 +350,45 @@ export async function getWorkspaceDiff(
       // Skip unreadable files
     }
   }
-  const untrackedDiff = untrackedPatches.join("\n");
+
+  return untrackedPatches.join("\n");
+}
+
+export async function getWorkspaceDiff(
+  wsId: string,
+  dataDir = getDataDir(),
+  scope: DiffScope = "combined",
+): Promise<string> {
+  const { bare, wsPath, defaultBranch, workspace } =
+    await resolveWorkspacePaths(wsId, dataDir);
+
+  // Keep these scopes aligned with the modified-file UX: branch commits,
+  // working tree changes, or a combined review against the default branch.
+  if (scope === "committed") {
+    return git(["diff", "--find-renames", `${defaultBranch}...${workspace.branch}`], bare)
+      .then((r) => r.stdout)
+      .catch(() => "");
+  }
+
+  if (scope === "uncommitted") {
+    const [trackedDiff, untrackedDiff] = await Promise.all([
+      git(["diff", "HEAD"], wsPath).then((r) => r.stdout).catch(() => ""),
+      getUntrackedDiff(wsPath),
+    ]);
+    return [trackedDiff, untrackedDiff].filter(Boolean).join("\n");
+  }
+
+  const mergeBase = await git(
+    ["merge-base", defaultBranch, workspace.branch],
+    wsPath,
+  ).then((r) => r.stdout.trim()).catch(() => "");
+
+  const [combinedDiff, untrackedDiff] = await Promise.all([
+    mergeBase
+      ? git(["diff", mergeBase], wsPath).then((r) => r.stdout).catch(() => "")
+      : git(["diff", "HEAD"], wsPath).then((r) => r.stdout).catch(() => ""),
+    getUntrackedDiff(wsPath),
+  ]);
 
   return [combinedDiff, untrackedDiff].filter(Boolean).join("\n");
 }

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -124,7 +124,10 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const { models, defaultModelId, selectedModelId, selectedModel, setSelectedModelId, capabilities } = useModels(lockedProvider);
   const contextUsage = useContextUsage(messages, selectedModel);
 
-  const thinkingLevels: ThinkingLevel[] = capabilities?.thinkingLevels ?? [];
+  const thinkingLevels = useMemo<ThinkingLevel[]>(
+    () => capabilities?.thinkingLevels ?? [],
+    [capabilities?.thinkingLevels],
+  );
   const supportsThinking = thinkingLevels.length > 0;
   const supportsPlanMode = capabilities?.planMode ?? true;
   const supportsCompletions = capabilities?.completions ?? true;

--- a/frontend/src/components/FileContentToolbar.tsx
+++ b/frontend/src/components/FileContentToolbar.tsx
@@ -2,12 +2,22 @@ import { Columns2Icon, Rows3Icon, MessageSquarePlusIcon } from "lucide-react";
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import type { FileViewMode } from "@/hooks/useTabs";
+import type { DiffScope } from "@/types";
+
+const DIFF_SCOPE_LABELS: Record<DiffScope, string> = {
+  uncommitted: "Working tree",
+  committed: "Branch commits",
+  combined: "Combined",
+};
 
 interface FileContentToolbarProps {
   filePath: string;
   mode: FileViewMode;
   onModeChange: (mode: FileViewMode) => void;
   isModified: boolean;
+  diffScope: DiffScope;
+  availableDiffScopes: DiffScope[];
+  onDiffScopeChange: (scope: DiffScope) => void;
   diffStyle: "split" | "unified";
   onDiffStyleChange: (style: "split" | "unified") => void;
   commentCount: number;
@@ -19,6 +29,9 @@ export function FileContentToolbar({
   mode,
   onModeChange,
   isModified,
+  diffScope,
+  availableDiffScopes,
+  onDiffScopeChange,
   diffStyle,
   onDiffStyleChange,
   commentCount,
@@ -58,6 +71,20 @@ export function FileContentToolbar({
                   <MessageSquarePlusIcon className="size-3" />
                   Paste to prompt ({commentCount})
                 </button>
+              )}
+              {availableDiffScopes.length > 1 && (
+                <div className="flex items-center rounded-lg bg-muted p-0.5">
+                  {availableDiffScopes.map((scope) => (
+                    <button
+                      key={scope}
+                      type="button"
+                      onClick={() => onDiffScopeChange(scope)}
+                      className={toggleCls(diffScope === scope)}
+                    >
+                      {DIFF_SCOPE_LABELS[scope]}
+                    </button>
+                  ))}
+                </div>
               )}
               <div className="flex items-center rounded-lg bg-muted p-0.5">
                 <Tooltip>

--- a/frontend/src/components/ResizeHandle.tsx
+++ b/frontend/src/components/ResizeHandle.tsx
@@ -5,14 +5,26 @@ interface ResizeHandleProps {
   orientation?: "horizontal" | "vertical";
   className?: string;
   disabled?: boolean;
+  separator?: "before" | "after";
 }
 
 export function ResizeHandle({
   orientation = "vertical",
   className,
   disabled,
+  separator,
 }: ResizeHandleProps) {
   const isVertical = orientation === "vertical";
+  const separatorClassName =
+    separator === "before"
+      ? isVertical
+        ? "border-l border-sidebar-border/60"
+        : "border-t border-sidebar-border/60"
+      : separator === "after"
+        ? isVertical
+          ? "border-r border-sidebar-border/60"
+          : "border-b border-sidebar-border/60"
+        : undefined;
 
   return (
     <Separator
@@ -21,6 +33,7 @@ export function ResizeHandle({
       className={cn(
         "group relative flex shrink-0 items-center justify-center bg-transparent",
         isVertical ? "w-1.5" : "h-1.5",
+        separatorClassName,
         className,
       )}
     >

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Settings,
 } from "lucide-react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
+import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
 import { TooltipProvider } from "@/components/ui/tooltip";
@@ -36,6 +37,7 @@ import { cn } from "@/lib/utils";
 import { aggregateScriptRunning, aggregateWorkspaceActivity } from "@/lib/workspace-activity";
 import { useAutomations } from "@/hooks/useAutomations";
 import { SidebarShell } from "@/components/SidebarShell";
+import { ResizeHandle } from "@/components/ResizeHandle";
 import { SidebarFolderComposer } from "@/components/sidebar/SidebarFolderComposer";
 import { SidebarFolderItem } from "@/components/sidebar/SidebarFolderItem";
 import {
@@ -62,6 +64,23 @@ type ProjectOrderDropTarget = {
   projectId: string;
   position: "before" | "after";
 };
+
+const sidebarPanelScrollClassName =
+  "[&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full";
+
+function SidebarPanelScroll({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <ScrollArea className={cn(sidebarPanelScrollClassName, className)}>
+      <div className="p-2">{children}</div>
+    </ScrollArea>
+  );
+}
 
 export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps) {
   const {
@@ -95,6 +114,13 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   const [folderOrderDropTarget, setFolderOrderDropTarget] = useState<FolderOrderDropTarget | null>(null);
   const [projectOrderDropTarget, setProjectOrderDropTarget] = useState<ProjectOrderDropTarget | null>(null);
   const liveData = useWorkspaceLiveDataContext();
+  const {
+    defaultLayout: sidebarSectionsLayout,
+    onLayoutChanged: onSidebarSectionsLayoutChanged,
+  } = useDefaultLayout({
+    id: "hive-sidebar-sections-layout",
+    storage: localStorage,
+  });
 
   const activeProjectId = projects.find((project) =>
     (project.workspaces ?? []).some((workspace) => workspace.id === activeWsId),
@@ -418,7 +444,15 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   };
 
   const footerActions = (
-    <div className="flex items-center justify-end px-2 py-1.5">
+    <div className="flex items-center justify-between px-2 py-1.5">
+      <button
+        type="button"
+        className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
+        onClick={onAddProject}
+      >
+        <FolderPlus className="h-3.5 w-3.5 shrink-0" />
+        Add repository
+      </button>
       <Link
         to="/settings"
         state={{ from: pathname }}
@@ -430,185 +464,195 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
       </Link>
     </div>
   );
+
+  const workspacePanelContent = loading ? (
+    <div className="space-y-2 px-2">
+      <Skeleton className="h-6 w-full" />
+      <Skeleton className="h-6 w-3/4" />
+      <Skeleton className="h-6 w-full" />
+    </div>
+  ) : (
+    <>
+      {(projectsUnavailable || projectsAppearIncomplete) && (
+        <div
+          className="mb-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3"
+          role="alert"
+        >
+          <div className="flex items-start gap-2.5">
+            {projectsRecovering ? (
+              <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-amber-500" />
+            ) : (
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+            )}
+            <div className="min-w-0 flex-1">
+              <p className="text-xs font-medium text-sidebar-foreground">
+                {projectsAppearIncomplete
+                  ? "Repository list looks incomplete"
+                  : "Unable to load repositories"}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {projectsAppearIncomplete
+                  ? "Folders were restored, but the repository list is empty. Hive is retrying automatically."
+                  : `${projectsErrorMessage ?? "The repository list is unavailable."} Hive will keep retrying automatically.`}
+              </p>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                className="mt-3"
+                onClick={() => { void retryProjects(); }}
+                disabled={projectsRecovering}
+              >
+                {projectsRecovering && <Loader2 className="h-3 w-3 animate-spin" />}
+                {projectsRecovering ? "Retrying..." : "Retry now"}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      <SidebarSectionHeader
+        label="Workspaces"
+        className="mb-1"
+        onAdd={() => {
+          if (!hasInitialHydration) return;
+          setIsCreatingFolder(true);
+          setNewFolderName("");
+        }}
+        addLabel="New folder"
+        addDisabled={!hasInitialHydration}
+        addIcon={<FolderPlus className="h-4 w-4" />}
+        addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
+      />
+
+      <SidebarFolderComposer
+        isOpen={isCreatingFolder}
+        name={newFolderName}
+        onNameChange={setNewFolderName}
+        onSubmit={handleCreateFolder}
+        onCancel={resetFolderComposer}
+      />
+
+      {folders.length > 0 && (
+        <div className="space-y-px">
+          {folders.map((folder) => {
+            const expanded = isFolderExpanded(folder.id);
+            const isActiveDropTarget =
+              dropTarget?.type === "folder" && dropTarget.folderId === folder.id;
+            const containsActiveProject = folder.projects.some((project) => project.id === activeProjectId);
+            const isDraggedFolder = draggingFolderId === folder.id;
+            const folderInsertIndicator = folderOrderDropTarget?.folderId === folder.id
+              ? folderOrderDropTarget.position
+              : null;
+
+            const isRenaming = renamingFolderId === folder.id;
+            const isEmptyFolder = folder.projects.length === 0;
+            const folderWorkspaceIds = folder.projects.flatMap((project) =>
+              (project.workspaces ?? []).map((ws) => ws.id),
+            );
+            const folderActivity = aggregateWorkspaceActivity(folderWorkspaceIds, liveData);
+            const folderScriptRunning = aggregateScriptRunning(folderWorkspaceIds, liveData);
+
+            return (
+              <SidebarFolderItem
+                key={folder.id}
+                folder={folder}
+                expanded={expanded}
+                canInteract={hasInitialHydration}
+                isActiveDropTarget={isActiveDropTarget}
+                containsActiveProject={containsActiveProject}
+                isDraggedFolder={isDraggedFolder}
+                isRenaming={isRenaming}
+                isEmptyFolder={isEmptyFolder}
+                draggingFolderId={draggingFolderId}
+                folderInsertIndicator={folderInsertIndicator}
+                activityState={folderActivity}
+                scriptRunning={folderScriptRunning}
+                renameDraft={renameDraft}
+                onOpenChange={(open) => setFolderExpanded(folder.id, open)}
+                onFolderDragOver={handleFolderDragOver}
+                onFolderDrop={handleFolderDrop}
+                onFolderDragStart={handleFolderDragStart}
+                onFolderDragEnd={handleFolderDragEnd}
+                onFolderReorderDragOver={handleFolderReorderDragOver}
+                onFolderReorderDrop={handleFolderReorderDrop}
+                onStartRenaming={startRenamingFolder}
+                onDeleteRequest={(folderId, folderName) =>
+                  setDeleteFolderTarget({ id: folderId, name: folderName })
+                }
+                onRenameDraftChange={setRenameDraft}
+                onCommitRename={commitRenamingFolder}
+                onCancelRename={cancelRenamingFolder}
+                renderProjectItem={renderProjectItem}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {rootProjects.length > 0 && (
+        <div className={cn("space-y-px", folders.length > 0 && "mt-0.5")}>
+          {rootProjects.map((project) => renderProjectItem(project, null))}
+        </div>
+      )}
+    </>
+  );
+
+  const automationPanelContent = (
+    <>
+      <SidebarSectionHeader
+        label="Automations"
+        isLoading={automationsLoading}
+        onAdd={onAddAutomation}
+        addLabel="Add automation"
+      />
+
+      {automationsLoading ? (
+        <div className="mt-2 space-y-1.5">
+          <Skeleton className="h-12 w-full rounded-md" />
+          <Skeleton className="h-12 w-full rounded-md" />
+        </div>
+      ) : sortedAutomations.length === 0 ? (
+        <div className="mt-2 py-1">
+          <p className="text-xs text-muted-foreground/60">no automations</p>
+        </div>
+      ) : (
+        <div className="mt-2 space-y-1.5">
+          {sortedAutomations.map((auto) => (
+            <AutomationRow key={auto.id} auto={auto} pathname={pathname} />
+          ))}
+        </div>
+      )}
+    </>
+  );
   const deleteFolderTargetId = deleteFolderTarget?.id ?? null;
 
   return (
     <SidebarShell footerActions={footerActions}>
-      <ScrollArea className="flex-1 [&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full">
-        <div className="p-2">
-          {loading ? (
-            <div className="space-y-2 px-2">
-              <Skeleton className="h-6 w-full" />
-              <Skeleton className="h-6 w-3/4" />
-              <Skeleton className="h-6 w-full" />
-            </div>
-          ) : (
-            <TooltipProvider delayDuration={400}>
-              {(projectsUnavailable || projectsAppearIncomplete) && (
-                <div
-                  className="mb-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3"
-                  role="alert"
-                >
-                  <div className="flex items-start gap-2.5">
-                    {projectsRecovering ? (
-                      <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-amber-500" />
-                    ) : (
-                      <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
-                    )}
-                    <div className="min-w-0 flex-1">
-                      <p className="text-xs font-medium text-sidebar-foreground">
-                        {projectsAppearIncomplete
-                          ? "Repository list looks incomplete"
-                          : "Unable to load repositories"}
-                      </p>
-                      <p className="mt-1 text-xs text-muted-foreground">
-                        {projectsAppearIncomplete
-                          ? "Folders were restored, but the repository list is empty. Hive is retrying automatically."
-                          : `${projectsErrorMessage ?? "The repository list is unavailable."} Hive will keep retrying automatically.`}
-                      </p>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="xs"
-                        className="mt-3"
-                        onClick={() => { void retryProjects(); }}
-                        disabled={projectsRecovering}
-                      >
-                        {projectsRecovering && <Loader2 className="h-3 w-3 animate-spin" />}
-                        {projectsRecovering ? "Retrying..." : "Retry now"}
-                      </Button>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              <SidebarSectionHeader
-                label="Workspaces"
-                className="mb-1"
-                onAdd={() => {
-                  if (!hasInitialHydration) return;
-                  setIsCreatingFolder(true);
-                  setNewFolderName("");
-                }}
-                addLabel="New folder"
-                addDisabled={!hasInitialHydration}
-                addIcon={<FolderPlus className="h-4 w-4" />}
-                addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
-              />
-
-              <SidebarFolderComposer
-                isOpen={isCreatingFolder}
-                name={newFolderName}
-                onNameChange={setNewFolderName}
-                onSubmit={handleCreateFolder}
-                onCancel={resetFolderComposer}
-              />
-
-              {folders.length > 0 && (
-                <div className="space-y-px">
-                  {folders.map((folder) => {
-                    const expanded = isFolderExpanded(folder.id);
-                    const isActiveDropTarget =
-                      dropTarget?.type === "folder" && dropTarget.folderId === folder.id;
-                    const containsActiveProject = folder.projects.some((project) => project.id === activeProjectId);
-                    const isDraggedFolder = draggingFolderId === folder.id;
-                    const folderInsertIndicator = folderOrderDropTarget?.folderId === folder.id
-                      ? folderOrderDropTarget.position
-                      : null;
-
-                    const isRenaming = renamingFolderId === folder.id;
-                    const isEmptyFolder = folder.projects.length === 0;
-                    const folderWorkspaceIds = folder.projects.flatMap((project) =>
-                      (project.workspaces ?? []).map((ws) => ws.id),
-                    );
-                    const folderActivity = aggregateWorkspaceActivity(folderWorkspaceIds, liveData);
-                    const folderScriptRunning = aggregateScriptRunning(folderWorkspaceIds, liveData);
-
-                    return (
-                      <SidebarFolderItem
-                        key={folder.id}
-                        folder={folder}
-                        expanded={expanded}
-                        canInteract={hasInitialHydration}
-                        isActiveDropTarget={isActiveDropTarget}
-                        containsActiveProject={containsActiveProject}
-                        isDraggedFolder={isDraggedFolder}
-                        isRenaming={isRenaming}
-                        isEmptyFolder={isEmptyFolder}
-                        draggingFolderId={draggingFolderId}
-                        folderInsertIndicator={folderInsertIndicator}
-                        activityState={folderActivity}
-                        scriptRunning={folderScriptRunning}
-                        renameDraft={renameDraft}
-                        onOpenChange={(open) => setFolderExpanded(folder.id, open)}
-                        onFolderDragOver={handleFolderDragOver}
-                        onFolderDrop={handleFolderDrop}
-                        onFolderDragStart={handleFolderDragStart}
-                        onFolderDragEnd={handleFolderDragEnd}
-                        onFolderReorderDragOver={handleFolderReorderDragOver}
-                        onFolderReorderDrop={handleFolderReorderDrop}
-                        onStartRenaming={startRenamingFolder}
-                        onDeleteRequest={(folderId, folderName) =>
-                          setDeleteFolderTarget({ id: folderId, name: folderName })
-                        }
-                        onRenameDraftChange={setRenameDraft}
-                        onCommitRename={commitRenamingFolder}
-                        onCancelRename={cancelRenamingFolder}
-                        renderProjectItem={renderProjectItem}
-                      />
-                    );
-                  })}
-                </div>
-              )}
-
-              {rootProjects.length > 0 && (
-                <div className={cn("space-y-px", folders.length > 0 && "mt-0.5")}>
-                  {rootProjects.map((project) => renderProjectItem(project, null))}
-                </div>
-              )}
-
-              <div className="mt-4">
-                <div className="mb-3 border-t border-white/10" />
-                <SidebarSectionHeader
-                  label="Automations"
-                  isLoading={automationsLoading}
-                  onAdd={onAddAutomation}
-                  addLabel="Add automation"
-                />
-
-                {automationsLoading ? (
-                  <div className="mt-2 space-y-1.5">
-                    <Skeleton className="h-12 w-full rounded-md" />
-                    <Skeleton className="h-12 w-full rounded-md" />
-                  </div>
-                ) : sortedAutomations.length === 0 ? (
-                  <div className="mt-2 py-1">
-                    <p className="text-xs text-muted-foreground/60">no automations</p>
-                  </div>
-                ) : (
-                  <div className="mt-2 space-y-1.5">
-                    {sortedAutomations.map((auto) => (
-                      <AutomationRow key={auto.id} auto={auto} pathname={pathname} />
-                    ))}
-                  </div>
-                )}
-              </div>
-            </TooltipProvider>
-          )}
-        </div>
-      </ScrollArea>
-
-      {/* ── Bottom action ─────────────────────────────────────────── */}
-      <div className="shrink-0 px-2 pb-1.5">
-        <button
-          type="button"
-          className="flex w-full items-center justify-center gap-2 rounded-lg border border-dashed border-primary/40 px-2 py-2 text-sm text-primary transition-colors hover:border-primary hover:bg-primary/10"
-          onClick={onAddProject}
+      <TooltipProvider delayDuration={400}>
+        <Group
+          orientation="vertical"
+          defaultLayout={sidebarSectionsLayout}
+          onLayoutChanged={onSidebarSectionsLayoutChanged}
+          style={{ flex: 1, minHeight: 0, overflow: "hidden" }}
         >
-          <FolderPlus className="h-4 w-4 shrink-0" />
-          Add repository
-        </button>
-      </div>
+          <Panel id="workspaces" defaultSize="70%" minSize="25%" className="min-h-0 overflow-hidden">
+            <div className="flex h-full min-h-0 flex-col">
+              <SidebarPanelScroll className="min-h-0 flex-1">
+                {workspacePanelContent}
+              </SidebarPanelScroll>
+            </div>
+          </Panel>
+
+          <ResizeHandle orientation="horizontal" separator="after" />
+
+          <Panel id="automations" defaultSize="30%" minSize="15%" className="min-h-0 overflow-hidden">
+            <SidebarPanelScroll className="h-full">
+              {automationPanelContent}
+            </SidebarPanelScroll>
+          </Panel>
+        </Group>
+      </TooltipProvider>
 
       <AlertDialog
         open={deleteFolderTarget !== null}

--- a/frontend/src/components/WorkspacePathCopyButton.tsx
+++ b/frontend/src/components/WorkspacePathCopyButton.tsx
@@ -1,0 +1,49 @@
+import { CheckIcon, ClipboardIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { useClipboardCopy } from "@/hooks/useClipboardCopy";
+
+interface WorkspacePathCopyButtonProps {
+  path: string;
+  disabledReason: string;
+}
+
+export function WorkspacePathCopyButton({
+  path,
+  disabledReason,
+}: WorkspacePathCopyButtonProps) {
+  const { copy, isCopied } = useClipboardCopy();
+  const canCopy = path.length > 0;
+  const copied = canCopy && isCopied(path);
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="inline-flex">
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="size-5 text-muted-foreground/70 hover:text-foreground"
+              onClick={() => { if (canCopy) void copy(path); }}
+              disabled={!canCopy}
+              aria-label={copied ? "Workspace path copied" : "Copy workspace path"}
+            >
+              {copied ? (
+                <CheckIcon className="size-3 text-green-500" />
+              ) : (
+                <ClipboardIcon className="size-3" />
+              )}
+            </Button>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent
+          side="bottom"
+          className={path ? "max-w-[28rem] break-all font-mono text-xs" : undefined}
+        >
+          {copied ? "Path copied" : path || disabledReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/chat/CopyButton.tsx
+++ b/frontend/src/components/chat/CopyButton.tsx
@@ -1,8 +1,8 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import { ClipboardIcon, CheckIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { copyToClipboard } from "@/lib/clipboard";
+import { useClipboardCopy } from "@/hooks/useClipboardCopy";
 
 interface CopyButtonProps {
   content: string;
@@ -13,12 +13,11 @@ export const CopyButton = memo(function CopyButton({
   content,
   className,
 }: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, isCopied } = useClipboardCopy();
+  const copied = isCopied(content);
 
   const handleCopy = async () => {
-    await copyToClipboard(content);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    await copy(content);
   };
 
   return (

--- a/frontend/src/components/chat/PlanActionBar.tsx
+++ b/frontend/src/components/chat/PlanActionBar.tsx
@@ -1,7 +1,7 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import { ArrowRightLeftIcon, ClipboardIcon, CheckIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { copyToClipboard } from "@/lib/clipboard";
+import { useClipboardCopy } from "@/hooks/useClipboardCopy";
 
 interface PlanActionBarProps {
   planContent?: string;
@@ -16,13 +16,12 @@ export const PlanActionBar = memo(function PlanActionBar({
   onApprove,
   onHandOff,
 }: PlanActionBarProps) {
-  const [copied, setCopied] = useState(false);
+  const { copy, isCopied } = useClipboardCopy();
+  const copied = planContent ? isCopied(planContent) : false;
 
   const handleCopy = async () => {
     if (!planContent) return;
-    await copyToClipboard(planContent);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    await copy(planContent);
   };
 
   return (

--- a/frontend/src/components/diff/InlineDiffViewer.tsx
+++ b/frontend/src/components/diff/InlineDiffViewer.tsx
@@ -25,6 +25,7 @@ import { cn } from "@/lib/utils";
 import { nanoid } from "nanoid";
 import { useThemeType } from "@/hooks/useThemeType";
 import { useDiff } from "@/hooks/useDiff";
+import type { DiffScope } from "@/types";
 
 // ---------- Types ----------
 
@@ -263,6 +264,7 @@ export interface InlineDiffViewerHandle {
 interface InlineDiffViewerProps {
   wsId: string;
   filePath: string;
+  diffScope: DiffScope;
   diffStyle: "split" | "unified";
   onCommentCountChange: (count: number) => void;
   onPasteToPrompt: (formattedText: string) => void;
@@ -272,17 +274,25 @@ export const InlineDiffViewer = forwardRef<InlineDiffViewerHandle, InlineDiffVie
   function InlineDiffViewer({
     wsId,
     filePath,
+    diffScope,
     diffStyle,
     onCommentCountChange,
     onPasteToPrompt,
   }, ref) {
-  const { patchFiles, loading: isLoading, error } = useDiff(wsId, true);
+  const { patchFiles, loading: isLoading, error } = useDiff(wsId, diffScope, true);
   const themeType = useThemeType();
 
   const [comments, setComments] = useState<DiffComment[]>([]);
   const [selectedRange, setSelectedRange] = useState<SelectedLineRange | null>(null);
   const [activeFileName, setActiveFileName] = useState<string | null>(null);
   const [showCommentInput, setShowCommentInput] = useState(false);
+
+  useEffect(() => {
+    setComments([]);
+    setSelectedRange(null);
+    setActiveFileName(null);
+    setShowCommentInput(false);
+  }, [filePath, diffScope]);
 
   // Bubble comment count up to toolbar
   useEffect(() => {

--- a/frontend/src/components/diff/ModifiedFileList.tsx
+++ b/frontend/src/components/diff/ModifiedFileList.tsx
@@ -1,20 +1,23 @@
 import { cn } from "@/lib/utils";
-import type { DiffFileStat } from "@/types";
+import type { DiffFileStat, DiffScope } from "@/types";
 
 interface ModifiedFileListProps {
   committed: DiffFileStat[];
   uncommitted: DiffFileStat[];
-  onFileClick: (filePath: string) => void;
+  onFileClick: (filePath: string, scope: DiffScope) => void;
   activeFile?: string;
+  activeScope?: DiffScope;
 }
 
 function FileRow({
   stat,
+  scope,
   onFileClick,
   isActive,
 }: {
   stat: DiffFileStat;
-  onFileClick: (filePath: string) => void;
+  scope: DiffScope;
+  onFileClick: (filePath: string, scope: DiffScope) => void;
   isActive: boolean;
 }) {
   return (
@@ -25,7 +28,7 @@ function FileRow({
         "flex w-full items-center gap-2 rounded px-2 py-1 text-left text-xs font-mono hover:bg-muted/50",
         isActive && "bg-primary/10 ring-1 ring-primary/20",
       )}
-      onClick={() => onFileClick(stat.file)}
+      onClick={() => onFileClick(stat.file, scope)}
     >
       <span className="min-w-0 flex-1 truncate text-muted-foreground">
         {stat.file.includes("/") && stat.file.slice(0, stat.file.lastIndexOf("/") + 1)}
@@ -67,6 +70,7 @@ export function ModifiedFileList({
   uncommitted,
   onFileClick,
   activeFile,
+  activeScope,
 }: ModifiedFileListProps) {
   if (committed.length === 0 && uncommitted.length === 0) {
     return (
@@ -80,20 +84,32 @@ export function ModifiedFileList({
     <div>
       {uncommitted.length > 0 && (
         <div>
-          <SectionHeader label="Uncommitted" stats={uncommitted} />
+          <SectionHeader label="Working tree" stats={uncommitted} />
           <div className="space-y-0.5">
             {uncommitted.map((stat) => (
-              <FileRow key={stat.file} stat={stat} onFileClick={onFileClick} isActive={stat.file === activeFile} />
+              <FileRow
+                key={stat.file}
+                stat={stat}
+                scope="uncommitted"
+                onFileClick={onFileClick}
+                isActive={stat.file === activeFile && activeScope === "uncommitted"}
+              />
             ))}
           </div>
         </div>
       )}
       {committed.length > 0 && (
         <div className={uncommitted.length > 0 ? "mt-3" : ""}>
-          <SectionHeader label="Committed" stats={committed} />
+          <SectionHeader label="Branch commits" stats={committed} />
           <div className="space-y-0.5">
             {committed.map((stat) => (
-              <FileRow key={stat.file} stat={stat} onFileClick={onFileClick} isActive={stat.file === activeFile} />
+              <FileRow
+                key={stat.file}
+                stat={stat}
+                scope="committed"
+                onFileClick={onFileClick}
+                isActive={stat.file === activeFile && activeScope === "committed"}
+              />
             ))}
           </div>
         </div>

--- a/frontend/src/hooks/useClipboardCopy.ts
+++ b/frontend/src/hooks/useClipboardCopy.ts
@@ -1,0 +1,33 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { copyToClipboard } from "@/lib/clipboard";
+
+export function useClipboardCopy(resetDelayMs = 2000) {
+  const [copiedValue, setCopiedValue] = useState<string | null>(null);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearResetTimer = useCallback(() => {
+    if (!resetTimerRef.current) return;
+    clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = null;
+  }, []);
+
+  useEffect(() => clearResetTimer, [clearResetTimer]);
+
+  const copy = useCallback(async (value: string) => {
+    await copyToClipboard(value);
+    setCopiedValue(value);
+
+    clearResetTimer();
+    resetTimerRef.current = setTimeout(() => {
+      setCopiedValue((current) => (current === value ? null : current));
+      resetTimerRef.current = null;
+    }, resetDelayMs);
+  }, [clearResetTimer, resetDelayMs]);
+
+  const isCopied = useCallback(
+    (value: string) => copiedValue === value,
+    [copiedValue],
+  );
+
+  return { copiedValue, copy, isCopied };
+}

--- a/frontend/src/hooks/useDiff.ts
+++ b/frontend/src/hooks/useDiff.ts
@@ -1,19 +1,24 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { parsePatchFiles, type ParsedPatch } from "@pierre/diffs";
 import { api } from "./useApi";
+import type { DiffScope } from "@/types";
 
 interface DiffData {
   patchFiles: ParsedPatch[];
 }
 
-export function useDiff(wsId: string | undefined, enabled = false) {
+export function useDiff(
+  wsId: string | undefined,
+  diffScope: DiffScope = "combined",
+  enabled = false,
+) {
   const queryClient = useQueryClient();
 
   const query = useQuery({
-    queryKey: ["diff", wsId],
+    queryKey: ["diff", wsId, diffScope],
     queryFn: async (): Promise<DiffData> => {
       const { diff } = await api.get<{ diff: string }>(
-        `/api/workspaces/${wsId}/diff`,
+        `/api/workspaces/${wsId}/diff?scope=${diffScope}`,
       );
       return {
         patchFiles: diff ? parsePatchFiles(diff) : [],
@@ -29,6 +34,6 @@ export function useDiff(wsId: string | undefined, enabled = false) {
     loading: query.isLoading,
     error: query.error?.message ?? null,
     refresh: () =>
-      queryClient.invalidateQueries({ queryKey: ["diff", wsId] }),
+      queryClient.invalidateQueries({ queryKey: ["diff", wsId, diffScope] }),
   };
 }

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -94,10 +94,11 @@ export function useProjects() {
         : false,
     refetchIntervalInBackground: true,
   });
+  const { refetch } = query;
 
   const retryProjects = useCallback(
-    () => query.refetch(),
-    [query.refetch],
+    () => refetch(),
+    [refetch],
   );
 
   /** Shared logic: create project → optimistic cache → create workspace → rollback on error. */

--- a/frontend/src/hooks/useTabs.ts
+++ b/frontend/src/hooks/useTabs.ts
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { parseTabId, tabId, type TabId } from "../types";
+import { parseTabId, tabId, type DiffScope, type TabId } from "../types";
 
 export type FileViewMode = "source" | "diff";
 
@@ -7,11 +7,13 @@ export interface UseTabsReturn {
   activeTabId: TabId | null;
   openFile: string | null;
   fileViewMode: FileViewMode;
+  diffScope: DiffScope;
   isFileTabActive: boolean;
   activateTab: (id: TabId) => void;
   openFileTab: (path: string) => void;
-  openDiffTab: (path: string) => void;
+  openDiffTab: (path: string, scope?: DiffScope) => void;
   setFileViewMode: (mode: FileViewMode) => void;
+  setDiffScope: (scope: DiffScope) => void;
   closeFileTab: () => void;
 }
 
@@ -19,6 +21,7 @@ interface TabSnapshot {
   activeTabId: TabId | null;
   openFile: string | null;
   fileViewMode: FileViewMode;
+  diffScope: DiffScope;
 }
 
 /** Module-level cache: survives component remounts, lost on page refresh. */
@@ -34,7 +37,7 @@ export function useTabs(
   wsId: string | undefined,
 ): UseTabsReturn {
   const prevWsId = useRef(wsId);
-  const latestSnapshot = useRef<TabSnapshot>({ activeTabId: null, openFile: null, fileViewMode: "source" });
+  const latestSnapshot = useRef<TabSnapshot>({ activeTabId: null, openFile: null, fileViewMode: "source", diffScope: "uncommitted" });
   const latestWsId = useRef<string | undefined>(wsId);
 
   // Resolve initial state: restore from cache if available, else default.
@@ -51,6 +54,10 @@ export function useTabs(
     const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
     return cached?.fileViewMode ?? "source";
   });
+  const [diffScope, setDiffScope] = useState<DiffScope>(() => {
+    const cached = wsId ? snapshotByWorkspace.get(wsId) : undefined;
+    return cached?.diffScope ?? "uncommitted";
+  });
 
   // On workspace switch: save outgoing state, restore incoming state.
   useEffect(() => {
@@ -58,7 +65,7 @@ export function useTabs(
 
     // Save outgoing workspace state.
     if (prevWsId.current) {
-      snapshotByWorkspace.set(prevWsId.current, { activeTabId, openFile, fileViewMode });
+      snapshotByWorkspace.set(prevWsId.current, { activeTabId, openFile, fileViewMode, diffScope });
     }
     prevWsId.current = wsId;
 
@@ -68,10 +75,12 @@ export function useTabs(
       setActiveTabId(cached.activeTabId);
       setOpenFile(cached.openFile);
       setFileViewMode(cached.fileViewMode);
+      setDiffScope(cached.diffScope ?? "uncommitted");
     } else {
       setActiveTabId(null);
       setOpenFile(null);
       setFileViewMode("source");
+      setDiffScope("uncommitted");
     }
   }, [wsId]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -97,22 +106,24 @@ export function useTabs(
     setActiveTabId(tabId({ type: "file", path }));
   }, []);
 
-  const openDiffTab = useCallback((path: string) => {
+  const openDiffTab = useCallback((path: string, scope: DiffScope = "uncommitted") => {
     setOpenFile(path);
     setFileViewMode("diff");
+    setDiffScope(scope);
     setActiveTabId(tabId({ type: "file", path }));
   }, []);
 
   const closeFileTab = useCallback(() => {
     setOpenFile(null);
     setFileViewMode("source");
+    setDiffScope("uncommitted");
     setActiveTabId(currentSessionId ? tabId({ type: "session", sessionId: currentSessionId }) : null);
   }, [currentSessionId]);
 
   useEffect(() => {
-    latestSnapshot.current = { activeTabId, openFile, fileViewMode };
+    latestSnapshot.current = { activeTabId, openFile, fileViewMode, diffScope };
     latestWsId.current = wsId;
-  }, [activeTabId, openFile, fileViewMode, wsId]);
+  }, [activeTabId, openFile, fileViewMode, diffScope, wsId]);
 
   // Preserve current workspace tab state across unmount/remount cycles.
   useEffect(() => {
@@ -128,11 +139,13 @@ export function useTabs(
     activeTabId,
     openFile,
     fileViewMode,
+    diffScope,
     isFileTabActive,
     activateTab,
     openFileTab,
     openDiffTab,
     setFileViewMode,
+    setDiffScope,
     closeFileTab,
   };
 }

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Group, Panel, useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { ChevronDownIcon, TerminalIcon } from "lucide-react";
+import { CheckIcon, ChevronDownIcon, ClipboardIcon, TerminalIcon } from "lucide-react";
 import { VscodeIcon, Iterm2Icon } from "@/components/icons/software-icons";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
@@ -45,6 +45,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTerminalApps } from "@/hooks/useTerminalApps";
 import { openTerminalSsh } from "@/lib/terminal";
+import { copyToClipboard } from "@/lib/clipboard";
 import { useLayoutContext } from "@/components/AppLayout";
 import { ResizeHandle } from "@/components/ResizeHandle";
 import { cn } from "@/lib/utils";
@@ -119,6 +120,7 @@ export default function WorkspaceView() {
   });
 
   const workspace = workspaceQuery.data ?? null;
+  const workspacePath = workspace?.worktreePath?.trim() ?? "";
   const fileTree = useMemo(() => filesQuery.data ?? [], [filesQuery.data]);
   const fileTreeError = filesQuery.error?.message ?? null;
   const initialDiffStats = diffStatQuery.data ?? null;
@@ -160,6 +162,26 @@ export default function WorkspaceView() {
       : null;
   const canOpenVscode = vscodeUri !== null;
   const canSsh = !!sshHost && !!workspace?.worktreePath;
+  const canCopyWorkspacePath = workspacePath.length > 0;
+  const copyWorkspacePathDisabledReason = "Workspace path unavailable. Restart backend and reload this workspace.";
+  const [copiedWorkspacePath, setCopiedWorkspacePath] = useState<string | null>(null);
+  const copyWorkspacePathResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const workspacePathCopied = canCopyWorkspacePath && copiedWorkspacePath === workspacePath;
+
+  const handleCopyWorkspacePath = useCallback(async () => {
+    if (!workspacePath) return;
+
+    await copyToClipboard(workspacePath);
+    setCopiedWorkspacePath(workspacePath);
+
+    if (copyWorkspacePathResetRef.current) {
+      clearTimeout(copyWorkspacePathResetRef.current);
+    }
+    copyWorkspacePathResetRef.current = setTimeout(() => {
+      setCopiedWorkspacePath((current) => (current === workspacePath ? null : current));
+      copyWorkspacePathResetRef.current = null;
+    }, 2000);
+  }, [workspacePath]);
 
   // Diff stats from WebSocket polling
   const diffCommitted = useMemo(
@@ -521,9 +543,41 @@ export default function WorkspaceView() {
             {displayBranch && (
               <BranchLabel branch={displayBranch} showIcon={false} className="text-xs text-muted-foreground" />
             )}
-            {workspace?.defaultBranch && (
-              <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
-            )}
+            <div className="flex min-w-0 items-center gap-1">
+              {workspace?.defaultBranch && (
+                <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
+              )}
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <Button
+                        variant="ghost"
+                        size="icon-xs"
+                        className="size-5 text-muted-foreground/70 hover:text-foreground"
+                        onClick={handleCopyWorkspacePath}
+                        disabled={!canCopyWorkspacePath}
+                        aria-label={workspacePathCopied ? "Workspace path copied" : "Copy workspace path"}
+                      >
+                        {workspacePathCopied ? (
+                          <CheckIcon className="size-3 text-green-500" />
+                        ) : (
+                          <ClipboardIcon className="size-3" />
+                        )}
+                      </Button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent
+                    side="bottom"
+                    className={workspacePath ? "max-w-[28rem] break-all font-mono text-xs" : undefined}
+                  >
+                    {workspacePathCopied
+                      ? "Path copied"
+                      : workspacePath || copyWorkspacePathDisabledReason}
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            </div>
             <div className="ml-auto" />
             {terminalApps.length > 0 ? (
               <DropdownMenu>

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -54,7 +54,7 @@ import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent }
 import { PlanActionBar } from "@/components/chat/PlanActionBar";
 import { useScripts } from "@/hooks/useScripts";
 import { useTabs } from "@/hooks/useTabs";
-import type { DiffStatResponse, FileMention, ImageAttachment, MessageOptions, QueuedMessage, Workspace, WorkspaceFileTreeNode } from "@/types";
+import type { DiffFileStat, DiffScope, DiffStatResponse, FileMention, ImageAttachment, MessageOptions, QueuedMessage, Workspace, WorkspaceFileTreeNode } from "@/types";
 
 const DEFAULT_EXPANDED = new Set<string>();
 
@@ -78,6 +78,10 @@ function buildInitialExpanded(nodes: WorkspaceFileTreeNode[]): Set<string> {
     expanded.add(firstDirectory.path);
   }
   return expanded;
+}
+
+function matchesDiffStat(filePath: string | null | undefined, stat: DiffFileStat): boolean {
+  return !!filePath && (stat.file === filePath || filePath.endsWith(`/${stat.file}`));
 }
 
 function renderFileTreeNodes(nodes: WorkspaceFileTreeNode[]) {
@@ -235,11 +239,13 @@ export default function WorkspaceView() {
   const {
     openFile,
     fileViewMode,
+    diffScope,
     isFileTabActive,
     activateTab,
     openFileTab,
     openDiffTab,
     setFileViewMode,
+    setDiffScope,
     closeFileTab,
   } = useTabs(sessionId, wsId);
 
@@ -399,9 +405,9 @@ export default function WorkspaceView() {
     openFileTab(path);
   }, [openFileTab]);
 
-  const handleModifiedFileClick = useCallback((filePath: string) => {
+  const handleModifiedFileClick = useCallback((filePath: string, scope: DiffScope) => {
     setSelectedPath(filePath);
-    openDiffTab(filePath);
+    openDiffTab(filePath, scope);
     setSidebarTab("modified");
   }, [openDiffTab]);
 
@@ -469,12 +475,37 @@ export default function WorkspaceView() {
   }, []);
   const [diffCommentCount, setDiffCommentCount] = useState(0);
 
-  const isFileModified = useMemo(() => {
-    if (!openFile) return false;
-    return [...diffCommitted, ...diffUncommitted].some(
-      (s) => s.file === openFile || openFile.endsWith(`/${s.file}`),
-    );
-  }, [openFile, diffCommitted, diffUncommitted]);
+  const fileHasUncommittedChanges = useMemo(
+    () => diffUncommitted.some((stat) => matchesDiffStat(openFile, stat)),
+    [openFile, diffUncommitted],
+  );
+  const fileHasCommittedChanges = useMemo(
+    () => diffCommitted.some((stat) => matchesDiffStat(openFile, stat)),
+    [openFile, diffCommitted],
+  );
+  const isFileModified = fileHasUncommittedChanges || fileHasCommittedChanges;
+  const availableDiffScopes = useMemo<DiffScope[]>(() => {
+    const scopes: DiffScope[] = [];
+    if (fileHasUncommittedChanges) scopes.push("uncommitted");
+    if (fileHasCommittedChanges) scopes.push("committed");
+    if (fileHasUncommittedChanges && fileHasCommittedChanges) scopes.push("combined");
+    return scopes;
+  }, [fileHasCommittedChanges, fileHasUncommittedChanges]);
+  const defaultDiffScope: DiffScope = fileHasUncommittedChanges ? "uncommitted" : "committed";
+
+  useEffect(() => {
+    if (fileViewMode !== "diff" || availableDiffScopes.length === 0) return;
+    if (!availableDiffScopes.includes(diffScope)) {
+      setDiffScope(defaultDiffScope);
+    }
+  }, [availableDiffScopes, defaultDiffScope, diffScope, fileViewMode, setDiffScope]);
+
+  const handleFileViewModeChange = useCallback((mode: "source" | "diff") => {
+    if (mode === "diff" && availableDiffScopes.length > 0 && !availableDiffScopes.includes(diffScope)) {
+      setDiffScope(defaultDiffScope);
+    }
+    setFileViewMode(mode);
+  }, [availableDiffScopes, defaultDiffScope, diffScope, setDiffScope, setFileViewMode]);
 
   const handlePasteToPrompt = useCallback(() => {
     diffViewerRef.current?.pasteToPrompt();
@@ -684,8 +715,11 @@ export default function WorkspaceView() {
               <FileContentToolbar
                 filePath={openFile}
                 mode={fileViewMode}
-                onModeChange={setFileViewMode}
+                onModeChange={handleFileViewModeChange}
                 isModified={isFileModified}
+                diffScope={diffScope}
+                availableDiffScopes={availableDiffScopes}
+                onDiffScopeChange={setDiffScope}
                 diffStyle={diffStyle}
                 onDiffStyleChange={handleDiffStyleChange}
                 commentCount={diffCommentCount}
@@ -698,6 +732,7 @@ export default function WorkspaceView() {
                   ref={diffViewerRef}
                   wsId={wsId}
                   filePath={openFile}
+                  diffScope={diffScope}
                   diffStyle={diffStyle}
                   onCommentCountChange={setDiffCommentCount}
                   onPasteToPrompt={handleDiffPasteText}
@@ -766,6 +801,7 @@ export default function WorkspaceView() {
                       uncommitted={diffUncommitted}
                       onFileClick={handleModifiedFileClick}
                       activeFile={isFileTabActive && fileViewMode === "diff" ? openFile ?? undefined : undefined}
+                      activeScope={isFileTabActive && fileViewMode === "diff" ? diffScope : undefined}
                     />
                   )}
                   {sidebarTab === "all" && fileTreeError && (

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Navigate, useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Group, Panel, useDefaultLayout, usePanelRef } from "react-resizable-panels";
-import { CheckIcon, ChevronDownIcon, ClipboardIcon, TerminalIcon } from "lucide-react";
+import { ChevronDownIcon, TerminalIcon } from "lucide-react";
 import { VscodeIcon, Iterm2Icon } from "@/components/icons/software-icons";
 import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
@@ -45,9 +45,9 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useTerminalApps } from "@/hooks/useTerminalApps";
 import { openTerminalSsh } from "@/lib/terminal";
-import { copyToClipboard } from "@/lib/clipboard";
 import { useLayoutContext } from "@/components/AppLayout";
 import { ResizeHandle } from "@/components/ResizeHandle";
+import { WorkspacePathCopyButton } from "@/components/WorkspacePathCopyButton";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent } from "@/lib/plan-state";
@@ -162,26 +162,7 @@ export default function WorkspaceView() {
       : null;
   const canOpenVscode = vscodeUri !== null;
   const canSsh = !!sshHost && !!workspace?.worktreePath;
-  const canCopyWorkspacePath = workspacePath.length > 0;
   const copyWorkspacePathDisabledReason = "Workspace path unavailable. Restart backend and reload this workspace.";
-  const [copiedWorkspacePath, setCopiedWorkspacePath] = useState<string | null>(null);
-  const copyWorkspacePathResetRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const workspacePathCopied = canCopyWorkspacePath && copiedWorkspacePath === workspacePath;
-
-  const handleCopyWorkspacePath = useCallback(async () => {
-    if (!workspacePath) return;
-
-    await copyToClipboard(workspacePath);
-    setCopiedWorkspacePath(workspacePath);
-
-    if (copyWorkspacePathResetRef.current) {
-      clearTimeout(copyWorkspacePathResetRef.current);
-    }
-    copyWorkspacePathResetRef.current = setTimeout(() => {
-      setCopiedWorkspacePath((current) => (current === workspacePath ? null : current));
-      copyWorkspacePathResetRef.current = null;
-    }, 2000);
-  }, [workspacePath]);
 
   // Diff stats from WebSocket polling
   const diffCommitted = useMemo(
@@ -547,36 +528,10 @@ export default function WorkspaceView() {
               {workspace?.defaultBranch && (
                 <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
               )}
-              <TooltipProvider>
-                <Tooltip>
-                  <TooltipTrigger asChild>
-                    <span className="inline-flex">
-                      <Button
-                        variant="ghost"
-                        size="icon-xs"
-                        className="size-5 text-muted-foreground/70 hover:text-foreground"
-                        onClick={handleCopyWorkspacePath}
-                        disabled={!canCopyWorkspacePath}
-                        aria-label={workspacePathCopied ? "Workspace path copied" : "Copy workspace path"}
-                      >
-                        {workspacePathCopied ? (
-                          <CheckIcon className="size-3 text-green-500" />
-                        ) : (
-                          <ClipboardIcon className="size-3" />
-                        )}
-                      </Button>
-                    </span>
-                  </TooltipTrigger>
-                  <TooltipContent
-                    side="bottom"
-                    className={workspacePath ? "max-w-[28rem] break-all font-mono text-xs" : undefined}
-                  >
-                    {workspacePathCopied
-                      ? "Path copied"
-                      : workspacePath || copyWorkspacePathDisabledReason}
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
+              <WorkspacePathCopyButton
+                path={workspacePath}
+                disabledReason={copyWorkspacePathDisabledReason}
+              />
             </div>
             <div className="ml-auto" />
             {terminalApps.length > 0 ? (

--- a/frontend/src/pages/settings/AccountSettings.tsx
+++ b/frontend/src/pages/settings/AccountSettings.tsx
@@ -5,7 +5,7 @@ import { SettingsHeader } from "@/components/AppLayout";
 import { cn } from "@/lib/utils";
 import { api } from "@/hooks/useApi";
 import { openExternal } from "@/lib/open-external";
-import { copyToClipboard } from "@/lib/clipboard";
+import { useClipboardCopy } from "@/hooks/useClipboardCopy";
 
 interface GitHubUser {
   login: string;
@@ -45,7 +45,7 @@ export default function AccountSettings() {
   const queryClient = useQueryClient();
   const [state, setState] = useState<PageState>({ kind: "loading" });
   const [disconnecting, setDisconnecting] = useState(false);
-  const [copied, setCopied] = useState(false);
+  const { copy, isCopied } = useClipboardCopy();
   const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pollInterval = useRef(5);
 
@@ -150,9 +150,7 @@ export default function AccountSettings() {
   };
 
   const handleCopyCode = async (code: string) => {
-    await copyToClipboard(code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    await copy(code);
   };
 
   const handleRetry = () => {
@@ -231,14 +229,14 @@ export default function AccountSettings() {
                 <button
                   type="button"
                   onClick={() => void handleCopyCode(state.userCode)}
-                  aria-label={copied ? "Code copied" : "Copy code to clipboard"}
+                  aria-label={isCopied(state.userCode) ? "Code copied" : "Copy code to clipboard"}
                   className="mt-4 group inline-flex cursor-pointer items-center gap-3 rounded-lg border border-border bg-muted/50 px-5 py-2.5 transition-colors hover:bg-muted/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                 >
                   <code className="font-mono text-lg font-bold tracking-widest">
                     {state.userCode}
                   </code>
                   <span className="text-muted-foreground transition-colors group-hover:text-foreground">
-                    {copied
+                    {isCopied(state.userCode)
                       ? <Check className="h-4 w-4 text-emerald-500" />
                       : <Copy className="h-4 w-4" />}
                   </span>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -225,6 +225,7 @@ export interface WorkspaceScriptsResponse {
 // ── Diff types ───────────────────────────────────────────────────────
 
 export type DiffFileStatus = "added" | "modified" | "deleted" | "renamed";
+export type DiffScope = "combined" | "committed" | "uncommitted";
 
 export interface DiffFileStat {
   file: string;

--- a/frontend/tests/components/FileContentToolbar.test.tsx
+++ b/frontend/tests/components/FileContentToolbar.test.tsx
@@ -6,6 +6,7 @@ import { FileContentToolbar } from "@/components/FileContentToolbar";
 
 function renderToolbar(overrides?: Partial<ComponentProps<typeof FileContentToolbar>>) {
   const onModeChange = overrides?.onModeChange ?? vi.fn();
+  const onDiffScopeChange = overrides?.onDiffScopeChange ?? vi.fn();
   const onDiffStyleChange = overrides?.onDiffStyleChange ?? vi.fn();
   const onPasteToPrompt = overrides?.onPasteToPrompt ?? vi.fn();
 
@@ -15,6 +16,9 @@ function renderToolbar(overrides?: Partial<ComponentProps<typeof FileContentTool
       mode="source"
       onModeChange={onModeChange}
       isModified
+      diffScope="uncommitted"
+      availableDiffScopes={["uncommitted"]}
+      onDiffScopeChange={onDiffScopeChange}
       diffStyle="unified"
       onDiffStyleChange={onDiffStyleChange}
       commentCount={0}
@@ -23,7 +27,7 @@ function renderToolbar(overrides?: Partial<ComponentProps<typeof FileContentTool
     />,
   );
 
-  return { onModeChange, onDiffStyleChange, onPasteToPrompt };
+  return { onModeChange, onDiffScopeChange, onDiffStyleChange, onPasteToPrompt };
 }
 
 describe("FileContentToolbar", () => {
@@ -69,6 +73,21 @@ describe("FileContentToolbar", () => {
     expect(onDiffStyleChange).toHaveBeenNthCalledWith(1, "split");
     expect(onDiffStyleChange).toHaveBeenNthCalledWith(2, "unified");
     expect(screen.queryByRole("button", { name: /Paste to prompt/i })).not.toBeInTheDocument();
+  });
+
+  it("shows scope controls when more than one diff scope is available", async () => {
+    const user = userEvent.setup();
+    const { onDiffScopeChange } = renderToolbar({
+      mode: "diff",
+      diffScope: "uncommitted",
+      availableDiffScopes: ["uncommitted", "committed", "combined"],
+    });
+
+    await user.click(screen.getByRole("button", { name: "Branch commits" }));
+    await user.click(screen.getByRole("button", { name: "Combined" }));
+
+    expect(onDiffScopeChange).toHaveBeenNthCalledWith(1, "committed");
+    expect(onDiffScopeChange).toHaveBeenNthCalledWith(2, "combined");
   });
 
   it("shows paste button when comments exist and triggers callback", async () => {

--- a/frontend/tests/components/InlineDiffViewer.test.tsx
+++ b/frontend/tests/components/InlineDiffViewer.test.tsx
@@ -107,6 +107,7 @@ function renderViewer(
     <InlineDiffViewer
       wsId="ws-1"
       filePath="src/a.ts"
+      diffScope="uncommitted"
       diffStyle="unified"
       onCommentCountChange={onCommentCountChange}
       onPasteToPrompt={onPasteToPrompt}
@@ -201,6 +202,7 @@ describe("InlineDiffViewer", () => {
         ref={ref}
         wsId="ws-1"
         filePath="src/a.ts"
+        diffScope="uncommitted"
         diffStyle="unified"
         onCommentCountChange={onCommentCountChange}
         onPasteToPrompt={onPasteToPrompt}

--- a/frontend/tests/components/ModifiedFileList.test.tsx
+++ b/frontend/tests/components/ModifiedFileList.test.tsx
@@ -57,8 +57,8 @@ describe("ModifiedFileList", () => {
       />,
     );
 
-    expect(screen.getByText("Uncommitted")).toBeInTheDocument();
-    expect(screen.getByText("Committed")).toBeInTheDocument();
+    expect(screen.getByText("Working tree")).toBeInTheDocument();
+    expect(screen.getByText("Branch commits")).toBeInTheDocument();
     expect(screen.getByText("new-file.ts")).toBeInTheDocument();
     expect(screen.getByText("removed-file.ts")).toBeInTheDocument();
     expect(screen.getByText("committed.ts")).toBeInTheDocument();
@@ -66,7 +66,7 @@ describe("ModifiedFileList", () => {
     expect(screen.getAllByText("-2").length).toBeGreaterThan(0);
 
     await user.click(screen.getByRole("button", { name: /new-file\.ts/i }));
-    expect(onFileClick).toHaveBeenCalledWith("src/new-file.ts");
+    expect(onFileClick).toHaveBeenCalledWith("src/new-file.ts", "uncommitted");
   });
 
   it("highlights the active file row", () => {
@@ -79,6 +79,7 @@ describe("ModifiedFileList", () => {
         ]}
         onFileClick={() => {}}
         activeFile="src/a.ts"
+        activeScope="uncommitted"
       />,
     );
 
@@ -86,5 +87,21 @@ describe("ModifiedFileList", () => {
     const bBtn = screen.getByRole("button", { name: /b\.ts/i });
     expect(aBtn.className).toContain("ring");
     expect(bBtn.className).not.toContain("ring");
+  });
+
+  it("only highlights the active scope when a file appears in both sections", () => {
+    render(
+      <ModifiedFileList
+        committed={[stat({ file: "src/a.ts", additions: 3 })]}
+        uncommitted={[stat({ file: "src/a.ts", additions: 1 })]}
+        onFileClick={() => {}}
+        activeFile="src/a.ts"
+        activeScope="committed"
+      />,
+    );
+
+    const rows = screen.getAllByRole("button", { name: /a\.ts/i });
+    expect(rows[0].className).not.toContain("ring");
+    expect(rows[1].className).toContain("ring");
   });
 });

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -26,6 +26,20 @@ vi.mock("@/hooks/useApi", () => ({
   },
 }));
 
+vi.mock("react-resizable-panels", () => {
+  const React = require("react");
+
+  return {
+    Group: ({ children, style, className }: any) =>
+      React.createElement("div", { style, className, "data-testid": "sidebar-sections-group" }, children),
+    Panel: ({ children, style, className, id }: any) =>
+      React.createElement("div", { style, className, "data-testid": id ? `panel-${id}` : "panel" }, children),
+    Separator: ({ className }: any) =>
+      React.createElement("div", { className, "data-testid": "panel-separator", role: "separator" }),
+    useDefaultLayout: () => ({ defaultLayout: undefined, onLayoutChanged: () => {} }),
+  };
+});
+
 vi.mock("@/lib/ws-transport", () => {
   const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
 
@@ -1507,6 +1521,20 @@ describe("Sidebar", () => {
     });
   });
 
+  it("keeps add repository compact in the footer next to settings", async () => {
+    renderSidebar("/workspaces/w1", projects);
+
+    await screen.findByText("workspace/tokyo");
+
+    const addRepository = screen.getByRole("button", { name: "Add repository" });
+    const settings = screen.getByRole("link", { name: "Settings" });
+
+    expect(addRepository.parentElement).toBe(settings.parentElement);
+    expect(addRepository.parentElement).toHaveClass("justify-between");
+    expect(addRepository).toHaveClass("text-xs");
+    expect(addRepository).not.toHaveClass("border");
+  });
+
   it("shows PR loading text while bulk status is in flight", async () => {
     let resolve!: (value: unknown) => void;
     const pending = new Promise((res) => {
@@ -1600,6 +1628,14 @@ describe("Sidebar", () => {
   it("shows 'Automations' section header", async () => {
     renderSidebar("/home", projects);
     expect(await screen.findByText("Automations")).toBeInTheDocument();
+  });
+
+  it("renders workspaces and automations in split panels", async () => {
+    renderSidebar("/home", projects);
+
+    expect(await screen.findByTestId("panel-workspaces")).toBeInTheDocument();
+    expect(screen.getByTestId("panel-automations")).toBeInTheDocument();
+    expect(screen.getByRole("separator")).toBeInTheDocument();
   });
 
   it("shows automation empty state when no automations exist", async () => {

--- a/frontend/tests/hooks/useDiff.test.tsx
+++ b/frontend/tests/hooks/useDiff.test.tsx
@@ -35,7 +35,7 @@ describe("useDiff", () => {
 
   it("does nothing when enabled is false", async () => {
     const { wrapper } = createWrapper();
-    const { result } = renderHook(() => useDiff("ws-1", false), { wrapper });
+    const { result } = renderHook(() => useDiff("ws-1", "combined", false), { wrapper });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -51,13 +51,13 @@ describe("useDiff", () => {
     vi.mocked(parsePatchFiles).mockReturnValueOnce(parsed);
     const { wrapper } = createWrapper();
 
-    const { result } = renderHook(() => useDiff("ws-1", true), { wrapper });
+    const { result } = renderHook(() => useDiff("ws-1", "uncommitted", true), { wrapper });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
     });
 
-    expect(api.get).toHaveBeenCalledWith("/api/workspaces/ws-1/diff");
+    expect(api.get).toHaveBeenCalledWith("/api/workspaces/ws-1/diff?scope=uncommitted");
     expect(parsePatchFiles).toHaveBeenCalledWith("patch-content");
     expect(result.current.patchFiles).toBe(parsed);
     expect(result.current.error).toBeNull();
@@ -68,7 +68,7 @@ describe("useDiff", () => {
     vi.mocked(api.get).mockResolvedValueOnce({ diff: "" });
     const { wrapper } = createWrapper();
 
-    const { result } = renderHook(() => useDiff("ws-1", true), { wrapper });
+    const { result } = renderHook(() => useDiff("ws-1", "combined", true), { wrapper });
 
     await waitFor(() => {
       expect(result.current.loading).toBe(false);
@@ -82,7 +82,7 @@ describe("useDiff", () => {
     vi.mocked(api.get).mockRejectedValueOnce(new Error("boom"));
     const { wrapper } = createWrapper();
 
-    const { result } = renderHook(() => useDiff("ws-1", true), { wrapper });
+    const { result } = renderHook(() => useDiff("ws-1", "combined", true), { wrapper });
 
     await waitFor(() => {
       expect(result.current.error).toBe("boom");
@@ -98,7 +98,7 @@ describe("useDiff", () => {
     });
     const { wrapper } = createWrapper();
 
-    const { result } = renderHook(() => useDiff("ws-1", true), { wrapper });
+    const { result } = renderHook(() => useDiff("ws-1", "combined", true), { wrapper });
 
     await waitFor(() => {
       expect(result.current.error).toBe("invalid patch");

--- a/frontend/tests/hooks/useTabs.test.ts
+++ b/frontend/tests/hooks/useTabs.test.ts
@@ -106,10 +106,11 @@ describe("useTabs", () => {
 
   it("openDiffTab sets mode to diff", () => {
     const { result } = renderHook(() => useTabs("s1", "ws1"));
-    act(() => result.current.openDiffTab("a.ts"));
+    act(() => result.current.openDiffTab("a.ts", "committed"));
     expect(result.current.activeTabId).toBe("file:a.ts");
     expect(result.current.openFile).toBe("a.ts");
     expect(result.current.fileViewMode).toBe("diff");
+    expect(result.current.diffScope).toBe("committed");
     expect(result.current.isFileTabActive).toBe(true);
   });
 
@@ -124,10 +125,19 @@ describe("useTabs", () => {
 
   it("closeFileTab resets fileViewMode to source", () => {
     const { result } = renderHook(() => useTabs("s1", "ws1"));
-    act(() => result.current.openDiffTab("a.ts"));
+    act(() => result.current.openDiffTab("a.ts", "committed"));
     expect(result.current.fileViewMode).toBe("diff");
     act(() => result.current.closeFileTab());
     expect(result.current.fileViewMode).toBe("source");
+    expect(result.current.diffScope).toBe("uncommitted");
+  });
+
+  it("setDiffScope updates the active diff scope", () => {
+    const { result } = renderHook(() => useTabs("s1", "ws1"));
+    act(() => result.current.openDiffTab("a.ts"));
+    expect(result.current.diffScope).toBe("uncommitted");
+    act(() => result.current.setDiffScope("combined"));
+    expect(result.current.diffScope).toBe("combined");
   });
 
   // ---- workspace switch persistence ----
@@ -189,8 +199,9 @@ describe("useTabs", () => {
       ({ sid, ws }) => useTabs(sid, ws),
       { initialProps: { sid: "s1", ws: "ws1" } },
     );
-    act(() => result.current.openDiffTab("a.ts"));
+    act(() => result.current.openDiffTab("a.ts", "committed"));
     expect(result.current.fileViewMode).toBe("diff");
+    expect(result.current.diffScope).toBe("committed");
 
     // Switch to ws2
     rerender({ sid: "s3", ws: "ws2" });
@@ -199,6 +210,7 @@ describe("useTabs", () => {
     // Switch back to ws1
     rerender({ sid: "s1", ws: "ws1" });
     expect(result.current.fileViewMode).toBe("diff");
+    expect(result.current.diffScope).toBe("committed");
     expect(result.current.openFile).toBe("a.ts");
   });
 

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -49,6 +49,7 @@ const mocks = vi.hoisted(() => ({
   openExternal: vi.fn(),
   useTerminalApps: vi.fn().mockReturnValue([]),
   openTerminalSsh: vi.fn(),
+  copyToClipboard: vi.fn(),
   captureConversationTabsProps: vi.fn(),
 }));
 
@@ -90,6 +91,10 @@ vi.mock("@/hooks/useTerminalApps", () => ({
 
 vi.mock("@/lib/terminal", () => ({
   openTerminalSsh: mocks.openTerminalSsh,
+}));
+
+vi.mock("@/lib/clipboard", () => ({
+  copyToClipboard: mocks.copyToClipboard,
 }));
 
 // react-resizable-panels needs real DOM layout (getBoundingClientRect, ResizeObserver)
@@ -375,6 +380,8 @@ beforeEach(() => {
   mocks.useTerminalApps.mockReset();
   mocks.useTerminalApps.mockReturnValue([]);
   mocks.openTerminalSsh.mockReset();
+  mocks.copyToClipboard.mockReset();
+  mocks.copyToClipboard.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -439,6 +446,38 @@ describe("WorkspaceView behavior", () => {
 
     await screen.findByText("tokyo");
     expect(screen.getByRole("button", { name: "VS Code" })).toBeDisabled();
+  });
+
+  it("disables workspace path copy button when workspace path is unavailable", async () => {
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    expect(screen.getByRole("button", { name: "Copy workspace path" })).toBeDisabled();
+  });
+
+  it("copies the workspace path from the header", async () => {
+    const user = userEvent.setup();
+
+    mocks.apiGet.mockImplementation(async (url: string) => {
+      const workspaceMatch = url.match(/^\/api\/workspaces\/([^/]+)$/);
+      const filesMatch = url.match(/^\/api\/workspaces\/([^/]+)\/files$/);
+      const diffStatsMatch = url.match(/^\/api\/workspaces\/([^/]+)\/diff\/stat$/);
+      if (workspaceMatch) {
+        const workspace = WORKSPACES[workspaceMatch[1]];
+        return workspace ? { ...workspace, worktreePath: "/srv/hive/tokyo" } : null;
+      }
+      if (filesMatch) return FILE_TREE;
+      if (diffStatsMatch) return DIFF_STATS;
+      throw new Error(`Unexpected URL: ${url}`);
+    });
+
+    renderWorkspace();
+
+    await screen.findByText("tokyo");
+    await user.click(screen.getByRole("button", { name: "Copy workspace path" }));
+
+    expect(mocks.copyToClipboard).toHaveBeenCalledWith("/srv/hive/tokyo");
+    expect(screen.getByRole("button", { name: "Workspace path copied" })).toBeInTheDocument();
   });
 
   it("opens VS Code URI with tailscale host and SSH user when configured", async () => {


### PR DESCRIPTION
## Summary
- Add a compact header action to copy the current workspace path
- Show copied feedback and disable the action when the path is unavailable
- Cover the new behavior in WorkspaceView tests

## Tests
- npm --prefix frontend test -- WorkspaceView.test.tsx
- npm --prefix frontend run typecheck
- npx eslint src/pages/WorkspaceView.tsx
- git diff --check