### PR TITLE
Add project environment management

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It manages:
 - Notification settings (Telegram + APNs, instant-apply toggles, test message).
 - Agent settings (installed providers, versions, update availability).
 - Prompt settings (base prompt editor, template library, prompt flow explainer).
-- Per-repository detail view with deletion controls.
+- Per-repository detail view with deletion controls and CodeMirror-powered project `.env` editing.
 
 **Desktop**
 - Tauri v2 desktop app (macOS `.dmg`, Windows `.exe`) with native titlebar integration.

--- a/README.md
+++ b/README.md
@@ -242,6 +242,9 @@ npm test
 | `GET` | `/api/projects/:id` | Get project |
 | `DELETE` | `/api/projects/:id` | Delete project (must have zero active workspaces) |
 | `POST` | `/api/projects/:id/fetch` | Fetch remote updates |
+| `GET` | `/api/projects/:id/env` | Get project-managed `.env` |
+| `PUT` | `/api/projects/:id/env` | Save project-managed `.env` |
+| `DELETE` | `/api/projects/:id/env` | Delete project-managed `.env` |
 
 ### Workspaces
 
@@ -464,6 +467,8 @@ $DATA_DIR/
 │       └── workspace/
 └── proj-<id>/
     ├── state.json
+    ├── env/
+    │   └── .env
     ├── repo.git/
     ├── workspaces/
     │   └── <workspace-name>/

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -79,6 +79,20 @@ function resultLine(sessionId = "sess-123", costUsd = 0.01): string {
   return JSON.stringify({ type: "result", session_id: sessionId, cost_usd: costUsd }) + "\n";
 }
 
+async function waitForMessages(
+  messages: WsOutgoing[],
+  type: WsOutgoing["type"],
+  count = 1,
+): Promise<WsOutgoing[]> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    const matches = messages.filter((msg) => msg.type === type);
+    if (matches.length >= count) return matches;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  return messages.filter((msg) => msg.type === type);
+}
+
 function geminiInitLine(sessionId: string, model = "gemini-3.1-pro-preview"): string {
   return JSON.stringify({ type: "init", session_id: sessionId, model }) + "\n";
 }
