### PR TITLE
Improve project environment management UX

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -165,6 +165,7 @@ Once connected, you can configure additional integrations from the app:
 
 - **Settings > Account** — Connect your GitHub account via OAuth device flow. This authenticates the `gh` CLI on the VPS and configures git credentials, enabling PR status detection and authenticated cloning.
 - **Settings > Notifications** — Enable Telegram notifications to receive alerts when an agent turn completes. Enter your bot token and chat ID, then hit "Test" to verify.
+- **Settings > Projects > Environment** — Configure project-level environment variables. Hive stores structured variables locally and generates a workspace `.env` only when a project has variables.
 
 ## Environment Variables Reference
 

--- a/backend/src/api/project-env.test.ts
+++ b/backend/src/api/project-env.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { createTempDir } from "../utils/test-helpers.js";
 import { saveProject } from "../state/state.js";
 import { projectEnvRoutes } from "./project-env.js";
-import type { ProjectState } from "../types.js";
+import type { ProjectEnvConfig, ProjectState } from "../types.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -40,41 +40,41 @@ describe("project environment routes", () => {
     const res = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ exists: false, content: "" });
+    expect(res.json()).toEqual({ exists: false, config: { variables: [] } });
   });
 
-  it("saves and returns project environment content", async () => {
+  it("saves and returns project environment config", async () => {
+    const config = envConfig("API_KEY", "secret");
     const put = await app.inject({
       method: "PUT",
       url: "/api/projects/proj-1/env",
-      payload: { content: "API_KEY=secret\n" },
+      payload: { config },
     });
 
     expect(put.statusCode).toBe(200);
     expect(put.json()).toMatchObject({
       exists: true,
-      content: "API_KEY=secret\n",
-      path: join(dataDir, "proj-1", "env", ".env"),
-      sizeBytes: Buffer.byteLength("API_KEY=secret\n"),
+      config,
+      path: join(dataDir, "proj-1", "env", "env.json"),
     });
 
     const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
-    expect(get.json().content).toBe("API_KEY=secret\n");
-    expect(get.json().path).toBe(join(dataDir, "proj-1", "env", ".env"));
+    expect(get.json().config).toEqual(config);
+    expect(get.json().path).toBe(join(dataDir, "proj-1", "env", "env.json"));
   });
 
-  it("deletes project environment content", async () => {
+  it("deletes project environment config", async () => {
     await app.inject({
       method: "PUT",
       url: "/api/projects/proj-1/env",
-      payload: { content: "API_KEY=secret\n" },
+      payload: { config: envConfig("API_KEY", "secret") },
     });
 
     const del = await app.inject({ method: "DELETE", url: "/api/projects/proj-1/env" });
     expect(del.statusCode).toBe(204);
 
     const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
-    expect(get.json()).toEqual({ exists: false, content: "" });
+    expect(get.json()).toEqual({ exists: false, config: { variables: [] } });
   });
 
   it("returns 404 for unknown projects", async () => {
@@ -84,14 +84,31 @@ describe("project environment routes", () => {
     expect(res.json()).toEqual({ error: "Project not found" });
   });
 
-  it("validates request content", async () => {
+  it("validates request config", async () => {
     const res = await app.inject({
       method: "PUT",
       url: "/api/projects/proj-1/env",
-      payload: { content: 123 },
+      payload: { config: 123 },
     });
 
     expect(res.statusCode).toBe(400);
-    expect(res.json()).toEqual({ error: "Content is required" });
+    expect(res.json()).toEqual({ error: "Config is required" });
+  });
+
+  it("rejects invalid variable keys", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/projects/proj-1/env",
+      payload: { config: envConfig("API KEY", "secret") },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("not a valid environment variable key");
   });
 });
+
+function envConfig(key: string, value: string): ProjectEnvConfig {
+  return {
+    variables: [{ id: "var-1", key, value }],
+  };
+}

--- a/backend/src/api/project-env.test.ts
+++ b/backend/src/api/project-env.test.ts
@@ -105,6 +105,17 @@ describe("project environment routes", () => {
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toContain("not a valid environment variable key");
   });
+
+  it("rejects variable values with line breaks", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/projects/proj-1/env",
+      payload: { config: envConfig("API_KEY", "one\ntwo") },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("value cannot contain line breaks");
+  });
 });
 
 function envConfig(key: string, value: string): ProjectEnvConfig {

--- a/backend/src/api/project-env.test.ts
+++ b/backend/src/api/project-env.test.ts
@@ -63,20 +63,6 @@ describe("project environment routes", () => {
     expect(get.json().path).toBe(join(dataDir, "proj-1", "env", "env.json"));
   });
 
-  it("deletes project environment config", async () => {
-    await app.inject({
-      method: "PUT",
-      url: "/api/projects/proj-1/env",
-      payload: { config: envConfig("API_KEY", "secret") },
-    });
-
-    const del = await app.inject({ method: "DELETE", url: "/api/projects/proj-1/env" });
-    expect(del.statusCode).toBe(204);
-
-    const get = await app.inject({ method: "GET", url: "/api/projects/proj-1/env" });
-    expect(get.json()).toEqual({ exists: false, config: { variables: [] } });
-  });
-
   it("returns 404 for unknown projects", async () => {
     const res = await app.inject({ method: "GET", url: "/api/projects/missing/env" });
 

--- a/backend/src/api/project-env.ts
+++ b/backend/src/api/project-env.ts
@@ -1,6 +1,6 @@
 import type { FastifyInstance } from "fastify";
 import { getProject } from "../projects/project-manager.js";
-import { loadProjectEnv, saveProjectEnv, deleteProjectEnv } from "../state/project-env.js";
+import { loadProjectEnv, saveProjectEnv } from "../state/project-env.js";
 import { getDataDir } from "../state/state.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
 import { parseProjectEnvConfig } from "@hive/shared/project-env";
@@ -41,16 +41,4 @@ export async function projectEnvRoutes(app: FastifyInstance, dataDir?: string) {
       }
     },
   );
-
-  app.delete<{ Params: { id: string } }>("/api/projects/:id/env", async (req, reply) => {
-    try {
-      if (!(await ensureProject(req.params.id, dir))) {
-        return reply.status(404).send({ error: "Project not found" });
-      }
-      await deleteProjectEnv(req.params.id, dir);
-      return reply.status(204).send();
-    } catch (err: unknown) {
-      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed to delete environment") });
-    }
-  });
 }

--- a/backend/src/api/project-env.ts
+++ b/backend/src/api/project-env.ts
@@ -3,6 +3,7 @@ import { getProject } from "../projects/project-manager.js";
 import { loadProjectEnv, saveProjectEnv, deleteProjectEnv } from "../state/project-env.js";
 import { getDataDir } from "../state/state.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
+import { parseProjectEnvConfig } from "@hive/shared/project-env";
 
 async function ensureProject(projectId: string, dataDir: string): Promise<boolean> {
   return (await getProject(projectId, dataDir)) !== null;
@@ -22,18 +23,19 @@ export async function projectEnvRoutes(app: FastifyInstance, dataDir?: string) {
     }
   });
 
-  app.put<{ Params: { id: string }; Body: { content?: unknown } }>(
+  app.put<{ Params: { id: string }; Body: { config?: unknown } }>(
     "/api/projects/:id/env",
     async (req, reply) => {
       try {
         if (!(await ensureProject(req.params.id, dir))) {
           return reply.status(404).send({ error: "Project not found" });
         }
-        const { content } = req.body ?? {};
-        if (typeof content !== "string") {
-          return reply.status(400).send({ error: "Content is required" });
+        const { config: rawConfig } = req.body ?? {};
+        const config = parseProjectEnvConfig(rawConfig);
+        if (!config) {
+          return reply.status(400).send({ error: "Config is required" });
         }
-        return reply.send(await saveProjectEnv(req.params.id, content, dir));
+        return reply.send(await saveProjectEnv(req.params.id, config, dir));
       } catch (err: unknown) {
         return reply.status(errorStatus(err, 400)).send({ error: errorMessage(err, "Failed to save environment") });
       }

--- a/backend/src/state/project-env.test.ts
+++ b/backend/src/state/project-env.test.ts
@@ -55,6 +55,11 @@ describe("project environment storage", () => {
       .rejects.toThrow("256KB or smaller");
   });
 
+  it("rejects values that would inject additional .env lines", async () => {
+    await expect(saveProjectEnv("proj-1", envConfig("API_KEY", "secret\nINJECTED=1"), dataDir))
+      .rejects.toThrow("value cannot contain line breaks");
+  });
+
   it("deletes storage when saving an empty config", async () => {
     await saveProjectEnv("proj-1", envConfig("API_KEY", "secret"), dataDir);
 

--- a/backend/src/state/project-env.test.ts
+++ b/backend/src/state/project-env.test.ts
@@ -10,6 +10,7 @@ import {
   projectEnvPath,
   saveProjectEnv,
 } from "./project-env.js";
+import type { ProjectEnvConfig } from "@hive/shared/project-env";
 
 let tempDir: string;
 let dataDir: string;
@@ -25,33 +26,43 @@ afterEach(async () => {
 });
 
 describe("project environment storage", () => {
-  it("returns not configured when no project .env exists", async () => {
+  it("returns not configured when no project environment exists", async () => {
     await expect(loadProjectEnv("proj-1", dataDir)).resolves.toEqual({
       exists: false,
-      content: "",
+      config: { variables: [] },
     });
   });
 
-  it("saves, loads, and deletes a project .env", async () => {
-    const saved = await saveProjectEnv("proj-1", "API_KEY=secret\n", dataDir);
+  it("saves, loads, and deletes a project environment config", async () => {
+    const config = envConfig("API_KEY", "secret");
+    const saved = await saveProjectEnv("proj-1", config, dataDir);
 
     expect(saved.exists).toBe(true);
-    expect(saved.content).toBe("API_KEY=secret\n");
+    expect(saved.config).toEqual(config);
     expect(saved.path).toBe(projectEnvPath(dataDir, "proj-1"));
-    expect(saved.sizeBytes).toBe(Buffer.byteLength("API_KEY=secret\n"));
     expect(saved.updatedAt).toBeTruthy();
-    expect(await readFile(projectEnvPath(dataDir, "proj-1"), "utf-8")).toBe("API_KEY=secret\n");
+    expect(JSON.parse(await readFile(projectEnvPath(dataDir, "proj-1"), "utf-8"))).toEqual(config);
 
     await deleteProjectEnv("proj-1", dataDir);
     expect(await loadProjectEnv("proj-1", dataDir)).toEqual({
       exists: false,
-      content: "",
+      config: { variables: [] },
     });
   });
 
-  it("rejects environment files larger than 256KB", async () => {
-    await expect(saveProjectEnv("proj-1", "x".repeat(256 * 1024 + 1), dataDir))
+  it("rejects generated environment files larger than 256KB", async () => {
+    await expect(saveProjectEnv("proj-1", envConfig("API_KEY", "x".repeat(256 * 1024 + 1)), dataDir))
       .rejects.toThrow("256KB or smaller");
+  });
+
+  it("deletes storage when saving an empty config", async () => {
+    await saveProjectEnv("proj-1", envConfig("API_KEY", "secret"), dataDir);
+
+    await expect(saveProjectEnv("proj-1", { variables: [] }, dataDir)).resolves.toEqual({
+      exists: false,
+      config: { variables: [] },
+    });
+    expect(existsSync(projectEnvPath(dataDir, "proj-1"))).toBe(false);
   });
 });
 
@@ -67,20 +78,38 @@ describe("copyProjectEnvToWorkspace", () => {
   it("copies the configured project .env into a workspace", async () => {
     const wsPath = join(tempDir, "workspace");
     await mkdir(wsPath, { recursive: true });
-    await saveProjectEnv("proj-1", "DATABASE_URL=postgres://local\n", dataDir);
+    await saveProjectEnv("proj-1", {
+      variables: [
+        {
+          id: "var-1",
+          key: "DATABASE_URL",
+          value: "postgres://local",
+          comment: "Local database",
+        },
+      ],
+    }, dataDir);
 
     await expect(copyProjectEnvToWorkspace("proj-1", wsPath, dataDir)).resolves.toBe(true);
-    expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe("DATABASE_URL=postgres://local\n");
+    expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe(
+      "# Local database\nDATABASE_URL=postgres://local\n",
+    );
   });
 
   it("overwrites an existing workspace .env when called during workspace creation", async () => {
     const wsPath = join(tempDir, "workspace");
     await mkdir(wsPath, { recursive: true });
-    await saveProjectEnv("proj-1", "API_KEY=managed\n", dataDir);
+    await saveProjectEnv("proj-1", envConfig("API_KEY", "managed"), dataDir);
     await writeFile(join(wsPath, ".env"), "API_KEY=old\n", "utf-8");
 
     await copyProjectEnvToWorkspace("proj-1", wsPath, dataDir);
 
     expect(await readFile(join(wsPath, ".env"), "utf-8")).toBe("API_KEY=managed\n");
   });
+
 });
+
+function envConfig(key: string, value: string): ProjectEnvConfig {
+  return {
+    variables: [{ id: "var-1", key, value }],
+  };
+}

--- a/backend/src/state/project-env.ts
+++ b/backend/src/state/project-env.ts
@@ -3,19 +3,42 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { getDataDir } from "./state.js";
 import { BadRequestError } from "../utils/errors.js";
-import type { ProjectEnvData } from "../types.js";
+import {
+  EMPTY_PROJECT_ENV_CONFIG,
+  generateProjectEnvContent,
+  hasProjectEnvVariables,
+  normalizeProjectEnvConfig,
+  parseProjectEnvConfig,
+  validateProjectEnvConfig,
+  type ProjectEnvConfig,
+  type ProjectEnvData,
+} from "@hive/shared/project-env";
 
 const MAX_PROJECT_ENV_BYTES = 256 * 1024;
 
 export function projectEnvPath(dataDir: string, projectId: string): string {
-  return join(dataDir, projectId, "env", ".env");
+  return join(dataDir, projectId, "env", "env.json");
 }
 
-function assertEnvSize(content: string): void {
-  const size = Buffer.byteLength(content, "utf-8");
+function assertEnvConfig(config: ProjectEnvConfig): ProjectEnvConfig {
+  const normalized = normalizeProjectEnvConfig(config);
+  const validation = validateProjectEnvConfig(normalized);
+  if (!validation.valid) {
+    throw new BadRequestError(validation.errors[0] ?? "Invalid environment config");
+  }
+
+  const generatedContent = generateProjectEnvContent(normalized);
+  const size = Buffer.byteLength(generatedContent, "utf-8");
   if (size > MAX_PROJECT_ENV_BYTES) {
     throw new BadRequestError("Environment file must be 256KB or smaller");
   }
+
+  const jsonSize = Buffer.byteLength(JSON.stringify(normalized), "utf-8");
+  if (jsonSize > MAX_PROJECT_ENV_BYTES) {
+    throw new BadRequestError("Environment config must be 256KB or smaller");
+  }
+
+  return normalized;
 }
 
 export async function loadProjectEnv(
@@ -28,16 +51,21 @@ export async function loadProjectEnv(
       readFile(path, "utf-8"),
       stat(path),
     ]);
+    const config = parseProjectEnvConfig(JSON.parse(content));
+    if (!config) {
+      throw new BadRequestError("Invalid project environment config");
+    }
+
     return {
       exists: true,
-      content,
+      config,
       path,
       sizeBytes: info.size,
       updatedAt: info.mtime.toISOString(),
     };
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-      return { exists: false, content: "" };
+      return { exists: false, config: EMPTY_PROJECT_ENV_CONFIG };
     }
     throw err;
   }
@@ -45,17 +73,21 @@ export async function loadProjectEnv(
 
 export async function saveProjectEnv(
   projectId: string,
-  content: string,
+  config: ProjectEnvConfig,
   dataDir = getDataDir(),
 ): Promise<ProjectEnvData> {
-  assertEnvSize(content);
+  const normalized = assertEnvConfig(config);
+  if (!hasProjectEnvVariables(normalized)) {
+    await deleteProjectEnv(projectId, dataDir);
+    return { exists: false, config: EMPTY_PROJECT_ENV_CONFIG };
+  }
 
   const dir = join(dataDir, projectId, "env");
   await mkdir(dir, { recursive: true });
 
   const target = projectEnvPath(dataDir, projectId);
-  const tmp = join(dir, `.env.${randomUUID()}.tmp`);
-  await writeFile(tmp, content, { encoding: "utf-8", mode: 0o600 });
+  const tmp = join(dir, `env.${randomUUID()}.json.tmp`);
+  await writeFile(tmp, `${JSON.stringify(normalized, null, 2)}\n`, { encoding: "utf-8", mode: 0o600 });
   await rename(tmp, target);
   await chmod(target, 0o600).catch(() => {});
 
@@ -74,14 +106,11 @@ export async function copyProjectEnvToWorkspace(
   workspacePath: string,
   dataDir = getDataDir(),
 ): Promise<boolean> {
-  const source = projectEnvPath(dataDir, projectId);
-  let content: string;
-  try {
-    content = await readFile(source, "utf-8");
-  } catch (err: unknown) {
-    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
-    throw err;
-  }
+  const env = await loadProjectEnv(projectId, dataDir);
+  if (!env.exists) return false;
+
+  const content = generateProjectEnvContent(env.config);
+  if (!content) return false;
 
   const target = join(workspacePath, ".env");
   await writeFile(target, content, { encoding: "utf-8", mode: 0o600 });

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -85,13 +85,11 @@ export interface ProjectState {
   workspaces: Workspace[];
 }
 
-export interface ProjectEnvData {
-  exists: boolean;
-  content: string;
-  path?: string;
-  sizeBytes?: number;
-  updatedAt?: string;
-}
+export type {
+  ProjectEnvConfig,
+  ProjectEnvData,
+  ProjectEnvVariable,
+} from "@hive/shared/project-env";
 
 export type CreateProjectRequest =
   | { mode?: "clone"; url: string }

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -67,7 +67,9 @@ describe("createWorkspace", () => {
   });
 
   it("copies the project environment into a new workspace", async () => {
-    await saveProjectEnv(projectId, "API_KEY=secret\n", dataDir);
+    await saveProjectEnv(projectId, {
+      variables: [{ id: "var-1", key: "API_KEY", value: "secret" }],
+    }, dataDir);
 
     const ws = await createWorkspace(projectId, dataDir);
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);

--- a/frontend/src/components/ProjectEnvStructuredEditor.tsx
+++ b/frontend/src/components/ProjectEnvStructuredEditor.tsx
@@ -1,16 +1,27 @@
 import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { Eye, EyeOff, Plus, X } from "lucide-react";
+import { Eye, EyeOff, FileUp, Plus, X } from "lucide-react";
 import { nanoid } from "nanoid";
 import {
   hasProjectEnvValueLineBreaks,
   isValidProjectEnvKey,
+  parseProjectEnvContent,
   type ProjectEnvConfig,
   type ProjectEnvVariable,
 } from "@hive/shared/project-env";
 import { CopyButton } from "@/components/chat/CopyButton";
+import { EnvEditor } from "@/components/EnvEditor";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 interface ProjectEnvStructuredEditorProps {
@@ -24,7 +35,10 @@ export function ProjectEnvStructuredEditor({
   onChange,
   readOnly = false,
 }: ProjectEnvStructuredEditorProps) {
+  const [importOpen, setImportOpen] = useState(false);
+  const [importText, setImportText] = useState("");
   const keyCounts = useMemo(() => countKeys(value.variables), [value.variables]);
+  const importedEntries = useMemo(() => parseProjectEnvContent(importText), [importText]);
 
   const updateVariable = (id: string, next: ProjectEnvVariable) => {
     onChange({
@@ -45,9 +59,32 @@ export function ProjectEnvStructuredEditor({
     });
   };
 
+  const openImportDialog = () => {
+    setImportText("");
+    setImportOpen(true);
+  };
+
+  const handleImport = () => {
+    if (importedEntries.length === 0) return;
+
+    onChange({
+      variables: [
+        ...value.variables,
+        ...importedEntries.map((entry) => ({
+          id: nanoid(),
+          key: entry.key,
+          value: entry.value,
+          comment: "",
+        })),
+      ],
+    });
+    setImportText("");
+    setImportOpen(false);
+  };
+
   return (
     <div className="space-y-3">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center gap-2">
         <Button
           type="button"
           variant="outline"
@@ -58,6 +95,17 @@ export function ProjectEnvStructuredEditor({
         >
           <Plus className="h-3.5 w-3.5" />
           Variable
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="xs"
+          disabled={readOnly}
+          onClick={openImportDialog}
+          className="border-border/50 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+        >
+          <FileUp className="h-3.5 w-3.5" />
+          Import .env
         </Button>
       </div>
 
@@ -88,6 +136,45 @@ export function ProjectEnvStructuredEditor({
           ))}
         </div>
       )}
+
+      <Dialog
+        open={importOpen}
+        onOpenChange={(open) => {
+          setImportOpen(open);
+          if (!open) setImportText("");
+        }}
+      >
+        <DialogContent className="sm:max-w-2xl">
+          <DialogHeader>
+            <DialogTitle>Import .env</DialogTitle>
+            <DialogDescription>
+              Paste raw .env content. Comments are ignored and each key-value pair is added as a variable.
+            </DialogDescription>
+          </DialogHeader>
+          <EnvEditor
+            value={importText}
+            onChange={setImportText}
+            maxHeight="18rem"
+            ariaLabel="Raw environment file"
+            className="bg-background/70"
+          />
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="ghost">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button
+              type="button"
+              disabled={importedEntries.length === 0}
+              onClick={handleImport}
+            >
+              <FileUp className="h-3.5 w-3.5" />
+              Import variables
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/src/components/ProjectEnvStructuredEditor.tsx
+++ b/frontend/src/components/ProjectEnvStructuredEditor.tsx
@@ -1,0 +1,202 @@
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+import { Eye, EyeOff, Plus, Trash2 } from "lucide-react";
+import { nanoid } from "nanoid";
+import {
+  isValidProjectEnvKey,
+  type ProjectEnvConfig,
+  type ProjectEnvVariable,
+} from "@hive/shared/project-env";
+import { CopyButton } from "@/components/chat/CopyButton";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+
+interface ProjectEnvStructuredEditorProps {
+  value: ProjectEnvConfig;
+  onChange: (value: ProjectEnvConfig) => void;
+  readOnly?: boolean;
+}
+
+export function ProjectEnvStructuredEditor({
+  value,
+  onChange,
+  readOnly = false,
+}: ProjectEnvStructuredEditorProps) {
+  const keyCounts = useMemo(() => countKeys(value.variables), [value.variables]);
+
+  const updateVariable = (id: string, next: ProjectEnvVariable) => {
+    onChange({
+      variables: value.variables.map((variable) => (variable.id === id ? next : variable)),
+    });
+  };
+
+  const deleteVariable = (id: string) => {
+    onChange({ variables: value.variables.filter((variable) => variable.id !== id) });
+  };
+
+  const addVariable = () => {
+    onChange({
+      variables: [
+        ...value.variables,
+        { id: nanoid(), key: "", value: "", comment: "" },
+      ],
+    });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <button
+          type="button"
+          disabled={readOnly}
+          onClick={addVariable}
+          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Variable
+        </button>
+      </div>
+
+      {value.variables.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border/60 bg-background/50 p-5 text-center">
+          <p className="text-sm font-medium text-foreground">No variables configured</p>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Add a variable when this project needs a generated workspace .env file.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-md border border-border/50 bg-background/40">
+          <div className="grid grid-cols-[minmax(8rem,0.85fr)_minmax(10rem,1fr)_minmax(8rem,1fr)_2rem] gap-3 border-b border-border/50 px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+            <span>Key</span>
+            <span>Value</span>
+            <span>Comment</span>
+            <span className="sr-only">Actions</span>
+          </div>
+          {value.variables.map((variable) => (
+            <VariableRow
+              key={variable.id}
+              variable={variable}
+              duplicate={keyCounts.get(variable.key.trim()) !== undefined && (keyCounts.get(variable.key.trim()) ?? 0) > 1}
+              readOnly={readOnly}
+              onChange={(next) => updateVariable(variable.id, next)}
+              onDelete={() => deleteVariable(variable.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VariableRow({
+  variable,
+  duplicate,
+  readOnly,
+  onChange,
+  onDelete,
+}: {
+  variable: ProjectEnvVariable;
+  duplicate: boolean;
+  readOnly: boolean;
+  onChange: (variable: ProjectEnvVariable) => void;
+  onDelete: () => void;
+}) {
+  const [revealed, setRevealed] = useState(false);
+  const key = variable.key.trim();
+  const invalidKey = key !== "" && !isValidProjectEnvKey(key);
+
+  return (
+    <div className={cn(
+      "grid gap-3 border-b border-border/40 px-3 py-2 last:border-b-0",
+      "sm:grid-cols-[minmax(8rem,0.85fr)_minmax(10rem,1fr)_minmax(8rem,1fr)_2rem]",
+    )}>
+      <div>
+        <Input
+          value={variable.key}
+          disabled={readOnly}
+          onChange={(event) => onChange({ ...variable, key: event.target.value })}
+          placeholder="API_KEY"
+          aria-label="Environment variable key"
+          aria-invalid={invalidKey || duplicate || undefined}
+          className="h-8 font-mono text-xs"
+        />
+        {duplicate && <p className="mt-1 text-[11px] text-destructive">Duplicate key</p>}
+      </div>
+
+      <div className="relative">
+        <Input
+          value={variable.value}
+          disabled={readOnly}
+          type={revealed ? "text" : "password"}
+          onChange={(event) => onChange({ ...variable, value: event.target.value })}
+          placeholder="value"
+          aria-label="Environment variable value"
+          className="h-8 pr-16 font-mono text-xs"
+        />
+        <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
+          <IconButton label={revealed ? "Hide value" : "Reveal value"} onClick={() => setRevealed(!revealed)}>
+            {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+          </IconButton>
+          <CopyButton
+            content={variable.value}
+            disabled={!variable.value}
+            ariaLabel="Copy value"
+            copiedAriaLabel="Value copied"
+            iconClassName="h-3.5 w-3.5"
+            className="h-7 w-7 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+          />
+        </div>
+      </div>
+
+      <Input
+        value={variable.comment ?? ""}
+        disabled={readOnly}
+        onChange={(event) => onChange({ ...variable, comment: event.target.value })}
+        placeholder="Comment"
+        aria-label="Environment variable comment"
+        className="h-8 text-xs"
+      />
+
+      <div className="flex items-center justify-end">
+        <IconButton label="Delete variable" disabled={readOnly} onClick={onDelete}>
+          <Trash2 className="h-3.5 w-3.5" />
+        </IconButton>
+      </div>
+    </div>
+  );
+}
+
+function IconButton({
+  label,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  disabled?: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={label}
+      disabled={disabled}
+      onClick={onClick}
+      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {children}
+    </button>
+  );
+}
+
+function countKeys(variables: ProjectEnvVariable[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const variable of variables) {
+    const key = variable.key.trim();
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/frontend/src/components/ProjectEnvStructuredEditor.tsx
+++ b/frontend/src/components/ProjectEnvStructuredEditor.tsx
@@ -117,8 +117,8 @@ export function ProjectEnvStructuredEditor({
           </p>
         </div>
       ) : (
-        <div className="overflow-hidden rounded-md border border-border/50 bg-background/40">
-          <div className="grid grid-cols-[minmax(8rem,0.85fr)_minmax(10rem,1fr)_minmax(8rem,1fr)_2rem] gap-3 border-b border-border/50 px-3 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        <div>
+          <div className="grid grid-cols-[minmax(8rem,0.85fr)_minmax(10rem,1fr)_minmax(8rem,1fr)_2rem] gap-3 border-b border-border/50 py-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
             <span>Key</span>
             <span>Value</span>
             <span>Comment</span>
@@ -199,7 +199,7 @@ function VariableRow({
 
   return (
     <div className={cn(
-      "grid gap-3 border-b border-border/40 px-3 py-2 last:border-b-0",
+      "grid items-start gap-3 py-2",
       "sm:grid-cols-[minmax(8rem,0.85fr)_minmax(10rem,1fr)_minmax(8rem,1fr)_2rem]",
     )}>
       <div>
@@ -215,29 +215,31 @@ function VariableRow({
         {keyError && <p className="mt-1 text-[11px] text-destructive">{keyError}</p>}
       </div>
 
-      <div className="relative">
-        <Input
-          value={variable.value}
-          disabled={readOnly}
-          type={revealed ? "text" : "password"}
-          onChange={(event) => onChange({ ...variable, value: event.target.value })}
-          placeholder="value"
-          aria-label="Environment variable value"
-          aria-invalid={Boolean(valueError) || undefined}
-          className="h-8 pr-16 font-mono text-xs"
-        />
-        <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
-          <IconButton label={revealed ? "Hide value" : "Reveal value"} onClick={() => setRevealed(!revealed)}>
-            {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
-          </IconButton>
-          <CopyButton
-            content={variable.value}
-            disabled={!variable.value}
-            ariaLabel="Copy value"
-            copiedAriaLabel="Value copied"
-            iconClassName="h-3.5 w-3.5"
-            className="h-7 w-7 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+      <div>
+        <div className="relative">
+          <Input
+            value={variable.value}
+            disabled={readOnly}
+            type={revealed ? "text" : "password"}
+            onChange={(event) => onChange({ ...variable, value: event.target.value })}
+            placeholder="value"
+            aria-label="Environment variable value"
+            aria-invalid={Boolean(valueError) || undefined}
+            className="h-8 pr-16 font-mono text-xs"
           />
+          <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
+            <IconButton label={revealed ? "Hide value" : "Reveal value"} onClick={() => setRevealed(!revealed)}>
+              {revealed ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
+            </IconButton>
+            <CopyButton
+              content={variable.value}
+              disabled={!variable.value}
+              ariaLabel="Copy value"
+              copiedAriaLabel="Value copied"
+              iconClassName="h-3.5 w-3.5"
+              className="h-7 w-7 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+            />
+          </div>
         </div>
         {valueError && <p className="mt-1 text-[11px] text-destructive">{valueError}</p>}
       </div>
@@ -251,7 +253,7 @@ function VariableRow({
         className="h-8 text-xs"
       />
 
-      <div className="flex items-center justify-end">
+      <div className="flex h-8 items-center justify-end">
         <IconButton label="Remove variable" disabled={readOnly} onClick={onDelete}>
           <X className="h-3.5 w-3.5" />
         </IconButton>

--- a/frontend/src/components/ProjectEnvStructuredEditor.tsx
+++ b/frontend/src/components/ProjectEnvStructuredEditor.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { Eye, EyeOff, Plus, Trash2 } from "lucide-react";
 import { nanoid } from "nanoid";
 import {
+  hasProjectEnvValueLineBreaks,
   isValidProjectEnvKey,
   type ProjectEnvConfig,
   type ProjectEnvVariable,
@@ -103,7 +104,8 @@ function VariableRow({
 }) {
   const [revealed, setRevealed] = useState(false);
   const key = variable.key.trim();
-  const invalidKey = key !== "" && !isValidProjectEnvKey(key);
+  const keyError = getKeyError(key, duplicate);
+  const valueError = hasProjectEnvValueLineBreaks(variable.value) ? "Value cannot contain line breaks" : null;
 
   return (
     <div className={cn(
@@ -117,10 +119,10 @@ function VariableRow({
           onChange={(event) => onChange({ ...variable, key: event.target.value })}
           placeholder="API_KEY"
           aria-label="Environment variable key"
-          aria-invalid={invalidKey || duplicate || undefined}
+          aria-invalid={Boolean(keyError) || undefined}
           className="h-8 font-mono text-xs"
         />
-        {duplicate && <p className="mt-1 text-[11px] text-destructive">Duplicate key</p>}
+        {keyError && <p className="mt-1 text-[11px] text-destructive">{keyError}</p>}
       </div>
 
       <div className="relative">
@@ -131,6 +133,7 @@ function VariableRow({
           onChange={(event) => onChange({ ...variable, value: event.target.value })}
           placeholder="value"
           aria-label="Environment variable value"
+          aria-invalid={Boolean(valueError) || undefined}
           className="h-8 pr-16 font-mono text-xs"
         />
         <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
@@ -146,6 +149,7 @@ function VariableRow({
             className="h-7 w-7 text-muted-foreground hover:bg-muted/50 hover:text-foreground"
           />
         </div>
+        {valueError && <p className="mt-1 text-[11px] text-destructive">{valueError}</p>}
       </div>
 
       <Input
@@ -199,4 +203,11 @@ function countKeys(variables: ProjectEnvVariable[]): Map<string, number> {
     counts.set(key, (counts.get(key) ?? 0) + 1);
   }
   return counts;
+}
+
+function getKeyError(key: string, duplicate: boolean): string | null {
+  if (!key) return "Key is required";
+  if (!isValidProjectEnvKey(key)) return "Use letters, numbers, and underscores only";
+  if (duplicate) return "Duplicate key";
+  return null;
 }

--- a/frontend/src/components/ProjectEnvStructuredEditor.tsx
+++ b/frontend/src/components/ProjectEnvStructuredEditor.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
-import { Eye, EyeOff, Plus, Trash2 } from "lucide-react";
+import { Eye, EyeOff, Plus, X } from "lucide-react";
 import { nanoid } from "nanoid";
 import {
   hasProjectEnvValueLineBreaks,
@@ -10,6 +10,7 @@ import {
 } from "@hive/shared/project-env";
 import { CopyButton } from "@/components/chat/CopyButton";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
 interface ProjectEnvStructuredEditorProps {
@@ -47,15 +48,17 @@ export function ProjectEnvStructuredEditor({
   return (
     <div className="space-y-3">
       <div className="flex items-center justify-between">
-        <button
+        <Button
           type="button"
+          variant="outline"
+          size="xs"
           disabled={readOnly}
           onClick={addVariable}
-          className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+          className="border-border/50 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
         >
           <Plus className="h-3.5 w-3.5" />
           Variable
-        </button>
+        </Button>
       </div>
 
       {value.variables.length === 0 ? (
@@ -162,8 +165,8 @@ function VariableRow({
       />
 
       <div className="flex items-center justify-end">
-        <IconButton label="Delete variable" disabled={readOnly} onClick={onDelete}>
-          <Trash2 className="h-3.5 w-3.5" />
+        <IconButton label="Remove variable" disabled={readOnly} onClick={onDelete}>
+          <X className="h-3.5 w-3.5" />
         </IconButton>
       </div>
     </div>
@@ -182,16 +185,18 @@ function IconButton({
   children: ReactNode;
 }) {
   return (
-    <button
+    <Button
       type="button"
+      variant="ghost"
+      size="icon-xs"
       aria-label={label}
       title={label}
       disabled={disabled}
       onClick={onClick}
-      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      className="text-muted-foreground hover:bg-muted/50 hover:text-foreground"
     >
       {children}
-    </button>
+    </Button>
   );
 }
 

--- a/frontend/src/components/chat/CopyButton.tsx
+++ b/frontend/src/components/chat/CopyButton.tsx
@@ -7,16 +7,25 @@ import { useClipboardCopy } from "@/hooks/useClipboardCopy";
 interface CopyButtonProps {
   content: string;
   className?: string;
+  ariaLabel?: string;
+  copiedAriaLabel?: string;
+  iconClassName?: string;
+  disabled?: boolean;
 }
 
 export const CopyButton = memo(function CopyButton({
   content,
   className,
+  ariaLabel = "Copy message",
+  copiedAriaLabel = "Copied",
+  iconClassName = "size-3",
+  disabled = false,
 }: CopyButtonProps) {
   const { copy, isCopied } = useClipboardCopy();
   const copied = isCopied(content);
 
   const handleCopy = async () => {
+    if (disabled) return;
     await copy(content);
   };
 
@@ -25,16 +34,17 @@ export const CopyButton = memo(function CopyButton({
       variant="ghost"
       size="icon-xs"
       onClick={handleCopy}
+      disabled={disabled}
       className={cn(
         "transition-opacity",
         className,
       )}
-      aria-label={copied ? "Copied" : "Copy message"}
+      aria-label={copied ? copiedAriaLabel : ariaLabel}
     >
       {copied ? (
-        <CheckIcon className="size-3 text-green-500" />
+        <CheckIcon className={cn(iconClassName, "text-green-500")} />
       ) : (
-        <ClipboardIcon className="size-3" />
+        <ClipboardIcon className={iconClassName} />
       )}
     </Button>
   );

--- a/frontend/src/hooks/useProjectEnv.ts
+++ b/frontend/src/hooks/useProjectEnv.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./useApi";
-import { EMPTY_PROJECT_ENV_CONFIG, type ProjectEnvConfig, type ProjectEnvData } from "@hive/shared/project-env";
+import type { ProjectEnvConfig, ProjectEnvData } from "@hive/shared/project-env";
 
 const projectEnvQueryKey = (projectId: string | undefined) => ["project-env", projectId] as const;
 
@@ -19,19 +19,6 @@ export function useUpdateProjectEnv(projectId: string) {
       api.put<ProjectEnvData>(`/api/projects/${projectId}/env`, { config }),
     onSuccess: (data) => {
       qc.setQueryData(projectEnvQueryKey(projectId), data);
-    },
-  });
-}
-
-export function useDeleteProjectEnv(projectId: string) {
-  const qc = useQueryClient();
-  return useMutation({
-    mutationFn: () => api.delete(`/api/projects/${projectId}/env`),
-    onSuccess: () => {
-      qc.setQueryData<ProjectEnvData>(projectEnvQueryKey(projectId), {
-        exists: false,
-        config: EMPTY_PROJECT_ENV_CONFIG,
-      });
     },
   });
 }

--- a/frontend/src/hooks/useProjectEnv.ts
+++ b/frontend/src/hooks/useProjectEnv.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "./useApi";
-import type { ProjectEnvData } from "@/types";
+import { EMPTY_PROJECT_ENV_CONFIG, type ProjectEnvConfig, type ProjectEnvData } from "@hive/shared/project-env";
 
 const projectEnvQueryKey = (projectId: string | undefined) => ["project-env", projectId] as const;
 
@@ -15,8 +15,8 @@ export function useProjectEnv(projectId: string | undefined) {
 export function useUpdateProjectEnv(projectId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: (content: string) =>
-      api.put<ProjectEnvData>(`/api/projects/${projectId}/env`, { content }),
+    mutationFn: (config: ProjectEnvConfig) =>
+      api.put<ProjectEnvData>(`/api/projects/${projectId}/env`, { config }),
     onSuccess: (data) => {
       qc.setQueryData(projectEnvQueryKey(projectId), data);
     },
@@ -30,7 +30,7 @@ export function useDeleteProjectEnv(projectId: string) {
     onSuccess: () => {
       qc.setQueryData<ProjectEnvData>(projectEnvQueryKey(projectId), {
         exists: false,
-        content: "",
+        config: EMPTY_PROJECT_ENV_CONFIG,
       });
     },
   });

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -1,8 +1,9 @@
 import { useState, type ReactNode } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Trash2, ExternalLink, Save, Pencil, Plus, X } from "lucide-react";
+import { Trash2, ExternalLink, Save, Pencil, Plus, X, Eye } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { EnvEditor } from "@/components/EnvEditor";
+import { ProjectEnvStructuredEditor } from "@/components/ProjectEnvStructuredEditor";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -13,11 +14,25 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
 import { useProjectEnv, useUpdateProjectEnv, useDeleteProjectEnv } from "@/hooks/useProjectEnv";
 import { cn } from "@/lib/utils";
-import type { Project, ProjectEnvData } from "@/types";
+import type { Project, ProjectEnvConfig, ProjectEnvData } from "@/types";
+import {
+  countProjectEnvVariables,
+  EMPTY_PROJECT_ENV_CONFIG,
+  generateProjectEnvContent,
+  normalizeProjectEnvConfig,
+  validateProjectEnvConfig,
+} from "@hive/shared/project-env";
 
 export default function ProjectDetail() {
   const { projects, deleteProject } = useProjects();
@@ -40,7 +55,7 @@ export default function ProjectDetail() {
   const hasWorkspaces = (project.workspaces ?? []).length > 0;
   const workspaceCount = (project.workspaces ?? []).length;
   const envEditorOpen = editingEnvProjectId === project.id;
-  const envContent = envQuery.data?.content ?? "";
+  const envConfig = envQuery.data?.config ?? EMPTY_PROJECT_ENV_CONFIG;
   const envConfigured = envQuery.data?.exists ?? false;
   const envPath = envQuery.data?.path;
   const envRevision = getEnvRevision(envQuery.data);
@@ -94,7 +109,7 @@ export default function ProjectDetail() {
               {project.workspacesPath ?? "\u2014"}
             </InfoRow>
             {envConfigured && envPath && (
-              <InfoRow label="Env file" mono>
+              <InfoRow label="Env config" mono>
                 {envPath}
               </InfoRow>
             )}
@@ -104,7 +119,7 @@ export default function ProjectDetail() {
         <ProjectEnvSection
           project={project}
           envConfigured={envConfigured}
-          envContent={envContent}
+          envConfig={envConfig}
           envRevision={envRevision}
           envLoading={envQuery.isLoading}
           editorOpen={envEditorOpen}
@@ -163,7 +178,7 @@ export default function ProjectDetail() {
 function ProjectEnvSection({
   project,
   envConfigured,
-  envContent,
+  envConfig,
   envRevision,
   envLoading,
   editorOpen,
@@ -172,7 +187,7 @@ function ProjectEnvSection({
 }: {
   project: Project;
   envConfigured: boolean;
-  envContent: string;
+  envConfig: ProjectEnvConfig;
   envRevision: string;
   envLoading: boolean;
   editorOpen: boolean;
@@ -181,9 +196,9 @@ function ProjectEnvSection({
 }) {
   const updateEnv = useUpdateProjectEnv(project.id);
   const deleteEnv = useDeleteProjectEnv(project.id);
-  const envEntryCount = countEnvEntries(envContent);
+  const [viewerOpen, setViewerOpen] = useState(false);
+  const envEntryCount = countProjectEnvVariables(envConfig);
   const envStatusLabel = getEnvStatusLabel(envLoading, envConfigured);
-  const envButtonLabel = getEnvButtonLabel(envLoading, editorOpen, envConfigured);
   const envDescription = getEnvDescription(envLoading, envConfigured, envEntryCount);
 
   const handleDeleteEnv = async () => {
@@ -191,8 +206,8 @@ function ProjectEnvSection({
     onCloseEditor();
   };
 
-  const handleSaveEnv = async (content: string) => {
-    await updateEnv.mutateAsync(content);
+  const handleSaveEnv = async (config: ProjectEnvConfig) => {
+    await updateEnv.mutateAsync(config);
     onCloseEditor();
   };
 
@@ -202,16 +217,21 @@ function ProjectEnvSection({
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h2 className="text-sm font-medium text-foreground">Environment</h2>
-            <span
-              className={cn(
-                "rounded-md px-2 py-0.5 text-[11px] font-medium",
-                envConfigured && !envLoading
-                  ? "bg-primary/10 text-primary"
-                  : "bg-muted text-muted-foreground",
-              )}
-            >
-              {envStatusLabel}
-            </span>
+            {envConfigured && !envLoading ? (
+              <button
+                type="button"
+                onClick={() => setViewerOpen(true)}
+                className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/15"
+                title="View generated .env"
+              >
+                {envStatusLabel}
+                <Eye className="h-3 w-3" aria-hidden="true" />
+              </button>
+            ) : (
+              <span className="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {envStatusLabel}
+              </span>
+            )}
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
             {envDescription}
@@ -236,28 +256,21 @@ function ProjectEnvSection({
             type="button"
             disabled={envLoading}
             onClick={editorOpen ? onCloseEditor : onOpenEditor}
+            title={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
+            aria-label={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
             className={cn(
-              "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/50 px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+              "inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border/50 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
               envLoading && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
             )}
           >
             {envLoading ? (
-              envButtonLabel
+              <span className="h-3.5 w-3.5" />
             ) : editorOpen ? (
-              <>
-                <X className="h-3.5 w-3.5" />
-                {envButtonLabel}
-              </>
+              <X className="h-3.5 w-3.5" />
             ) : envConfigured ? (
-              <>
-                <Pencil className="h-3.5 w-3.5" />
-                {envButtonLabel}
-              </>
+              <Pencil className="h-3.5 w-3.5" />
             ) : (
-              <>
-                <Plus className="h-3.5 w-3.5" />
-                {envButtonLabel}
-              </>
+              <Plus className="h-3.5 w-3.5" />
             )}
           </button>
         </div>
@@ -266,49 +279,93 @@ function ProjectEnvSection({
       {editorOpen && (
         <ProjectEnvEditor
           key={`${project.id}:${envRevision}`}
-          initialContent={envContent}
+          initialConfig={envConfig}
           loading={envLoading}
           saving={updateEnv.isPending}
-          onSave={(content) => void handleSaveEnv(content)}
+          onSave={(config) => void handleSaveEnv(config)}
         />
       )}
+
+      <ProjectEnvViewer
+        open={viewerOpen}
+        onOpenChange={setViewerOpen}
+        config={envConfig}
+      />
     </section>
   );
 }
 
+function ProjectEnvViewer({
+  open,
+  onOpenChange,
+  config,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  config: ProjectEnvConfig;
+}) {
+  const content = generateProjectEnvContent(config);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Generated .env</DialogTitle>
+          <DialogDescription>
+            Read-only view of the file generated for new workspaces.
+          </DialogDescription>
+        </DialogHeader>
+        {content ? (
+          <EnvEditor
+            value={content}
+            readOnly
+            maxHeight="22rem"
+            ariaLabel="Generated environment file"
+            className="bg-background/70"
+          />
+        ) : (
+          <div className="rounded-md border border-border/50 bg-background/60 px-3 py-2 text-xs text-muted-foreground">
+            No variables configured.
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 function ProjectEnvEditor({
-  initialContent,
+  initialConfig,
   loading,
   saving,
   onSave,
 }: {
-  initialContent: string;
+  initialConfig: ProjectEnvConfig;
   loading: boolean;
   saving: boolean;
-  onSave: (content: string) => void;
+  onSave: (config: ProjectEnvConfig) => void;
 }) {
-  const [draft, setDraft] = useState(initialContent);
-  const dirty = draft !== initialContent;
+  const [draft, setDraft] = useState(initialConfig);
+  const normalizedInitial = normalizeProjectEnvConfig(initialConfig);
+  const normalizedDraft = normalizeProjectEnvConfig(draft);
+  const validation = validateProjectEnvConfig(normalizedDraft);
+  const dirty = JSON.stringify(normalizedDraft) !== JSON.stringify(normalizedInitial);
   const actionsDisabled = loading || saving || !dirty;
+  const saveDisabled = actionsDisabled || !validation.valid;
 
   return (
     <div className="mt-4 border-t border-border/50 pt-4">
-      <EnvEditor
+      <ProjectEnvStructuredEditor
         value={draft}
         onChange={setDraft}
         readOnly={loading}
-        className="bg-background/70"
       />
 
-      <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <p className="text-xs text-muted-foreground">
-          Saved values are copied into workspaces created after this point.
-        </p>
+      <div className="mt-3 flex justify-end">
         <div className="flex shrink-0 items-center gap-2">
           <button
             type="button"
             disabled={actionsDisabled}
-            onClick={() => setDraft(initialContent)}
+            onClick={() => setDraft(initialConfig)}
             className={cn(
               "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
               actionsDisabled && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
@@ -318,11 +375,11 @@ function ProjectEnvEditor({
           </button>
           <button
             type="button"
-            disabled={actionsDisabled}
+            disabled={saveDisabled}
             onClick={() => onSave(draft)}
             className={cn(
               "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
-              actionsDisabled && "cursor-not-allowed opacity-50 hover:opacity-50",
+              saveDisabled && "cursor-not-allowed opacity-50 hover:opacity-50",
             )}
           >
             <Save className="h-3.5 w-3.5" />
@@ -339,30 +396,30 @@ function getEnvStatusLabel(envLoading: boolean, envConfigured: boolean): string 
   return envConfigured ? "Configured" : "Not configured";
 }
 
-function getEnvButtonLabel(
+function getEnvToggleTitle(
   envLoading: boolean,
   editorOpen: boolean,
   envConfigured: boolean,
 ): string {
   if (envLoading) return "Loading";
   if (editorOpen) return "Close";
-  return envConfigured ? "Edit" : "Configure";
+  return envConfigured ? "Edit environment" : "Configure environment";
 }
 
 function getEnvDescription(
   envLoading: boolean,
   envConfigured: boolean,
-  envEntryCount: number,
+  envVariableCount: number,
 ): string {
   if (envLoading) return "Loading project-level variables.";
-  if (!envConfigured) return "Add project-level variables that will be copied into new workspaces.";
-  return `${envEntryCount} entr${envEntryCount === 1 ? "y" : "ies"} stored locally for new workspaces.`;
+  if (!envConfigured) return "Add project-level variables for generated workspace .env files.";
+  return `${envVariableCount} variable${envVariableCount === 1 ? "" : "s"} stored locally for new workspaces.`;
 }
 
 function getEnvRevision(data: ProjectEnvData | undefined): string {
   if (!data) return "loading";
   if (!data.exists) return "missing";
-  return data.updatedAt ?? `${data.sizeBytes ?? data.content.length}:${data.content}`;
+  return data.updatedAt ?? `${data.sizeBytes ?? 0}:${JSON.stringify(data.config)}`;
 }
 
 function InfoRow({ label, mono, children }: { label: string; mono?: boolean; children: ReactNode }) {
@@ -372,13 +429,4 @@ function InfoRow({ label, mono, children }: { label: string; mono?: boolean; chi
       <dd className={cn("min-w-0 text-sm text-foreground", mono && "break-all font-mono text-xs")}>{children}</dd>
     </div>
   );
-}
-
-function countEnvEntries(content: string): number {
-  return content
-    .split(/\r?\n/)
-    .filter((line) => {
-      const trimmed = line.trim();
-      return trimmed !== "" && !trimmed.startsWith("#");
-    }).length;
 }

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -23,7 +23,9 @@ import {
 } from "@/components/ui/dialog";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
-import { useProjectEnv, useUpdateProjectEnv, useDeleteProjectEnv } from "@/hooks/useProjectEnv";
+import { useProjectEnv, useUpdateProjectEnv } from "@/hooks/useProjectEnv";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { Project, ProjectEnvConfig, ProjectEnvData } from "@/types";
 import {
@@ -75,7 +77,7 @@ export default function ProjectDetail() {
       </SettingsHeader>
 
       <div className="max-w-2xl space-y-4 px-4 py-5">
-        <section className="rounded-lg border border-border/50 bg-card/50 p-4">
+        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <h2 className="text-sm font-medium text-foreground">Overview</h2>
             <span className="rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium tabular-nums text-primary">
@@ -127,7 +129,7 @@ export default function ProjectDetail() {
           onCloseEditor={() => setEditingEnvProjectId(null)}
         />
 
-        <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-4">
+        <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-5">
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
               <h2 className="text-sm font-medium text-destructive">Danger zone</h2>
@@ -195,16 +197,10 @@ function ProjectEnvSection({
   onCloseEditor: () => void;
 }) {
   const updateEnv = useUpdateProjectEnv(project.id);
-  const deleteEnv = useDeleteProjectEnv(project.id);
   const [viewerOpen, setViewerOpen] = useState(false);
   const envEntryCount = countProjectEnvVariables(envConfig);
   const envStatusLabel = getEnvStatusLabel(envLoading, envConfigured);
   const envDescription = getEnvDescription(envLoading, envConfigured, envEntryCount);
-
-  const handleDeleteEnv = async () => {
-    await deleteEnv.mutateAsync();
-    onCloseEditor();
-  };
 
   const handleSaveEnv = async (config: ProjectEnvConfig) => {
     await updateEnv.mutateAsync(config);
@@ -212,25 +208,28 @@ function ProjectEnvSection({
   };
 
   return (
-    <section className="rounded-lg border border-border/50 bg-card/50 p-4">
+    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
             <h2 className="text-sm font-medium text-foreground">Environment</h2>
             {envConfigured && !envLoading ? (
-              <button
+              <Button
                 type="button"
+                variant="ghost"
+                size="xs"
                 onClick={() => setViewerOpen(true)}
-                className="inline-flex cursor-pointer items-center gap-1 rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary transition-colors hover:bg-primary/15"
+                className="h-6 border border-primary/20 bg-primary/10 px-2 text-[11px] text-primary hover:bg-primary/15 hover:text-primary"
+                aria-label="View generated .env"
                 title="View generated .env"
               >
                 {envStatusLabel}
                 <Eye className="h-3 w-3" aria-hidden="true" />
-              </button>
+              </Button>
             ) : (
-              <span className="rounded-md bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+              <Badge variant="secondary" className="h-6 rounded-md px-2 text-[11px] text-muted-foreground">
                 {envStatusLabel}
-              </span>
+              </Badge>
             )}
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
@@ -238,30 +237,15 @@ function ProjectEnvSection({
           </p>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {envConfigured && (
-            <button
-              type="button"
-              disabled={deleteEnv.isPending}
-              onClick={() => void handleDeleteEnv()}
-              className={cn(
-                "inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-destructive/40 px-2.5 py-1 text-xs font-medium text-destructive transition-colors hover:bg-destructive/10",
-                deleteEnv.isPending && "cursor-not-allowed opacity-50",
-              )}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Delete
-            </button>
-          )}
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="icon-sm"
             disabled={envLoading}
             onClick={editorOpen ? onCloseEditor : onOpenEditor}
             title={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
             aria-label={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
-            className={cn(
-              "inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md border border-border/50 text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
-              envLoading && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
-            )}
+            className="border-border/50 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
           >
             {envLoading ? (
               <span className="h-3.5 w-3.5" />
@@ -272,7 +256,7 @@ function ProjectEnvSection({
             ) : (
               <Plus className="h-3.5 w-3.5" />
             )}
-          </button>
+          </Button>
         </div>
       </div>
 
@@ -362,29 +346,28 @@ function ProjectEnvEditor({
 
       <div className="mt-3 flex justify-end">
         <div className="flex shrink-0 items-center gap-2">
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="xs"
             disabled={actionsDisabled}
             onClick={() => setDraft(initialConfig)}
             className={cn(
-              "rounded-md px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+              "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
               actionsDisabled && "cursor-not-allowed opacity-50 hover:bg-transparent hover:text-muted-foreground",
             )}
           >
             Discard
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            size="xs"
             disabled={saveDisabled}
             onClick={() => onSave(draft)}
-            className={cn(
-              "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-2.5 py-1 text-xs font-medium text-primary-foreground transition-opacity hover:opacity-90",
-              saveDisabled && "cursor-not-allowed opacity-50 hover:opacity-50",
-            )}
           >
             <Save className="h-3.5 w-3.5" />
             Save
-          </button>
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -76,7 +76,7 @@ export default function ProjectDetail() {
         </div>
       </SettingsHeader>
 
-      <div className="max-w-2xl space-y-4 px-4 py-5">
+      <div className="max-w-4xl space-y-4 px-4 py-5">
         <section className="rounded-lg border border-border/50 bg-card/50 p-5">
           <div className="mb-4 flex items-center justify-between gap-3">
             <h2 className="text-sm font-medium text-foreground">Overview</h2>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -11,13 +11,11 @@ export interface Project {
   warning?: string;
 }
 
-export interface ProjectEnvData {
-  exists: boolean;
-  content: string;
-  path?: string;
-  sizeBytes?: number;
-  updatedAt?: string;
-}
+export type {
+  ProjectEnvConfig,
+  ProjectEnvData,
+  ProjectEnvVariable,
+} from "@hive/shared/project-env";
 
 export interface Workspace {
   id: string;

--- a/frontend/tests/hooks/useProjectEnv.test.tsx
+++ b/frontend/tests/hooks/useProjectEnv.test.tsx
@@ -1,7 +1,7 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { api } from "@/hooks/useApi";
-import { useDeleteProjectEnv, useProjectEnv, useUpdateProjectEnv } from "@/hooks/useProjectEnv";
+import { useProjectEnv, useUpdateProjectEnv } from "@/hooks/useProjectEnv";
 import { createWrapper } from "../test-utils";
 import type { ProjectEnvConfig } from "@hive/shared/project-env";
 
@@ -57,26 +57,6 @@ describe("useProjectEnv", () => {
     });
   });
 
-  it("clears project environment content from the query cache", async () => {
-    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
-
-    const { queryClient, wrapper } = createWrapper();
-    queryClient.setQueryData(["project-env", "proj-1"], {
-      exists: true,
-      config: envConfig("API_KEY", "secret"),
-    });
-    const { result } = renderHook(() => useDeleteProjectEnv("proj-1"), { wrapper });
-
-    await act(async () => {
-      await result.current.mutateAsync();
-    });
-
-    expect(api.delete).toHaveBeenCalledWith("/api/projects/proj-1/env");
-    expect(queryClient.getQueryData(["project-env", "proj-1"])).toEqual({
-      exists: false,
-      config: { variables: [] },
-    });
-  });
 });
 
 function envConfig(key: string, value: string): ProjectEnvConfig {

--- a/frontend/tests/hooks/useProjectEnv.test.tsx
+++ b/frontend/tests/hooks/useProjectEnv.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { api } from "@/hooks/useApi";
 import { useDeleteProjectEnv, useProjectEnv, useUpdateProjectEnv } from "@/hooks/useProjectEnv";
 import { createWrapper } from "../test-utils";
+import type { ProjectEnvConfig } from "@hive/shared/project-env";
 
 vi.mock("@/hooks/useApi", () => ({
   api: {
@@ -17,10 +18,11 @@ describe("useProjectEnv", () => {
     vi.clearAllMocks();
   });
 
-  it("loads project environment content", async () => {
+  it("loads project environment config", async () => {
+    const config = envConfig("API_KEY", "secret");
     vi.mocked(api.get).mockResolvedValueOnce({
       exists: true,
-      content: "API_KEY=secret\n",
+      config,
     });
 
     const { wrapper } = createWrapper();
@@ -29,28 +31,29 @@ describe("useProjectEnv", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(api.get).toHaveBeenCalledWith("/api/projects/proj-1/env");
-    expect(result.current.data?.content).toBe("API_KEY=secret\n");
+    expect(result.current.data?.config).toEqual(config);
   });
 
-  it("saves project environment content into the query cache", async () => {
+  it("saves project environment config into the query cache", async () => {
+    const config = envConfig("API_KEY", "updated");
     vi.mocked(api.put).mockResolvedValueOnce({
       exists: true,
-      content: "API_KEY=updated\n",
+      config,
     });
 
     const { queryClient, wrapper } = createWrapper();
     const { result } = renderHook(() => useUpdateProjectEnv("proj-1"), { wrapper });
 
     await act(async () => {
-      await result.current.mutateAsync("API_KEY=updated\n");
+      await result.current.mutateAsync(config);
     });
 
     expect(api.put).toHaveBeenCalledWith("/api/projects/proj-1/env", {
-      content: "API_KEY=updated\n",
+      config,
     });
     expect(queryClient.getQueryData(["project-env", "proj-1"])).toEqual({
       exists: true,
-      content: "API_KEY=updated\n",
+      config,
     });
   });
 
@@ -60,7 +63,7 @@ describe("useProjectEnv", () => {
     const { queryClient, wrapper } = createWrapper();
     queryClient.setQueryData(["project-env", "proj-1"], {
       exists: true,
-      content: "API_KEY=secret\n",
+      config: envConfig("API_KEY", "secret"),
     });
     const { result } = renderHook(() => useDeleteProjectEnv("proj-1"), { wrapper });
 
@@ -71,7 +74,13 @@ describe("useProjectEnv", () => {
     expect(api.delete).toHaveBeenCalledWith("/api/projects/proj-1/env");
     expect(queryClient.getQueryData(["project-env", "proj-1"])).toEqual({
       exists: false,
-      content: "",
+      config: { variables: [] },
     });
   });
 });
+
+function envConfig(key: string, value: string): ProjectEnvConfig {
+  return {
+    variables: [{ id: "var-1", key, value }],
+  };
+}

--- a/frontend/tests/lib/project-env.test.ts
+++ b/frontend/tests/lib/project-env.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   countProjectEnvVariables,
   generateProjectEnvContent,
+  parseProjectEnvContent,
   parseProjectEnvConfig,
   validateProjectEnvConfig,
   type ProjectEnvConfig,
@@ -32,6 +33,59 @@ describe("project env config helpers", () => {
 
   it("does not generate a .env file when variables are absent", () => {
     expect(generateProjectEnvContent({ variables: [] })).toBe("");
+  });
+
+  it("parses raw .env content into key-value entries", () => {
+    expect(parseProjectEnvContent([
+      "# Local settings",
+      "DATABASE_URL=postgres://local # main database",
+      "export API_KEY=secret",
+      "EMPTY_VALUE=",
+      "QUOTED=\"value # not a comment\" # ignored",
+      "INVALID_LINE",
+      "",
+    ].join("\n"))).toEqual([
+      { key: "DATABASE_URL", value: "postgres://local" },
+      { key: "API_KEY", value: "secret" },
+      { key: "EMPTY_VALUE", value: "" },
+      { key: "QUOTED", value: "value # not a comment" },
+    ]);
+  });
+
+  it("round-trips generated .env values that need quoting", () => {
+    const config: ProjectEnvConfig = {
+      variables: [
+        { id: "var-1", key: "SAFE", value: "simple" },
+        { id: "var-2", key: "HASH", value: "abc # def" },
+        { id: "var-3", key: "SPACE", value: "hello world" },
+        { id: "var-4", key: "QUOTE", value: "say \"hi\"" },
+        { id: "var-5", key: "BACKSLASH", value: "C:\\tmp\\app" },
+        { id: "var-6", key: "PADDED", value: "  padded  " },
+        { id: "var-7", key: "EMPTY", value: "" },
+      ],
+    };
+
+    const generated = generateProjectEnvContent(config);
+
+    expect(generated).toBe([
+      "SAFE=simple",
+      "HASH=\"abc # def\"",
+      "SPACE=\"hello world\"",
+      "QUOTE=\"say \\\"hi\\\"\"",
+      "BACKSLASH=\"C:\\\\tmp\\\\app\"",
+      "PADDED=\"  padded  \"",
+      "EMPTY=",
+      "",
+    ].join("\n"));
+    expect(parseProjectEnvContent(generated)).toEqual([
+      { key: "SAFE", value: "simple" },
+      { key: "HASH", value: "abc # def" },
+      { key: "SPACE", value: "hello world" },
+      { key: "QUOTE", value: "say \"hi\"" },
+      { key: "BACKSLASH", value: "C:\\tmp\\app" },
+      { key: "PADDED", value: "  padded  " },
+      { key: "EMPTY", value: "" },
+    ]);
   });
 
   it("validates empty, invalid, and duplicated keys", () => {

--- a/frontend/tests/lib/project-env.test.ts
+++ b/frontend/tests/lib/project-env.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+import {
+  countProjectEnvVariables,
+  generateProjectEnvContent,
+  parseProjectEnvConfig,
+  validateProjectEnvConfig,
+  type ProjectEnvConfig,
+} from "@hive/shared/project-env";
+
+describe("project env config helpers", () => {
+  it("generates .env content from structured variables", () => {
+    const config: ProjectEnvConfig = {
+      variables: [
+        {
+          id: "var-1",
+          key: "DATABASE_URL",
+          value: "postgres://local",
+          comment: "Local database",
+        },
+        {
+          id: "var-2",
+          key: "EMPTY_VALUE",
+          value: "",
+        },
+      ],
+    };
+
+    expect(generateProjectEnvContent(config)).toBe(
+      "# Local database\nDATABASE_URL=postgres://local\nEMPTY_VALUE=\n",
+    );
+  });
+
+  it("does not generate a .env file when variables are absent", () => {
+    expect(generateProjectEnvContent({ variables: [] })).toBe("");
+  });
+
+  it("validates empty, invalid, and duplicated keys", () => {
+    const result = validateProjectEnvConfig({
+      variables: [
+        { id: "var-1", key: "", value: "" },
+        { id: "var-2", key: "API KEY", value: "" },
+        { id: "var-3", key: "TOKEN", value: "" },
+        { id: "var-4", key: "TOKEN", value: "" },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.errors).toContain("Variable keys cannot be empty.");
+    expect(result.errors).toContain("API KEY is not a valid environment variable key.");
+    expect(result.errors).toContain("TOKEN is duplicated.");
+  });
+
+  it("normalizes parsed config and counts variables", () => {
+    const parsed = parseProjectEnvConfig({
+      variables: [
+        { id: "var-1", key: " API_KEY ", value: "secret", comment: "  Token  " },
+      ],
+    });
+
+    expect(parsed).toEqual({
+      variables: [
+        { id: "var-1", key: "API_KEY", value: "secret", comment: "Token" },
+      ],
+    });
+    expect(countProjectEnvVariables(parsed ?? { variables: [] })).toBe(1);
+  });
+});

--- a/frontend/tests/lib/project-env.test.ts
+++ b/frontend/tests/lib/project-env.test.ts
@@ -41,6 +41,7 @@ describe("project env config helpers", () => {
         { id: "var-2", key: "API KEY", value: "" },
         { id: "var-3", key: "TOKEN", value: "" },
         { id: "var-4", key: "TOKEN", value: "" },
+        { id: "var-5", key: "MULTILINE", value: "one\ntwo" },
       ],
     });
 
@@ -48,6 +49,7 @@ describe("project env config helpers", () => {
     expect(result.errors).toContain("Variable keys cannot be empty.");
     expect(result.errors).toContain("API KEY is not a valid environment variable key.");
     expect(result.errors).toContain("TOKEN is duplicated.");
+    expect(result.errors).toContain("MULTILINE value cannot contain line breaks.");
   });
 
   it("normalizes parsed config and counts variables", () => {

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -5,7 +5,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import ProjectDetail from "@/pages/settings/ProjectDetail";
 import { api } from "@/hooks/useApi";
-import type { Project } from "@/types";
+import type { Project, ProjectEnvConfig } from "@/types";
 
 vi.mock("@/hooks/useApi", () => ({
   api: {
@@ -19,7 +19,7 @@ vi.mock("@/hooks/useApi", () => ({
 function renderProjectDetail(
   path: string,
   projects: Project[],
-  env = { exists: false, content: "" },
+  env = { exists: false, config: { variables: [] } },
 ) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -115,9 +115,10 @@ describe("ProjectDetail", () => {
 
   it("saves project environment changes", async () => {
     const user = userEvent.setup();
+    const savedConfig = envConfig("API_KEY", "secret");
     vi.mocked(api.put).mockResolvedValueOnce({
       exists: true,
-      content: "API_KEY=secret\n",
+      config: savedConfig,
     });
     const projects: Project[] = [
       {
@@ -131,19 +132,25 @@ describe("ProjectDetail", () => {
 
     renderProjectDetail("/settings/repositories/p1", projects);
 
-    expect(await screen.findByRole("button", { name: "Configure" })).toBeInTheDocument();
+    expect(await screen.findByRole("button", { name: "Configure environment" })).toBeInTheDocument();
     expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Configure" }));
-    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
-    expect(editor.closest(".cm-editor")).toBeInTheDocument();
-    await user.click(editor);
-    await user.paste("API_KEY=secret\n");
+    await user.click(screen.getByRole("button", { name: "Configure environment" }));
+    await user.click(await screen.findByRole("button", { name: "Variable" }));
+    await user.type(screen.getByRole("textbox", { name: "Environment variable key" }), "API_KEY");
+    await user.type(screen.getByLabelText("Environment variable value"), "secret");
     await user.click(screen.getByRole("button", { name: "Save" }));
 
     await waitFor(() => {
       expect(api.put).toHaveBeenCalledWith("/api/projects/p1/env", {
-        content: "API_KEY=secret\n",
+        config: {
+          variables: [{
+            id: expect.any(String),
+            key: "API_KEY",
+            value: "secret",
+            comment: "",
+          }],
+        },
       });
     });
   });
@@ -163,15 +170,12 @@ describe("ProjectDetail", () => {
 
     renderProjectDetail("/settings/repositories/p1", projects, {
       exists: true,
-      content: "API_KEY=secret\n",
+      config: envConfig("API_KEY", "secret"),
     });
 
-    expect(await screen.findByText("1 entry stored locally for new workspaces.")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Edit" }));
-    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
-    await waitFor(() => {
-      expect(editor).toHaveTextContent("API_KEY=secret");
-    });
+    expect(await screen.findByText("1 variable stored locally for new workspaces.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Edit environment" }));
+    expect(await screen.findByDisplayValue("API_KEY")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Delete" }));
 
     await waitFor(() => {
@@ -180,7 +184,7 @@ describe("ProjectDetail", () => {
     expect(screen.getByText("Not configured")).toBeInTheDocument();
   });
 
-  it("does not count project environment comments or blank lines as entries", async () => {
+  it("shows configured project environment variable count", async () => {
     const projects: Project[] = [
       {
         id: "p1",
@@ -193,16 +197,21 @@ describe("ProjectDetail", () => {
 
     renderProjectDetail("/settings/repositories/p1", projects, {
       exists: true,
-      content: "# API credentials\n\nAPI_KEY=secret\n   # ignored\nDATABASE_URL=postgres://local\n",
-      path: "/hive-data/proj-1/env/.env",
+      config: {
+        variables: [
+          { id: "var-1", key: "API_KEY", value: "secret" },
+          { id: "var-2", key: "DATABASE_URL", value: "postgres://local" },
+        ],
+      },
+      path: "/hive-data/proj-1/env/env.json",
     });
 
-    expect(await screen.findByText("Env file")).toBeInTheDocument();
-    expect(screen.getByText("/hive-data/proj-1/env/.env")).toBeInTheDocument();
-    expect(await screen.findByText("2 entries stored locally for new workspaces.")).toBeInTheDocument();
+    expect(await screen.findByText("Env config")).toBeInTheDocument();
+    expect(screen.getByText("/hive-data/proj-1/env/env.json")).toBeInTheDocument();
+    expect(await screen.findByText("2 variables stored locally for new workspaces.")).toBeInTheDocument();
   });
 
-  it("renders project environment content in the shared CodeMirror editor", async () => {
+  it("renders project environment config and opens generated view-only modal", async () => {
     const user = userEvent.setup();
     const projects: Project[] = [
       {
@@ -216,16 +225,30 @@ describe("ProjectDetail", () => {
 
     renderProjectDetail("/settings/repositories/p1", projects, {
       exists: true,
-      content: "# API credentials\nAPI_KEY=secret\n",
+      config: {
+        variables: [
+          {
+            id: "var-1",
+            key: "API_KEY",
+            value: "secret",
+            comment: "Token for API calls",
+          },
+        ],
+      },
     });
 
-    await user.click(await screen.findByRole("button", { name: "Edit" }));
-    const editor = await screen.findByRole("textbox", { name: "Environment variables" });
+    await user.click(await screen.findByRole("button", { name: "Edit environment" }));
+    expect(await screen.findByDisplayValue("API_KEY")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("Token for API calls")).toBeInTheDocument();
+    expect(screen.queryByRole("textbox", { name: "Generated environment file" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Configured" }));
+    const editor = await screen.findByRole("textbox", { name: "Generated environment file" });
     const codeMirror = editor.closest(".cm-editor");
 
     expect(codeMirror).toBeInTheDocument();
     expect(within(codeMirror as HTMLElement).queryByRole("textbox")).toBe(editor);
-    expect(editor).toHaveTextContent("# API credentials");
+    expect(editor).toHaveTextContent("# Token for API calls");
     expect(editor).toHaveTextContent("API_KEY=secret");
   });
 
@@ -258,3 +281,9 @@ describe("ProjectDetail", () => {
     });
   });
 });
+
+function envConfig(key: string, value: string): ProjectEnvConfig {
+  return {
+    variables: [{ id: "var-1", key, value }],
+  };
+}

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -181,6 +181,45 @@ describe("ProjectDetail", () => {
     expect(api.put).not.toHaveBeenCalled();
   });
 
+  it("imports raw project environment variables without comments", async () => {
+    const user = userEvent.setup();
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Repo",
+        repoPath: "/repos/repo",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects);
+
+    await user.click(await screen.findByRole("button", { name: "Configure environment" }));
+    await user.click(await screen.findByRole("button", { name: "Import .env" }));
+    const editor = await screen.findByRole("textbox", { name: "Raw environment file" });
+
+    await user.click(editor);
+    await user.paste([
+      "# Local settings",
+      "API_KEY=secret",
+      "DATABASE_URL=postgres://local # main database",
+      "EMPTY_VALUE=",
+    ].join("\n"));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Import variables" })).toBeEnabled();
+    });
+    await user.click(screen.getByRole("button", { name: "Import variables" }));
+
+    expect(await screen.findByDisplayValue("API_KEY")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("DATABASE_URL")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("EMPTY_VALUE")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("secret")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("postgres://local")).toBeInTheDocument();
+    expect(screen.queryByDisplayValue("Local settings")).not.toBeInTheDocument();
+    expect(screen.queryByDisplayValue("main database")).not.toBeInTheDocument();
+  });
+
   it("does not expose a delete action for configured project environment", async () => {
     const user = userEvent.setup();
     const projects: Project[] = [

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -181,9 +181,8 @@ describe("ProjectDetail", () => {
     expect(api.put).not.toHaveBeenCalled();
   });
 
-  it("deletes configured project environment", async () => {
+  it("does not expose a delete action for configured project environment", async () => {
     const user = userEvent.setup();
-    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
     const projects: Project[] = [
       {
         id: "p1",
@@ -202,12 +201,7 @@ describe("ProjectDetail", () => {
     expect(await screen.findByText("1 variable stored locally for new workspaces.")).toBeInTheDocument();
     await user.click(screen.getByRole("button", { name: "Edit environment" }));
     expect(await screen.findByDisplayValue("API_KEY")).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Delete" }));
-
-    await waitFor(() => {
-      expect(api.delete).toHaveBeenCalledWith("/api/projects/p1/env");
-    });
-    expect(screen.getByText("Not configured")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Delete" })).not.toBeInTheDocument();
   });
 
   it("shows configured project environment variable count", async () => {
@@ -268,7 +262,7 @@ describe("ProjectDetail", () => {
     expect(screen.getByDisplayValue("Token for API calls")).toBeInTheDocument();
     expect(screen.queryByRole("textbox", { name: "Generated environment file" })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole("button", { name: "Configured" }));
+    await user.click(screen.getByRole("button", { name: "View generated .env" }));
     const editor = await screen.findByRole("textbox", { name: "Generated environment file" });
     const codeMirror = editor.closest(".cm-editor");
 

--- a/frontend/tests/pages/ProjectDetail.test.tsx
+++ b/frontend/tests/pages/ProjectDetail.test.tsx
@@ -155,6 +155,32 @@ describe("ProjectDetail", () => {
     });
   });
 
+  it("explains invalid project environment keys before saving", async () => {
+    const user = userEvent.setup();
+    const projects: Project[] = [
+      {
+        id: "p1",
+        name: "Repo",
+        repoPath: "/repos/repo",
+        workspaces: [],
+      },
+    ];
+
+    renderProjectDetail("/settings/repositories/p1", projects);
+
+    await user.click(await screen.findByRole("button", { name: "Configure environment" }));
+    await user.click(await screen.findByRole("button", { name: "Variable" }));
+
+    expect(screen.getByText("Key is required")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+
+    await user.type(screen.getByRole("textbox", { name: "Environment variable key" }), "API KEY");
+
+    expect(screen.getByText("Use letters, numbers, and underscores only")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Save" })).toBeDisabled();
+    expect(api.put).not.toHaveBeenCalled();
+  });
+
   it("deletes configured project environment", async () => {
     const user = userEvent.setup();
     vi.mocked(api.delete).mockResolvedValueOnce(undefined);

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,8 +47,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
-        "@codemirror/legacy-modes": "^6.5.2",
         "@codemirror/language-data": "^6.5.2",
+        "@codemirror/legacy-modes": "^6.5.2",
         "@codemirror/theme-one-dark": "^6.1.3",
         "@hive/shared": "^0.1.0",
         "@pierre/diffs": "^1.0.10",

--- a/shared/package.json
+++ b/shared/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    "./project-env": "./dist/project-env.js",
     "./sidebar-preferences": "./dist/sidebar-preferences.js"
   },
   "files": [

--- a/shared/project-env.ts
+++ b/shared/project-env.ts
@@ -22,10 +22,16 @@ export interface ProjectEnvValidationResult {
   errors: string[];
 }
 
+export interface ParsedProjectEnvEntry {
+  key: string;
+  value: string;
+}
+
 export const EMPTY_PROJECT_ENV_CONFIG: ProjectEnvConfig = { variables: [] };
 
 const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const LINE_BREAK_PATTERN = /\r|\n/;
+const VALUE_NEEDS_QUOTES_PATTERN = /[\s#"\\]/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -116,10 +122,96 @@ export function parseProjectEnvConfig(raw: unknown): ProjectEnvConfig | null {
   return normalizeProjectEnvConfig({ variables });
 }
 
+export function parseProjectEnvContent(raw: string): ParsedProjectEnvEntry[] {
+  const entries: ParsedProjectEnvEntry[] = [];
+
+  for (const rawLine of raw.split(/\r?\n/)) {
+    const trimmedLine = rawLine.trim();
+    if (!trimmedLine || trimmedLine.startsWith("#")) continue;
+
+    const line = trimmedLine.startsWith("export ")
+      ? trimmedLine.slice("export ".length).trimStart()
+      : trimmedLine;
+    const equalsIndex = line.indexOf("=");
+    if (equalsIndex <= 0) continue;
+
+    const key = line.slice(0, equalsIndex).trim();
+    if (!key) continue;
+
+    entries.push({
+      key,
+      value: parseProjectEnvValue(line.slice(equalsIndex + 1)),
+    });
+  }
+
+  return entries;
+}
+
+function parseProjectEnvValue(rawValue: string): string {
+  const value = rawValue.trim();
+  const quote = value[0];
+  if (quote === "\"") {
+    const endIndex = findClosingQuote(value, quote);
+    if (endIndex > 0) return unescapeDoubleQuotedValue(value.slice(1, endIndex));
+  }
+  if (quote === "'") {
+    const endIndex = findClosingQuote(value, quote);
+    if (endIndex > 0) return value.slice(1, endIndex);
+  }
+
+  return stripInlineComment(value).trimEnd();
+}
+
+function unescapeDoubleQuotedValue(value: string): string {
+  let parsed = "";
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "\\" || index + 1 >= value.length) {
+      parsed += value[index];
+      continue;
+    }
+
+    const next = value[index + 1];
+    if (next === "\\" || next === "\"") {
+      parsed += next;
+    } else {
+      parsed += `\\${next}`;
+    }
+    index += 1;
+  }
+
+  return parsed;
+}
+
+function findClosingQuote(value: string, quote: string): number {
+  for (let index = 1; index < value.length; index += 1) {
+    if (quote === "\"" && value[index] === "\\" && index + 1 < value.length) {
+      index += 1;
+      continue;
+    }
+    if (value[index] === quote) return index;
+  }
+
+  return -1;
+}
+
+function stripInlineComment(value: string): string {
+  for (let index = 0; index < value.length; index += 1) {
+    if (value[index] !== "#") continue;
+    if (index === 0 || /\s/.test(value[index - 1])) return value.slice(0, index);
+  }
+
+  return value;
+}
+
 function commentLines(text: string): string[] {
   return text
     .split(/\r?\n/)
     .map((line) => `# ${line.trim()}`.trimEnd());
+}
+
+function formatProjectEnvValue(value: string): string {
+  if (!value || !VALUE_NEEDS_QUOTES_PATTERN.test(value)) return value;
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, "\\\"")}"`;
 }
 
 export function generateProjectEnvContent(config: ProjectEnvConfig): string {
@@ -130,7 +222,7 @@ export function generateProjectEnvContent(config: ProjectEnvConfig): string {
       if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
       lines.push(...commentLines(variable.comment));
     }
-    lines.push(`${variable.key}=${variable.value}`);
+    lines.push(`${variable.key}=${formatProjectEnvValue(variable.value)}`);
   }
 
   const content = lines.join("\n").trim();

--- a/shared/project-env.ts
+++ b/shared/project-env.ts
@@ -25,6 +25,7 @@ export interface ProjectEnvValidationResult {
 export const EMPTY_PROJECT_ENV_CONFIG: ProjectEnvConfig = { variables: [] };
 
 const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+const LINE_BREAK_PATTERN = /\r|\n/;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -62,6 +63,10 @@ export function isValidProjectEnvKey(key: string): boolean {
   return ENV_KEY_PATTERN.test(key);
 }
 
+export function hasProjectEnvValueLineBreaks(value: string): boolean {
+  return LINE_BREAK_PATTERN.test(value);
+}
+
 export function validateProjectEnvConfig(config: ProjectEnvConfig): ProjectEnvValidationResult {
   const errors: string[] = [];
   const keys = new Map<string, number>();
@@ -73,6 +78,9 @@ export function validateProjectEnvConfig(config: ProjectEnvConfig): ProjectEnvVa
     }
     if (!isValidProjectEnvKey(variable.key)) {
       errors.push(`${variable.key} is not a valid environment variable key.`);
+    }
+    if (hasProjectEnvValueLineBreaks(variable.value)) {
+      errors.push(`${variable.key || "Variable"} value cannot contain line breaks.`);
     }
 
     keys.set(variable.key, (keys.get(variable.key) ?? 0) + 1);

--- a/shared/project-env.ts
+++ b/shared/project-env.ts
@@ -1,0 +1,130 @@
+export interface ProjectEnvVariable {
+  id: string;
+  key: string;
+  value: string;
+  comment?: string;
+}
+
+export interface ProjectEnvConfig {
+  variables: ProjectEnvVariable[];
+}
+
+export interface ProjectEnvData {
+  exists: boolean;
+  config: ProjectEnvConfig;
+  path?: string;
+  sizeBytes?: number;
+  updatedAt?: string;
+}
+
+export interface ProjectEnvValidationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export const EMPTY_PROJECT_ENV_CONFIG: ProjectEnvConfig = { variables: [] };
+
+const ENV_KEY_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeOptionalText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+export function normalizeProjectEnvConfig(config: ProjectEnvConfig): ProjectEnvConfig {
+  return {
+    variables: config.variables.flatMap((variable): ProjectEnvVariable[] => {
+      if (!variable.id) return [];
+      return [{
+        id: variable.id,
+        key: variable.key.trim(),
+        value: variable.value,
+        comment: normalizeOptionalText(variable.comment),
+      }];
+    }),
+  };
+}
+
+export function hasProjectEnvVariables(config: ProjectEnvConfig): boolean {
+  return normalizeProjectEnvConfig(config).variables.length > 0;
+}
+
+export function countProjectEnvVariables(config: ProjectEnvConfig): number {
+  return normalizeProjectEnvConfig(config).variables.length;
+}
+
+export function isValidProjectEnvKey(key: string): boolean {
+  return ENV_KEY_PATTERN.test(key);
+}
+
+export function validateProjectEnvConfig(config: ProjectEnvConfig): ProjectEnvValidationResult {
+  const errors: string[] = [];
+  const keys = new Map<string, number>();
+
+  for (const variable of normalizeProjectEnvConfig(config).variables) {
+    if (!variable.key) {
+      errors.push("Variable keys cannot be empty.");
+      continue;
+    }
+    if (!isValidProjectEnvKey(variable.key)) {
+      errors.push(`${variable.key} is not a valid environment variable key.`);
+    }
+
+    keys.set(variable.key, (keys.get(variable.key) ?? 0) + 1);
+  }
+
+  for (const [key, count] of keys) {
+    if (count > 1) errors.push(`${key} is duplicated.`);
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function parseProjectEnvConfig(raw: unknown): ProjectEnvConfig | null {
+  if (!isRecord(raw) || !Array.isArray(raw.variables)) return null;
+
+  const variables: ProjectEnvVariable[] = [];
+  for (const rawVariable of raw.variables) {
+    if (!isRecord(rawVariable) || typeof rawVariable.id !== "string") return null;
+    if (typeof rawVariable.key !== "string" || typeof rawVariable.value !== "string") return null;
+    if (rawVariable.comment !== undefined && typeof rawVariable.comment !== "string") return null;
+
+    variables.push({
+      id: rawVariable.id,
+      key: rawVariable.key,
+      value: rawVariable.value,
+      comment: rawVariable.comment,
+    });
+  }
+
+  return normalizeProjectEnvConfig({ variables });
+}
+
+function commentLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => `# ${line.trim()}`.trimEnd());
+}
+
+export function generateProjectEnvContent(config: ProjectEnvConfig): string {
+  const lines: string[] = [];
+
+  for (const variable of normalizeProjectEnvConfig(config).variables) {
+    if (variable.comment) {
+      if (lines.length > 0 && lines[lines.length - 1] !== "") lines.push("");
+      lines.push(...commentLines(variable.comment));
+    }
+    lines.push(`${variable.key}=${variable.value}`);
+  }
+
+  const content = lines.join("\n").trim();
+  return content ? `${content}\n` : "";
+}

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -4,5 +4,5 @@
     "outDir": "dist",
     "rootDir": "."
   },
-  "include": ["sidebar-preferences.ts"]
+  "include": ["project-env.ts", "sidebar-preferences.ts"]
 }


### PR DESCRIPTION
## Summary
- replace raw project env editing with structured variable editing and generated .env preview
- centralize project env config validation in the shared package
- reject multiline env values to prevent generated .env line injection
- remove the explicit project env delete action; clearing all variables and saving disables project env generation

## Tests
- npm run typecheck
- npm run lint
- npm run test --workspace @hive/backend -- project-env
- npm run test --workspace @hive/frontend -- useProjectEnv ProjectDetail project-env
- npm run build --workspace @hive/backend && npm run build --workspace @hive/frontend