### PR TITLE
Fix new repository workspace creation

### DIFF
--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -137,6 +137,7 @@ export async function initProject(
     await git(["add", "."], tempWork);
     await git(["commit", "-m", "Initial commit"], tempWork);
     await git(["push", "origin", "main"], tempWork);
+    await git(["symbolic-ref", "HEAD", "refs/heads/main"], bare);
 
     // 3. Clean up the temp working tree and create workspace/log dirs
     await rm(tempWork, { recursive: true, force: true });

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -3,7 +3,8 @@ import { rm, writeFile, mkdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
-import { createProject } from "../projects/project-manager.js";
+import { createProject, initProject } from "../projects/project-manager.js";
+import { bareRepoPath } from "../utils/paths.js";
 import {
   createWorkspace,
   listWorkspaces,
@@ -56,6 +57,20 @@ describe("createWorkspace", () => {
     // Verify worktree directory exists
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);
     expect(existsSync(wsPath)).toBe(true);
+    expect(existsSync(join(wsPath, "README.md"))).toBe(true);
+  });
+
+  it("creates a workspace from the main branch for newly initialized projects", async () => {
+    const { state } = await initProject("brand-new-repo", {}, dataDir);
+    const bare = bareRepoPath(dataDir, state.id);
+
+    const { stdout: headRef } = await git(["symbolic-ref", "HEAD"], bare);
+    expect(headRef).toBe("refs/heads/main");
+
+    const ws = await createWorkspace(state.id, dataDir);
+    const wsPath = join(dataDir, state.id, "workspaces", ws.name);
+
+    expect(ws.branch).toBe(`workspace/${ws.name}`);
     expect(existsSync(join(wsPath, "README.md"))).toBe(true);
   });
 

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -1,18 +1,46 @@
-import { useRef } from "react";
-import { ArrowLeft, Bell, Bot, CircleUser, FileText, Paintbrush, Wifi, GitFork } from "lucide-react";
+import { useRef, useState } from "react";
+import {
+  ArrowLeft,
+  Bell,
+  Bot,
+  ChevronRight,
+  CircleUser,
+  FileText,
+  Folder,
+  FolderOpen,
+  GitFork,
+  Paintbrush,
+  Wifi,
+} from "lucide-react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "@/components/ProjectAvatar";
 import { useProjects } from "@/hooks/useProjects";
+import {
+  useReadonlySidebarProjectFolders,
+  type SidebarProjectFolderView,
+} from "@/hooks/useSidebarProjectFolders";
 import { SidebarShell } from "@/components/SidebarShell";
+import type { Project } from "@/types";
 
 export default function SettingsSidebar() {
-  const { projects } = useProjects();
+  const { projects, ready: projectsReady } = useProjects();
   const navigate = useNavigate();
   const location = useLocation();
   const { pathname } = location;
   const returnTo = useRef((location.state as { from?: string } | null)?.from ?? "/home");
+  const [expandedFolders, setExpandedFolders] = useState<Record<string, boolean>>({});
+  const { folders, rootProjects } = useReadonlySidebarProjectFolders(projects, projectsReady);
+  const visibleFolders = folders.filter((folder) => folder.projects.length > 0);
+
+  const isFolderExpanded = (folderId: string) => expandedFolders[folderId] ?? false;
+  const toggleFolder = (folderId: string) => {
+    setExpandedFolders((prev) => ({
+      ...prev,
+      [folderId]: !(prev[folderId] ?? false),
+    }));
+  };
 
   const footerActions = (
     <div className="flex items-center justify-end px-2 py-1.5">
@@ -72,27 +100,22 @@ export default function SettingsSidebar() {
 
           {projects.length > 0 && (
             <SidebarSection label="Repositories">
-              {projects.map((project) => {
-                const isActive = pathname === `/settings/repositories/${project.id}`;
-                return (
-                  <Link
-                    key={project.id}
-                    to={`/settings/repositories/${project.id}`}
-                    className={cn(
-                      "group flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors",
-                      isActive
-                        ? "bg-primary/10 text-sidebar-foreground"
-                        : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
-                    )}
-                  >
-                    <ProjectAvatar name={project.name} projectId={project.id} hasFavicon={project.hasFavicon} />
-                    <span className="min-w-0 flex-1 truncate">{project.name}</span>
-                    {isActive && (
-                      <GitFork className="h-3 w-3 shrink-0 text-primary/60" />
-                    )}
-                  </Link>
-                );
-              })}
+              {visibleFolders.map((folder) => (
+                <SettingsRepositoryFolder
+                  key={folder.id}
+                  folder={folder}
+                  pathname={pathname}
+                  expanded={isFolderExpanded(folder.id)}
+                  onToggle={() => toggleFolder(folder.id)}
+                />
+              ))}
+              {rootProjects.map((project) => (
+                <RepositoryNavItem
+                  key={project.id}
+                  project={project}
+                  pathname={pathname}
+                />
+              ))}
             </SidebarSection>
           )}
         </div>
@@ -109,6 +132,95 @@ function SidebarSection({ label, children }: { label: string; children: React.Re
       </h3>
       <div className="space-y-0.5">{children}</div>
     </div>
+  );
+}
+
+function SettingsRepositoryFolder({
+  folder,
+  pathname,
+  expanded,
+  onToggle,
+}: {
+  folder: SidebarProjectFolderView;
+  pathname: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const containsActiveProject = folder.projects.some(
+    (project) => pathname === `/settings/repositories/${project.id}`,
+  );
+
+  return (
+    <div className="space-y-0.5">
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className={cn(
+          "flex w-full items-center gap-1.5 rounded-md px-1 py-1 text-left text-sm transition-colors hover:bg-sidebar-accent/40",
+          containsActiveProject ? "text-sidebar-foreground" : "text-muted-foreground",
+        )}
+      >
+        <ChevronRight
+          className={cn(
+            "h-3.5 w-3.5 shrink-0 transition-transform",
+            expanded && "rotate-90",
+          )}
+        />
+        {expanded ? (
+          <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <Folder className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <span className="min-w-0 flex-1 truncate text-[12px] font-medium">
+          {folder.name}
+        </span>
+      </button>
+
+      {expanded && (
+        <div className="ml-2 border-l border-sidebar-border/40 pl-2">
+          {folder.projects.map((project) => (
+            <RepositoryNavItem
+              key={project.id}
+              project={project}
+              pathname={pathname}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RepositoryNavItem({
+  project,
+  pathname,
+}: {
+  project: Project;
+  pathname: string;
+}) {
+  const isActive = pathname === `/settings/repositories/${project.id}`;
+
+  return (
+    <Link
+      to={`/settings/repositories/${project.id}`}
+      className={cn(
+        "group flex items-center gap-2.5 rounded-md px-2 py-1.5 text-sm transition-colors",
+        isActive
+          ? "bg-primary/10 text-sidebar-foreground"
+          : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground",
+      )}
+    >
+      <ProjectAvatar
+        name={project.name}
+        projectId={project.id}
+        hasFavicon={project.hasFavicon}
+      />
+      <span className="min-w-0 flex-1 truncate">{project.name}</span>
+      {isActive && (
+        <GitFork className="h-3 w-3 shrink-0 text-primary/60" />
+      )}
+    </Link>
   );
 }
 

--- a/frontend/src/hooks/useApi.ts
+++ b/frontend/src/hooks/useApi.ts
@@ -21,6 +21,24 @@ function hasHeader(headers: Record<string, string>, name: string): boolean {
   return Object.keys(headers).some((k) => k.toLowerCase() === target);
 }
 
+function errorMessageFromResponseBody(body: string, fallback: string): string {
+  if (!body.trim()) return fallback;
+
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    if (typeof parsed === "string" && parsed.trim()) return parsed;
+    if (typeof parsed === "object" && parsed !== null) {
+      const { error, message } = parsed as { error?: unknown; message?: unknown };
+      if (typeof error === "string" && error.trim()) return error;
+      if (typeof message === "string" && message.trim()) return message;
+    }
+  } catch {
+    // Plain text error responses are already display-ready.
+  }
+
+  return body;
+}
+
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
   const headers = headerRecord(options?.headers);
   const authToken = import.meta.env.VITE_HIVE_AUTH_TOKEN?.trim();
@@ -36,7 +54,7 @@ async function request<T>(url: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${base}${url}`, { ...options, headers });
   if (!res.ok) {
     const body = await res.text().catch(() => "");
-    throw new ApiError(res.status, body || res.statusText);
+    throw new ApiError(res.status, errorMessageFromResponseBody(body, res.statusText));
   }
   if (res.status === 204) return undefined as T;
   return res.json();

--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -30,12 +30,21 @@ export interface SidebarProjectFolderView extends SidebarProjectFolder {
 
 const FLUSH_DEBOUNCE_MS = 300;
 
+interface UseSidebarProjectFoldersOptions {
+  persist?: boolean;
+}
+
 function createId(): string {
   return self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
 }
 
-export function useSidebarProjectFolders(projects: Project[], projectsReady = true) {
+export function useSidebarProjectFolders(
+  projects: Project[],
+  projectsReady = true,
+  options: UseSidebarProjectFoldersOptions = {},
+) {
   const queryClient = useQueryClient();
+  const persist = options.persist ?? true;
 
   const initialLocalSeedRef = useRef(readSidebarPreferencesLocalSeed());
   const bootstrappedRef = useRef(false);
@@ -129,6 +138,8 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
 
   // Persist local cache immediately + schedule a debounced PUT to the backend.
   useEffect(() => {
+    if (!persist) return;
+
     const canWriteLocalCache =
       bootstrappedRef.current
       && (hydratedRef.current || initialLocalSeedRef.current.source !== "legacy");
@@ -206,7 +217,7 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
         flushTimerRef.current = null;
       }
     };
-  }, [queryClient, refetchPreferences, state]);
+  }, [persist, queryClient, refetchPreferences, state]);
 
   const folders = useMemo<SidebarProjectFolderView[]>(
     () => mapSidebarFolderProjects(state.folders, projects),
@@ -340,5 +351,22 @@ export function useSidebarProjectFolders(projects: Project[], projectsReady = tr
     isFolderExpanded,
     setFolderExpanded,
     getFolderIdForProject,
+  };
+}
+
+export function useReadonlySidebarProjectFolders(
+  projects: Project[],
+  projectsReady = true,
+) {
+  const {
+    folders,
+    rootProjects,
+    hasInitialHydration,
+  } = useSidebarProjectFolders(projects, projectsReady, { persist: false });
+
+  return {
+    folders,
+    rootProjects,
+    hasInitialHydration,
   };
 }

--- a/frontend/tests/components/SettingsSidebar.test.tsx
+++ b/frontend/tests/components/SettingsSidebar.test.tsx
@@ -1,25 +1,63 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Outlet, Route, Routes } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import SettingsSidebar from "@/components/SettingsSidebar";
 
-vi.mock("@/hooks/useApi", () => ({
-  api: {
-    get: vi.fn().mockResolvedValue([
-      {
-        id: "p1",
-        name: "Alpha",
-        url: "https://github.com/acme/alpha.git",
-        createdAt: "2026-02-11T00:00:00.000Z",
-        workspaces: [],
-      },
-    ]),
-    post: vi.fn(),
-    delete: vi.fn(),
-  },
+const apiMock = vi.hoisted(() => ({
+  delete: vi.fn(),
+  get: vi.fn(),
+  post: vi.fn(),
+  put: vi.fn(),
 }));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: apiMock,
+}));
+
+function mockDefaultApi() {
+  apiMock.get.mockImplementation((url: string) => {
+    if (url === "/api/projects") {
+      return Promise.resolve([
+        {
+          id: "p1",
+          name: "Alpha",
+          url: "https://github.com/acme/alpha.git",
+          createdAt: "2026-02-11T00:00:00.000Z",
+          workspaces: [],
+        },
+        {
+          id: "p2",
+          name: "Beta",
+          url: "https://github.com/acme/beta.git",
+          createdAt: "2026-02-12T00:00:00.000Z",
+          workspaces: [],
+        },
+        {
+          id: "p3",
+          name: "Gamma",
+          url: "https://github.com/acme/gamma.git",
+          createdAt: "2026-02-13T00:00:00.000Z",
+          workspaces: [],
+        },
+      ]);
+    }
+
+    if (url === "/api/ui-preferences") {
+      return Promise.resolve({
+        sidebar: {
+          folders: [
+            { id: "folder-1", name: "Client work", projectIds: ["p1", "p2"] },
+          ],
+          folderOpenState: { "folder-1": true },
+        },
+      });
+    }
+
+    return Promise.reject(new Error(`Unexpected GET ${url}`));
+  });
+}
 
 function SettingsShell() {
   return (
@@ -43,6 +81,14 @@ function renderWithProviders(ui: React.ReactElement) {
 }
 
 describe("SettingsSidebar", () => {
+  beforeEach(() => {
+    apiMock.delete.mockReset();
+    apiMock.get.mockReset();
+    apiMock.post.mockReset();
+    apiMock.put.mockReset();
+    mockDefaultApi();
+  });
+
   it("keeps initial return route when navigating inside settings", async () => {
     const user = userEvent.setup();
     renderWithProviders(
@@ -59,6 +105,7 @@ describe("SettingsSidebar", () => {
       </MemoryRouter>,
     );
 
+    await user.click(await screen.findByRole("button", { name: /Client work/i }));
     await user.click(await screen.findByRole("link", { name: /Alpha/i }));
     await waitFor(() => {
       expect(screen.getByText("Repository settings")).toBeInTheDocument();
@@ -143,5 +190,47 @@ describe("SettingsSidebar", () => {
 
     await screen.findByText("Agents settings");
     expect(screen.getByRole("link", { name: /Agents/i })).toHaveClass("bg-primary/10");
+  });
+
+  it("groups repositories with sidebar folders in settings", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="appearance" element={<div>Appearance settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const folder = await screen.findByRole("button", { name: /Client work/i });
+    expect(screen.queryByRole("link", { name: /Alpha/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Beta/i })).not.toBeInTheDocument();
+    await user.click(folder);
+    expect(screen.getByRole("link", { name: /Alpha/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Beta/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Gamma/i })).toBeInTheDocument();
+  });
+
+  it("uses local folder expansion without persisting settings", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="appearance" element={<div>Appearance settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    const folder = await screen.findByRole("button", { name: /Client work/i });
+    await user.click(folder);
+
+    expect(screen.getByRole("link", { name: /Alpha/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Beta/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Gamma/i })).toBeInTheDocument();
+    expect(apiMock.put).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/hooks/useApi.test.ts
+++ b/frontend/tests/hooks/useApi.test.ts
@@ -81,6 +81,17 @@ describe("api", () => {
     await expect(api.get("/api/fail")).rejects.toEqual(new ApiError(400, "bad request"));
   });
 
+  it("throws ApiError with parsed error from JSON error responses", async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(
+      jsonResponse({ error: "Failed to create workspace" }, 500),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(api.get("/api/fail")).rejects.toEqual(
+      new ApiError(500, "Failed to create workspace"),
+    );
+  });
+
   it("throws ApiError with statusText when response body is empty", async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce(
       new Response("", { status: 500, statusText: "Internal Server Error" }),


### PR DESCRIPTION
## Summary
- point newly initialized bare repositories at main so workspace creation does not fall back to master
- parse JSON API error responses so dialogs show the error text instead of raw JSON
- add regression coverage for new-project workspace creation and parsed API errors

## Tests
- npm --prefix backend test -- src/workspaces/workspace-manager.test.ts src/projects/project-manager.test.ts
- npm --prefix frontend test -- tests/hooks/useApi.test.ts
- npm --prefix backend run typecheck
- npm --prefix frontend run typecheck