@@ -970,7 +984,7 @@ describe("ConversationSession", () => {
     expect(mockProc.kill).toHaveBeenCalledWith("SIGKILL");
 
     mockProc._emitClose(137);
-    await new Promise((r) => setTimeout(r, 50));
+    await waitForMessages(messages, "tool_input_required");
 
     const doneEvents = messages.filter((m) => m.type === "done");
     const cancelledEvents = messages.filter((m) => m.type === "cancelled");
@@ -1782,10 +1796,8 @@ describe("ConversationSession", () => {
     mockProc._stdout.push(resultLine());
     mockProc._emitClose(0);
 
-    await new Promise((r) => setTimeout(r, 100));
-
-    const doneMsgs = messages.filter((m) => m.type === "done");
-    expect(doneMsgs[0]).toMatchObject({
+    const [doneMsg] = await waitForMessages(messages, "done");
+    expect(doneMsg).toMatchObject({
       inputTokens: 1800, // 1000 + 500 + 300
       outputTokens: 100,
     });
@@ -1888,10 +1900,8 @@ describe("ConversationSession", () => {
     );
     mockProc._emitClose(0);
 
-    await new Promise((r) => setTimeout(r, 100));
-
-    const doneMsgs = messages.filter((m) => m.type === "done");
-    expect(doneMsgs[0]).toMatchObject({
+    const [doneMsg] = await waitForMessages(messages, "done");
+    expect(doneMsg).toMatchObject({
       inputTokens: 800, // 500 + 200 + 100 from assistant event
       outputTokens: 80,
     });
@@ -1948,11 +1958,9 @@ describe("ConversationSession", () => {
     );
     mockProc._emitClose(0);
 
-    await new Promise((r) => setTimeout(r, 100));
-
-    const doneMsgs = messages.filter((m) => m.type === "done");
+    const [doneMsg] = await waitForMessages(messages, "done");
     // Should use the LAST assistant event (140K), not the cumulative result (260K)
-    expect(doneMsgs[0]).toMatchObject({
+    expect(doneMsg).toMatchObject({
       inputTokens: 140_000,
       outputTokens: 200,
     });
@@ -2121,10 +2129,8 @@ describe("ConversationSession", () => {
     );
     mockProc._emitClose(0);
 
-    await new Promise((r) => setTimeout(r, 100));
-
-    const doneMsgs = messages.filter((m) => m.type === "done");
-    expect(doneMsgs[0]).toMatchObject({
+    const [doneMsg] = await waitForMessages(messages, "done");
+    expect(doneMsg).toMatchObject({
       inputTokens: 5000, // from assistant, not result
       outputTokens: 100,
       durationMs: 3500, // from result — always captured

--- a/backend/src/api/project-env.test.ts
+++ b/backend/src/api/project-env.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdir, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { createTempDir } from "../utils/test-helpers.js";
+import { saveProject } from "../state/state.js";
+import { projectEnvRoutes } from "./project-env.js";
+import type { ProjectState } from "../types.js";
+
+let tempDir: string;
+let dataDir: string;
+let app: ReturnType<typeof Fastify>;
+
+const project: ProjectState = {
+  id: "proj-1",
+  name: "Alpha",
+  url: "https://github.com/acme/alpha.git",
+  createdAt: "2026-05-12T00:00:00.000Z",
+  workspaces: [],
+};
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-project-env-api-test-");
+  dataDir = join(tempDir, "data");
+  await mkdir(dataDir, { recursive: true });
+  await saveProject(project, dataDir);
+
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => projectEnvRoutes(instance, dataDir));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("project environment routes", () => {
+  it("returns not configured by default", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ exists: false, content: "" });
+  });
+
+  it("saves and returns project environment content", async () => {
+    const put = await app.inject({
+      method: "PUT",
+      url: "/api/projects/proj-1/env",
+      payload: { content: "API_KEY=secret\n" },
+    });
+
+    expect(put.statusCode).toBe(200);
+    expect(put.json()).toMatchObject({
+      exists: true,
+      content: "API_KEY=secret\n",
+      sizeBytes: Buffer.byteLength("API_KEY=secret\n"),
+    });
+
+    const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
+    expect(get.json().content).toBe("API_KEY=secret\n");
+  });
+
+  it("deletes project environment content", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/projects/proj-1/env",
+      payload: { content: "API_KEY=secret\n" },
+    });
+
+    const del = await app.inject({ method: "DELETE", url: "/api/projects/proj-1/env" });
+    expect(del.statusCode).toBe(204);
+
+    const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
+    expect(get.json()).toEqual({ exists: false, content: "" });
+  });
+
+  it("returns 404 for unknown projects", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/projects/missing/env" });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Project not found" });
+  });
+
+  it("validates request content", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/projects/proj-1/env",
+      payload: { content: 123 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Content is required" });
+  });
+});

--- a/backend/src/api/project-env.test.ts
+++ b/backend/src/api/project-env.test.ts
@@ -54,11 +54,13 @@ describe("project environment routes", () => {
     expect(put.json()).toMatchObject({
       exists: true,
       content: "API_KEY=secret\n",
+      path: join(dataDir, "proj-1", "env", ".env"),
       sizeBytes: Buffer.byteLength("API_KEY=secret\n"),
     });
 
     const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
     expect(get.json().content).toBe("API_KEY=secret\n");
+    expect(get.json().path).toBe(join(dataDir, "proj-1", "env", ".env"));
   });
 
   it("deletes project environment content", async () => {

--- a/backend/src/api/project-env.ts
+++ b/backend/src/api/project-env.ts
@@ -1,0 +1,54 @@
+import type { FastifyInstance } from "fastify";
+import { getProject } from "../projects/project-manager.js";
+import { loadProjectEnv, saveProjectEnv, deleteProjectEnv } from "../state/project-env.js";
+import { getDataDir } from "../state/state.js";
+import { errorMessage, errorStatus } from "../utils/errors.js";
+
+async function ensureProject(projectId: string, dataDir: string): Promise<boolean> {
+  return (await getProject(projectId, dataDir)) !== null;
+}
+
+export async function projectEnvRoutes(app: FastifyInstance, dataDir?: string) {
+  const dir = dataDir ?? getDataDir();
+
+  app.get<{ Params: { id: string } }>("/api/projects/:id/env", async (req, reply) => {
+    try {
+      if (!(await ensureProject(req.params.id, dir))) {
+        return reply.status(404).send({ error: "Project not found" });
+      }
+      return reply.send(await loadProjectEnv(req.params.id, dir));
+    } catch (err: unknown) {
+      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed to load environment") });
+    }
+  });
+
+  app.put<{ Params: { id: string }; Body: { content?: unknown } }>(
+    "/api/projects/:id/env",
+    async (req, reply) => {
+      try {
+        if (!(await ensureProject(req.params.id, dir))) {
+          return reply.status(404).send({ error: "Project not found" });
+        }
+        const { content } = req.body ?? {};
+        if (typeof content !== "string") {
+          return reply.status(400).send({ error: "Content is required" });
+        }
+        return reply.send(await saveProjectEnv(req.params.id, content, dir));
+      } catch (err: unknown) {
+        return reply.status(errorStatus(err, 400)).send({ error: errorMessage(err, "Failed to save environment") });
+      }
+    },
+  );
+
+  app.delete<{ Params: { id: string } }>("/api/projects/:id/env", async (req, reply) => {
+    try {
+      if (!(await ensureProject(req.params.id, dir))) {
+        return reply.status(404).send({ error: "Project not found" });
+      }
+      await deleteProjectEnv(req.params.id, dir);
+      return reply.status(204).send();
+    } catch (err: unknown) {
+      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed to delete environment") });
+    }
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -5,6 +5,7 @@ import type { FastifyInstance } from "fastify";
 import cors from "@fastify/cors";
 import websocket from "@fastify/websocket";
 import { projectRoutes } from "./api/projects.js";
+import { projectEnvRoutes } from "./api/project-env.js";
 import { workspaceRoutes } from "./api/workspaces.js";
 import { completionRoutes } from "./api/completions.js";
 import { modelRoutes } from "./api/models.js";
@@ -295,6 +296,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   });
 
   await app.register((instance: FastifyInstance) => projectRoutes(instance));
+  await app.register((instance: FastifyInstance) => projectEnvRoutes(instance));
   await app.register((instance: FastifyInstance) => workspaceRoutes(instance));
   await app.register((instance: FastifyInstance) => completionRoutes(instance));
   await app.register((instance: FastifyInstance) => modelRoutes(instance));

--- a/backend/src/state/project-env.test.ts
+++ b/backend/src/state/project-env.test.ts
@@ -37,6 +37,7 @@ describe("project environment storage", () => {
 
     expect(saved.exists).toBe(true);
     expect(saved.content).toBe("API_KEY=secret\n");
+    expect(saved.path).toBe(projectEnvPath(dataDir, "proj-1"));
     expect(saved.sizeBytes).toBe(Buffer.byteLength("API_KEY=secret\n"));
     expect(saved.updatedAt).toBeTruthy();
     expect(await readFile(projectEnvPath(dataDir, "proj-1"), "utf-8")).toBe("API_KEY=secret\n");

--- a/backend/src/state/project-env.test.ts
+++ b/backend/src/state/project-env.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { createTempDir } from "../utils/test-helpers.js";
+import {
+  copyProjectEnvToWorkspace,
+  deleteProjectEnv,
+  loadProjectEnv,
+  projectEnvPath,
+  saveProjectEnv,
+} from "./project-env.js";
+
+let tempDir: string;
+let dataDir: string;
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-project-env-test-");
+  dataDir = join(tempDir, "data");
+  await mkdir(dataDir, { recursive: true });
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("project environment storage", () => {
+  it("returns not configured when no project .env exists", async () => {
+    await expect(loadProjectEnv("proj-1", dataDir)).resolves.toEqual({
+      exists: false,
+      content: "",
+    });
+  });
+
+  it("saves, loads, and deletes a project .env", async () => {
+    const saved = await saveProjectEnv("proj-1", "API_KEY=secret\n", dataDir);
+
+    expect(saved.exists).toBe(true);
+    expect(saved.content).toBe("API_KEY=secret\n");
+    expect(saved.sizeBytes).toBe(Buffer.byteLength("API_KEY=secret\n"));
+    expect(saved.updatedAt).toBeTruthy();
+    expect(await readFile(projectEnvPath(dataDir, "proj-1"), "utf-8")).toBe("API_KEY=secret\n");
+
+    await deleteProjectEnv("proj-1", dataDir);
+    expect(await loadProjectEnv("proj-1", dataDir)).toEqual({
+      exists: false,
+      content: "",
+    });
+  });
+
+  it("rejects environment files larger than 256KB", async () => {
+    await expect(saveProjectEnv("proj-1", "x".repeat(256 * 1024 + 1), dataDir))
+      .rejects.toThrow("256KB or smaller");
+  });
+});
+
+describe("copyProjectEnvToWorkspace", () => {
+  it("does nothing when the project is not configured", async () => {
+    const wsPath = join(tempDir, "workspace");
+    await mkdir(wsPath, { recursive: true });
+
+    await expect(copyProjectEnvToWorkspace("proj-1", wsPath, dataDir)).resolves.toBe(false);
+    expect(existsSync(join(wsPath, ".env"))).toBe(false);
+  });
+
+  it("copies the configured project .env into a workspace", async () => {
+    const wsPath = join(tempDir, "workspace");
+    await mkdir(wsPath, { recursive: true });
+    await saveProjectEnv("proj-1", "DATABASE_URL=postgres://local\n", dataDir);
+
+    await expect(copyProjectEnvToWorkspace("proj-1", wsPath, dataDir)).resolves.toBe(true);
+    expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe("DATABASE_URL=postgres://local\n");
+  });
+
+  it("overwrites an existing workspace .env when called during workspace creation", async () => {
+    const wsPath = join(tempDir, "workspace");
+    await mkdir(wsPath, { recursive: true });
+    await saveProjectEnv("proj-1", "API_KEY=managed\n", dataDir);
+    await writeFile(join(wsPath, ".env"), "API_KEY=old\n", "utf-8");
+
+    await copyProjectEnvToWorkspace("proj-1", wsPath, dataDir);
+
+    expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe("API_KEY=managed\n");
+  });
+});

--- a/backend/src/state/project-env.ts
+++ b/backend/src/state/project-env.ts
@@ -1,0 +1,89 @@
+import { access, chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { getDataDir } from "./state.js";
+import { BadRequestError } from "../utils/errors.js";
+import type { ProjectEnvData } from "../types.js";
+
+const MAX_PROJECT_ENV_BYTES = 256 * 1024;
+
+export function projectEnvPath(dataDir: string, projectId: string): string {
+  return join(dataDir, projectId, "env", ".env");
+}
+
+function assertEnvSize(content: string): void {
+  const size = Buffer.byteLength(content, "utf-8");
+  if (size > MAX_PROJECT_ENV_BYTES) {
+    throw new BadRequestError("Environment file must be 256KB or smaller");
+  }
+}
+
+export async function loadProjectEnv(
+  projectId: string,
+  dataDir = getDataDir(),
+): Promise<ProjectEnvData> {
+  const path = projectEnvPath(dataDir, projectId);
+  try {
+    const [content, info] = await Promise.all([
+      readFile(path, "utf-8"),
+      stat(path),
+    ]);
+    return {
+      exists: true,
+      content,
+      sizeBytes: info.size,
+      updatedAt: info.mtime.toISOString(),
+    };
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { exists: false, content: "" };
+    }
+    throw err;
+  }
+}
+
+export async function saveProjectEnv(
+  projectId: string,
+  content: string,
+  dataDir = getDataDir(),
+): Promise<ProjectEnvData> {
+  assertEnvSize(content);
+
+  const dir = join(dataDir, projectId, "env");
+  await mkdir(dir, { recursive: true });
+
+  const target = projectEnvPath(dataDir, projectId);
+  const tmp = join(dir, `.env.${randomUUID()}.tmp`);
+  await writeFile(tmp, content, { encoding: "utf-8", mode: 0o600 });
+  await rename(tmp, target);
+  await chmod(target, 0o600).catch(() => {});
+
+  return loadProjectEnv(projectId, dataDir);
+}
+
+export async function deleteProjectEnv(
+  projectId: string,
+  dataDir = getDataDir(),
+): Promise<void> {
+  await rm(projectEnvPath(dataDir, projectId), { force: true });
+}
+
+export async function copyProjectEnvToWorkspace(
+  projectId: string,
+  workspacePath: string,
+  dataDir = getDataDir(),
+): Promise<boolean> {
+  const source = projectEnvPath(dataDir, projectId);
+  try {
+    await access(source);
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+
+  const content = await readFile(source, "utf-8");
+  const target = join(workspacePath, ".env");
+  await writeFile(target, content, { encoding: "utf-8", mode: 0o600 });
+  await chmod(target, 0o600).catch(() => {});
+  return true;
+}

--- a/backend/src/state/project-env.ts
+++ b/backend/src/state/project-env.ts
@@ -1,4 +1,4 @@
-import { access, chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { getDataDir } from "./state.js";
@@ -75,14 +75,14 @@ export async function copyProjectEnvToWorkspace(
   dataDir = getDataDir(),
 ): Promise<boolean> {
   const source = projectEnvPath(dataDir, projectId);
+  let content: string;
   try {
-    await access(source);
+    content = await readFile(source, "utf-8");
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
     throw err;
   }
 
-  const content = await readFile(source, "utf-8");
   const target = join(workspacePath, ".env");
   await writeFile(target, content, { encoding: "utf-8", mode: 0o600 });
   await chmod(target, 0o600).catch(() => {});

--- a/backend/src/state/project-env.ts
+++ b/backend/src/state/project-env.ts
@@ -31,6 +31,7 @@ export async function loadProjectEnv(
     return {
       exists: true,
       content,
+      path,
       sizeBytes: info.size,
       updatedAt: info.mtime.toISOString(),
     };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -85,6 +85,13 @@ export interface ProjectState {
   workspaces: Workspace[];
 }
 
+export interface ProjectEnvData {
+  exists: boolean;
+  content: string;
+  sizeBytes?: number;
+  updatedAt?: string;
+}
+
 export type CreateProjectRequest =
   | { mode?: "clone"; url: string }
   | { mode: "create"; name: string; visibility?: "public" | "private" };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -88,6 +88,7 @@ export interface ProjectState {
 export interface ProjectEnvData {
   exists: boolean;
   content: string;
+  path?: string;
   sizeBytes?: number;
   updatedAt?: string;
 }

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -17,6 +17,7 @@ import {
 import { git } from "../utils/git.js";
 import { loadProject, saveProject } from "../state/state.js";
 import * as stateStore from "../state/state.js";
+import { saveProjectEnv } from "../state/project-env.js";
 import { initWorkspaceIndex, _clearForTests as clearWorkspaceIndexForTests } from "../state/workspace-index.js";
 
 let tempDir: string;
@@ -56,6 +57,22 @@ describe("createWorkspace", () => {
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);
     expect(existsSync(wsPath)).toBe(true);
     expect(existsSync(join(wsPath, "README.md"))).toBe(true);
+  });
+
+  it("does not create a .env when the project environment is not configured", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    expect(existsSync(join(wsPath, ".env"))).toBe(false);
+  });
+
+  it("copies the project environment into a new workspace", async () => {
+    await saveProjectEnv(projectId, "API_KEY=secret\n", dataDir);
+
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+
+    expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe("API_KEY=secret\n");
   });
 
   it("creates multiple workspaces with unique names", async () => {

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -10,6 +10,7 @@ import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/path
 import { pickCityName } from "../utils/city-names.js";
 import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
 import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
+import { copyProjectEnvToWorkspace } from "../state/project-env.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.js";
 import { stopAllForWorkspace } from "../services/script-runner.js";
 import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffScope, DiffStatResponse } from "../types.js";
@@ -156,6 +157,7 @@ export async function createWorkspace(
 
       // Create worktree from the default branch
       await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranch);
+      await copyProjectEnvToWorkspace(projectId, wsPath, dataDir);
 
       const workspace: Workspace = {
         id: `ws-${nanoid(8)}`,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hive/shared": "^0.1.0",
     "@codemirror/lang-markdown": "^6.5.0",
+    "@codemirror/legacy-modes": "^6.5.2",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/theme-one-dark": "^6.1.3",
     "@pierre/diffs": "^1.0.10",

--- a/frontend/src/components/CodeEditor.tsx
+++ b/frontend/src/components/CodeEditor.tsx
@@ -1,0 +1,130 @@
+import { useEffect, useMemo, useRef } from "react";
+import { EditorView, placeholder as cmPlaceholder } from "@codemirror/view";
+import { EditorState, Compartment, type Extension } from "@codemirror/state";
+import { minimalSetup } from "codemirror";
+import { cn } from "@/lib/utils";
+
+const appTheme = EditorView.theme(
+  {
+    "&": {
+      fontSize: "13px",
+      background: "transparent",
+      border: "none",
+      borderRadius: "0.5rem",
+      overflow: "hidden",
+      height: "100%",
+    },
+    "&.cm-focused": {
+      outline: "2px solid hsl(var(--ring))",
+      outlineOffset: "0px",
+    },
+    ".cm-scroller": {
+      fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
+      lineHeight: "1.6",
+      background: "transparent",
+    },
+    ".cm-gutters": {
+      display: "none",
+    },
+    ".cm-content": {
+      padding: "0.75rem",
+    },
+  },
+  { dark: true },
+);
+
+interface CodeEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  maxHeight?: string;
+  placeholder?: string;
+  extensions?: Extension[];
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function CodeEditor({
+  value,
+  onChange,
+  readOnly = false,
+  maxHeight = "24rem",
+  placeholder,
+  extensions = [],
+  ariaLabel,
+  className,
+}: CodeEditorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const viewRef = useRef<EditorView | null>(null);
+  const readOnlyComp = useMemo(() => new Compartment(), []);
+  const editableComp = useMemo(() => new Compartment(), []);
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+
+    const editorExtensions = [
+      minimalSetup,
+      ...extensions,
+      appTheme,
+      EditorView.lineWrapping,
+      readOnlyComp.of(EditorState.readOnly.of(readOnly)),
+      editableComp.of(EditorView.editable.of(!readOnly)),
+      EditorView.updateListener.of((update) => {
+        if (update.docChanged && onChangeRef.current) {
+          onChangeRef.current(update.state.doc.toString());
+        }
+      }),
+    ];
+
+    if (placeholder) {
+      editorExtensions.push(cmPlaceholder(placeholder));
+    }
+
+    if (ariaLabel) {
+      editorExtensions.push(EditorView.contentAttributes.of({ "aria-label": ariaLabel }));
+    }
+
+    const view = new EditorView({
+      state: EditorState.create({ doc: value, extensions: editorExtensions }),
+      parent: containerRef.current,
+    });
+
+    viewRef.current = view;
+    return () => {
+      view.destroy();
+      viewRef.current = null;
+    };
+    // Extensions are intentionally mounted once; callers provide static editor configuration.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    const current = view.state.doc.toString();
+    if (current === value) return;
+    view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
+  }, [value]);
+
+  useEffect(() => {
+    const view = viewRef.current;
+    if (!view) return;
+    view.dispatch({
+      effects: [
+        readOnlyComp.reconfigure(EditorState.readOnly.of(readOnly)),
+        editableComp.reconfigure(EditorView.editable.of(!readOnly)),
+      ],
+    });
+  }, [editableComp, readOnly, readOnlyComp]);
+
+  return (
+    <div
+      ref={containerRef}
+      aria-disabled={readOnly}
+      className={cn("rounded-lg border border-border/50 bg-card/50", className)}
+      style={{ height: maxHeight, minHeight: "6rem", resize: "vertical", overflow: "hidden" }}
+    />
+  );
+}

--- a/frontend/src/components/EnvEditor.tsx
+++ b/frontend/src/components/EnvEditor.tsx
@@ -1,0 +1,47 @@
+import { useMemo } from "react";
+import { StreamLanguage, syntaxHighlighting } from "@codemirror/language";
+import { properties } from "@codemirror/legacy-modes/mode/properties";
+import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
+import { CodeEditor } from "@/components/CodeEditor";
+
+interface EnvEditorProps {
+  value: string;
+  onChange?: (value: string) => void;
+  readOnly?: boolean;
+  maxHeight?: string;
+  placeholder?: string;
+  ariaLabel?: string;
+  className?: string;
+}
+
+export function EnvEditor({
+  value,
+  onChange,
+  readOnly = false,
+  maxHeight = "10rem",
+  placeholder = "DATABASE_URL=...\nAPI_KEY=...",
+  ariaLabel = "Environment variables",
+  className,
+}: EnvEditorProps) {
+  const extensions = useMemo(
+    () => [
+      // .env files follow the same core shape as properties files: comments plus KEY=VALUE pairs.
+      StreamLanguage.define(properties),
+      syntaxHighlighting(oneDarkHighlightStyle),
+    ],
+    [],
+  );
+
+  return (
+    <CodeEditor
+      value={value}
+      onChange={onChange}
+      readOnly={readOnly}
+      maxHeight={maxHeight}
+      placeholder={placeholder}
+      extensions={extensions}
+      ariaLabel={ariaLabel}
+      className={className}
+    />
+  );
+}

--- a/frontend/src/components/PromptEditor.tsx
+++ b/frontend/src/components/PromptEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useMemo } from "react";
 import {
   EditorView,
   ViewPlugin,
@@ -6,14 +6,12 @@ import {
   Decoration,
   type DecorationSet,
   type ViewUpdate,
-  placeholder as cmPlaceholder,
 } from "@codemirror/view";
-import { EditorState, Compartment } from "@codemirror/state";
-import { minimalSetup } from "codemirror";
 import { markdown } from "@codemirror/lang-markdown";
 import { languages } from "@codemirror/language-data";
 import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
 import { syntaxHighlighting } from "@codemirror/language";
+import { CodeEditor } from "@/components/CodeEditor";
 
 // ── Template variable highlighting ─────────────────────────────────────
 
@@ -39,48 +37,15 @@ const templateVarPlugin = ViewPlugin.fromClass(
   { decorations: (instance) => instance.decorations },
 );
 
-// ── Theme overrides to match app palette ───────────────────────────────
-
-const appTheme = EditorView.theme(
-  {
-    "&": {
-      fontSize: "13px",
-      background: "transparent",
-      border: "none",
-      borderRadius: "0.5rem",
-      overflow: "hidden",
-      height: "100%",
-    },
-    "&.cm-focused": {
-      outline: "2px solid hsl(var(--ring))",
-      outlineOffset: "0px",
-    },
-    ".cm-scroller": {
-      fontFamily: "ui-monospace, SFMono-Regular, 'SF Mono', Menlo, monospace",
-      lineHeight: "1.6",
-      background: "transparent",
-    },
-    ".cm-gutters": {
-      display: "none",
-    },
-    ".cm-content": {
-      padding: "0.75rem",
-    },
-    ".cm-template-var": {
-      color: "var(--primary)",
-      background: "hsl(from var(--primary) h s l / 0.15)",
-      borderRadius: "3px",
-      padding: "0 2px",
-      fontWeight: "600",
-    },
+const templateVarTheme = EditorView.theme({
+  ".cm-template-var": {
+    color: "var(--primary)",
+    background: "hsl(from var(--primary) h s l / 0.15)",
+    borderRadius: "3px",
+    padding: "0 2px",
+    fontWeight: "600",
   },
-  { dark: true },
-);
-
-// ── Compartments for dynamic reconfiguration ───────────────────────────
-
-const readOnlyComp = new Compartment();
-const editableComp = new Compartment();
+});
 
 // ── Component ──────────────────────────────────────────────────────────
 
@@ -99,75 +64,24 @@ export function PromptEditor({
   maxHeight = "24rem",
   placeholder,
 }: PromptEditorProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const viewRef = useRef<EditorView | null>(null);
-  // Keep onChange stable across renders without recreating the view
-  const onChangeRef = useRef(onChange);
-  onChangeRef.current = onChange;
-
-  // Mount editor once
-  useEffect(() => {
-    if (!containerRef.current) return;
-
-    const extensions = [
-      minimalSetup,
+  const extensions = useMemo(
+    () => [
       markdown({ codeLanguages: languages }),
       syntaxHighlighting(oneDarkHighlightStyle),
-      appTheme,
       templateVarPlugin,
-      EditorView.lineWrapping,
-      readOnlyComp.of(EditorState.readOnly.of(readOnly)),
-      editableComp.of(EditorView.editable.of(!readOnly)),
-      EditorView.updateListener.of((update) => {
-        if (update.docChanged && onChangeRef.current) {
-          onChangeRef.current(update.state.doc.toString());
-        }
-      }),
-    ];
-
-    if (placeholder) {
-      extensions.push(cmPlaceholder(placeholder));
-    }
-
-    const view = new EditorView({
-      state: EditorState.create({ doc: value, extensions }),
-      parent: containerRef.current,
-    });
-
-    viewRef.current = view;
-    return () => {
-      view.destroy();
-      viewRef.current = null;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  // Sync external value → editor (skip if editor already matches)
-  useEffect(() => {
-    const view = viewRef.current;
-    if (!view) return;
-    const current = view.state.doc.toString();
-    if (current === value) return;
-    view.dispatch({ changes: { from: 0, to: current.length, insert: value } });
-  }, [value]);
-
-  // Sync readOnly prop
-  useEffect(() => {
-    const view = viewRef.current;
-    if (!view) return;
-    view.dispatch({
-      effects: [
-        readOnlyComp.reconfigure(EditorState.readOnly.of(readOnly)),
-        editableComp.reconfigure(EditorView.editable.of(!readOnly)),
-      ],
-    });
-  }, [readOnly]);
+      templateVarTheme,
+    ],
+    [],
+  );
 
   return (
-    <div
-      ref={containerRef}
-      className="rounded-lg border border-border/50 bg-card/50"
-      style={{ height: maxHeight, minHeight: "6rem", resize: "vertical", overflow: "hidden" }}
+    <CodeEditor
+      value={value}
+      onChange={onChange}
+      readOnly={readOnly}
+      maxHeight={maxHeight}
+      placeholder={placeholder}
+      extensions={extensions}
     />
   );
 }

--- a/frontend/src/hooks/useProjectEnv.ts
+++ b/frontend/src/hooks/useProjectEnv.ts
@@ -1,0 +1,35 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "./useApi";
+import type { ProjectEnvData } from "@/types";
+
+export function useProjectEnv(projectId: string | undefined) {
+  return useQuery({
+    queryKey: ["project-env", projectId],
+    queryFn: () => api.get<ProjectEnvData>(`/api/projects/${projectId}/env`),
+    enabled: !!projectId,
+  });
+}
+
+export function useUpdateProjectEnv(projectId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (content: string) =>
+      api.put<ProjectEnvData>(`/api/projects/${projectId}/env`, { content }),
+    onSuccess: (data) => {
+      qc.setQueryData(["project-env", projectId], data);
+    },
+  });
+}
+
+export function useDeleteProjectEnv(projectId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.delete(`/api/projects/${projectId}/env`),
+    onSuccess: () => {
+      qc.setQueryData<ProjectEnvData>(["project-env", projectId], {
+        exists: false,
+        content: "",
+      });
+    },
+  });
+}

--- a/frontend/src/hooks/useProjectEnv.ts
+++ b/frontend/src/hooks/useProjectEnv.ts
@@ -2,31 +2,33 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./useApi";
 import type { ProjectEnvData } from "@/types";
 
+const projectEnvQueryKey = (projectId: string | undefined) => ["project-env", projectId] as const;
+
 export function useProjectEnv(projectId: string | undefined) {
   return useQuery({
-    queryKey: ["project-env", projectId],
+    queryKey: projectEnvQueryKey(projectId),
     queryFn: () => api.get<ProjectEnvData>(`/api/projects/${projectId}/env`),
     enabled: !!projectId,
   });
 }
 
-export function useUpdateProjectEnv(projectId: string | undefined) {
+export function useUpdateProjectEnv(projectId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (content: string) =>
       api.put<ProjectEnvData>(`/api/projects/${projectId}/env`, { content }),
     onSuccess: (data) => {
-      qc.setQueryData(["project-env", projectId], data);
+      qc.setQueryData(projectEnvQueryKey(projectId), data);
     },
   });
 }
 
-export function useDeleteProjectEnv(projectId: string | undefined) {
+export function useDeleteProjectEnv(projectId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.delete(`/api/projects/${projectId}/env`),
     onSuccess: () => {
-      qc.setQueryData<ProjectEnvData>(["project-env", projectId], {
+      qc.setQueryData<ProjectEnvData>(projectEnvQueryKey(projectId), {
         exists: false,
         content: "",
       });

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Trash2, ExternalLink } from "lucide-react";
+import { Trash2, ExternalLink, Save } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import {
   AlertDialog,
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
+import { useProjectEnv, useUpdateProjectEnv, useDeleteProjectEnv } from "@/hooks/useProjectEnv";
 import { cn } from "@/lib/utils";
 
 export default function ProjectDetail() {
@@ -23,6 +24,15 @@ export default function ProjectDetail() {
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
 
   const project = projects.find((p) => p.id === projectId);
+  const envQuery = useProjectEnv(project?.id);
+  const updateEnv = useUpdateProjectEnv(project?.id);
+  const deleteEnv = useDeleteProjectEnv(project?.id);
+  const [envDraft, setEnvDraft] = useState("");
+
+  useEffect(() => {
+    setEnvDraft(envQuery.data?.content ?? "");
+  }, [envQuery.data?.content, project?.id]);
+
   if (!project) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
@@ -33,10 +43,21 @@ export default function ProjectDetail() {
 
   const hasWorkspaces = (project.workspaces ?? []).length > 0;
   const workspaceCount = (project.workspaces ?? []).length;
+  const envContent = envQuery.data?.content ?? "";
+  const envConfigured = envQuery.data?.exists ?? false;
+  const envDirty = envDraft !== envContent;
 
   const handleDelete = async () => {
     await deleteProject(project.id);
     navigate("/settings/appearance");
+  };
+
+  const handleSaveEnv = async () => {
+    await updateEnv.mutateAsync(envDraft);
+  };
+
+  const handleDeleteEnv = async () => {
+    await deleteEnv.mutateAsync();
   };
 
   return (
@@ -77,6 +98,76 @@ export default function ProjectDetail() {
             <InfoRow label="Workspaces path" mono>
               {project.workspacesPath ?? "\u2014"}
             </InfoRow>
+          </div>
+        </section>
+
+        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+          <div className="mb-4 flex items-center gap-3">
+            <h2 className="text-sm font-medium text-foreground">Environment</h2>
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-[11px] font-medium",
+                envConfigured
+                  ? "bg-primary/10 text-primary"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {envConfigured ? "Configured" : "Not configured"}
+            </span>
+          </div>
+
+          <textarea
+            value={envDraft}
+            onChange={(event) => setEnvDraft(event.target.value)}
+            disabled={envQuery.isLoading}
+            spellCheck={false}
+            className="min-h-44 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
+            placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
+          />
+
+          <div className="mt-3 flex items-center justify-between gap-3">
+            <p className="text-xs text-muted-foreground">
+              Stored locally and copied into new workspaces at creation.
+            </p>
+            <div className="flex shrink-0 items-center gap-2">
+              <button
+                type="button"
+                disabled={!envDirty || updateEnv.isPending}
+                onClick={() => setEnvDraft(envContent)}
+                className={cn(
+                  "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+                  (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
+                )}
+              >
+                Discard
+              </button>
+              <button
+                type="button"
+                disabled={!envConfigured || deleteEnv.isPending}
+                onClick={() => void handleDeleteEnv()}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                  envConfigured
+                    ? "border-destructive/40 text-destructive hover:bg-destructive/10"
+                    : "cursor-not-allowed border-border/30 text-muted-foreground/50",
+                )}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete
+              </button>
+              <button
+                type="button"
+                disabled={!envDirty || updateEnv.isPending}
+                onClick={() => void handleSaveEnv()}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
+                  (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:opacity-50",
+                )}
+              >
+                <Save className="h-3.5 w-3.5" />
+                Save
+              </button>
+            </div>
           </div>
         </section>
 

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -17,7 +17,7 @@ import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
 import { useProjectEnv, useUpdateProjectEnv, useDeleteProjectEnv } from "@/hooks/useProjectEnv";
 import { cn } from "@/lib/utils";
-import type { Project } from "@/types";
+import type { Project, ProjectEnvData } from "@/types";
 
 export default function ProjectDetail() {
   const { projects, deleteProject } = useProjects();
@@ -43,6 +43,7 @@ export default function ProjectDetail() {
   const envContent = envQuery.data?.content ?? "";
   const envConfigured = envQuery.data?.exists ?? false;
   const envPath = envQuery.data?.path;
+  const envRevision = getEnvRevision(envQuery.data);
 
   const handleDelete = async () => {
     await deleteProject(project.id);
@@ -104,6 +105,7 @@ export default function ProjectDetail() {
           project={project}
           envConfigured={envConfigured}
           envContent={envContent}
+          envRevision={envRevision}
           envLoading={envQuery.isLoading}
           editorOpen={envEditorOpen}
           onOpenEditor={() => setEditingEnvProjectId(project.id)}
@@ -162,6 +164,7 @@ function ProjectEnvSection({
   project,
   envConfigured,
   envContent,
+  envRevision,
   envLoading,
   editorOpen,
   onOpenEditor,
@@ -170,6 +173,7 @@ function ProjectEnvSection({
   project: Project;
   envConfigured: boolean;
   envContent: string;
+  envRevision: string;
   envLoading: boolean;
   editorOpen: boolean;
   onOpenEditor: () => void;
@@ -178,6 +182,9 @@ function ProjectEnvSection({
   const updateEnv = useUpdateProjectEnv(project.id);
   const deleteEnv = useDeleteProjectEnv(project.id);
   const envEntryCount = countEnvEntries(envContent);
+  const envStatusLabel = getEnvStatusLabel(envLoading, envConfigured);
+  const envButtonLabel = getEnvButtonLabel(envLoading, editorOpen, envConfigured);
+  const envDescription = getEnvDescription(envLoading, envConfigured, envEntryCount);
 
   const handleDeleteEnv = async () => {
     await deleteEnv.mutateAsync();
@@ -198,18 +205,16 @@ function ProjectEnvSection({
             <span
               className={cn(
                 "rounded-md px-2 py-0.5 text-[11px] font-medium",
-                envConfigured
+                envConfigured && !envLoading
                   ? "bg-primary/10 text-primary"
                   : "bg-muted text-muted-foreground",
               )}
             >
-              {envConfigured ? "Configured" : "Not configured"}
+              {envStatusLabel}
             </span>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
-            {envConfigured
-              ? `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`
-              : "Add project-level variables that will be copied into new workspaces."}
+            {envDescription}
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -229,23 +234,29 @@ function ProjectEnvSection({
           )}
           <button
             type="button"
+            disabled={envLoading}
             onClick={editorOpen ? onCloseEditor : onOpenEditor}
-            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+            className={cn(
+              "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+              envLoading && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
+            )}
           >
-            {editorOpen ? (
+            {envLoading ? (
+              envButtonLabel
+            ) : editorOpen ? (
               <>
                 <X className="h-3.5 w-3.5" />
-                Close
+                {envButtonLabel}
               </>
             ) : envConfigured ? (
               <>
                 <Pencil className="h-3.5 w-3.5" />
-                Edit
+                {envButtonLabel}
               </>
             ) : (
               <>
                 <Plus className="h-3.5 w-3.5" />
-                Configure
+                {envButtonLabel}
               </>
             )}
           </button>
@@ -254,6 +265,7 @@ function ProjectEnvSection({
 
       {editorOpen && (
         <ProjectEnvEditor
+          key={`${project.id}:${envRevision}`}
           initialContent={envContent}
           loading={envLoading}
           saving={updateEnv.isPending}
@@ -277,6 +289,7 @@ function ProjectEnvEditor({
 }) {
   const [draft, setDraft] = useState(initialContent);
   const dirty = draft !== initialContent;
+  const actionsDisabled = loading || saving || !dirty;
 
   return (
     <div className="mt-4 border-t border-border/50 pt-4">
@@ -294,22 +307,22 @@ function ProjectEnvEditor({
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
-            disabled={!dirty || saving}
+            disabled={actionsDisabled}
             onClick={() => setDraft(initialContent)}
             className={cn(
               "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
-              (!dirty || saving) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
+              actionsDisabled && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
             )}
           >
             Discard
           </button>
           <button
             type="button"
-            disabled={!dirty || saving}
+            disabled={actionsDisabled}
             onClick={() => onSave(draft)}
             className={cn(
               "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
-              (!dirty || saving) && "cursor-not-allowed opacity-50 hover:opacity-50",
+              actionsDisabled && "cursor-not-allowed opacity-50 hover:opacity-50",
             )}
           >
             <Save className="h-3.5 w-3.5" />
@@ -319,6 +332,37 @@ function ProjectEnvEditor({
       </div>
     </div>
   );
+}
+
+function getEnvStatusLabel(envLoading: boolean, envConfigured: boolean): string {
+  if (envLoading) return "Loading";
+  return envConfigured ? "Configured" : "Not configured";
+}
+
+function getEnvButtonLabel(
+  envLoading: boolean,
+  editorOpen: boolean,
+  envConfigured: boolean,
+): string {
+  if (envLoading) return "Loading";
+  if (editorOpen) return "Close";
+  return envConfigured ? "Edit" : "Configure";
+}
+
+function getEnvDescription(
+  envLoading: boolean,
+  envConfigured: boolean,
+  envEntryCount: number,
+): string {
+  if (envLoading) return "Loading project-level variables.";
+  if (!envConfigured) return "Add project-level variables that will be copied into new workspaces.";
+  return `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`;
+}
+
+function getEnvRevision(data: ProjectEnvData | undefined): string {
+  if (!data) return "loading";
+  if (!data.exists) return "missing";
+  return data.updatedAt ?? `${data.sizeBytes ?? data.content.length}:${data.content}`;
 }
 
 function InfoRow({ label, mono, children }: { label: string; mono?: boolean; children: ReactNode }) {

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Trash2, ExternalLink, Save, Pencil, Plus, X } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
@@ -16,6 +16,7 @@ import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
 import { useProjectEnv, useUpdateProjectEnv, useDeleteProjectEnv } from "@/hooks/useProjectEnv";
 import { cn } from "@/lib/utils";
+import type { Project } from "@/types";
 
 export default function ProjectDetail() {
   const { projects, deleteProject } = useProjects();
@@ -25,18 +26,7 @@ export default function ProjectDetail() {
 
   const project = projects.find((p) => p.id === projectId);
   const envQuery = useProjectEnv(project?.id);
-  const updateEnv = useUpdateProjectEnv(project?.id);
-  const deleteEnv = useDeleteProjectEnv(project?.id);
-  const [envDraft, setEnvDraft] = useState("");
-  const [envEditorOpen, setEnvEditorOpen] = useState(false);
-
-  useEffect(() => {
-    setEnvDraft(envQuery.data?.content ?? "");
-  }, [envQuery.data?.content, project?.id]);
-
-  useEffect(() => {
-    setEnvEditorOpen(false);
-  }, [project?.id]);
+  const [editingEnvProjectId, setEditingEnvProjectId] = useState<string | null>(null);
 
   if (!project) {
     return (
@@ -48,31 +38,14 @@ export default function ProjectDetail() {
 
   const hasWorkspaces = (project.workspaces ?? []).length > 0;
   const workspaceCount = (project.workspaces ?? []).length;
+  const envEditorOpen = editingEnvProjectId === project.id;
   const envContent = envQuery.data?.content ?? "";
   const envConfigured = envQuery.data?.exists ?? false;
   const envPath = envQuery.data?.path;
-  const envDirty = envDraft !== envContent;
-  const envEntryCount = countEnvEntries(envContent);
 
   const handleDelete = async () => {
     await deleteProject(project.id);
     navigate("/settings/appearance");
-  };
-
-  const handleSaveEnv = async () => {
-    await updateEnv.mutateAsync(envDraft);
-    setEnvEditorOpen(false);
-  };
-
-  const handleDeleteEnv = async () => {
-    await deleteEnv.mutateAsync();
-    setEnvDraft("");
-    setEnvEditorOpen(false);
-  };
-
-  const openEnvEditor = () => {
-    setEnvDraft(envContent);
-    setEnvEditorOpen(true);
   };
 
   return (
@@ -126,112 +99,15 @@ export default function ProjectDetail() {
           </div>
         </section>
 
-        <section className="rounded-lg border border-border/50 bg-card/50 p-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-            <div className="min-w-0">
-              <div className="flex items-center gap-2">
-                <h2 className="text-sm font-medium text-foreground">Environment</h2>
-                <span
-                  className={cn(
-                    "rounded-md px-2 py-0.5 text-[11px] font-medium",
-                    envConfigured
-                      ? "bg-primary/10 text-primary"
-                      : "bg-muted text-muted-foreground",
-                  )}
-                >
-                  {envConfigured ? "Configured" : "Not configured"}
-                </span>
-              </div>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {envConfigured
-                  ? `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`
-                  : "Add project-level variables that will be copied into new workspaces."}
-              </p>
-            </div>
-            <div className="flex shrink-0 items-center gap-2">
-              {envConfigured && (
-                <button
-                  type="button"
-                  disabled={deleteEnv.isPending}
-                  onClick={() => void handleDeleteEnv()}
-                  className={cn(
-                    "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10",
-                    deleteEnv.isPending && "cursor-not-allowed opacity-50",
-                  )}
-                >
-                  <Trash2 className="h-3.5 w-3.5" />
-                  Delete
-                </button>
-              )}
-              <button
-                type="button"
-                onClick={() => envEditorOpen ? setEnvEditorOpen(false) : openEnvEditor()}
-                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
-              >
-                {envEditorOpen ? (
-                  <>
-                    <X className="h-3.5 w-3.5" />
-                    Close
-                  </>
-                ) : envConfigured ? (
-                  <>
-                    <Pencil className="h-3.5 w-3.5" />
-                    Edit
-                  </>
-                ) : (
-                  <>
-                    <Plus className="h-3.5 w-3.5" />
-                    Configure
-                  </>
-                )}
-              </button>
-            </div>
-          </div>
-
-          {envEditorOpen && (
-            <div className="mt-4 border-t border-border/50 pt-4">
-              <textarea
-                value={envDraft}
-                onChange={(event) => setEnvDraft(event.target.value)}
-                disabled={envQuery.isLoading}
-                spellCheck={false}
-                className="min-h-32 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
-                placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
-              />
-
-              <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-                <p className="text-xs text-muted-foreground">
-                  Saved values are copied into workspaces created after this point.
-                </p>
-                <div className="flex shrink-0 items-center gap-2">
-                  <button
-                    type="button"
-                    disabled={!envDirty || updateEnv.isPending}
-                    onClick={() => setEnvDraft(envContent)}
-                    className={cn(
-                      "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
-                      (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
-                    )}
-                  >
-                    Discard
-                  </button>
-                  <button
-                    type="button"
-                    disabled={!envDirty || updateEnv.isPending}
-                    onClick={() => void handleSaveEnv()}
-                    className={cn(
-                      "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
-                      (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:opacity-50",
-                    )}
-                  >
-                    <Save className="h-3.5 w-3.5" />
-                    Save
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-        </section>
+        <ProjectEnvSection
+          project={project}
+          envConfigured={envConfigured}
+          envContent={envContent}
+          envLoading={envQuery.isLoading}
+          editorOpen={envEditorOpen}
+          onOpenEditor={() => setEditingEnvProjectId(project.id)}
+          onCloseEditor={() => setEditingEnvProjectId(null)}
+        />
 
         <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-4">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
@@ -281,11 +157,176 @@ export default function ProjectDetail() {
   );
 }
 
+function ProjectEnvSection({
+  project,
+  envConfigured,
+  envContent,
+  envLoading,
+  editorOpen,
+  onOpenEditor,
+  onCloseEditor,
+}: {
+  project: Project;
+  envConfigured: boolean;
+  envContent: string;
+  envLoading: boolean;
+  editorOpen: boolean;
+  onOpenEditor: () => void;
+  onCloseEditor: () => void;
+}) {
+  const updateEnv = useUpdateProjectEnv(project.id);
+  const deleteEnv = useDeleteProjectEnv(project.id);
+  const envEntryCount = countEnvEntries(envContent);
+
+  const handleDeleteEnv = async () => {
+    await deleteEnv.mutateAsync();
+    onCloseEditor();
+  };
+
+  const handleSaveEnv = async (content: string) => {
+    await updateEnv.mutateAsync(content);
+    onCloseEditor();
+  };
+
+  return (
+    <section className="rounded-lg border border-border/50 bg-card/50 p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h2 className="text-sm font-medium text-foreground">Environment</h2>
+            <span
+              className={cn(
+                "rounded-md px-2 py-0.5 text-[11px] font-medium",
+                envConfigured
+                  ? "bg-primary/10 text-primary"
+                  : "bg-muted text-muted-foreground",
+              )}
+            >
+              {envConfigured ? "Configured" : "Not configured"}
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {envConfigured
+              ? `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`
+              : "Add project-level variables that will be copied into new workspaces."}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {envConfigured && (
+            <button
+              type="button"
+              disabled={deleteEnv.isPending}
+              onClick={() => void handleDeleteEnv()}
+              className={cn(
+                "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10",
+                deleteEnv.isPending && "cursor-not-allowed opacity-50",
+              )}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={editorOpen ? onCloseEditor : onOpenEditor}
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
+          >
+            {editorOpen ? (
+              <>
+                <X className="h-3.5 w-3.5" />
+                Close
+              </>
+            ) : envConfigured ? (
+              <>
+                <Pencil className="h-3.5 w-3.5" />
+                Edit
+              </>
+            ) : (
+              <>
+                <Plus className="h-3.5 w-3.5" />
+                Configure
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {editorOpen && (
+        <ProjectEnvEditor
+          initialContent={envContent}
+          loading={envLoading}
+          saving={updateEnv.isPending}
+          onSave={(content) => void handleSaveEnv(content)}
+        />
+      )}
+    </section>
+  );
+}
+
+function ProjectEnvEditor({
+  initialContent,
+  loading,
+  saving,
+  onSave,
+}: {
+  initialContent: string;
+  loading: boolean;
+  saving: boolean;
+  onSave: (content: string) => void;
+}) {
+  const [draft, setDraft] = useState(initialContent);
+  const dirty = draft !== initialContent;
+
+  return (
+    <div className="mt-4 border-t border-border/50 pt-4">
+      <textarea
+        value={draft}
+        onChange={(event) => setDraft(event.target.value)}
+        disabled={loading}
+        spellCheck={false}
+        className="min-h-32 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
+        placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
+      />
+
+      <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-muted-foreground">
+          Saved values are copied into workspaces created after this point.
+        </p>
+        <div className="flex shrink-0 items-center gap-2">
+          <button
+            type="button"
+            disabled={!dirty || saving}
+            onClick={() => setDraft(initialContent)}
+            className={cn(
+              "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+              (!dirty || saving) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
+            )}
+          >
+            Discard
+          </button>
+          <button
+            type="button"
+            disabled={!dirty || saving}
+            onClick={() => onSave(draft)}
+            className={cn(
+              "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
+              (!dirty || saving) && "cursor-not-allowed opacity-50 hover:opacity-50",
+            )}
+          >
+            <Save className="h-3.5 w-3.5" />
+            Save
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function InfoRow({ label, mono, children }: { label: string; mono?: boolean; children: ReactNode }) {
   return (
     <div className="grid grid-cols-[112px_minmax(0,1fr)] items-baseline gap-3">
       <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
-      <dd className={cn("min-w-0 text-sm text-foreground", mono && "font-mono text-xs")}>{children}</dd>
+      <dd className={cn("min-w-0 text-sm text-foreground", mono && "break-all font-mono text-xs")}>{children}</dd>
     </div>
   );
 }

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Trash2, ExternalLink, Save, Pencil, Plus, X } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
+import { EnvEditor } from "@/components/EnvEditor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -279,13 +280,11 @@ function ProjectEnvEditor({
 
   return (
     <div className="mt-4 border-t border-border/50 pt-4">
-      <textarea
+      <EnvEditor
         value={draft}
-        onChange={(event) => setDraft(event.target.value)}
-        disabled={loading}
-        spellCheck={false}
-        className="min-h-32 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
-        placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
+        onChange={setDraft}
+        readOnly={loading}
+        className="bg-background/70"
       />
 
       <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Trash2, ExternalLink, Save } from "lucide-react";
+import { Trash2, ExternalLink, Save, Pencil, Plus, X } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import {
   AlertDialog,
@@ -28,10 +28,15 @@ export default function ProjectDetail() {
   const updateEnv = useUpdateProjectEnv(project?.id);
   const deleteEnv = useDeleteProjectEnv(project?.id);
   const [envDraft, setEnvDraft] = useState("");
+  const [envEditorOpen, setEnvEditorOpen] = useState(false);
 
   useEffect(() => {
     setEnvDraft(envQuery.data?.content ?? "");
   }, [envQuery.data?.content, project?.id]);
+
+  useEffect(() => {
+    setEnvEditorOpen(false);
+  }, [project?.id]);
 
   if (!project) {
     return (
@@ -45,7 +50,9 @@ export default function ProjectDetail() {
   const workspaceCount = (project.workspaces ?? []).length;
   const envContent = envQuery.data?.content ?? "";
   const envConfigured = envQuery.data?.exists ?? false;
+  const envPath = envQuery.data?.path;
   const envDirty = envDraft !== envContent;
+  const envEntryCount = countEnvEntries(envContent);
 
   const handleDelete = async () => {
     await deleteProject(project.id);
@@ -54,10 +61,18 @@ export default function ProjectDetail() {
 
   const handleSaveEnv = async () => {
     await updateEnv.mutateAsync(envDraft);
+    setEnvEditorOpen(false);
   };
 
   const handleDeleteEnv = async () => {
     await deleteEnv.mutateAsync();
+    setEnvDraft("");
+    setEnvEditorOpen(false);
+  };
+
+  const openEnvEditor = () => {
+    setEnvDraft(envContent);
+    setEnvEditorOpen(true);
   };
 
   return (
@@ -69,14 +84,19 @@ export default function ProjectDetail() {
         </div>
       </SettingsHeader>
 
-      <div className="max-w-2xl space-y-6 px-4 py-5">
-        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-          <h2 className="mb-4 text-sm font-medium text-foreground">General</h2>
+      <div className="max-w-2xl space-y-4 px-4 py-5">
+        <section className="rounded-lg border border-border/50 bg-card/50 p-4">
+          <div className="mb-4 flex items-center justify-between gap-3">
+            <h2 className="text-sm font-medium text-foreground">Overview</h2>
+            <span className="rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium tabular-nums text-primary">
+              {workspaceCount} workspace{workspaceCount !== 1 ? "s" : ""}
+            </span>
+          </div>
 
-          <div className="space-y-4">
-            <InfoRow label="Repository URL" mono>
+          <div className="space-y-3">
+            <InfoRow label="Repository" mono>
               {project.url ? (
-                <span className="inline-flex items-center gap-1.5">
+                <span className="inline-flex max-w-full items-center gap-1.5">
                   <span className="truncate">{project.url}</span>
                   <a
                     href={project.url}
@@ -92,118 +112,152 @@ export default function ProjectDetail() {
                 <span className="text-muted-foreground">Local only</span>
               )}
             </InfoRow>
-            <InfoRow label="Bare repo path" mono>
+            <InfoRow label="Bare repo" mono>
               {project.repoPath ?? "\u2014"}
             </InfoRow>
-            <InfoRow label="Workspaces path" mono>
+            <InfoRow label="Workspaces" mono>
               {project.workspacesPath ?? "\u2014"}
             </InfoRow>
+            {envConfigured && envPath && (
+              <InfoRow label="Env file" mono>
+                {envPath}
+              </InfoRow>
+            )}
           </div>
         </section>
 
-        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-          <div className="mb-4 flex items-center gap-3">
-            <h2 className="text-sm font-medium text-foreground">Environment</h2>
-            <span
-              className={cn(
-                "rounded-md px-2 py-0.5 text-[11px] font-medium",
-                envConfigured
-                  ? "bg-primary/10 text-primary"
-                  : "bg-muted text-muted-foreground",
-              )}
-            >
-              {envConfigured ? "Configured" : "Not configured"}
-            </span>
-          </div>
-
-          <textarea
-            value={envDraft}
-            onChange={(event) => setEnvDraft(event.target.value)}
-            disabled={envQuery.isLoading}
-            spellCheck={false}
-            className="min-h-44 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
-            placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
-          />
-
-          <div className="mt-3 flex items-center justify-between gap-3">
-            <p className="text-xs text-muted-foreground">
-              Stored locally and copied into new workspaces at creation.
-            </p>
+        <section className="rounded-lg border border-border/50 bg-card/50 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <h2 className="text-sm font-medium text-foreground">Environment</h2>
+                <span
+                  className={cn(
+                    "rounded-md px-2 py-0.5 text-[11px] font-medium",
+                    envConfigured
+                      ? "bg-primary/10 text-primary"
+                      : "bg-muted text-muted-foreground",
+                  )}
+                >
+                  {envConfigured ? "Configured" : "Not configured"}
+                </span>
+              </div>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {envConfigured
+                  ? `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`
+                  : "Add project-level variables that will be copied into new workspaces."}
+              </p>
+            </div>
             <div className="flex shrink-0 items-center gap-2">
+              {envConfigured && (
+                <button
+                  type="button"
+                  disabled={deleteEnv.isPending}
+                  onClick={() => void handleDeleteEnv()}
+                  className={cn(
+                    "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10",
+                    deleteEnv.isPending && "cursor-not-allowed opacity-50",
+                  )}
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                  Delete
+                </button>
+              )}
               <button
                 type="button"
-                disabled={!envDirty || updateEnv.isPending}
-                onClick={() => setEnvDraft(envContent)}
-                className={cn(
-                  "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
-                  (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
-                )}
+                onClick={() => envEditorOpen ? setEnvEditorOpen(false) : openEnvEditor()}
+                className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground"
               >
-                Discard
-              </button>
-              <button
-                type="button"
-                disabled={!envConfigured || deleteEnv.isPending}
-                onClick={() => void handleDeleteEnv()}
-                className={cn(
-                  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
-                  envConfigured
-                    ? "border-destructive/40 text-destructive hover:bg-destructive/10"
-                    : "cursor-not-allowed border-border/30 text-muted-foreground/50",
+                {envEditorOpen ? (
+                  <>
+                    <X className="h-3.5 w-3.5" />
+                    Close
+                  </>
+                ) : envConfigured ? (
+                  <>
+                    <Pencil className="h-3.5 w-3.5" />
+                    Edit
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-3.5 w-3.5" />
+                    Configure
+                  </>
                 )}
-              >
-                <Trash2 className="h-3.5 w-3.5" />
-                Delete
-              </button>
-              <button
-                type="button"
-                disabled={!envDirty || updateEnv.isPending}
-                onClick={() => void handleSaveEnv()}
-                className={cn(
-                  "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
-                  (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:opacity-50",
-                )}
-              >
-                <Save className="h-3.5 w-3.5" />
-                Save
               </button>
             </div>
           </div>
+
+          {envEditorOpen && (
+            <div className="mt-4 border-t border-border/50 pt-4">
+              <textarea
+                value={envDraft}
+                onChange={(event) => setEnvDraft(event.target.value)}
+                disabled={envQuery.isLoading}
+                spellCheck={false}
+                className="min-h-32 w-full resize-y rounded-lg border border-border/50 bg-background/70 p-3 font-mono text-xs leading-5 text-foreground outline-none transition-colors placeholder:text-muted-foreground/50 focus:border-ring"
+                placeholder={"DATABASE_URL=...\nAPI_KEY=..."}
+              />
+
+              <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <p className="text-xs text-muted-foreground">
+                  Saved values are copied into workspaces created after this point.
+                </p>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    type="button"
+                    disabled={!envDirty || updateEnv.isPending}
+                    onClick={() => setEnvDraft(envContent)}
+                    className={cn(
+                      "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+                      (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
+                    )}
+                  >
+                    Discard
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!envDirty || updateEnv.isPending}
+                    onClick={() => void handleSaveEnv()}
+                    className={cn(
+                      "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
+                      (!envDirty || updateEnv.isPending) && "cursor-not-allowed opacity-50 hover:opacity-50",
+                    )}
+                  >
+                    <Save className="h-3.5 w-3.5" />
+                    Save
+                  </button>
+                </div>
+              </div>
+            </div>
+          )}
         </section>
 
-        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-          <h2 className="mb-4 text-sm font-medium text-foreground">Activity</h2>
-          <div className="flex items-center gap-3">
-            <span className="inline-flex items-center justify-center rounded-md bg-primary/10 px-2.5 py-1 text-sm font-semibold tabular-nums text-primary">
-              {workspaceCount}
-            </span>
-            <span className="text-sm text-muted-foreground">
-              active workspace{workspaceCount !== 1 ? "s" : ""}
-            </span>
+        <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h2 className="text-sm font-medium text-destructive">Danger zone</h2>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {hasWorkspaces
+                  ? "Cannot delete a project with active workspaces. Archive all workspaces first."
+                  : "This will permanently delete the bare repository and all associated data."}
+              </p>
+            </div>
+            <button
+              type="button"
+              disabled={hasWorkspaces}
+              onClick={() => setShowDeleteConfirm(true)}
+              className={cn(
+                "inline-flex cursor-pointer items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                hasWorkspaces
+                  ? "cursor-not-allowed border-border/30 text-muted-foreground/50"
+                  : "border-destructive/40 text-destructive hover:bg-destructive/10",
+              )}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+              Delete project
+            </button>
           </div>
-        </section>
-
-        <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-5">
-          <h2 className="mb-1 text-sm font-medium text-destructive">Danger zone</h2>
-          <p className="mb-4 text-xs text-muted-foreground">
-            {hasWorkspaces
-              ? "Cannot delete a project with active workspaces. Archive all workspaces first."
-              : "This will permanently delete the bare repository and all associated data."}
-          </p>
-          <button
-            type="button"
-            disabled={hasWorkspaces}
-            onClick={() => setShowDeleteConfirm(true)}
-            className={cn(
-              "inline-flex cursor-pointer items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
-              hasWorkspaces
-                ? "cursor-not-allowed border-border/30 text-muted-foreground/50"
-                : "border-destructive/40 text-destructive hover:bg-destructive/10",
-            )}
-          >
-            <Trash2 className="h-3.5 w-3.5" />
-            Delete project
-          </button>
         </section>
       </div>
 
@@ -227,11 +281,20 @@ export default function ProjectDetail() {
   );
 }
 
-function InfoRow({ label, mono, children }: { label: string; mono?: boolean; children: React.ReactNode }) {
+function InfoRow({ label, mono, children }: { label: string; mono?: boolean; children: ReactNode }) {
   return (
-    <div className="grid grid-cols-[140px_1fr] items-baseline gap-3">
+    <div className="grid grid-cols-[112px_minmax(0,1fr)] items-baseline gap-3">
       <dt className="text-xs font-medium text-muted-foreground">{label}</dt>
       <dd className={cn("min-w-0 text-sm text-foreground", mono && "font-mono text-xs")}>{children}</dd>
     </div>
   );
+}
+
+function countEnvEntries(content: string): number {
+  return content
+    .split(/\r?\n/)
+    .filter((line) => {
+      const trimmed = line.trim();
+      return trimmed !== "" && !trimmed.startsWith("#");
+    }).length;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -14,6 +14,7 @@ export interface Project {
 export interface ProjectEnvData {
   exists: boolean;
   content: string;
+  path?: string;
   sizeBytes?: number;
   updatedAt?: string;
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,6 +11,13 @@ export interface Project {
   warning?: string;
 }
 
+export interface ProjectEnvData {
+  exists: boolean;
+  content: string;
+  sizeBytes?: number;
+  updatedAt?: string;
+}
+
 export interface Workspace {
   id: string;
   name: string;

--- a/frontend/tests/hooks/useProjectEnv.test.tsx
+++ b/frontend/tests/hooks/useProjectEnv.test.tsx
@@ -1,0 +1,77 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { api } from "@/hooks/useApi";
+import { useDeleteProjectEnv, useProjectEnv, useUpdateProjectEnv } from "@/hooks/useProjectEnv";
+import { createWrapper } from "../test-utils";
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+describe("useProjectEnv", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("loads project environment content", async () => {
+    vi.mocked(api.get).mockResolvedValueOnce({
+      exists: true,
+      content: "API_KEY=secret\n",
+    });
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjectEnv("proj-1"), { wrapper });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(api.get).toHaveBeenCalledWith("/api/projects/proj-1/env");
+    expect(result.current.data?.content).toBe("API_KEY=secret\n");
+  });
+
+  it("saves project environment content into the query cache", async () => {
+    vi.mocked(api.put).mockResolvedValueOnce({
+      exists: true,
+      content: "API_KEY=updated\n",
+    });
+
+    const { queryClient, wrapper } = createWrapper();
+    const { result } = renderHook(() => useUpdateProjectEnv("proj-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync("API_KEY=updated\n");
+    });
+
+    expect(api.put).toHaveBeenCalledWith("/api/projects/proj-1/env", {
+      content: "API_KEY=updated\n",
+    });
+    expect(queryClient.getQueryData(["project-env", "proj-1"])).toEqual({
+      exists: true,
+      content: "API_KEY=updated\n",
+    });
+  });
+
+  it("clears project environment content from the query cache", async () => {
+    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
+
+    const { queryClient, wrapper } = createWrapper();
+    queryClient.setQueryData(["project-env", "proj-1"], {
+      exists: true,
+      content: "API_KEY=secret\n",
+    });
+    const { result } = renderHook(() => useDeleteProjectEnv("proj-1"), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync();
+    });
+
+    expect(api.delete).toHaveBeenCalledWith("/api/projects/proj-1/env");
+    expect(queryClient.getQueryData(["project-env", "proj-1"])).toEqual({
+      exists: false,
+      content: "",
+    });
+  });
+});

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -10,17 +10,27 @@ import type { Project } from "@/types";
 vi.mock("@/hooks/useApi", () => ({
   api: {
     get: vi.fn(),
+    put: vi.fn(),
     post: vi.fn(),
     delete: vi.fn(),
   },
 }));
 
-function renderProjectDetail(path: string, projects: Project[]) {
+function renderProjectDetail(
+  path: string,
+  projects: Project[],
+  env = { exists: false, content: "" },
+) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
 
-  vi.mocked(api.get).mockResolvedValue(projects);
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url.includes("/env")) {
+      return Promise.resolve(env);
+    }
+    return Promise.resolve(projects);
+  });
 
   return render(
     <QueryClientProvider client={queryClient}>
@@ -40,6 +50,7 @@ function renderProjectDetail(path: string, projects: Project[]) {
 describe("ProjectDetail", () => {
   beforeEach(() => {
     vi.mocked(api.get).mockReset();
+    vi.mocked(api.put).mockReset();
     vi.mocked(api.post).mockReset();
     vi.mocked(api.delete).mockReset();
   });
@@ -81,6 +92,86 @@ describe("ProjectDetail", () => {
 
     expect(await screen.findByText("/repos/alpha.git")).toBeInTheDocument();
     expect(screen.getByText("/workspaces/alpha")).toBeInTheDocument();
+  });
+
+  it("shows project environment as not configured by default", async () => {
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects);
+
+    expect(await screen.findByText("Environment")).toBeInTheDocument();
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue(/API_KEY/)).not.toBeInTheDocument();
+  });
+
+  it("saves project environment changes", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.put).mockResolvedValueOnce({
+      exists: true,
+      content: "API_KEY=secret\n",
+    });
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects);
+
+    const editor = await screen.findByRole("textbox");
+    await waitFor(() => {
+      expect(editor).not.toBeDisabled();
+    });
+    await user.type(editor, "API_KEY=secret{enter}");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith("/api/projects/p1/env", {
+        content: "API_KEY=secret\n",
+      });
+    });
+  });
+
+  it("deletes configured project environment", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects, {
+      exists: true,
+      content: "API_KEY=secret\n",
+    });
+
+    const editor = await screen.findByRole("textbox");
+    await waitFor(() => {
+      expect(editor).toHaveValue("API_KEY=secret\n");
+    });
+    await user.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(api.delete).toHaveBeenCalledWith("/api/projects/p1/env");
+    });
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
   });
 
   it("deletes project after confirmation and returns to appearance settings", async () => {

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -108,7 +108,8 @@ describe("ProjectDetail", () => {
     renderProjectDetail("/settings/repositories/p1", projects);
 
     expect(await screen.findByText("Environment")).toBeInTheDocument();
-    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Loading" })).toBeDisabled();
+    expect(await screen.findByText("Not configured")).toBeInTheDocument();
     expect(screen.queryByDisplayValue(/API_KEY/)).not.toBeInTheDocument();
   });
 

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -70,8 +70,8 @@ describe("ProjectDetail", () => {
 
     const heading = await screen.findByRole("heading", { name: "Alpha" });
     expect(heading.closest("[data-tauri-drag-region]")).toBeInTheDocument();
-    expect(screen.getByText("Bare repo path")).toBeInTheDocument();
-    expect(screen.getByText("Workspaces path")).toBeInTheDocument();
+    expect(screen.getByText("Bare repo")).toBeInTheDocument();
+    expect(screen.getByText("Workspaces")).toBeInTheDocument();
     expect(screen.getAllByText("\u2014")).toHaveLength(2);
   });
 
@@ -130,6 +130,10 @@ describe("ProjectDetail", () => {
 
     renderProjectDetail("/settings/repositories/p1", projects);
 
+    expect(await screen.findByRole("button", { name: "Configure" })).toBeInTheDocument();
+    expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Configure" }));
     const editor = await screen.findByRole("textbox");
     await waitFor(() => {
       expect(editor).not.toBeDisabled();
@@ -162,6 +166,8 @@ describe("ProjectDetail", () => {
       content: "API_KEY=secret\n",
     });
 
+    expect(await screen.findByText("1 entry stored locally for new workspaces.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit" }));
     const editor = await screen.findByRole("textbox");
     await waitFor(() => {
       expect(editor).toHaveValue("API_KEY=secret\n");
@@ -172,6 +178,28 @@ describe("ProjectDetail", () => {
       expect(api.delete).toHaveBeenCalledWith("/api/projects/p1/env");
     });
     expect(screen.getByText("Not configured")).toBeInTheDocument();
+  });
+
+  it("does not count project environment comments or blank lines as entries", async () => {
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects, {
+      exists: true,
+      content: "# API credentials\n\nAPI_KEY=secret\n   # ignored\nDATABASE_URL=postgres://local\n",
+      path: "/hive-data/proj-1/env/.env",
+    });
+
+    expect(await screen.findByText("Env file")).toBeInTheDocument();
+    expect(screen.getByText("/hive-data/proj-1/env/.env")).toBeInTheDocument();
+    expect(await screen.findByText("2 entries stored locally for new workspaces.")).toBeInTheDocument();
   });
 
   it("deletes project after confirmation and returns to appearance settings", async () => {

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { describe, expect, it, vi, beforeEach } from "vitest";
@@ -134,11 +134,10 @@ describe("ProjectDetail", () => {
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "Configure" }));
-    const editor = await screen.findByRole("textbox");
-    await waitFor(() => {
-      expect(editor).not.toBeDisabled();
-    });
-    await user.type(editor, "API_KEY=secret{enter}");
+    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
+    expect(editor.closest(".cm-editor")).toBeInTheDocument();
+    await user.click(editor);
+    await user.paste("API_KEY=secret\n");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
@@ -168,9 +167,9 @@ describe("ProjectDetail", () => {
 
     expect(await screen.findByText("1 entry stored locally for new workspaces.")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Edit" }));
-    const editor = await screen.findByRole("textbox");
+    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
     await waitFor(() => {
-      expect(editor).toHaveValue("API_KEY=secret\n");
+      expect(editor).toHaveTextContent("API_KEY=secret");
     });
     await user.click(screen.getByRole("button", { name: "Delete" }));
 
@@ -200,6 +199,33 @@ describe("ProjectDetail", () => {
     expect(await screen.findByText("Env file")).toBeInTheDocument();
     expect(screen.getByText("/hive-data/proj-1/env/.env")).toBeInTheDocument();
     expect(await screen.findByText("2 entries stored locally for new workspaces.")).toBeInTheDocument();
+  });
+
+  it("renders project environment content in the shared CodeMirror editor", async () => {
+    const user = userEvent.setup();
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Alpha",
+        url: "https://github.com/acme/alpha.git",
+        createdAt: "2026-02-11T00:00:00.000Z",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects, {
+      exists: true,
+      content: "# API credentials\nAPI_KEY=secret\n",
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Edit" }));
+    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
+    const codeMirror = editor.closest(".cm-editor");
+
+    expect(codeMirror).toBeInTheDocument();
+    expect(within(codeMirror as HTMLElement).queryByRole("textbox")).toBe(editor);
+    expect(editor).toHaveTextContent("# API credentials");
+    expect(editor).toHaveTextContent("API_KEY=secret");
   });
 
   it("deletes project after confirmation and returns to appearance settings", async () => {

--- a/frontend/tests/setup.ts
+++ b/frontend/tests/setup.ts
@@ -62,3 +62,25 @@ if (typeof window !== "undefined" && !window.matchMedia) {
 if (typeof Element !== "undefined" && !Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = vi.fn();
 }
+
+// CodeMirror measures DOM ranges for cursor and selection rendering. jsdom does
+// not provide these layout APIs, so expose deterministic zero-sized rectangles.
+if (typeof Range !== "undefined") {
+  Range.prototype.getClientRects ??= vi.fn(() => ({
+    length: 0,
+    item: () => null,
+    [Symbol.iterator]: function* () {},
+  }) as DOMRectList);
+
+  Range.prototype.getBoundingClientRect ??= vi.fn(() => ({
+    x: 0,
+    y: 0,
+    width: 0,
+    height: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    left: 0,
+    toJSON: () => ({}),
+  }) as DOMRect);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/legacy-modes": "^6.5.2",
         "@codemirror/language-data": "^6.5.2",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@hive/shared": "^0.1.0",


### PR DESCRIPTION
## Summary
- add project-scoped .env storage under DATA_DIR with dedicated API routes
- copy the managed .env into newly created workspaces only
- add project settings UI to view, edit, save, and delete the managed environment file

## Tests
- npm --prefix backend test -- project-env workspace-manager
- npm --prefix frontend test -- useProjectEnv ProjectDetail
- npm --prefix backend run typecheck
- npm --prefix frontend run typecheck
- npm --prefix backend run lint
- npm --prefix frontend run lint