### PR TITLE
Add provider-native custom agent settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `backend/src/api/prompt-templates.ts`: prompt template CRUD (deletion guard if referenced by automation)
 - `backend/src/api/agent-instructions.ts`: global instruction settings (`GET/PUT/DELETE/POST /api/settings/instructions`) with `.codex/AGENTS.md` canonicalization, Claude symlink sync, and Codex override visibility
 - `backend/src/api/skills.ts`: global skill settings (`GET/POST/PUT/DELETE /api/settings/skills`) with `.agents/skills` canonicalization and Claude symlink sync
+- `backend/src/api/custom-agents.ts`: global custom agent settings (`GET/POST/PUT/DELETE /api/settings/custom-agents`) with provider-native Markdown/TOML editing and explicit counterpart creation
 - `backend/src/ws/stream.ts`: multiplexed hub WebSocket protocol (`/ws/hub`; `sync_workspaces` subscription, `HubOutgoing` envelopes)
 - `backend/src/ws/script.ts`: script execution WebSocket (PTY output streaming)
 - `backend/src/services/git-sync.ts`: branch/diff polling and workspace broadcasts (PR status moved to REST)
@@ -96,6 +97,8 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `backend/src/state/base-prompt.ts`: base prompt persistence (`~/.hive/prompts/base.md`), atomic write, reset-to-default
 - `backend/src/state/agent-instructions.ts`: global instruction discovery and synchronization (`~/.codex/AGENTS.md` canonical, `~/.claude/CLAUDE.md` symlink, `AGENTS.override.md` read-only visibility)
 - `backend/src/state/skills.ts`: global skill discovery and synchronization (`~/.agents/skills` canonical, `~/.claude/skills` symlinks)
+- `backend/src/state/custom-agents.ts`: global custom agent discovery and provider-native persistence (`~/.claude/agents/*.md`, `~/.codex/agents/*.toml`) without symlink sync
+- `backend/src/utils/custom-agent-manifest.ts`: Claude Markdown frontmatter + Codex TOML manifest parsing and counterpart formatting
 - `backend/src/state/ui-preferences.ts`: UI preferences persistence (`$DATA_DIR/ui-preferences.json`) — atomic write, sanitize helper drops folders/project refs that no longer exist
 - `backend/src/state/state.ts`: JSON persistence + per-project locks
 - `backend/src/state/config.ts`: file-based app config (`$DATA_DIR/config.json`)
@@ -161,6 +164,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/pages/settings/PromptTemplatesSettings.tsx`: master-detail split view — base prompt + template list (left) + CodeMirror editor (right) + prompt flow explainer dialog
 - `frontend/src/pages/settings/InstructionsSettings.tsx`: global instructions editor — `.codex/AGENTS.md` canonical storage, Claude symlink sync, Codex override visibility, provider diff view
 - `frontend/src/pages/settings/SkillsSettings.tsx`: master-detail global skills editor — `.agents/skills` canonical storage, Claude symlink sync, provider/status badges
+- `frontend/src/pages/settings/CustomAgentsSettings.tsx`: master-detail global custom agent editor — provider tabs, Markdown/TOML editors, provider-specific delete, explicit counterpart creation
 - `frontend/src/contexts/WorkspaceLiveDataContext.tsx`: React context for `useWorkspaceLiveData` — provides per-session unread tracking, `clearUnread(wsId, sessionId?)`
 - `frontend/src/hooks/useConversation.ts`: reducer-driven WS conversation state + tool responses + `lockedProvider` tracking
 - `frontend/src/hooks/useSessions.ts`: list/create/activate/delete sessions (max 4)
@@ -178,6 +182,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/hooks/useAutomations.ts`: automation CRUD + trigger + run history + run messages hooks (TanStack Query)
 - `frontend/src/hooks/usePromptTemplates.ts`: prompt template CRUD hooks
 - `frontend/src/hooks/useBasePrompt.ts`: base prompt query + update + reset hooks
+- `frontend/src/hooks/useCustomAgents.ts`: custom agent CRUD hooks + completion cache invalidation
 - `frontend/src/hooks/useContextUsage.ts`: context window usage calculation from last assistant message tokens
 - `frontend/src/hooks/useBackgroundAgents.ts`: scans tool calls for background `Task` agents, returns running count
 - `frontend/src/hooks/useTabs.ts`: multi-tab state (session + file tabs) with workspace-level snapshot cache, `FileViewMode = "source" | "diff"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,7 +164,8 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - `frontend/src/pages/settings/PromptTemplatesSettings.tsx`: master-detail split view — base prompt + template list (left) + CodeMirror editor (right) + prompt flow explainer dialog
 - `frontend/src/pages/settings/InstructionsSettings.tsx`: global instructions editor — `.codex/AGENTS.md` canonical storage, Claude symlink sync, Codex override visibility, provider diff view
 - `frontend/src/pages/settings/SkillsSettings.tsx`: master-detail global skills editor — `.agents/skills` canonical storage, Claude symlink sync, provider/status badges
-- `frontend/src/pages/settings/CustomAgentsSettings.tsx`: master-detail global custom agent editor — provider tabs, Markdown/TOML editors, provider-specific delete, explicit counterpart creation
+- `frontend/src/pages/settings/CustomAgentsSettings.tsx`: master-detail global custom agent editor — provider tabs, validated Markdown/TOML editors, provider-specific delete, explicit counterpart creation
+- `frontend/src/components/settings/`: shared settings editor frame, resource list, provider status primitives, and selection helpers
 - `frontend/src/contexts/WorkspaceLiveDataContext.tsx`: React context for `useWorkspaceLiveData` — provides per-session unread tracking, `clearUnread(wsId, sessionId?)`
 - `frontend/src/hooks/useConversation.ts`: reducer-driven WS conversation state + tool responses + `lockedProvider` tracking
 - `frontend/src/hooks/useSessions.ts`: list/create/activate/delete sessions (max 4)

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ It manages:
 - Notification settings (Telegram + APNs, instant-apply toggles, test message).
 - Agent settings (installed providers, versions, update availability).
 - Prompt settings (base prompt editor, template library, prompt flow explainer).
+- Global custom agents settings (provider-native Claude Markdown and Codex TOML, explicit counterpart creation).
 - Global skills settings (single view over Claude/Codex skills, `.agents/skills` canonical storage, Claude symlink sync).
 - Global instructions settings (single editor for Claude/Codex instruction files, `.codex/AGENTS.md` canonical storage, Claude symlink sync, override visibility).
 - Per-repository detail view with deletion controls and CodeMirror-powered project `.env` editing.
@@ -340,6 +341,12 @@ npm test
 | `DELETE` | `/api/settings/skills/:id` | Delete a global skill from Claude and Codex |
 | `POST` | `/api/settings/skills/:id/sync` | Sync one skill into canonical storage |
 | `POST` | `/api/settings/skills/sync-missing` | Sync Claude-only, Codex-only, and matching duplicate global skills |
+| `GET` | `/api/settings/custom-agents` | List global Claude/Codex custom agents and provider presence |
+| `POST` | `/api/settings/custom-agents` | Create a provider-native global custom agent |
+| `GET` | `/api/settings/custom-agents/:id` | Get a custom agent detail with provider-native file contents |
+| `PUT` | `/api/settings/custom-agents/:id/providers/:provider` | Save one provider copy (`claude` Markdown or `codex` TOML) |
+| `DELETE` | `/api/settings/custom-agents/:id/providers/:provider` | Delete one provider copy |
+| `POST` | `/api/settings/custom-agents/:id/providers/:provider/counterpart` | Create an explicit provider-native counterpart from the other provider |
 
 ### Account
 
@@ -402,6 +409,7 @@ Backend key modules:
 - `backend/src/api/prompt-templates.ts` prompt template CRUD
 - `backend/src/api/agent-instructions.ts` global instruction settings + Claude/Codex sync
 - `backend/src/api/skills.ts` global skill settings + Claude/Codex sync
+- `backend/src/api/custom-agents.ts` provider-native global custom agent CRUD + explicit counterpart creation
 - `backend/src/ws/stream.ts` multiplexed hub WebSocket protocol
 - `backend/src/ws/script.ts` script execution WebSocket
 - `backend/src/agents/agent-manager.ts` in-memory session registry, persistence, switching
@@ -420,6 +428,7 @@ Backend key modules:
 - `backend/src/state/base-prompt.ts` base prompt persistence
 - `backend/src/state/agent-instructions.ts` global instruction discovery/canonicalization (`.codex/AGENTS.md`, `.claude/CLAUDE.md`, override visibility)
 - `backend/src/state/skills.ts` global skill discovery/canonicalization (`.agents/skills` + `.claude/skills` symlinks)
+- `backend/src/state/custom-agents.ts` global custom agent discovery (`.claude/agents/*.md`, `.codex/agents/*.toml`) without automatic cross-provider sync
 - `backend/src/utils/preflight.ts` startup dependency checks (git, claude, gh; codex/gemini optional)
 - `backend/src/utils/github.ts` GitHub URL parsing, `gh` CLI wrapper, PR status fetching
 - `backend/src/utils/hive-config.ts` `hive.json` parser for workspace scripts
@@ -427,7 +436,7 @@ Backend key modules:
 Frontend key modules:
 - `frontend/src/pages/WorkspaceView.tsx` main chat/inline diff/file tree/scripts/PR status UI
 - `frontend/src/pages/AutomationDetail.tsx` automation config + run history + run log
-- `frontend/src/pages/settings/` settings pages (Appearance, Connection, Account, Notifications, Agents, Prompts, Instructions, Skills, ProjectDetail)
+- `frontend/src/pages/settings/` settings pages (Appearance, Connection, Account, Notifications, CLI Agents, Custom Agents, Prompts, Instructions, Skills, ProjectDetail)
 - `frontend/src/contexts/WorkspaceLiveDataContext.tsx` WS live data context + unread tracking
 - `frontend/src/hooks/useConversation.ts` reducer-driven conversation state + tool responses + lockedProvider
 - `frontend/src/hooks/useSessions.ts` multi-session operations (max 4)

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ It manages:
 - Notification settings (Telegram + APNs, instant-apply toggles, test message).
 - Agent settings (installed providers, versions, update availability).
 - Prompt settings (base prompt editor, template library, prompt flow explainer).
-- Global custom agents settings (provider-native Claude Markdown and Codex TOML, explicit counterpart creation).
+- Global custom agents settings (validated provider-native Claude Markdown and Codex TOML, explicit counterpart creation).
 - Global skills settings (single view over Claude/Codex skills, `.agents/skills` canonical storage, Claude symlink sync).
 - Global instructions settings (single editor for Claude/Codex instruction files, `.codex/AGENTS.md` canonical storage, Claude symlink sync, override visibility).
 - Per-repository detail view with deletion controls and CodeMirror-powered project `.env` editing.
@@ -437,6 +437,7 @@ Frontend key modules:
 - `frontend/src/pages/WorkspaceView.tsx` main chat/inline diff/file tree/scripts/PR status UI
 - `frontend/src/pages/AutomationDetail.tsx` automation config + run history + run log
 - `frontend/src/pages/settings/` settings pages (Appearance, Connection, Account, Notifications, CLI Agents, Custom Agents, Prompts, Instructions, Skills, ProjectDetail)
+- `frontend/src/components/settings/` shared settings list/editor/status primitives used by instructions, skills, and custom agents
 - `frontend/src/contexts/WorkspaceLiveDataContext.tsx` WS live data context + unread tracking
 - `frontend/src/hooks/useConversation.ts` reducer-driven conversation state + tool responses + lockedProvider
 - `frontend/src/hooks/useSessions.ts` multi-session operations (max 4)

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,14 +18,15 @@
     "postinstall": "chmod +x ../node_modules/node-pty/prebuilds/darwin-*/spawn-helper 2>/dev/null || true"
   },
   "dependencies": {
-    "@hive/shared": "^0.1.0",
     "@fastify/cors": "^11.2.0",
     "@fastify/websocket": "^11.2.0",
+    "@hive/shared": "^0.1.0",
     "croner": "^10.0.1",
     "fastify": "^5.7.4",
     "nanoid": "^3.3.11",
     "node-pty": "^1.1.0",
     "sharp": "^0.34.5",
+    "smol-toml": "^1.6.1",
     "ws": "^8.19.0"
   },
   "devDependencies": {

--- a/backend/src/api/custom-agents.test.ts
+++ b/backend/src/api/custom-agents.test.ts
@@ -154,4 +154,16 @@ describe("custom agent settings routes", () => {
     expect(res.json().status).toBe("both");
     await expect(readFile(join(roots.codex, "reviewer.toml"), "utf-8")).resolves.toContain("developer_instructions");
   });
+
+  it("rejects counterpart creation when the source provider is invalid", async () => {
+    await writeAgent(roots.codex, "reviewer.toml", "name = \"reviewer\"\n");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/settings/custom-agents/reviewer/providers/claude/counterpart",
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Source custom agent is invalid" });
+  });
 });

--- a/backend/src/api/custom-agents.test.ts
+++ b/backend/src/api/custom-agents.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { customAgentRoutes } from "./custom-agents.js";
+import { _clearCustomAgentsLockForTests, type CustomAgentRoots } from "../state/custom-agents.js";
+import { createTempDir } from "../utils/test-helpers.js";
+
+let tmpDir: string;
+let roots: CustomAgentRoots;
+let app: FastifyInstance;
+
+async function writeAgent(root: string, fileName: string, content: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, fileName), content, "utf-8");
+}
+
+beforeEach(async () => {
+  tmpDir = await createTempDir();
+  roots = {
+    claude: join(tmpDir, ".claude", "agents"),
+    codex: join(tmpDir, ".codex", "agents"),
+  };
+  _clearCustomAgentsLockForTests();
+  app = Fastify();
+  await app.register((instance) => customAgentRoutes(instance, { roots }));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+  await rm(tmpDir, { recursive: true, force: true });
+  _clearCustomAgentsLockForTests();
+});
+
+describe("custom agent settings routes", () => {
+  it("returns global custom agents", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Reviewer\n");
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/custom-agents" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      agents: [
+        expect.objectContaining({
+          id: "reviewer",
+          status: "claude_only",
+        }),
+      ],
+    });
+  });
+
+  it("returns detail with provider contents", async () => {
+    await writeAgent(
+      roots.codex,
+      "reviewer.toml",
+      "name = \"reviewer\"\ndeveloper_instructions = \"Review changes.\"\n",
+    );
+
+    const res = await app.inject({ method: "GET", url: "/api/settings/custom-agents/reviewer" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual(
+      expect.objectContaining({
+        id: "reviewer",
+        contents: expect.objectContaining({
+          codex: expect.stringContaining("developer_instructions"),
+        }),
+      }),
+    );
+  });
+
+  it("creates a Claude custom agent", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/settings/custom-agents",
+      payload: {
+        provider: "claude",
+        content: "---\nname: reviewer\ndescription: Review code\n---\n# Reviewer\n",
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(res.json()).toEqual(expect.objectContaining({ id: "reviewer", status: "claude_only" }));
+    await expect(readFile(join(roots.claude, "reviewer.md"), "utf-8")).resolves.toContain("# Reviewer");
+  });
+
+  it("rejects invalid providers and invalid content", async () => {
+    const badProvider = await app.inject({
+      method: "POST",
+      url: "/api/settings/custom-agents",
+      payload: { provider: "gemini", content: "name = \"x\"" },
+    });
+    expect(badProvider.statusCode).toBe(400);
+
+    const badContent = await app.inject({
+      method: "POST",
+      url: "/api/settings/custom-agents",
+      payload: { provider: "codex", content: "name = \"reviewer\"\n" },
+    });
+    expect(badContent.statusCode).toBe(400);
+    expect(badContent.json()).toEqual({ error: "developer_instructions is required" });
+  });
+
+  it("saves an existing provider copy", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Old\n");
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/custom-agents/reviewer/providers/claude",
+      payload: { content: "---\nname: reviewer\n---\n# New\n" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe("reviewer");
+    await expect(readFile(join(roots.claude, "reviewer.md"), "utf-8")).resolves.toContain("# New");
+  });
+
+  it("returns 409 when saving would collide with another provider copy", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Reviewer\n");
+    await writeAgent(roots.claude, "tester.md", "---\nname: tester\n---\n# Tester\n");
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/custom-agents/reviewer/providers/claude",
+      payload: { content: "---\nname: tester\n---\n# Renamed\n" },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: "Custom agent already exists" });
+  });
+
+  it("deletes a provider copy", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Reviewer\n");
+
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/api/settings/custom-agents/reviewer/providers/claude",
+    });
+
+    expect(res.statusCode).toBe(204);
+    await expect(lstat(join(roots.claude, "reviewer.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("creates a counterpart", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Reviewer\n");
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/settings/custom-agents/reviewer/providers/codex/counterpart",
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().status).toBe("both");
+    await expect(readFile(join(roots.codex, "reviewer.toml"), "utf-8")).resolves.toContain("developer_instructions");
+  });
+});

--- a/backend/src/api/custom-agents.ts
+++ b/backend/src/api/custom-agents.ts
@@ -1,0 +1,141 @@
+import type { FastifyInstance } from "fastify";
+import {
+  createGlobalCustomAgent,
+  createGlobalCustomAgentCounterpart,
+  deleteGlobalCustomAgentProvider,
+  globalCustomAgentRoots,
+  listGlobalCustomAgents,
+  loadGlobalCustomAgent,
+  saveGlobalCustomAgentProvider,
+  withCustomAgentsLock,
+  type CustomAgentRoots,
+} from "../state/custom-agents.js";
+import type {
+  CreateCustomAgentRequest,
+  CustomAgentProviderId,
+  UpdateCustomAgentRequest,
+} from "../types.js";
+import { errorMessage, errorStatus } from "../utils/errors.js";
+
+interface CustomAgentRoutesOptions {
+  roots?: CustomAgentRoots;
+}
+
+function parseProvider(value: string | undefined): CustomAgentProviderId | null {
+  return value === "claude" || value === "codex" ? value : null;
+}
+
+export async function customAgentRoutes(
+  app: FastifyInstance,
+  opts: CustomAgentRoutesOptions = {},
+): Promise<void> {
+  const roots = opts.roots ?? globalCustomAgentRoots();
+
+  app.get("/api/settings/custom-agents", async (_req, reply) => {
+    try {
+      return await listGlobalCustomAgents(roots);
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Failed to list custom agents") });
+    }
+  });
+
+  app.post<{ Body: CreateCustomAgentRequest }>("/api/settings/custom-agents", async (req, reply) => {
+    try {
+      const provider = parseProvider(req.body?.provider);
+      if (!provider) return reply.status(400).send({ error: "Unsupported custom agent provider" });
+
+      const { content } = req.body ?? {};
+      if (typeof content !== "string" || !content.trim()) {
+        return reply.status(400).send({ error: "Content is required" });
+      }
+
+      const agent = await withCustomAgentsLock(() =>
+        createGlobalCustomAgent(provider, content, roots),
+      );
+      return reply.status(201).send(agent);
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Failed to create custom agent") });
+    }
+  });
+
+  app.get<{ Params: { id: string } }>("/api/settings/custom-agents/:id", async (req, reply) => {
+    try {
+      const agent = await loadGlobalCustomAgent(req.params.id, roots);
+      if (!agent) return reply.status(404).send({ error: "Custom agent not found" });
+      return agent;
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Failed to load custom agent") });
+    }
+  });
+
+  app.put<{
+    Params: { id: string; provider: string };
+    Body: UpdateCustomAgentRequest;
+  }>("/api/settings/custom-agents/:id/providers/:provider", async (req, reply) => {
+    try {
+      const provider = parseProvider(req.params.provider);
+      if (!provider) return reply.status(400).send({ error: "Unsupported custom agent provider" });
+
+      const { content } = req.body ?? {};
+      if (typeof content !== "string" || !content.trim()) {
+        return reply.status(400).send({ error: "Content is required" });
+      }
+
+      const agent = await withCustomAgentsLock(() =>
+        saveGlobalCustomAgentProvider(req.params.id, provider, content, roots),
+      );
+      if (!agent) return reply.status(404).send({ error: "Custom agent not found" });
+      return agent;
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Failed to save custom agent") });
+    }
+  });
+
+  app.delete<{ Params: { id: string; provider: string } }>(
+    "/api/settings/custom-agents/:id/providers/:provider",
+    async (req, reply) => {
+      try {
+        const provider = parseProvider(req.params.provider);
+        if (!provider) return reply.status(400).send({ error: "Unsupported custom agent provider" });
+
+        const deleted = await withCustomAgentsLock(() =>
+          deleteGlobalCustomAgentProvider(req.params.id, provider, roots),
+        );
+        if (!deleted) return reply.status(404).send({ error: "Custom agent not found" });
+        return reply.status(204).send();
+      } catch (err: unknown) {
+        return reply
+          .status(errorStatus(err))
+          .send({ error: errorMessage(err, "Failed to delete custom agent") });
+      }
+    },
+  );
+
+  app.post<{ Params: { id: string; provider: string } }>(
+    "/api/settings/custom-agents/:id/providers/:provider/counterpart",
+    async (req, reply) => {
+      try {
+        const provider = parseProvider(req.params.provider);
+        if (!provider) return reply.status(400).send({ error: "Unsupported custom agent provider" });
+
+        const agent = await withCustomAgentsLock(() =>
+          createGlobalCustomAgentCounterpart(req.params.id, provider, roots),
+        );
+        if (!agent) return reply.status(404).send({ error: "Custom agent not found" });
+        return agent;
+      } catch (err: unknown) {
+        return reply
+          .status(errorStatus(err))
+          .send({ error: errorMessage(err, "Failed to create custom agent counterpart") });
+      }
+    },
+  );
+}

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -126,6 +126,16 @@ describe("buildApp", () => {
     });
   });
 
+  it("registers custom agent settings routes", async () => {
+    app = await buildApp();
+    const res = await app.inject({ method: "GET", url: "/api/settings/custom-agents" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({
+      agents: expect.any(Array),
+    });
+  });
+
   it("registers session routes", async () => {
     app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/api/workspaces/test-ws/session" });

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -27,6 +27,7 @@ import { promptTemplateRoutes } from "./api/prompt-templates.js";
 import { basePromptRoutes } from "./api/base-prompt.js";
 import { skillRoutes } from "./api/skills.js";
 import { instructionRoutes } from "./api/agent-instructions.js";
+import { customAgentRoutes } from "./api/custom-agents.js";
 import { uiPreferencesRoutes } from "./api/ui-preferences.js";
 import { AutomationScheduler } from "./services/automation-scheduler.js";
 import { loadConfig } from "./state/config.js";
@@ -331,6 +332,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   await app.register((instance: FastifyInstance) => basePromptRoutes(instance));
   await app.register((instance: FastifyInstance) => skillRoutes(instance));
   await app.register((instance: FastifyInstance) => instructionRoutes(instance));
+  await app.register((instance: FastifyInstance) => customAgentRoutes(instance));
   await app.register((instance: FastifyInstance) => uiPreferencesRoutes(instance));
 
   return app;

--- a/backend/src/state/custom-agents.test.ts
+++ b/backend/src/state/custom-agents.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { lstat, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { createTempDir } from "../utils/test-helpers.js";
+import {
+  _clearCustomAgentsLockForTests,
+  createGlobalCustomAgent,
+  createGlobalCustomAgentCounterpart,
+  deleteGlobalCustomAgentProvider,
+  listGlobalCustomAgents,
+  loadGlobalCustomAgent,
+  saveGlobalCustomAgentProvider,
+  type CustomAgentRoots,
+} from "./custom-agents.js";
+
+let tmpDir: string;
+let roots: CustomAgentRoots;
+
+async function writeAgent(root: string, fileName: string, content: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, fileName), content, "utf-8");
+}
+
+beforeEach(async () => {
+  tmpDir = await createTempDir();
+  roots = {
+    claude: join(tmpDir, ".claude", "agents"),
+    codex: join(tmpDir, ".codex", "agents"),
+  };
+  _clearCustomAgentsLockForTests();
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+  _clearCustomAgentsLockForTests();
+});
+
+describe("global custom agents state", () => {
+  it("lists Claude and Codex custom agents as one collection", async () => {
+    await writeAgent(
+      roots.claude,
+      "reviewer.md",
+      "---\nname: reviewer\ndescription: Review code\n---\n# Reviewer\n",
+    );
+    await writeAgent(
+      roots.codex,
+      "planner.toml",
+      "name = \"planner\"\ndescription = \"Plan work\"\ndeveloper_instructions = \"Plan changes.\"\n",
+    );
+
+    const { agents } = await listGlobalCustomAgents(roots);
+
+    expect(agents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "reviewer",
+          status: "claude_only",
+          providers: expect.objectContaining({
+            claude: expect.objectContaining({ present: true }),
+            codex: expect.objectContaining({ present: false }),
+          }),
+        }),
+        expect.objectContaining({
+          id: "planner",
+          status: "codex_only",
+        }),
+      ]),
+    );
+  });
+
+  it("groups matching Claude and Codex agents as both", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Claude\n");
+    await writeAgent(
+      roots.codex,
+      "reviewer.toml",
+      "name = \"reviewer\"\ndeveloper_instructions = \"Codex\"\n",
+    );
+
+    const detail = await loadGlobalCustomAgent("reviewer", roots);
+
+    expect(detail?.status).toBe("both");
+    expect(detail?.contents.claude).toContain("# Claude");
+    expect(detail?.contents.codex).toContain("developer_instructions");
+  });
+
+  it("keeps invalid provider content editable", async () => {
+    await writeAgent(roots.codex, "broken.toml", "name = \"broken\"\n=");
+
+    const detail = await loadGlobalCustomAgent("broken", roots);
+
+    expect(detail?.status).toBe("invalid");
+    expect(detail?.invalidReason).toBeTruthy();
+    expect(detail?.contents.codex).toBe("name = \"broken\"\n=");
+  });
+
+  it("creates a provider-native custom agent", async () => {
+    const created = await createGlobalCustomAgent(
+      "claude",
+      "---\nname: reviewer\ndescription: Review code\n---\n# Reviewer\n",
+      roots,
+    );
+
+    expect(created.id).toBe("reviewer");
+    expect(created.status).toBe("claude_only");
+    await expect(readFile(join(roots.claude, "reviewer.md"), "utf-8")).resolves.toContain("# Reviewer");
+  });
+
+  it("rejects creating Codex content without developer_instructions", async () => {
+    await expect(
+      createGlobalCustomAgent("codex", "name = \"reviewer\"\n", roots),
+    ).rejects.toThrow("developer_instructions is required");
+  });
+
+  it("renames only the edited provider copy", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Reviewer\n");
+
+    const saved = await saveGlobalCustomAgentProvider(
+      "reviewer",
+      "claude",
+      "---\nname: auditor\n---\n# Auditor\n",
+      roots,
+    );
+
+    expect(saved?.id).toBe("auditor");
+    await expect(readFile(join(roots.claude, "auditor.md"), "utf-8")).resolves.toContain("# Auditor");
+    await expect(lstat(join(roots.claude, "reviewer.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("deletes a single provider copy", async () => {
+    await writeAgent(roots.claude, "reviewer.md", "---\nname: reviewer\n---\n# Claude\n");
+    await writeAgent(
+      roots.codex,
+      "reviewer.toml",
+      "name = \"reviewer\"\ndeveloper_instructions = \"Codex\"\n",
+    );
+
+    await expect(deleteGlobalCustomAgentProvider("reviewer", "claude", roots)).resolves.toBe(true);
+
+    const detail = await loadGlobalCustomAgent("reviewer", roots);
+    expect(detail?.status).toBe("codex_only");
+    await expect(lstat(join(roots.claude, "reviewer.md"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("creates an explicit Codex counterpart from Claude content", async () => {
+    await writeAgent(
+      roots.claude,
+      "reviewer.md",
+      "---\nname: reviewer\ndescription: Review code\n---\n# Reviewer\n\nReview changes carefully.\n",
+    );
+
+    const created = await createGlobalCustomAgentCounterpart("reviewer", "codex", roots);
+
+    expect(created?.status).toBe("both");
+    const content = await readFile(join(roots.codex, "reviewer.toml"), "utf-8");
+    expect(content).toContain("name = \"reviewer\"");
+    expect(content).toContain("developer_instructions");
+    expect(content).toContain("Review changes carefully");
+  });
+});

--- a/backend/src/state/custom-agents.test.ts
+++ b/backend/src/state/custom-agents.test.ts
@@ -93,6 +93,17 @@ describe("global custom agents state", () => {
     expect(detail?.contents.codex).toBe("name = \"broken\"\n=");
   });
 
+  it("marks Codex agents without developer instructions invalid but editable", async () => {
+    await writeAgent(roots.codex, "reviewer.toml", "name = \"reviewer\"\n");
+
+    const detail = await loadGlobalCustomAgent("reviewer", roots);
+
+    expect(detail?.status).toBe("invalid");
+    expect(detail?.invalidReason).toBe("developer_instructions is required");
+    expect(detail?.contents.codex).toBe("name = \"reviewer\"\n");
+    expect(detail?.manifests.codex).toBeUndefined();
+  });
+
   it("creates a provider-native custom agent", async () => {
     const created = await createGlobalCustomAgent(
       "claude",
@@ -155,5 +166,13 @@ describe("global custom agents state", () => {
     expect(content).toContain("name = \"reviewer\"");
     expect(content).toContain("developer_instructions");
     expect(content).toContain("Review changes carefully");
+  });
+
+  it("rejects counterpart creation from an invalid source provider", async () => {
+    await writeAgent(roots.codex, "reviewer.toml", "name = \"reviewer\"\n");
+
+    await expect(
+      createGlobalCustomAgentCounterpart("reviewer", "claude", roots),
+    ).rejects.toThrow("Source custom agent is invalid");
   });
 });

--- a/backend/src/state/custom-agents.ts
+++ b/backend/src/state/custom-agents.ts
@@ -1,0 +1,413 @@
+import { homedir } from "node:os";
+import { basename, dirname, join, relative } from "node:path";
+import { lstat, mkdir, readdir, readFile, realpath } from "node:fs/promises";
+import { BadRequestError, ConflictError } from "../utils/errors.js";
+import { hashContent, pathExists, removePath, writeAtomic } from "../utils/file-sync.js";
+import {
+  customAgentFileStem,
+  formatClaudeCustomAgent,
+  formatCodexCustomAgent,
+  parseCustomAgentManifest,
+  type CustomAgentManifest,
+} from "../utils/custom-agent-manifest.js";
+import type {
+  CustomAgentDetail,
+  CustomAgentListResponse,
+  CustomAgentProviderId,
+  CustomAgentProviderState,
+  CustomAgentSummary,
+} from "../types.js";
+
+export interface CustomAgentRoots {
+  claude: string;
+  codex: string;
+}
+
+interface ProviderAgentEntry {
+  provider: CustomAgentProviderId;
+  fileName: string;
+  path: string;
+  present: true;
+  isSymlink: boolean;
+  realPath?: string;
+  content?: string;
+  hash?: string;
+  manifest?: CustomAgentManifest;
+  fallbackName: string;
+  updatedAt?: string;
+  error?: string;
+}
+
+interface FileEntry {
+  path: string;
+  relativePath: string;
+}
+
+let customAgentsLock: Promise<void> = Promise.resolve();
+
+export function globalCustomAgentRoots(home = homedir()): CustomAgentRoots {
+  return {
+    claude: join(home, ".claude", "agents"),
+    codex: join(home, ".codex", "agents"),
+  };
+}
+
+export async function withCustomAgentsLock<T>(fn: () => Promise<T>): Promise<T> {
+  const prev = customAgentsLock;
+  let release: (() => void) | undefined;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  customAgentsLock = prev.then(() => current);
+
+  await prev;
+  try {
+    return await fn();
+  } finally {
+    release?.();
+  }
+}
+
+export function _clearCustomAgentsLockForTests(): void {
+  customAgentsLock = Promise.resolve();
+}
+
+function providerRoot(roots: CustomAgentRoots, provider: CustomAgentProviderId): string {
+  return provider === "claude" ? roots.claude : roots.codex;
+}
+
+function providerExtension(provider: CustomAgentProviderId): ".md" | ".toml" {
+  return provider === "claude" ? ".md" : ".toml";
+}
+
+function defaultProviderPath(
+  roots: CustomAgentRoots,
+  provider: CustomAgentProviderId,
+  id: string,
+): string {
+  return join(providerRoot(roots, provider), `${id}${providerExtension(provider)}`);
+}
+
+function providerState(
+  roots: CustomAgentRoots,
+  provider: CustomAgentProviderId,
+  id: string,
+  entry?: ProviderAgentEntry,
+): CustomAgentProviderState {
+  if (!entry) {
+    return {
+      present: false,
+      path: defaultProviderPath(roots, provider, id),
+    };
+  }
+
+  return {
+    present: true,
+    path: entry.path,
+    fileName: entry.fileName,
+    isSymlink: entry.isSymlink,
+    realPath: entry.realPath,
+    hash: entry.hash,
+    updatedAt: entry.updatedAt,
+    error: entry.error,
+  };
+}
+
+function newestDate(values: Array<string | undefined>): string | undefined {
+  return values.filter(Boolean).sort().at(-1);
+}
+
+function entryId(entry: ProviderAgentEntry): string {
+  return customAgentFileStem(entry.manifest?.name ?? entry.fallbackName);
+}
+
+async function walkFiles(dir: string, extension: string, root = dir): Promise<FileEntry[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+
+  const files: FileEntry[] = [];
+  for (const entry of entries) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await walkFiles(fullPath, extension, root));
+      continue;
+    }
+    if ((!entry.isFile() && !entry.isSymbolicLink()) || !entry.name.endsWith(extension)) continue;
+    files.push({ path: fullPath, relativePath: relative(root, fullPath) });
+  }
+  return files;
+}
+
+async function readProviderAgent(
+  provider: CustomAgentProviderId,
+  file: FileEntry,
+): Promise<ProviderAgentEntry> {
+  const extension = providerExtension(provider);
+  const fallbackName = basename(file.relativePath, extension);
+  const stat = await lstat(file.path);
+  const isSymlink = stat.isSymbolicLink();
+  const realPath = await realpath(file.path).catch(() => undefined);
+
+  try {
+    const content = await readFile(file.path, "utf-8");
+    const manifest = parseCustomAgentManifest(provider, content, fallbackName);
+    const fileStat = await lstat(file.path).catch(() => stat);
+
+    return {
+      provider,
+      fileName: file.relativePath,
+      path: file.path,
+      present: true,
+      isSymlink,
+      realPath,
+      content,
+      hash: hashContent(content),
+      manifest,
+      fallbackName,
+      updatedAt: fileStat.mtime.toISOString(),
+    };
+  } catch (err: unknown) {
+    return {
+      provider,
+      fileName: file.relativePath,
+      path: file.path,
+      present: true,
+      isSymlink,
+      realPath,
+      fallbackName,
+      error: err instanceof Error ? err.message : "Unreadable custom agent",
+      updatedAt: stat.mtime.toISOString(),
+    };
+  }
+}
+
+async function scanProviderAgents(
+  roots: CustomAgentRoots,
+  provider: CustomAgentProviderId,
+): Promise<ProviderAgentEntry[]> {
+  const files = await walkFiles(providerRoot(roots, provider), providerExtension(provider));
+  const entries: ProviderAgentEntry[] = [];
+  for (const file of files) {
+    entries.push(await readProviderAgent(provider, file));
+  }
+  return entries;
+}
+
+function summarizeGroup(
+  roots: CustomAgentRoots,
+  id: string,
+  entries: Partial<Record<CustomAgentProviderId, ProviderAgentEntry>>,
+): CustomAgentSummary {
+  const claude = entries.claude;
+  const codex = entries.codex;
+  const primary = codex?.manifest ? codex : claude?.manifest ? claude : codex ?? claude;
+  const hasClaude = Boolean(claude?.manifest);
+  const hasCodex = Boolean(codex?.manifest);
+  const hasError = Boolean(claude?.error || codex?.error);
+
+  let status: CustomAgentSummary["status"];
+  if (hasError || (!hasClaude && !hasCodex)) {
+    status = "invalid";
+  } else if (hasClaude && hasCodex) {
+    status = "both";
+  } else if (hasClaude) {
+    status = "claude_only";
+  } else {
+    status = "codex_only";
+  }
+
+  return {
+    id,
+    name: primary?.manifest?.name ?? primary?.fallbackName ?? id,
+    description: primary?.manifest?.description,
+    status,
+    providers: {
+      claude: providerState(roots, "claude", id, claude),
+      codex: providerState(roots, "codex", id, codex),
+    },
+    invalidReason: status === "invalid" ? claude?.error ?? codex?.error ?? "Invalid custom agent" : undefined,
+    updatedAt: newestDate([claude?.updatedAt, codex?.updatedAt]),
+  };
+}
+
+export async function listGlobalCustomAgents(
+  roots = globalCustomAgentRoots(),
+): Promise<CustomAgentListResponse> {
+  const [claudeEntries, codexEntries] = await Promise.all([
+    scanProviderAgents(roots, "claude"),
+    scanProviderAgents(roots, "codex"),
+  ]);
+
+  const groups = new Map<string, Partial<Record<CustomAgentProviderId, ProviderAgentEntry>>>();
+  for (const entry of [...claudeEntries, ...codexEntries]) {
+    const id = entryId(entry);
+    if (!id) continue;
+    const group = groups.get(id) ?? {};
+    if (!group[entry.provider]) group[entry.provider] = entry;
+    groups.set(id, group);
+  }
+
+  const agents = [...groups.entries()]
+    .map(([id, entries]) => summarizeGroup(roots, id, entries))
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return { agents };
+}
+
+export async function loadGlobalCustomAgent(
+  id: string,
+  roots = globalCustomAgentRoots(),
+): Promise<CustomAgentDetail | null> {
+  const normalizedId = customAgentFileStem(id);
+  if (!normalizedId) return null;
+
+  const { agents } = await listGlobalCustomAgents(roots);
+  const summary = agents.find((agent) => agent.id === normalizedId);
+  if (!summary) return null;
+
+  const contents: CustomAgentDetail["contents"] = {};
+  const manifests: CustomAgentDetail["manifests"] = {};
+  for (const provider of ["claude", "codex"] as const) {
+    const state = summary.providers[provider];
+    if (!state.present) continue;
+    try {
+      const content = await readFile(state.path, "utf-8");
+      contents[provider] = content;
+      try {
+        manifests[provider] = parseCustomAgentManifest(provider, content, normalizedId);
+      } catch {
+        // The raw file is still editable even when its manifest is invalid.
+      }
+    } catch {
+      // Summary already includes provider-specific read or parse errors.
+    }
+  }
+
+  return {
+    ...summary,
+    contents,
+    manifests,
+  };
+}
+
+function validateContent(
+  provider: CustomAgentProviderId,
+  content: string,
+): CustomAgentManifest {
+  if (!content.trim()) throw new BadRequestError("Content is required");
+  try {
+    return parseCustomAgentManifest(provider, content, "", { strict: true });
+  } catch (err: unknown) {
+    throw new BadRequestError(err instanceof Error ? err.message : "Invalid custom agent");
+  }
+}
+
+async function writeProviderContent(
+  roots: CustomAgentRoots,
+  provider: CustomAgentProviderId,
+  id: string,
+  content: string,
+  existingPath?: string,
+): Promise<string> {
+  const targetPath = existingPath ?? defaultProviderPath(roots, provider, id);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeAtomic(targetPath, content);
+  return targetPath;
+}
+
+export async function createGlobalCustomAgent(
+  provider: CustomAgentProviderId,
+  content: string,
+  roots = globalCustomAgentRoots(),
+): Promise<CustomAgentDetail> {
+  const manifest = validateContent(provider, content);
+  const id = customAgentFileStem(manifest.name);
+  if (!id) throw new BadRequestError("Agent name is invalid");
+
+  const existing = await loadGlobalCustomAgent(id, roots);
+  if (existing?.providers[provider].present) throw new ConflictError("Custom agent already exists");
+
+  const targetPath = defaultProviderPath(roots, provider, id);
+  if (await pathExists(targetPath)) throw new ConflictError("Custom agent already exists");
+
+  await writeProviderContent(roots, provider, id, content);
+
+  const created = await loadGlobalCustomAgent(id, roots);
+  if (!created) throw new Error("Created custom agent could not be loaded");
+  return created;
+}
+
+export async function saveGlobalCustomAgentProvider(
+  id: string,
+  provider: CustomAgentProviderId,
+  content: string,
+  roots = globalCustomAgentRoots(),
+): Promise<CustomAgentDetail | null> {
+  const existing = await loadGlobalCustomAgent(id, roots);
+  if (!existing?.providers[provider].present) return null;
+
+  const manifest = validateContent(provider, content);
+  const nextId = customAgentFileStem(manifest.name);
+  if (!nextId) throw new BadRequestError("Agent name is invalid");
+
+  const currentState = existing.providers[provider];
+  const isRename = nextId !== existing.id;
+  const targetPath = isRename
+    ? defaultProviderPath(roots, provider, nextId)
+    : currentState.path;
+
+  if (isRename) {
+    const conflict = await loadGlobalCustomAgent(nextId, roots);
+    if (conflict?.providers[provider].present || await pathExists(targetPath)) {
+      throw new ConflictError("Custom agent already exists");
+    }
+  }
+
+  await writeProviderContent(roots, provider, nextId, content, targetPath);
+  if (isRename) await removePath(currentState.path);
+
+  return loadGlobalCustomAgent(nextId, roots);
+}
+
+export async function deleteGlobalCustomAgentProvider(
+  id: string,
+  provider: CustomAgentProviderId,
+  roots = globalCustomAgentRoots(),
+): Promise<boolean> {
+  const existing = await loadGlobalCustomAgent(id, roots);
+  const state = existing?.providers[provider];
+  if (!state?.present) return false;
+  await removePath(state.path);
+  return true;
+}
+
+export async function createGlobalCustomAgentCounterpart(
+  id: string,
+  targetProvider: CustomAgentProviderId,
+  roots = globalCustomAgentRoots(),
+): Promise<CustomAgentDetail | null> {
+  const existing = await loadGlobalCustomAgent(id, roots);
+  if (!existing) return null;
+  if (existing.providers[targetProvider].present) {
+    throw new ConflictError("Custom agent already exists");
+  }
+
+  const sourceProvider: CustomAgentProviderId = targetProvider === "claude" ? "codex" : "claude";
+  const sourceManifest = existing.manifests[sourceProvider];
+  if (!sourceManifest) throw new BadRequestError("Source custom agent is invalid");
+
+  const content = targetProvider === "claude"
+    ? formatClaudeCustomAgent(sourceManifest)
+    : formatCodexCustomAgent(sourceManifest);
+  const targetId = customAgentFileStem(sourceManifest.name);
+  const targetPath = defaultProviderPath(roots, targetProvider, targetId);
+  if (await pathExists(targetPath)) throw new ConflictError("Custom agent already exists");
+
+  await writeProviderContent(roots, targetProvider, targetId, content);
+  return loadGlobalCustomAgent(targetId, roots);
+}

--- a/backend/src/state/custom-agents.ts
+++ b/backend/src/state/custom-agents.ts
@@ -121,6 +121,16 @@ function entryId(entry: ProviderAgentEntry): string {
   return customAgentFileStem(entry.manifest?.name ?? entry.fallbackName);
 }
 
+function manifestValidationError(
+  provider: CustomAgentProviderId,
+  manifest: CustomAgentManifest,
+): string | undefined {
+  if (provider === "codex" && !manifest.developerInstructions) {
+    return "developer_instructions is required";
+  }
+  return undefined;
+}
+
 async function walkFiles(dir: string, extension: string, root = dir): Promise<FileEntry[]> {
   let entries;
   try {
@@ -157,6 +167,7 @@ async function readProviderAgent(
     const content = await readFile(file.path, "utf-8");
     const manifest = parseCustomAgentManifest(provider, content, fallbackName);
     const fileStat = await lstat(file.path).catch(() => stat);
+    const error = manifestValidationError(provider, manifest);
 
     return {
       provider,
@@ -170,6 +181,7 @@ async function readProviderAgent(
       manifest,
       fallbackName,
       updatedAt: fileStat.mtime.toISOString(),
+      error,
     };
   } catch (err: unknown) {
     return {
@@ -279,7 +291,10 @@ export async function loadGlobalCustomAgent(
       const content = await readFile(state.path, "utf-8");
       contents[provider] = content;
       try {
-        manifests[provider] = parseCustomAgentManifest(provider, content, normalizedId);
+        const manifest = parseCustomAgentManifest(provider, content, normalizedId);
+        if (!manifestValidationError(provider, manifest)) {
+          manifests[provider] = manifest;
+        }
       } catch {
         // The raw file is still editable even when its manifest is invalid.
       }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -531,6 +531,58 @@ export interface UpdateInstructionsRequest {
   content: string;
 }
 
+// ── Global custom agent settings ────────────────────────────────────
+
+export type CustomAgentProviderId = "claude" | "codex";
+export type CustomAgentStatus =
+  | "both"
+  | "claude_only"
+  | "codex_only"
+  | "invalid";
+
+export interface CustomAgentProviderState {
+  present: boolean;
+  path: string;
+  fileName?: string;
+  isSymlink?: boolean;
+  realPath?: string;
+  hash?: string;
+  updatedAt?: string;
+  error?: string;
+}
+
+export interface CustomAgentSummary {
+  id: string;
+  name: string;
+  description?: string;
+  status: CustomAgentStatus;
+  providers: Record<CustomAgentProviderId, CustomAgentProviderState>;
+  invalidReason?: string;
+  updatedAt?: string;
+}
+
+export interface CustomAgentDetail extends CustomAgentSummary {
+  contents: Partial<Record<CustomAgentProviderId, string>>;
+  manifests: Partial<Record<CustomAgentProviderId, {
+    name: string;
+    description?: string;
+    developerInstructions?: string;
+  }>>;
+}
+
+export interface CustomAgentListResponse {
+  agents: CustomAgentSummary[];
+}
+
+export interface CreateCustomAgentRequest {
+  provider: CustomAgentProviderId;
+  content: string;
+}
+
+export interface UpdateCustomAgentRequest {
+  content: string;
+}
+
 // ── Hub WebSocket protocol (multiplexed) ────────────────────────────
 
 /** Client -> Server (hub-level). */

--- a/backend/src/utils/completion-scanner.test.ts
+++ b/backend/src/utils/completion-scanner.test.ts
@@ -511,4 +511,24 @@ name: local-fix
 
     expect(result).toBe("please $local-fix and keep /review");
   });
+
+  it("replaces Claude agent aliases with native agent mentions", async () => {
+    await writeAgent(
+      join(homeDir, ".claude", "agents"),
+      "reviewer.md",
+      `---
+name: reviewer
+description: Reviews changes
+---
+`,
+    );
+
+    const result = await replaceCompletionAliases(
+      "ask @reviewer to inspect this",
+      workspaceCwd,
+      "claude",
+    );
+
+    expect(result).toBe("ask @agent-reviewer to inspect this");
+  });
 });

--- a/backend/src/utils/completion-scanner.ts
+++ b/backend/src/utils/completion-scanner.ts
@@ -3,6 +3,7 @@ import { basename, join, relative, sep } from "node:path";
 import { readdir, readFile } from "node:fs/promises";
 import { parseFrontmatter } from "./frontmatter.js";
 import { parseSkillManifest } from "./skill-manifest.js";
+import { parseCustomAgentManifest } from "./custom-agent-manifest.js";
 import type { CompletionItem, CompletionSource } from "../types.js";
 
 export type CompletionProvider = "claude" | "codex";
@@ -188,19 +189,14 @@ async function scanMarkdownAgents(
   for (const file of files) {
     try {
       const content = await readFile(file.path, "utf-8");
-      const fm = parseFrontmatter(content);
-      const name =
-        typeof fm.name === "string"
-          ? fm.name
-          : basename(file.relativePath, ".md");
-      const description =
-        typeof fm.description === "string" ? fm.description : undefined;
+      const manifest = parseCustomAgentManifest("claude", content, basename(file.relativePath, ".md"));
 
       items.push({
         type: "agent",
-        name,
-        label: `@${name}`,
-        description,
+        name: manifest.name,
+        label: `@${manifest.name}`,
+        replacementLabel: `@agent-${manifest.name}`,
+        description: manifest.description,
         source,
       });
     } catch {
@@ -209,18 +205,6 @@ async function scanMarkdownAgents(
   }
 
   return items;
-}
-
-function parseTomlString(content: string, key: string): string | undefined {
-  const pattern = new RegExp(`^\\s*${key}\\s*=\\s*("(?:[^"\\\\]|\\\\.)*"|'(?:[^'\\\\]|\\\\.)*'|[^\\r\\n#]+)`, "m");
-  const match = content.match(pattern);
-  if (!match) return undefined;
-  let value = match[1].trim();
-  const quoted =
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"));
-  if (quoted) value = value.slice(1, -1);
-  return value.trim() || undefined;
 }
 
 async function scanTomlAgents(
@@ -233,14 +217,13 @@ async function scanTomlAgents(
   for (const file of files) {
     try {
       const content = await readFile(file.path, "utf-8");
-      const name = parseTomlString(content, "name") ?? basename(file.relativePath, ".toml");
-      const description = parseTomlString(content, "description");
+      const manifest = parseCustomAgentManifest("codex", content, basename(file.relativePath, ".toml"));
 
       items.push({
         type: "agent",
-        name,
-        label: `@${name}`,
-        description,
+        name: manifest.name,
+        label: `@${manifest.name}`,
+        description: manifest.description,
         source,
       });
     } catch {
@@ -418,9 +401,16 @@ export async function replaceCompletionAliases(
   workspaceCwd: string,
   provider: CompletionProvider,
 ): Promise<string> {
-  if (provider !== "codex" || !content.includes("/")) return content;
+  if (
+    (provider === "codex" && !content.includes("/")) ||
+    (provider === "claude" && !content.includes("@"))
+  ) {
+    return content;
+  }
 
-  const items = await scanCodexCompletions(workspaceCwd);
+  const items = provider === "codex"
+    ? await scanCodexCompletions(workspaceCwd)
+    : await scanClaudeCompletions(workspaceCwd);
   let resolved = content;
   for (const item of items) {
     if (!item.replacementLabel) continue;

--- a/backend/src/utils/config-names.ts
+++ b/backend/src/utils/config-names.ts
@@ -1,0 +1,16 @@
+export function normalizeConfigName(name: string, prefixes: string[] = []): string {
+  let normalized = name.trim();
+  for (const prefix of prefixes) {
+    normalized = normalized.replace(new RegExp(`^\\${prefix}`), "");
+  }
+  return normalized.trim();
+}
+
+export function safeConfigFileStem(name: string): string {
+  const stem = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return stem === "." || stem === ".." ? "" : stem;
+}

--- a/backend/src/utils/custom-agent-manifest.ts
+++ b/backend/src/utils/custom-agent-manifest.ts
@@ -1,0 +1,112 @@
+import { parse as parseToml, stringify as stringifyToml, type TomlTableWithoutBigInt } from "smol-toml";
+import { normalizeConfigName, safeConfigFileStem } from "./config-names.js";
+import { parseFrontmatter, stripFrontmatter } from "./frontmatter.js";
+import type { CustomAgentProviderId } from "../types.js";
+
+export interface CustomAgentManifest {
+  name: string;
+  description?: string;
+  developerInstructions?: string;
+}
+
+interface ParseOptions {
+  strict?: boolean;
+}
+
+export function normalizeCustomAgentName(name: string): string {
+  return normalizeConfigName(name, ["@"]);
+}
+
+export function customAgentFileStem(name: string): string {
+  return safeConfigFileStem(normalizeCustomAgentName(name));
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function requireName(name: string | undefined): string {
+  const normalized = normalizeCustomAgentName(name ?? "");
+  if (!normalized) throw new Error("Agent name is required");
+  if (!customAgentFileStem(normalized)) throw new Error("Agent name is invalid");
+  return normalized;
+}
+
+export function parseClaudeCustomAgent(
+  content: string,
+  fallbackName: string,
+  options: ParseOptions = {},
+): CustomAgentManifest {
+  const frontmatter = parseFrontmatter(content);
+  const rawName = stringValue(frontmatter.name) ?? (options.strict ? undefined : fallbackName);
+  const name = requireName(rawName);
+  return {
+    name,
+    description: stringValue(frontmatter.description),
+    developerInstructions: stripFrontmatter(content).trim(),
+  };
+}
+
+export function parseCodexCustomAgent(
+  content: string,
+  fallbackName: string,
+  options: ParseOptions = {},
+): CustomAgentManifest {
+  const parsed = parseToml(content) as TomlTableWithoutBigInt;
+  const rawName = stringValue(parsed.name) ?? (options.strict ? undefined : fallbackName);
+  const name = requireName(rawName);
+  const developerInstructions = stringValue(parsed.developer_instructions);
+
+  if (options.strict && !developerInstructions) {
+    throw new Error("developer_instructions is required");
+  }
+
+  return {
+    name,
+    description: stringValue(parsed.description),
+    developerInstructions,
+  };
+}
+
+export function parseCustomAgentManifest(
+  provider: CustomAgentProviderId,
+  content: string,
+  fallbackName: string,
+  options: ParseOptions = {},
+): CustomAgentManifest {
+  return provider === "claude"
+    ? parseClaudeCustomAgent(content, fallbackName, options)
+    : parseCodexCustomAgent(content, fallbackName, options);
+}
+
+function yamlString(value: string): string {
+  return JSON.stringify(value);
+}
+
+export function formatClaudeCustomAgent(manifest: CustomAgentManifest): string {
+  const name = requireName(manifest.name);
+  const description = manifest.description?.trim();
+  const body = manifest.developerInstructions?.trim() || `# ${name}\n\nDescribe this agent's role and workflow.`;
+  return [
+    "---",
+    `name: ${yamlString(name)}`,
+    ...(description ? [`description: ${yamlString(description)}`] : []),
+    "---",
+    "",
+    body,
+    "",
+  ].join("\n");
+}
+
+export function formatCodexCustomAgent(manifest: CustomAgentManifest): string {
+  const name = requireName(manifest.name);
+  const table: TomlTableWithoutBigInt = {
+    name,
+    developer_instructions:
+      manifest.developerInstructions?.trim() || `Describe this agent's role and workflow.`,
+  };
+  if (manifest.description?.trim()) {
+    table.description = manifest.description.trim();
+  }
+  return stringifyToml(table);
+}

--- a/backend/src/utils/frontmatter.ts
+++ b/backend/src/utils/frontmatter.ts
@@ -8,8 +8,10 @@ export interface Frontmatter {
   [key: string]: string | boolean | string[];
 }
 
+const FRONTMATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n)?/;
+
 export function parseFrontmatter(content: string): Frontmatter {
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  const match = content.match(FRONTMATTER_RE);
   if (!match) return {};
 
   const result: Frontmatter = {};
@@ -73,4 +75,9 @@ export function parseFrontmatter(content: string): Frontmatter {
   }
 
   return result;
+}
+
+export function stripFrontmatter(content: string): string {
+  const match = content.match(FRONTMATTER_RE);
+  return match ? content.slice(match[0].length) : content;
 }

--- a/backend/src/utils/skill-manifest.ts
+++ b/backend/src/utils/skill-manifest.ts
@@ -1,4 +1,5 @@
 import { parseFrontmatter } from "./frontmatter.js";
+import { normalizeConfigName, safeConfigFileStem } from "./config-names.js";
 
 export interface SkillManifest {
   name: string;
@@ -8,15 +9,11 @@ export interface SkillManifest {
 }
 
 export function normalizeSkillName(name: string): string {
-  return name.trim().replace(/^\//, "").replace(/^\$/, "");
+  return normalizeConfigName(name, ["/", "$"]);
 }
 
 export function skillFolderName(name: string): string {
-  const folderName = normalizeSkillName(name)
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return folderName === "." || folderName === ".." ? "" : folderName;
+  return safeConfigFileStem(normalizeSkillName(name));
 }
 
 export function parseSkillManifest(content: string, fallbackName: string): SkillManifest {

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -463,7 +463,8 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             targetSession.metadata.lockedProvider,
           );
           const shouldResolveCompletionAliases =
-            completionProvider === "codex" && incoming.content.includes("/");
+            (completionProvider === "codex" && incoming.content.includes("/")) ||
+            (completionProvider === "claude" && incoming.content.includes("@"));
           if (incoming.fileMentions?.length || shouldResolveCompletionAliases) {
             const dir = dataDir ?? getDataDir();
             const wsResult = await getWorkspace(wsId, dir);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ const AutomationDetail = lazy(() => import("@/pages/AutomationDetail"));
 const PromptTemplatesSettings = lazy(() => import("@/pages/settings/PromptTemplatesSettings"));
 const SkillsSettings = lazy(() => import("@/pages/settings/SkillsSettings"));
 const InstructionsSettings = lazy(() => import("@/pages/settings/InstructionsSettings"));
+const CustomAgentsSettings = lazy(() => import("@/pages/settings/CustomAgentsSettings"));
 const CreateAutomationDialog = lazy(() => import("@/components/CreateAutomationDialog"));
 
 function NotificationToastsBridge({ projects }: { projects: Project[] }) {
@@ -128,6 +129,7 @@ export default function App() {
             <Route path="settings/connection" element={<ConnectionSettings onRefreshConnection={() => { wsTransport.disconnectAll(); fetchProjects(); }} />} />
             <Route path="settings/notifications" element={<NotificationSettings />} />
             <Route path="settings/agents" element={<AgentSettings />} />
+            <Route path="settings/custom-agents" element={<Suspense fallback={null}><CustomAgentsSettings /></Suspense>} />
             <Route path="settings/instructions" element={<Suspense fallback={null}><InstructionsSettings /></Suspense>} />
             <Route path="settings/prompt-templates" element={<Suspense fallback={null}><PromptTemplatesSettings /></Suspense>} />
             <Route path="settings/skills" element={<Suspense fallback={null}><SkillsSettings /></Suspense>} />

--- a/frontend/src/components/AddProjectDialog.tsx
+++ b/frontend/src/components/AddProjectDialog.tsx
@@ -229,7 +229,7 @@ export default function AddProjectDialog({
                     Connected as <span className="font-medium text-foreground">@{account.user?.login}</span>
                   </span>
                 ) : (
-                  <span className="text-amber-500/80">
+                  <span className="text-warning-foreground">
                     GitHub not connected — will create local only
                   </span>
                 )}
@@ -239,7 +239,7 @@ export default function AddProjectDialog({
 
           {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
           {warning && (
-            <div className="mt-2 rounded-md bg-amber-500/10 px-3 py-2 text-sm text-amber-500">
+            <div className="mt-2 rounded-md bg-warning-muted px-3 py-2 text-sm text-warning-foreground">
               {warning}
             </div>
           )}

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -112,7 +112,7 @@ export default function AppLayout({ onAddProject, onAddAutomation }: AppLayoutPr
   return (
     <div className="flex h-screen flex-col">
       {import.meta.env.DEV && (
-        <div className="shrink-0 bg-amber-500/90 px-3 py-0.5 text-center text-xs font-medium text-black">
+        <div className="shrink-0 bg-warning/90 px-3 py-0.5 text-center text-xs font-medium text-warning-contrast">
           Dev frontend → {backendEnv ? `${backendEnv} backend` : "connecting…"}
         </div>
       )}

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -6,6 +6,7 @@ import {
   Bot,
   ChevronRight,
   CircleUser,
+  FileCode2,
   FileText,
   Folder,
   FolderOpen,
@@ -94,6 +95,12 @@ export default function SettingsSidebar() {
               label="CLI"
               icon={<Bot className="h-4 w-4" />}
               active={pathname === "/settings/agents"}
+            />
+            <NavItem
+              to="/settings/custom-agents"
+              label="Custom Agents"
+              icon={<FileCode2 className="h-4 w-4" />}
+              active={pathname === "/settings/custom-agents"}
             />
             <NavItem
               to="/settings/instructions"

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -475,14 +475,14 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     <>
       {(projectsUnavailable || projectsAppearIncomplete) && (
         <div
-          className="mb-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-3"
+          className="mb-3 rounded-lg border border-warning-border bg-warning-muted p-3"
           role="alert"
         >
           <div className="flex items-start gap-2.5">
             {projectsRecovering ? (
-              <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-amber-500" />
+              <Loader2 className="mt-0.5 h-4 w-4 shrink-0 animate-spin text-warning-foreground" />
             ) : (
-              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-warning-foreground" />
             )}
             <div className="min-w-0 flex-1">
               <p className="text-xs font-medium text-sidebar-foreground">

--- a/frontend/src/components/settings/ProviderSync.tsx
+++ b/frontend/src/components/settings/ProviderSync.tsx
@@ -77,7 +77,7 @@ export function SettingsBanner({
       className={cn(
         "flex shrink-0 items-center gap-2 rounded-md border px-3 py-2 text-xs",
         tone === "info" && "border-sky-500/25 bg-sky-500/10 text-sky-300",
-        tone === "warning" && "border-amber-500/25 bg-amber-500/10 text-amber-300",
+        tone === "warning" && "border-warning-border bg-warning-muted text-warning-foreground",
         tone === "danger" && "border-red-500/25 bg-red-500/10 text-red-300",
       )}
     >
@@ -133,7 +133,7 @@ export function CompactSyncStatusIcon({ status }: { status: ProviderSyncStatus }
   if (status === "invalid") {
     return <XCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-red-400" />;
   }
-  return <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-amber-400" />;
+  return <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-warning-foreground" />;
 }
 
 function statusConfig(status: ProviderSyncStatus): { label: string; className: string } {
@@ -147,11 +147,11 @@ function statusConfig(status: ProviderSyncStatus): { label: string; className: s
     case "synced":
       return { label: "Synced", className: "bg-sky-500/10 text-sky-400" };
     case "claude_only":
-      return { label: "Claude only", className: "bg-amber-500/10 text-amber-400" };
+      return { label: "Claude only", className: "bg-warning-muted text-warning-foreground" };
     case "codex_only":
-      return { label: "Codex only", className: "bg-amber-500/10 text-amber-400" };
+      return { label: "Codex only", className: "bg-warning-muted text-warning-foreground" };
     case "diverged":
-      return { label: "Diverged", className: "bg-amber-500/10 text-amber-400" };
+      return { label: "Diverged", className: "bg-warning-muted text-warning-foreground" };
     case "invalid":
       return { label: "Invalid", className: "bg-red-500/10 text-red-400" };
   }

--- a/frontend/src/components/settings/ProviderSync.tsx
+++ b/frontend/src/components/settings/ProviderSync.tsx
@@ -5,6 +5,7 @@ import { cn } from "@/lib/utils";
 
 export type ProviderSyncStatus =
   | "missing"
+  | "both"
   | "linked"
   | "synced"
   | "claude_only"
@@ -129,7 +130,7 @@ export function SyncStatusBadge({ status }: { status: ProviderSyncStatus }) {
 }
 
 export function CompactSyncStatusIcon({ status }: { status: ProviderSyncStatus }) {
-  if (status === "linked" || status === "synced") {
+  if (status === "both" || status === "linked" || status === "synced") {
     return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-400" />;
   }
   if (status === "invalid") {
@@ -142,6 +143,8 @@ function statusConfig(status: ProviderSyncStatus): { label: string; className: s
   switch (status) {
     case "missing":
       return { label: "Missing", className: "bg-muted text-muted-foreground" };
+    case "both":
+      return { label: "Both", className: "bg-emerald-500/10 text-emerald-400" };
     case "linked":
       return { label: "Linked", className: "bg-emerald-500/10 text-emerald-400" };
     case "synced":

--- a/frontend/src/components/settings/ProviderSync.tsx
+++ b/frontend/src/components/settings/ProviderSync.tsx
@@ -41,7 +41,7 @@ export function SettingsActionButton({
       onClick={onClick}
       disabled={disabledState}
       className={cn(
-        "inline-flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+        "inline-flex cursor-pointer items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
         variant === "primary"
           ? "bg-primary text-primary-foreground hover:bg-primary/90"
           : "text-muted-foreground",
@@ -51,7 +51,13 @@ export function SettingsActionButton({
         disabledState && "pointer-events-none opacity-60",
       )}
     >
-      {pending ? <Loader2 className="h-3 w-3 animate-spin" /> : icon}
+      {pending ? (
+        <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
+      ) : (
+        <span aria-hidden="true" className="flex">
+          {icon}
+        </span>
+      )}
       {children}
     </button>
   );
@@ -75,7 +81,9 @@ export function SettingsBanner({
         tone === "danger" && "border-red-500/25 bg-red-500/10 text-red-300",
       )}
     >
-      {icon}
+      <span aria-hidden="true" className="shrink-0">
+        {icon}
+      </span>
       {children}
     </div>
   );
@@ -98,24 +106,13 @@ export function ProviderBadge({
           : "border-border bg-muted/50 text-muted-foreground",
       )}
     >
-      {state.present ? <CheckCircle2 className="h-3 w-3" /> : <XCircle className="h-3 w-3" />}
-      {label}
-      {state.isSymlink && <Link2 className="h-3 w-3" />}
-    </span>
-  );
-}
-
-export function ProviderMiniBadge({ label, present }: { label: string; present: boolean }) {
-  return (
-    <span
-      className={cn(
-        "rounded-full border px-1.5 py-0 text-[10px] font-medium",
-        present
-          ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-400"
-          : "border-border bg-muted/40 text-muted-foreground/80",
+      {state.present ? (
+        <CheckCircle2 aria-hidden="true" className="h-3 w-3" />
+      ) : (
+        <XCircle aria-hidden="true" className="h-3 w-3" />
       )}
-    >
       {label}
+      {state.isSymlink && <Link2 aria-hidden="true" className="h-3 w-3" />}
     </span>
   );
 }
@@ -131,12 +128,12 @@ export function SyncStatusBadge({ status }: { status: ProviderSyncStatus }) {
 
 export function CompactSyncStatusIcon({ status }: { status: ProviderSyncStatus }) {
   if (status === "both" || status === "linked" || status === "synced") {
-    return <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-emerald-400" />;
+    return <CheckCircle2 aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-emerald-400" />;
   }
   if (status === "invalid") {
-    return <XCircle className="h-3.5 w-3.5 shrink-0 text-red-400" />;
+    return <XCircle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-red-400" />;
   }
-  return <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-amber-400" />;
+  return <AlertTriangle aria-hidden="true" className="h-3.5 w-3.5 shrink-0 text-amber-400" />;
 }
 
 function statusConfig(status: ProviderSyncStatus): { label: string; className: string } {

--- a/frontend/src/components/settings/SettingsEditorFrame.tsx
+++ b/frontend/src/components/settings/SettingsEditorFrame.tsx
@@ -1,6 +1,16 @@
 import type { ReactNode } from "react";
+import { StreamLanguage } from "@codemirror/language";
+import { syntaxHighlighting } from "@codemirror/language";
+import { oneDarkHighlightStyle } from "@codemirror/theme-one-dark";
+import { toml } from "@codemirror/legacy-modes/mode/toml";
 import { MarkdownEditor } from "@/components/MarkdownEditor";
+import { CodeEditor } from "@/components/CodeEditor";
 import { cn } from "@/lib/utils";
+
+const TOML_EXTENSIONS = [
+  StreamLanguage.define(toml),
+  syntaxHighlighting(oneDarkHighlightStyle),
+];
 
 export function SettingsEditorFrame({
   title,
@@ -12,6 +22,7 @@ export function SettingsEditorFrame({
   onChange,
   placeholder,
   ariaLabel,
+  language = "markdown",
   actions,
 }: {
   title: string;
@@ -23,6 +34,7 @@ export function SettingsEditorFrame({
   onChange: (value: string) => void;
   placeholder: string;
   ariaLabel: string;
+  language?: "markdown" | "toml";
   actions: ReactNode;
 }) {
   return (
@@ -45,13 +57,24 @@ export function SettingsEditorFrame({
       {banner}
 
       <div className={cn("min-h-0 flex-1", banner && "mt-3")}>
-        <MarkdownEditor
-          value={value}
-          onChange={onChange}
-          maxHeight="100%"
-          placeholder={placeholder}
-          ariaLabel={ariaLabel}
-        />
+        {language === "toml" ? (
+          <CodeEditor
+            value={value}
+            onChange={onChange}
+            maxHeight="100%"
+            placeholder={placeholder}
+            ariaLabel={ariaLabel}
+            extensions={TOML_EXTENSIONS}
+          />
+        ) : (
+          <MarkdownEditor
+            value={value}
+            onChange={onChange}
+            maxHeight="100%"
+            placeholder={placeholder}
+            ariaLabel={ariaLabel}
+          />
+        )}
       </div>
 
       <div className="mt-4 flex shrink-0 items-center gap-2">

--- a/frontend/src/components/settings/SettingsResourceList.tsx
+++ b/frontend/src/components/settings/SettingsResourceList.tsx
@@ -1,0 +1,106 @@
+import type { ReactNode } from "react";
+import { Plus } from "lucide-react";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+const settingsFocusClass = "outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+
+export function SettingsResourceList({
+  children,
+  empty,
+  showEmpty,
+  actionLabel,
+  actionActive,
+  onAction,
+}: {
+  children: ReactNode;
+  empty: ReactNode;
+  showEmpty: boolean;
+  actionLabel: string;
+  actionActive: boolean;
+  onAction: () => void;
+}) {
+  return (
+    <div className="flex w-64 shrink-0 flex-col border-r border-border/50 max-md:h-56 max-md:w-full max-md:border-r-0 max-md:border-b">
+      <ScrollArea className="flex-1">
+        <div className="p-2">{showEmpty ? empty : children}</div>
+      </ScrollArea>
+      <div className="border-t border-border/30 p-2">
+        <button
+          type="button"
+          onClick={onAction}
+          className={cn(
+            "inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed border-primary/40 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/10",
+            settingsFocusClass,
+            actionActive && "border-primary bg-primary/10",
+          )}
+        >
+          <Plus aria-hidden="true" className="h-3 w-3" />
+          {actionLabel}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function SettingsResourceEmptyList({ children }: { children: ReactNode }) {
+  return (
+    <div className="px-2 py-8 text-center text-xs text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+export function SettingsResourceListItem({
+  icon,
+  title,
+  description,
+  trailing,
+  ariaLabel,
+  selected,
+  onClick,
+}: {
+  icon: ReactNode;
+  title: ReactNode;
+  description?: ReactNode;
+  trailing?: ReactNode;
+  ariaLabel?: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={cn(
+        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
+        settingsFocusClass,
+        selected
+          ? "bg-primary/15 text-foreground"
+          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <span aria-hidden="true" className="shrink-0">
+          {icon}
+        </span>
+        <span className="min-w-0 flex-1 truncate font-medium">{title}</span>
+        {trailing}
+      </div>
+      {description && (
+        <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
+          {description}
+        </p>
+      )}
+    </button>
+  );
+}
+
+export function SettingsEmptySelection({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/SettingsResourceList.tsx
+++ b/frontend/src/components/settings/SettingsResourceList.tsx
@@ -4,6 +4,8 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 
 const settingsFocusClass = "outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50";
+const settingsResourceScrollClassName =
+  "[&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full";
 
 export function SettingsResourceList({
   children,
@@ -22,7 +24,7 @@ export function SettingsResourceList({
 }) {
   return (
     <div className="flex w-64 shrink-0 flex-col border-r border-border/50 max-md:h-56 max-md:w-full max-md:border-r-0 max-md:border-b">
-      <ScrollArea className="flex-1">
+      <ScrollArea className={cn("flex-1", settingsResourceScrollClassName)}>
         <div className="p-2">{showEmpty ? empty : children}</div>
       </ScrollArea>
       <div className="border-t border-border/30 p-2">

--- a/frontend/src/components/settings/resource-selection.ts
+++ b/frontend/src/components/settings/resource-selection.ts
@@ -1,0 +1,17 @@
+export type SettingsResourceSelection =
+  | { kind: "existing"; id: string }
+  | { kind: "draft" }
+  | null;
+
+export function resolveSettingsResourceSelection<T extends { id: string }>(
+  selection: SettingsResourceSelection,
+  resources: T[],
+  hasDraft: boolean,
+): SettingsResourceSelection {
+  if (selection?.kind === "draft") return hasDraft ? selection : null;
+  if (selection?.kind === "existing" && resources.some((resource) => resource.id === selection.id)) {
+    return selection;
+  }
+  if (resources[0]) return { kind: "existing", id: resources[0].id };
+  return hasDraft ? { kind: "draft" } : null;
+}

--- a/frontend/src/hooks/useCustomAgents.ts
+++ b/frontend/src/hooks/useCustomAgents.ts
@@ -5,19 +5,54 @@ import type {
   CustomAgentDetail,
   CustomAgentListResponse,
   CustomAgentProviderId,
+  CustomAgentSummary,
   UpdateCustomAgentRequest,
 } from "@/types";
 
 function upsertCustomAgentInList(
   current: CustomAgentListResponse | undefined,
   agent: CustomAgentDetail,
+  replaced?: { id: string; provider: CustomAgentProviderId },
 ): CustomAgentListResponse | undefined {
   if (!current) return current;
-  const agents = current.agents
+  const candidates = replaced && replaced.id !== agent.id
+    ? current.agents.flatMap((item) => {
+        if (item.id !== replaced.id) return [item];
+        const updated = removeProviderFromSummary(item, replaced.provider);
+        return updated ? [updated] : [];
+      })
+    : current.agents;
+  const agents = candidates
     .filter((item) => item.id !== agent.id)
     .concat(agent)
     .sort((a, b) => a.name.localeCompare(b.name));
   return { ...current, agents };
+}
+
+function removeProviderFromSummary(
+  agent: CustomAgentSummary,
+  provider: CustomAgentProviderId,
+): CustomAgentSummary | null {
+  const otherProvider: CustomAgentProviderId = provider === "claude" ? "codex" : "claude";
+  const otherState = agent.providers[otherProvider];
+  if (!otherState.present) return null;
+
+  return {
+    ...agent,
+    status: otherState.error
+      ? "invalid"
+      : otherProvider === "claude"
+        ? "claude_only"
+        : "codex_only",
+    providers: {
+      ...agent.providers,
+      [provider]: {
+        ...agent.providers[provider],
+        present: false,
+      },
+    },
+    invalidReason: otherState.error,
+  };
 }
 
 function removeProviderFromList(
@@ -29,19 +64,7 @@ function removeProviderFromList(
   const agents = current.agents
     .map((agent) => {
       if (agent.id !== id) return agent;
-      const otherProvider: CustomAgentProviderId = provider === "claude" ? "codex" : "claude";
-      if (!agent.providers[otherProvider].present) return null;
-      return {
-        ...agent,
-        status: otherProvider === "claude" ? "claude_only" as const : "codex_only" as const,
-        providers: {
-          ...agent.providers,
-          [provider]: {
-            ...agent.providers[provider],
-            present: false,
-          },
-        },
-      };
+      return removeProviderFromSummary(agent, provider);
     })
     .filter((agent): agent is NonNullable<typeof agent> => agent !== null);
   return { ...current, agents };
@@ -98,7 +121,10 @@ export function useUpdateCustomAgentProvider() {
     onSuccess: (data, vars) => {
       qc.setQueryData(["settings", "custom-agents", data.id], data);
       qc.setQueryData<CustomAgentListResponse>(["settings", "custom-agents"], (current) =>
-        upsertCustomAgentInList(current, data),
+        upsertCustomAgentInList(current, data, {
+          id: vars.id,
+          provider: vars.provider,
+        }),
       );
       if (data.id !== vars.id) {
         qc.removeQueries({ queryKey: ["settings", "custom-agents", vars.id] });

--- a/frontend/src/hooks/useCustomAgents.ts
+++ b/frontend/src/hooks/useCustomAgents.ts
@@ -1,0 +1,144 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "./useApi";
+import type {
+  CreateCustomAgentRequest,
+  CustomAgentDetail,
+  CustomAgentListResponse,
+  CustomAgentProviderId,
+  UpdateCustomAgentRequest,
+} from "@/types";
+
+function upsertCustomAgentInList(
+  current: CustomAgentListResponse | undefined,
+  agent: CustomAgentDetail,
+): CustomAgentListResponse | undefined {
+  if (!current) return current;
+  const agents = current.agents
+    .filter((item) => item.id !== agent.id)
+    .concat(agent)
+    .sort((a, b) => a.name.localeCompare(b.name));
+  return { ...current, agents };
+}
+
+function removeProviderFromList(
+  current: CustomAgentListResponse | undefined,
+  id: string,
+  provider: CustomAgentProviderId,
+): CustomAgentListResponse | undefined {
+  if (!current) return current;
+  const agents = current.agents
+    .map((agent) => {
+      if (agent.id !== id) return agent;
+      const otherProvider: CustomAgentProviderId = provider === "claude" ? "codex" : "claude";
+      if (!agent.providers[otherProvider].present) return null;
+      return {
+        ...agent,
+        status: otherProvider === "claude" ? "claude_only" as const : "codex_only" as const,
+        providers: {
+          ...agent.providers,
+          [provider]: {
+            ...agent.providers[provider],
+            present: false,
+          },
+        },
+      };
+    })
+    .filter((agent): agent is NonNullable<typeof agent> => agent !== null);
+  return { ...current, agents };
+}
+
+export function useCustomAgents() {
+  return useQuery({
+    queryKey: ["settings", "custom-agents"],
+    queryFn: () => api.get<CustomAgentListResponse>("/api/settings/custom-agents"),
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+    placeholderData: keepPreviousData,
+  });
+}
+
+export function useCustomAgent(id: string | null | undefined) {
+  return useQuery({
+    queryKey: ["settings", "custom-agents", id],
+    queryFn: () => api.get<CustomAgentDetail>(`/api/settings/custom-agents/${id}`),
+    enabled: Boolean(id),
+    staleTime: 30_000,
+    gcTime: 5 * 60_000,
+  });
+}
+
+export function useCreateCustomAgent() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: CreateCustomAgentRequest) =>
+      api.post<CustomAgentDetail>("/api/settings/custom-agents", body),
+    onSuccess: (data) => {
+      qc.setQueryData(["settings", "custom-agents", data.id], data);
+      qc.setQueryData<CustomAgentListResponse>(["settings", "custom-agents"], (current) =>
+        upsertCustomAgentInList(current, data),
+      );
+      void qc.invalidateQueries({ queryKey: ["settings", "custom-agents"] });
+      void qc.invalidateQueries({ queryKey: ["completions"] });
+    },
+  });
+}
+
+export function useUpdateCustomAgentProvider() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      provider,
+      content,
+    }: { id: string; provider: CustomAgentProviderId } & UpdateCustomAgentRequest) =>
+      api.put<CustomAgentDetail>(
+        `/api/settings/custom-agents/${id}/providers/${provider}`,
+        { content },
+      ),
+    onSuccess: (data, vars) => {
+      qc.setQueryData(["settings", "custom-agents", data.id], data);
+      qc.setQueryData<CustomAgentListResponse>(["settings", "custom-agents"], (current) =>
+        upsertCustomAgentInList(current, data),
+      );
+      if (data.id !== vars.id) {
+        qc.removeQueries({ queryKey: ["settings", "custom-agents", vars.id] });
+      }
+      void qc.invalidateQueries({ queryKey: ["settings", "custom-agents"] });
+      void qc.invalidateQueries({ queryKey: ["completions"] });
+    },
+  });
+}
+
+export function useDeleteCustomAgentProvider() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, provider }: { id: string; provider: CustomAgentProviderId }) =>
+      api.delete<void>(`/api/settings/custom-agents/${id}/providers/${provider}`),
+    onSuccess: (_data, vars) => {
+      qc.removeQueries({ queryKey: ["settings", "custom-agents", vars.id] });
+      qc.setQueryData<CustomAgentListResponse>(["settings", "custom-agents"], (current) =>
+        removeProviderFromList(current, vars.id, vars.provider),
+      );
+      void qc.invalidateQueries({ queryKey: ["settings", "custom-agents"] });
+      void qc.invalidateQueries({ queryKey: ["completions"] });
+    },
+  });
+}
+
+export function useCreateCustomAgentCounterpart() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, provider }: { id: string; provider: CustomAgentProviderId }) =>
+      api.post<CustomAgentDetail>(
+        `/api/settings/custom-agents/${id}/providers/${provider}/counterpart`,
+      ),
+    onSuccess: (data) => {
+      qc.setQueryData(["settings", "custom-agents", data.id], data);
+      qc.setQueryData<CustomAgentListResponse>(["settings", "custom-agents"], (current) =>
+        upsertCustomAgentInList(current, data),
+      );
+      void qc.invalidateQueries({ queryKey: ["settings", "custom-agents"] });
+      void qc.invalidateQueries({ queryKey: ["completions"] });
+    },
+  });
+}

--- a/frontend/src/hooks/useSkills.ts
+++ b/frontend/src/hooks/useSkills.ts
@@ -11,10 +11,11 @@ import type {
 function upsertSkillInList(
   current: SkillListResponse | undefined,
   skill: SkillDetail,
+  replacedId?: string,
 ): SkillListResponse | undefined {
   if (!current) return current;
   const skills = current.skills
-    .filter((item) => item.id !== skill.id)
+    .filter((item) => item.id !== skill.id && item.id !== replacedId)
     .concat(skill)
     .sort((a, b) => a.name.localeCompare(b.name));
   return { ...current, skills };
@@ -59,7 +60,7 @@ export function useUpdateSkill() {
     onSuccess: (data, vars) => {
       qc.setQueryData(["settings", "skills", data.id], data);
       qc.setQueryData<SkillListResponse>(["settings", "skills"], (current) =>
-        upsertSkillInList(current, data),
+        upsertSkillInList(current, data, vars.id),
       );
       if (data.id !== vars.id) {
         qc.removeQueries({ queryKey: ["settings", "skills", vars.id] });
@@ -88,10 +89,10 @@ export function useSyncSkill() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (id: string) => api.post<SkillDetail>(`/api/settings/skills/${id}/sync`),
-    onSuccess: (data) => {
+    onSuccess: (data, id) => {
       qc.setQueryData(["settings", "skills", data.id], data);
       qc.setQueryData<SkillListResponse>(["settings", "skills"], (current) =>
-        upsertSkillInList(current, data),
+        upsertSkillInList(current, data, id),
       );
       void qc.invalidateQueries({ queryKey: ["settings", "skills"] });
     },

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -55,6 +55,11 @@
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
+  --color-warning-muted: var(--warning-muted);
+  --color-warning-border: var(--warning-border);
+  --color-warning-contrast: var(--warning-contrast);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -94,6 +99,11 @@
   --accent: oklch(0.97 0 0);
   --accent-foreground: oklch(0.205 0 0);
   --destructive: oklch(0.577 0.245 27.325);
+  --warning: oklch(0.769 0.188 70.08);
+  --warning-foreground: oklch(0.473 0.137 46.201);
+  --warning-muted: color-mix(in oklch, var(--warning) 10%, transparent);
+  --warning-border: color-mix(in oklch, var(--warning) 30%, transparent);
+  --warning-contrast: #000000;
   --border: oklch(0.86 0 0);
   --input: oklch(0.94 0 0);
   --ring: var(--hive-accent, #635BFF);
@@ -149,6 +159,11 @@
   --accent: oklch(0.2 0.015 270);
   --accent-foreground: oklch(0.93 0.005 260);
   --destructive: oklch(0.65 0.2 22);
+  --warning: oklch(0.769 0.188 70.08);
+  --warning-foreground: oklch(0.879 0.169 91.605);
+  --warning-muted: color-mix(in oklch, var(--warning) 10%, transparent);
+  --warning-border: color-mix(in oklch, var(--warning) 25%, transparent);
+  --warning-contrast: #000000;
   --border: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 10%);
   --ring: var(--hive-accent, #635BFF);

--- a/frontend/src/pages/settings/AccountSettings.tsx
+++ b/frontend/src/pages/settings/AccountSettings.tsx
@@ -178,7 +178,7 @@ export default function AccountSettings() {
           {state.kind === "no-gh" && (
             <section className="rounded-lg border border-border/50 bg-card/50 p-5">
               <div className="flex items-start gap-3">
-                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-warning-foreground" />
                 <div>
                   <h2 className="text-sm font-medium">GitHub CLI not found</h2>
                   <p className="mt-1 text-xs text-muted-foreground">

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -90,7 +90,7 @@ function StatusBadge({ agent }: { agent: AgentStatusEntry }) {
 
   if (agent.updateAvailable) {
     return (
-      <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-500/30 bg-amber-500/10 px-2.5 py-0.5 text-[11px] font-medium text-amber-400">
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-warning-border bg-warning-muted px-2.5 py-0.5 text-[11px] font-medium text-warning-foreground">
         <ArrowUpCircle className="h-3 w-3" />
         Update available{agent.latestVersion && ` (${agent.latestVersion})`}
       </span>

--- a/frontend/src/pages/settings/CustomAgentsSettings.tsx
+++ b/frontend/src/pages/settings/CustomAgentsSettings.tsx
@@ -4,7 +4,6 @@ import {
   Bot,
   FileCode2,
   Loader2,
-  Plus,
   Save,
   Sparkles,
   Trash2,
@@ -22,17 +21,20 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Badge } from "@/components/ui/badge";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { SettingsHeader } from "@/components/AppLayout";
 import {
   CompactSyncStatusIcon as CompactStatusIcon,
-  ProviderBadge,
-  ProviderMiniBadge,
   SettingsActionButton as EditorActionButton,
   SettingsBanner as Banner,
   SyncStatusBadge as StatusBadge,
 } from "@/components/settings/ProviderSync";
 import { SettingsEditorFrame } from "@/components/settings/SettingsEditorFrame";
+import {
+  SettingsEmptySelection,
+  SettingsResourceEmptyList,
+  SettingsResourceList,
+  SettingsResourceListItem,
+} from "@/components/settings/SettingsResourceList";
 import {
   useCreateCustomAgent,
   useCreateCustomAgentCounterpart,
@@ -184,15 +186,15 @@ export default function CustomAgentsSettings() {
 
       {isLoading ? (
         <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading custom agents
+          <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+          Loading custom agents…
         </div>
       ) : isError ? (
         <div className="flex flex-1 items-center justify-center text-xs text-red-400">
           Could not load custom agents.
         </div>
       ) : (
-        <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 overflow-hidden max-md:flex-col">
           <CustomAgentsList
             agents={agents}
             draftAgent={draftAgent}
@@ -256,118 +258,41 @@ function CustomAgentsList({
   onNewAgent: () => void;
 }) {
   return (
-    <div className="flex w-64 shrink-0 flex-col border-r border-border/50">
-      <ScrollArea className="flex-1">
-        <div className="p-2">
-          {draftAgent && (
-            <DraftAgentListItem
-              provider={draftAgent.provider}
-              selected={selection?.kind === "draft"}
-              onClick={onSelectDraft}
-            />
-          )}
-          {agents.length === 0 && !draftAgent ? (
-            <div className="px-2 py-8 text-center text-xs text-muted-foreground">
-              No global custom agents found.
-            </div>
-          ) : (
-            agents.map((agent) => (
-              <CustomAgentListItem
-                key={agent.id}
-                agent={agent}
-                selected={selection?.kind === "existing" && agent.id === selection.id}
-                onClick={() => onSelect(agent.id)}
-              />
-            ))
-          )}
-        </div>
-      </ScrollArea>
-      <div className="border-t border-border/30 p-2">
-        <button
-          type="button"
-          onClick={onNewAgent}
-          className={cn(
-            "inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed border-primary/40 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/10",
-            selection?.kind === "draft" && "border-primary bg-primary/10",
-          )}
-        >
-          <Plus className="h-3 w-3" />
-          New Agent
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function DraftAgentListItem({
-  provider,
-  selected,
-  onClick,
-}: {
-  provider: CustomAgentProviderId;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
-        selected
-          ? "bg-primary/15 text-foreground"
-          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
-      )}
+    <SettingsResourceList
+      showEmpty={agents.length === 0 && !draftAgent}
+      empty={<SettingsResourceEmptyList>No global custom agents found.</SettingsResourceEmptyList>}
+      actionLabel="New Agent"
+      actionActive={selection?.kind === "draft"}
+      onAction={onNewAgent}
     >
-      <div className="flex min-w-0 items-center gap-2">
-        <Bot className="h-3.5 w-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate font-medium">New Agent</span>
-        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
-          Unsaved
-        </Badge>
-      </div>
-      <p className="text-xs leading-snug text-muted-foreground">
-        {PROVIDER_LABELS[provider]} draft
-      </p>
-    </button>
-  );
-}
-
-function CustomAgentListItem({
-  agent,
-  selected,
-  onClick,
-}: {
-  agent: CustomAgentSummary;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
-        selected
-          ? "bg-primary/15 text-foreground"
-          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      {draftAgent && (
+        <SettingsResourceListItem
+          icon={<Bot className="h-3.5 w-3.5" />}
+          title="New Agent"
+          description={`${PROVIDER_LABELS[draftAgent.provider]} draft`}
+          ariaLabel={`New ${PROVIDER_LABELS[draftAgent.provider]} agent draft`}
+          trailing={
+            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+              Unsaved
+            </Badge>
+          }
+          selected={selection?.kind === "draft"}
+          onClick={onSelectDraft}
+        />
       )}
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <Bot className="h-3.5 w-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate font-medium">{agent.name}</span>
-        <CompactStatusIcon status={agent.status} />
-      </div>
-      {agent.description && (
-        <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
-          {agent.description}
-        </p>
-      )}
-      <div className="flex flex-wrap gap-1">
-        <ProviderMiniBadge label="Claude" present={agent.providers.claude.present} />
-        <ProviderMiniBadge label="Codex" present={agent.providers.codex.present} />
-      </div>
-    </button>
+      {agents.map((agent) => (
+        <SettingsResourceListItem
+          key={agent.id}
+          icon={<Bot className="h-3.5 w-3.5" />}
+          title={agent.name}
+          description={agent.description}
+          ariaLabel={`${agent.name} custom agent`}
+          trailing={<CompactStatusIcon status={agent.status} />}
+          selected={selection?.kind === "existing" && agent.id === selection.id}
+          onClick={() => onSelect(agent.id)}
+        />
+      ))}
+    </SettingsResourceList>
   );
 }
 
@@ -385,8 +310,8 @@ function CustomAgentDetailPanel({
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Loading custom agent
+        <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+        Loading custom agent…
       </div>
     );
   }
@@ -424,14 +349,18 @@ function LoadedCustomAgentDetailPanel({
 
   return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex shrink-0 items-center gap-1 border-b border-border/30 px-5 pt-4">
+      <div
+        className="flex shrink-0 items-center gap-1 border-b border-border/30 px-5 pt-4"
+        aria-label="Custom agent provider"
+      >
         {PROVIDERS.map((provider) => (
           <button
             key={provider}
             type="button"
+            aria-pressed={activeProvider === provider}
             onClick={() => setActiveProvider(provider)}
             className={cn(
-              "inline-flex cursor-pointer items-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium transition-colors",
+              "inline-flex cursor-pointer items-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
               activeProvider === provider
                 ? "border-primary text-foreground"
                 : "border-transparent text-muted-foreground hover:text-foreground",
@@ -439,6 +368,7 @@ function LoadedCustomAgentDetailPanel({
           >
             {PROVIDER_LABELS[provider]}
             <span
+              aria-hidden="true"
               className={cn(
                 "h-1.5 w-1.5 rounded-full",
                 data.providers[provider].present ? "bg-emerald-400" : "bg-muted-foreground/40",
@@ -514,12 +444,6 @@ function CustomAgentProviderEditor({
         title={data.name}
         badge={<StatusBadge status={data.status} />}
         description={data.description}
-        providers={
-          <>
-            <ProviderBadge label="Claude" state={data.providers.claude} />
-            <ProviderBadge label="Codex" state={data.providers.codex} />
-          </>
-        }
         banner={<CustomAgentBanner data={data} provider={provider} />}
         value={draft}
         onChange={setDraft}
@@ -569,7 +493,7 @@ function CustomAgentProviderEditor({
               onClick={() => void handleDelete()}
               className="bg-red-600 text-white hover:bg-red-700"
             >
-              {deleteMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : "Delete"}
+              {deleteMutation.isPending ? <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" /> : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -610,15 +534,11 @@ function MissingProviderPanel({
           <h2 className="text-base font-medium text-foreground">{data.name}</h2>
           <StatusBadge status={data.status} />
         </div>
-        <div className="mt-3 flex flex-wrap gap-2">
-          <ProviderBadge label="Claude" state={data.providers.claude} />
-          <ProviderBadge label="Codex" state={data.providers.codex} />
-        </div>
       </div>
 
       <div className="flex flex-1 items-center justify-center">
         <div className="max-w-sm text-center">
-          <FileCode2 className="mx-auto mb-3 h-8 w-8 text-muted-foreground/60" />
+          <FileCode2 aria-hidden="true" className="mx-auto mb-3 h-8 w-8 text-muted-foreground/60" />
           <h3 className="text-sm font-medium text-foreground">
             No {PROVIDER_LABELS[provider]} version
           </h3>
@@ -630,14 +550,14 @@ function MissingProviderPanel({
             onClick={() => void handleCreateCounterpart()}
             disabled={!canCreate || counterpartMutation.isPending}
             className={cn(
-              "mt-4 inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+              "mt-4 inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors outline-none hover:bg-primary/90 focus-visible:ring-[3px] focus-visible:ring-ring/50",
               (!canCreate || counterpartMutation.isPending) && "pointer-events-none opacity-60",
             )}
           >
             {counterpartMutation.isPending ? (
-              <Loader2 className="h-3 w-3 animate-spin" />
+              <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
             ) : (
-              <Sparkles className="h-3 w-3" />
+              <Sparkles aria-hidden="true" className="h-3 w-3" />
             )}
             Create {PROVIDER_LABELS[provider]} version
           </button>
@@ -759,9 +679,10 @@ function ProviderSelector({
         <button
           key={provider}
           type="button"
+          aria-pressed={value === provider}
           onClick={() => onChange(provider)}
           className={cn(
-            "cursor-pointer rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors",
+            "cursor-pointer rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50",
             value === provider
               ? "bg-primary/15 text-primary"
               : "text-muted-foreground hover:text-foreground",
@@ -806,8 +727,6 @@ function CustomAgentBanner({
 
 function EmptyState() {
   return (
-    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-      Select a custom agent to edit
-    </div>
+    <SettingsEmptySelection>Select a custom agent to edit</SettingsEmptySelection>
   );
 }

--- a/frontend/src/pages/settings/CustomAgentsSettings.tsx
+++ b/frontend/src/pages/settings/CustomAgentsSettings.tsx
@@ -1,0 +1,813 @@
+import { useState } from "react";
+import {
+  AlertTriangle,
+  Bot,
+  FileCode2,
+  Loader2,
+  Plus,
+  Save,
+  Sparkles,
+  Trash2,
+  X,
+  XCircle,
+} from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { SettingsHeader } from "@/components/AppLayout";
+import {
+  CompactSyncStatusIcon as CompactStatusIcon,
+  ProviderBadge,
+  ProviderMiniBadge,
+  SettingsActionButton as EditorActionButton,
+  SettingsBanner as Banner,
+  SyncStatusBadge as StatusBadge,
+} from "@/components/settings/ProviderSync";
+import { SettingsEditorFrame } from "@/components/settings/SettingsEditorFrame";
+import {
+  useCreateCustomAgent,
+  useCreateCustomAgentCounterpart,
+  useCustomAgent,
+  useCustomAgents,
+  useDeleteCustomAgentProvider,
+  useUpdateCustomAgentProvider,
+} from "@/hooks/useCustomAgents";
+import { ApiError } from "@/hooks/useApi";
+import { cn } from "@/lib/utils";
+import type {
+  CustomAgentDetail,
+  CustomAgentProviderId,
+  CustomAgentSummary,
+} from "@/types";
+
+const PROVIDERS: CustomAgentProviderId[] = ["claude", "codex"];
+const PROVIDER_LABELS: Record<CustomAgentProviderId, string> = {
+  claude: "Claude",
+  codex: "Codex",
+};
+
+const DEFAULT_CLAUDE_AGENT = `---
+name: new-agent
+description: Describe when this agent should be used.
+---
+
+# New Agent
+
+Describe this agent's role, workflow, and constraints.
+`;
+
+const DEFAULT_CODEX_AGENT = `name = "new-agent"
+description = "Describe when this agent should be used."
+developer_instructions = """
+Describe this agent's role, workflow, and constraints.
+"""
+`;
+
+const PLACEHOLDERS: Record<CustomAgentProviderId, string> = {
+  claude: "---\nname: reviewer\ndescription: Reviews changes\n---\n\n# Reviewer",
+  codex: "name = \"reviewer\"\ndescription = \"Reviews changes\"\ndeveloper_instructions = \"Review code changes.\"",
+};
+
+type AgentSelection = { kind: "existing"; id: string } | { kind: "draft" } | null;
+
+interface NewAgentDraft {
+  provider: CustomAgentProviderId;
+  content: string;
+  initialContent: string;
+  error: string | null;
+  conflictContent: string | null;
+}
+
+export default function CustomAgentsSettings() {
+  const { data, isLoading, isError } = useCustomAgents();
+  const agents = data?.agents ?? [];
+  const [selection, setSelection] = useState<AgentSelection>(null);
+  const [draftAgent, setDraftAgent] = useState<NewAgentDraft | null>(null);
+  const resolvedSelection = resolveAgentSelection(selection, agents, draftAgent !== null);
+  const selectedExistingId = resolvedSelection?.kind === "existing" ? resolvedSelection.id : null;
+
+  const handleNewAgent = () => {
+    setDraftAgent((current) =>
+      current ?? {
+        provider: "claude",
+        content: DEFAULT_CLAUDE_AGENT,
+        initialContent: DEFAULT_CLAUDE_AGENT,
+        error: null,
+        conflictContent: null,
+      },
+    );
+    setSelection({ kind: "draft" });
+  };
+
+  const handleDraftChange = (content: string) => {
+    setDraftAgent((current) => {
+      if (!current) return current;
+      const conflictContent = current.conflictContent === content ? current.conflictContent : null;
+      return {
+        ...current,
+        content,
+        conflictContent,
+        error: conflictContent ? current.error : null,
+      };
+    });
+  };
+
+  const handleDraftProviderChange = (provider: CustomAgentProviderId) => {
+    setDraftAgent((current) => {
+      const nextContent = provider === "claude" ? DEFAULT_CLAUDE_AGENT : DEFAULT_CODEX_AGENT;
+      if (!current) {
+        return {
+          provider,
+          content: nextContent,
+          initialContent: nextContent,
+          error: null,
+          conflictContent: null,
+        };
+      }
+      return {
+        provider,
+        content: current.content === current.initialContent ? nextContent : current.content,
+        initialContent: nextContent,
+        error: null,
+        conflictContent: null,
+      };
+    });
+  };
+
+  const handleDraftError = (message: string, conflict: boolean) => {
+    setDraftAgent((current) => {
+      if (!current) return current;
+      return {
+        ...current,
+        error: message,
+        conflictContent: conflict ? current.content : null,
+      };
+    });
+  };
+
+  const handleDraftDiscard = () => {
+    setDraftAgent(null);
+    setSelection(agents[0] ? { kind: "existing", id: agents[0].id } : null);
+  };
+
+  const handleDraftCreated = (id: string) => {
+    setDraftAgent(null);
+    setSelection({ kind: "existing", id });
+  };
+
+  const handleProviderDeleted = (id: string, provider: CustomAgentProviderId) => {
+    setSelection((current) => {
+      if (current?.kind !== "existing" || current.id !== id) return current;
+      const deletedAgent = agents.find((agent) => agent.id === id);
+      const otherProvider: CustomAgentProviderId = provider === "claude" ? "codex" : "claude";
+      if (deletedAgent?.providers[otherProvider].present) return current;
+      const nextAgent = agents.find((agent) => agent.id !== id);
+      if (nextAgent) return { kind: "existing", id: nextAgent.id };
+      return draftAgent ? { kind: "draft" } : null;
+    });
+  };
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <SettingsHeader>
+        <h1 className="text-sm font-medium">Custom Agents</h1>
+      </SettingsHeader>
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading custom agents
+        </div>
+      ) : isError ? (
+        <div className="flex flex-1 items-center justify-center text-xs text-red-400">
+          Could not load custom agents.
+        </div>
+      ) : (
+        <div className="flex flex-1 overflow-hidden">
+          <CustomAgentsList
+            agents={agents}
+            draftAgent={draftAgent}
+            selection={resolvedSelection}
+            onSelect={(id) => setSelection({ kind: "existing", id })}
+            onSelectDraft={() => setSelection({ kind: "draft" })}
+            onNewAgent={handleNewAgent}
+          />
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            {selectedExistingId ? (
+              <CustomAgentDetailPanel
+                id={selectedExistingId}
+                onSelectedIdChange={(id) => setSelection({ kind: "existing", id })}
+                onProviderDeleted={handleProviderDeleted}
+              />
+            ) : resolvedSelection?.kind === "draft" && draftAgent ? (
+              <NewCustomAgentPanel
+                draft={draftAgent}
+                onChange={handleDraftChange}
+                onProviderChange={handleDraftProviderChange}
+                onCreated={handleDraftCreated}
+                onDiscard={handleDraftDiscard}
+                onError={handleDraftError}
+              />
+            ) : (
+              <EmptyState />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function resolveAgentSelection(
+  selection: AgentSelection,
+  agents: CustomAgentSummary[],
+  hasDraft: boolean,
+): AgentSelection {
+  if (selection?.kind === "draft") return hasDraft ? selection : null;
+  if (selection?.kind === "existing" && agents.some((agent) => agent.id === selection.id)) {
+    return selection;
+  }
+  if (agents[0]) return { kind: "existing", id: agents[0].id };
+  return hasDraft ? { kind: "draft" } : null;
+}
+
+function CustomAgentsList({
+  agents,
+  draftAgent,
+  selection,
+  onSelect,
+  onSelectDraft,
+  onNewAgent,
+}: {
+  agents: CustomAgentSummary[];
+  draftAgent: NewAgentDraft | null;
+  selection: AgentSelection;
+  onSelect: (id: string) => void;
+  onSelectDraft: () => void;
+  onNewAgent: () => void;
+}) {
+  return (
+    <div className="flex w-64 shrink-0 flex-col border-r border-border/50">
+      <ScrollArea className="flex-1">
+        <div className="p-2">
+          {draftAgent && (
+            <DraftAgentListItem
+              provider={draftAgent.provider}
+              selected={selection?.kind === "draft"}
+              onClick={onSelectDraft}
+            />
+          )}
+          {agents.length === 0 && !draftAgent ? (
+            <div className="px-2 py-8 text-center text-xs text-muted-foreground">
+              No global custom agents found.
+            </div>
+          ) : (
+            agents.map((agent) => (
+              <CustomAgentListItem
+                key={agent.id}
+                agent={agent}
+                selected={selection?.kind === "existing" && agent.id === selection.id}
+                onClick={() => onSelect(agent.id)}
+              />
+            ))
+          )}
+        </div>
+      </ScrollArea>
+      <div className="border-t border-border/30 p-2">
+        <button
+          type="button"
+          onClick={onNewAgent}
+          className={cn(
+            "inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed border-primary/40 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/10",
+            selection?.kind === "draft" && "border-primary bg-primary/10",
+          )}
+        >
+          <Plus className="h-3 w-3" />
+          New Agent
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DraftAgentListItem({
+  provider,
+  selected,
+  onClick,
+}: {
+  provider: CustomAgentProviderId;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
+        selected
+          ? "bg-primary/15 text-foreground"
+          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Bot className="h-3.5 w-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate font-medium">New Agent</span>
+        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+          Unsaved
+        </Badge>
+      </div>
+      <p className="text-xs leading-snug text-muted-foreground">
+        {PROVIDER_LABELS[provider]} draft
+      </p>
+    </button>
+  );
+}
+
+function CustomAgentListItem({
+  agent,
+  selected,
+  onClick,
+}: {
+  agent: CustomAgentSummary;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
+        selected
+          ? "bg-primary/15 text-foreground"
+          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      )}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        <Bot className="h-3.5 w-3.5 shrink-0" />
+        <span className="min-w-0 flex-1 truncate font-medium">{agent.name}</span>
+        <CompactStatusIcon status={agent.status} />
+      </div>
+      {agent.description && (
+        <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
+          {agent.description}
+        </p>
+      )}
+      <div className="flex flex-wrap gap-1">
+        <ProviderMiniBadge label="Claude" present={agent.providers.claude.present} />
+        <ProviderMiniBadge label="Codex" present={agent.providers.codex.present} />
+      </div>
+    </button>
+  );
+}
+
+function CustomAgentDetailPanel({
+  id,
+  onSelectedIdChange,
+  onProviderDeleted,
+}: {
+  id: string;
+  onSelectedIdChange: (id: string) => void;
+  onProviderDeleted: (id: string, provider: CustomAgentProviderId) => void;
+}) {
+  const { data, isLoading, isError } = useCustomAgent(id);
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading custom agent
+      </div>
+    );
+  }
+
+  if (isError || !data) {
+    return (
+      <div className="flex h-full items-center justify-center text-xs text-red-400">
+        Could not load this custom agent.
+      </div>
+    );
+  }
+
+  return (
+    <LoadedCustomAgentDetailPanel
+      key={data.id}
+      data={data}
+      onSelectedIdChange={onSelectedIdChange}
+      onProviderDeleted={onProviderDeleted}
+    />
+  );
+}
+
+function LoadedCustomAgentDetailPanel({
+  data,
+  onSelectedIdChange,
+  onProviderDeleted,
+}: {
+  data: CustomAgentDetail;
+  onSelectedIdChange: (id: string) => void;
+  onProviderDeleted: (id: string, provider: CustomAgentProviderId) => void;
+}) {
+  const defaultProvider = data.providers.claude.present ? "claude" : "codex";
+  const [activeProvider, setActiveProvider] = useState<CustomAgentProviderId>(defaultProvider);
+  const providerState = data.providers[activeProvider];
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex shrink-0 items-center gap-1 border-b border-border/30 px-5 pt-4">
+        {PROVIDERS.map((provider) => (
+          <button
+            key={provider}
+            type="button"
+            onClick={() => setActiveProvider(provider)}
+            className={cn(
+              "inline-flex cursor-pointer items-center gap-1.5 border-b-2 px-3 py-2 text-xs font-medium transition-colors",
+              activeProvider === provider
+                ? "border-primary text-foreground"
+                : "border-transparent text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {PROVIDER_LABELS[provider]}
+            <span
+              className={cn(
+                "h-1.5 w-1.5 rounded-full",
+                data.providers[provider].present ? "bg-emerald-400" : "bg-muted-foreground/40",
+              )}
+            />
+          </button>
+        ))}
+      </div>
+
+      {providerState.present ? (
+        <CustomAgentProviderEditor
+          key={`${data.id}:${activeProvider}:${providerState.hash ?? "no-hash"}`}
+          data={data}
+          provider={activeProvider}
+          onSelectedIdChange={onSelectedIdChange}
+          onProviderDeleted={onProviderDeleted}
+        />
+      ) : (
+        <MissingProviderPanel
+          data={data}
+          provider={activeProvider}
+          onSelectedIdChange={onSelectedIdChange}
+        />
+      )}
+    </div>
+  );
+}
+
+function CustomAgentProviderEditor({
+  data,
+  provider,
+  onSelectedIdChange,
+  onProviderDeleted,
+}: {
+  data: CustomAgentDetail;
+  provider: CustomAgentProviderId;
+  onSelectedIdChange: (id: string) => void;
+  onProviderDeleted: (id: string, provider: CustomAgentProviderId) => void;
+}) {
+  const updateMutation = useUpdateCustomAgentProvider();
+  const deleteMutation = useDeleteCustomAgentProvider();
+  const [draft, setDraft] = useState(data.contents[provider] ?? "");
+  const [error, setError] = useState<string | null>(null);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const isDirty = draft !== (data.contents[provider] ?? "");
+
+  const handleSave = async () => {
+    if (!draft.trim()) return;
+    setError(null);
+    try {
+      const saved = await updateMutation.mutateAsync({ id: data.id, provider, content: draft });
+      onSelectedIdChange(saved.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save custom agent");
+    }
+  };
+
+  const handleDelete = async () => {
+    setError(null);
+    try {
+      await deleteMutation.mutateAsync({ id: data.id, provider });
+      setShowDeleteConfirm(false);
+      onProviderDeleted(data.id, provider);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to delete custom agent");
+    }
+  };
+
+  return (
+    <>
+      <SettingsEditorFrame
+        title={data.name}
+        badge={<StatusBadge status={data.status} />}
+        description={data.description}
+        providers={
+          <>
+            <ProviderBadge label="Claude" state={data.providers.claude} />
+            <ProviderBadge label="Codex" state={data.providers.codex} />
+          </>
+        }
+        banner={<CustomAgentBanner data={data} provider={provider} />}
+        value={draft}
+        onChange={setDraft}
+        language={provider === "codex" ? "toml" : "markdown"}
+        placeholder={PLACEHOLDERS[provider]}
+        ariaLabel={`${data.name} ${PROVIDER_LABELS[provider]} custom agent`}
+        actions={
+          <>
+            <EditorActionButton
+              variant="primary"
+              onClick={() => void handleSave()}
+              disabled={!isDirty || !draft.trim() || updateMutation.isPending}
+              pending={updateMutation.isPending}
+              icon={<Save className="h-3 w-3" />}
+            >
+              Save
+            </EditorActionButton>
+            <EditorActionButton
+              variant="danger"
+              onClick={() => setShowDeleteConfirm(true)}
+              disabled={deleteMutation.isPending}
+              pending={deleteMutation.isPending}
+              icon={<Trash2 className="h-3 w-3" />}
+            >
+              Delete {PROVIDER_LABELS[provider]}
+            </EditorActionButton>
+            {error && (
+              <span role="alert" className="text-xs text-red-400">
+                {error}
+              </span>
+            )}
+          </>
+        }
+      />
+
+      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete custom agent</AlertDialogTitle>
+            <AlertDialogDescription>
+              Delete the {PROVIDER_LABELS[provider]} version of &ldquo;{data.name}&rdquo;? This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => void handleDelete()}
+              className="bg-red-600 text-white hover:bg-red-700"
+            >
+              {deleteMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : "Delete"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+function MissingProviderPanel({
+  data,
+  provider,
+  onSelectedIdChange,
+}: {
+  data: CustomAgentDetail;
+  provider: CustomAgentProviderId;
+  onSelectedIdChange: (id: string) => void;
+}) {
+  const counterpartMutation = useCreateCustomAgentCounterpart();
+  const [error, setError] = useState<string | null>(null);
+  const sourceProvider: CustomAgentProviderId = provider === "claude" ? "codex" : "claude";
+  const canCreate = data.providers[sourceProvider].present;
+
+  const handleCreateCounterpart = async () => {
+    if (!canCreate) return;
+    setError(null);
+    try {
+      const created = await counterpartMutation.mutateAsync({ id: data.id, provider });
+      onSelectedIdChange(created.id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create counterpart");
+    }
+  };
+
+  return (
+    <div className="flex h-full flex-col px-5 pt-5 pb-2">
+      <div className="mb-4">
+        <div className="flex items-center gap-2">
+          <h2 className="text-base font-medium text-foreground">{data.name}</h2>
+          <StatusBadge status={data.status} />
+        </div>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <ProviderBadge label="Claude" state={data.providers.claude} />
+          <ProviderBadge label="Codex" state={data.providers.codex} />
+        </div>
+      </div>
+
+      <div className="flex flex-1 items-center justify-center">
+        <div className="max-w-sm text-center">
+          <FileCode2 className="mx-auto mb-3 h-8 w-8 text-muted-foreground/60" />
+          <h3 className="text-sm font-medium text-foreground">
+            No {PROVIDER_LABELS[provider]} version
+          </h3>
+          <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+            Create a provider-native counterpart from the existing {PROVIDER_LABELS[sourceProvider]} agent.
+          </p>
+          <button
+            type="button"
+            onClick={() => void handleCreateCounterpart()}
+            disabled={!canCreate || counterpartMutation.isPending}
+            className={cn(
+              "mt-4 inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+              (!canCreate || counterpartMutation.isPending) && "pointer-events-none opacity-60",
+            )}
+          >
+            {counterpartMutation.isPending ? (
+              <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+              <Sparkles className="h-3 w-3" />
+            )}
+            Create {PROVIDER_LABELS[provider]} version
+          </button>
+          {error && (
+            <p role="alert" className="mt-3 text-xs text-red-400">
+              {error}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function NewCustomAgentPanel({
+  draft,
+  onChange,
+  onProviderChange,
+  onCreated,
+  onDiscard,
+  onError,
+}: {
+  draft: NewAgentDraft;
+  onChange: (content: string) => void;
+  onProviderChange: (provider: CustomAgentProviderId) => void;
+  onCreated: (id: string) => void;
+  onDiscard: () => void;
+  onError: (message: string, conflict: boolean) => void;
+}) {
+  const createMutation = useCreateCustomAgent();
+  const isDirty = draft.content !== draft.initialContent;
+  const hasConflict = draft.conflictContent === draft.content;
+  const canSave = isDirty && Boolean(draft.content.trim()) && !hasConflict && !createMutation.isPending;
+
+  const handleSave = async () => {
+    if (!canSave) return;
+    try {
+      const created = await createMutation.mutateAsync({
+        provider: draft.provider,
+        content: draft.content,
+      });
+      onCreated(created.id);
+    } catch (err) {
+      const conflict = err instanceof ApiError && err.status === 409;
+      onError(
+        conflict
+          ? "Custom agent already exists"
+          : err instanceof Error
+            ? err.message
+            : "Failed to create custom agent",
+        conflict,
+      );
+    }
+  };
+
+  return (
+    <SettingsEditorFrame
+      title="New Custom Agent"
+      badge={
+        <Badge variant="secondary" className="bg-primary/10 text-[10px] text-primary">
+          Unsaved
+        </Badge>
+      }
+      description={`${PROVIDER_LABELS[draft.provider]} global agent`}
+      providers={
+        <ProviderSelector
+          value={draft.provider}
+          onChange={onProviderChange}
+        />
+      }
+      value={draft.content}
+      onChange={onChange}
+      language={draft.provider === "codex" ? "toml" : "markdown"}
+      placeholder={PLACEHOLDERS[draft.provider]}
+      ariaLabel="New custom agent"
+      actions={
+        <>
+          <EditorActionButton
+            variant="primary"
+            onClick={() => void handleSave()}
+            disabled={!canSave}
+            pending={createMutation.isPending}
+            icon={<Save className="h-3 w-3" />}
+          >
+            Save
+          </EditorActionButton>
+          <EditorActionButton
+            onClick={onDiscard}
+            icon={<X className="h-3 w-3" />}
+          >
+            Discard
+          </EditorActionButton>
+          {draft.error && (
+            <span role="alert" className="text-xs text-red-400">
+              {draft.error}
+            </span>
+          )}
+          {!isDirty && (
+            <span className="text-xs text-muted-foreground">
+              Edit the template before saving.
+            </span>
+          )}
+        </>
+      }
+    />
+  );
+}
+
+function ProviderSelector({
+  value,
+  onChange,
+}: {
+  value: CustomAgentProviderId;
+  onChange: (provider: CustomAgentProviderId) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-md border border-border/50 p-0.5">
+      {PROVIDERS.map((provider) => (
+        <button
+          key={provider}
+          type="button"
+          onClick={() => onChange(provider)}
+          className={cn(
+            "cursor-pointer rounded-sm px-2.5 py-1 text-[11px] font-medium transition-colors",
+            value === provider
+              ? "bg-primary/15 text-primary"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {PROVIDER_LABELS[provider]}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function CustomAgentBanner({
+  data,
+  provider,
+}: {
+  data: CustomAgentDetail;
+  provider: CustomAgentProviderId;
+}) {
+  if (data.status === "invalid") {
+    return (
+      <Banner tone="danger" icon={<XCircle className="h-3.5 w-3.5" />}>
+        {data.providers[provider].error ?? data.invalidReason ?? "This custom agent could not be read."}
+      </Banner>
+    );
+  }
+
+  if (data.status === "both") {
+    return (
+      <Banner tone="info" icon={<Bot className="h-3.5 w-3.5" />}>
+        Claude and Codex use separate native files. Saving edits only the selected provider version.
+      </Banner>
+    );
+  }
+
+  return (
+    <Banner tone="warning" icon={<AlertTriangle className="h-3.5 w-3.5" />}>
+      This custom agent exists only in {PROVIDER_LABELS[provider]}. Use the other provider tab to create a counterpart.
+    </Banner>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+      Select a custom agent to edit
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/CustomAgentsSettings.tsx
+++ b/frontend/src/pages/settings/CustomAgentsSettings.tsx
@@ -36,6 +36,10 @@ import {
   SettingsResourceListItem,
 } from "@/components/settings/SettingsResourceList";
 import {
+  resolveSettingsResourceSelection,
+  type SettingsResourceSelection,
+} from "@/components/settings/resource-selection";
+import {
   useCreateCustomAgent,
   useCreateCustomAgentCounterpart,
   useCustomAgent,
@@ -79,7 +83,7 @@ const PLACEHOLDERS: Record<CustomAgentProviderId, string> = {
   codex: "name = \"reviewer\"\ndescription = \"Reviews changes\"\ndeveloper_instructions = \"Review code changes.\"",
 };
 
-type AgentSelection = { kind: "existing"; id: string } | { kind: "draft" } | null;
+type AgentSelection = SettingsResourceSelection;
 
 interface NewAgentDraft {
   provider: CustomAgentProviderId;
@@ -94,7 +98,7 @@ export default function CustomAgentsSettings() {
   const agents = data?.agents ?? [];
   const [selection, setSelection] = useState<AgentSelection>(null);
   const [draftAgent, setDraftAgent] = useState<NewAgentDraft | null>(null);
-  const resolvedSelection = resolveAgentSelection(selection, agents, draftAgent !== null);
+  const resolvedSelection = resolveSettingsResourceSelection(selection, agents, draftAgent !== null);
   const selectedExistingId = resolvedSelection?.kind === "existing" ? resolvedSelection.id : null;
 
   const handleNewAgent = () => {
@@ -227,19 +231,6 @@ export default function CustomAgentsSettings() {
       )}
     </div>
   );
-}
-
-function resolveAgentSelection(
-  selection: AgentSelection,
-  agents: CustomAgentSummary[],
-  hasDraft: boolean,
-): AgentSelection {
-  if (selection?.kind === "draft") return hasDraft ? selection : null;
-  if (selection?.kind === "existing" && agents.some((agent) => agent.id === selection.id)) {
-    return selection;
-  }
-  if (agents[0]) return { kind: "existing", id: agents[0].id };
-  return hasDraft ? { kind: "draft" } : null;
 }
 
 function CustomAgentsList({

--- a/frontend/src/pages/settings/InstructionsSettings.tsx
+++ b/frontend/src/pages/settings/InstructionsSettings.tsx
@@ -58,7 +58,9 @@ export default function InstructionsSettings() {
   return (
     <div className="flex h-full flex-col overflow-hidden">
       <SettingsHeader>
-        <h1 className="text-sm font-medium">Instructions</h1>
+        <h1 className="text-sm font-medium">
+          Instructions <span className="text-[11px] font-normal text-muted-foreground">(AGENTS.md / CLAUDE.md)</span>
+        </h1>
       </SettingsHeader>
 
       {isLoading ? (

--- a/frontend/src/pages/settings/InstructionsSettings.tsx
+++ b/frontend/src/pages/settings/InstructionsSettings.tsx
@@ -280,14 +280,14 @@ function InstructionBanners({
             <button
               type="button"
               onClick={onViewDiff}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/15"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-warning-foreground transition-colors hover:bg-warning-muted"
             >
               View diff
             </button>
             <button
               type="button"
               onClick={() => onUseProvider("claude")}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/15"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-warning-foreground transition-colors hover:bg-warning-muted"
             >
               Use Claude copy
             </button>

--- a/frontend/src/pages/settings/SkillsSettings.tsx
+++ b/frontend/src/pages/settings/SkillsSettings.tsx
@@ -46,6 +46,10 @@ import {
   SettingsResourceListItem,
 } from "@/components/settings/SettingsResourceList";
 import {
+  resolveSettingsResourceSelection,
+  type SettingsResourceSelection,
+} from "@/components/settings/resource-selection";
+import {
   useCreateSkill,
   useDeleteSkill,
   useSkill,
@@ -72,7 +76,7 @@ Describe the workflow, rules, and context this skill should provide.
 `;
 const SKILL_EDITOR_PLACEHOLDER = "---\nname: my-skill\ndescription: When to use this skill\n---\n\n# My Skill";
 
-type SkillSelection = { kind: "existing"; id: string } | { kind: "draft" } | null;
+type SkillSelection = SettingsResourceSelection;
 
 interface NewSkillDraft {
   content: string;
@@ -87,7 +91,7 @@ export default function SkillsSettings() {
   const skills = data?.skills ?? [];
   const [selection, setSelection] = useState<SkillSelection>(null);
   const [draftSkill, setDraftSkill] = useState<NewSkillDraft | null>(null);
-  const resolvedSelection = resolveSkillSelection(selection, skills, draftSkill !== null);
+  const resolvedSelection = resolveSettingsResourceSelection(selection, skills, draftSkill !== null);
 
   const syncableCount = skills.filter((skill) => SYNCABLE_STATUSES.has(skill.syncStatus)).length;
   const selectedExistingId = resolvedSelection?.kind === "existing" ? resolvedSelection.id : null;
@@ -212,19 +216,6 @@ export default function SkillsSettings() {
       )}
     </div>
   );
-}
-
-function resolveSkillSelection(
-  selection: SkillSelection,
-  skills: SkillSummary[],
-  hasDraft: boolean,
-): SkillSelection {
-  if (selection?.kind === "draft") return hasDraft ? selection : null;
-  if (selection?.kind === "existing" && skills.some((skill) => skill.id === selection.id)) {
-    return selection;
-  }
-  if (skills[0]) return { kind: "existing", id: skills[0].id };
-  return hasDraft ? { kind: "draft" } : null;
 }
 
 function SkillsList({

--- a/frontend/src/pages/settings/SkillsSettings.tsx
+++ b/frontend/src/pages/settings/SkillsSettings.tsx
@@ -4,7 +4,6 @@ import {
   FileCode2,
   Link2,
   Loader2,
-  Plus,
   RefreshCw,
   Save,
   Trash2,
@@ -30,18 +29,22 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { SettingsHeader } from "@/components/AppLayout";
 import { DiffView } from "@/components/diff/DiffView";
 import {
   CompactSyncStatusIcon as CompactStatusIcon,
   ProviderBadge,
-  ProviderMiniBadge,
   SettingsActionButton as EditorActionButton,
   SettingsBanner as Banner,
   SyncStatusBadge as StatusBadge,
 } from "@/components/settings/ProviderSync";
 import { SettingsEditorFrame } from "@/components/settings/SettingsEditorFrame";
+import {
+  SettingsEmptySelection,
+  SettingsResourceEmptyList,
+  SettingsResourceList,
+  SettingsResourceListItem,
+} from "@/components/settings/SettingsResourceList";
 import {
   useCreateSkill,
   useDeleteSkill,
@@ -154,14 +157,14 @@ export default function SkillsSettings() {
           onClick={() => void syncMissingMutation.mutateAsync()}
           disabled={syncableCount === 0 || syncMissingMutation.isPending}
           className={cn(
-            "inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1 text-xs text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground",
+            "inline-flex cursor-pointer items-center gap-1.5 rounded-md px-2.5 py-1 text-xs text-muted-foreground transition-colors outline-none hover:bg-muted/40 hover:text-foreground focus-visible:ring-[3px] focus-visible:ring-ring/50",
             (syncableCount === 0 || syncMissingMutation.isPending) && "pointer-events-none opacity-50",
           )}
         >
           {syncMissingMutation.isPending ? (
-            <Loader2 className="h-3 w-3 animate-spin" />
+            <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" />
           ) : (
-            <RefreshCw className="h-3 w-3" />
+            <RefreshCw aria-hidden="true" className="h-3 w-3" />
           )}
           Sync pending{syncableCount > 0 ? ` (${syncableCount})` : ""}
         </button>
@@ -169,15 +172,15 @@ export default function SkillsSettings() {
 
       {isLoading ? (
         <div className="flex flex-1 items-center justify-center gap-2 text-xs text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading skills
+          <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+          Loading skills…
         </div>
       ) : isError ? (
         <div className="flex flex-1 items-center justify-center text-xs text-red-400">
           Could not load skills.
         </div>
       ) : (
-        <div className="flex flex-1 overflow-hidden">
+        <div className="flex flex-1 overflow-hidden max-md:flex-col">
           <SkillsList
             skills={skills}
             draftSkill={draftSkill}
@@ -240,115 +243,41 @@ function SkillsList({
   onNewSkill: () => void;
 }) {
   return (
-    <div className="flex w-64 shrink-0 flex-col border-r border-border/50">
-      <ScrollArea className="flex-1">
-        <div className="p-2">
-          {draftSkill && (
-            <DraftSkillListItem
-              selected={selection?.kind === "draft"}
-              onClick={onSelectDraft}
-            />
-          )}
-          {skills.length === 0 && !draftSkill ? (
-            <div className="px-2 py-8 text-center text-xs text-muted-foreground">
-              No global skills found.
-            </div>
-          ) : (
-            skills.map((skill) => (
-              <SkillListItem
-                key={skill.id}
-                skill={skill}
-                selected={selection?.kind === "existing" && skill.id === selection.id}
-                onClick={() => onSelect(skill.id)}
-              />
-            ))
-          )}
-        </div>
-      </ScrollArea>
-      <div className="border-t border-border/30 p-2">
-        <button
-          type="button"
-          onClick={onNewSkill}
-          className={cn(
-            "inline-flex w-full cursor-pointer items-center justify-center gap-1.5 rounded-md border border-dashed border-primary/40 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:border-primary hover:bg-primary/10",
-            selection?.kind === "draft" && "border-primary bg-primary/10",
-          )}
-        >
-          <Plus className="h-3 w-3" />
-          New Skill
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function DraftSkillListItem({
-  selected,
-  onClick,
-}: {
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
-        selected
-          ? "bg-primary/15 text-foreground"
-          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
-      )}
+    <SettingsResourceList
+      showEmpty={skills.length === 0 && !draftSkill}
+      empty={<SettingsResourceEmptyList>No global skills found.</SettingsResourceEmptyList>}
+      actionLabel="New Skill"
+      actionActive={selection?.kind === "draft"}
+      onAction={onNewSkill}
     >
-      <div className="flex min-w-0 items-center gap-2">
-        <FileCode2 className="h-3.5 w-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate font-medium">New Skill</span>
-        <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
-          Unsaved
-        </Badge>
-      </div>
-      <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
-        Local draft
-      </p>
-    </button>
-  );
-}
-
-function SkillListItem({
-  skill,
-  selected,
-  onClick,
-}: {
-  skill: SkillSummary;
-  selected: boolean;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={cn(
-        "mb-1 flex w-full cursor-pointer flex-col gap-1.5 rounded-md px-2 py-2 text-left text-sm transition-colors",
-        selected
-          ? "bg-primary/15 text-foreground"
-          : "text-muted-foreground hover:bg-muted/40 hover:text-foreground",
+      {draftSkill && (
+        <SettingsResourceListItem
+          icon={<FileCode2 className="h-3.5 w-3.5" />}
+          title="New Skill"
+          description="Local draft"
+          ariaLabel="New Skill draft"
+          trailing={
+            <Badge variant="secondary" className="shrink-0 px-1.5 py-0 text-[10px]">
+              Unsaved
+            </Badge>
+          }
+          selected={selection?.kind === "draft"}
+          onClick={onSelectDraft}
+        />
       )}
-    >
-      <div className="flex min-w-0 items-center gap-2">
-        <FileCode2 className="h-3.5 w-3.5 shrink-0" />
-        <span className="min-w-0 flex-1 truncate font-medium">{skill.name}</span>
-        <CompactStatusIcon status={skill.syncStatus} />
-      </div>
-      {skill.description && (
-        <p className="line-clamp-2 text-xs leading-snug text-muted-foreground">
-          {skill.description}
-        </p>
-      )}
-      <div className="flex flex-wrap gap-1">
-        <ProviderMiniBadge label="Claude" present={skill.providers.claude.present} />
-        <ProviderMiniBadge label="Codex" present={skill.providers.codex.present} />
-      </div>
-    </button>
+      {skills.map((skill) => (
+        <SettingsResourceListItem
+          key={skill.id}
+          icon={<FileCode2 className="h-3.5 w-3.5" />}
+          title={skill.name}
+          description={skill.description}
+          ariaLabel={`${skill.name} skill`}
+          trailing={<CompactStatusIcon status={skill.syncStatus} />}
+          selected={selection?.kind === "existing" && skill.id === selection.id}
+          onClick={() => onSelect(skill.id)}
+        />
+      ))}
+    </SettingsResourceList>
   );
 }
 
@@ -366,8 +295,8 @@ function SkillDetailPanel({
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center gap-2 text-xs text-muted-foreground">
-        <Loader2 className="h-4 w-4 animate-spin" />
-        Loading skill
+        <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />
+        Loading skill…
       </div>
     );
   }
@@ -527,7 +456,7 @@ function LoadedSkillDetailPanel({
               onClick={() => void handleDelete()}
               className="bg-red-600 text-white hover:bg-red-700"
             >
-              {deleteMutation.isPending ? <Loader2 className="h-3 w-3 animate-spin" /> : "Delete"}
+              {deleteMutation.isPending ? <Loader2 aria-hidden="true" className="h-3 w-3 animate-spin" /> : "Delete"}
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
@@ -643,14 +572,14 @@ function SkillBanner({
             <button
               type="button"
               onClick={onViewDiff}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/15"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors outline-none hover:bg-amber-500/15 focus-visible:ring-[3px] focus-visible:ring-amber-300/40"
             >
               View diff
             </button>
             <button
               type="button"
               onClick={() => onUseProvider("claude")}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors hover:bg-amber-500/15"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors outline-none hover:bg-amber-500/15 focus-visible:ring-[3px] focus-visible:ring-amber-300/40"
             >
               Use Claude copy
             </button>
@@ -735,8 +664,6 @@ function SkillDiffDialog({
 
 function EmptyState() {
   return (
-    <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
-      Select a skill to edit
-    </div>
+    <SettingsEmptySelection>Select a skill to edit</SettingsEmptySelection>
   );
 }

--- a/frontend/src/pages/settings/SkillsSettings.tsx
+++ b/frontend/src/pages/settings/SkillsSettings.tsx
@@ -563,14 +563,14 @@ function SkillBanner({
             <button
               type="button"
               onClick={onViewDiff}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors outline-none hover:bg-amber-500/15 focus-visible:ring-[3px] focus-visible:ring-amber-300/40"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-warning-foreground transition-colors outline-none hover:bg-warning-muted focus-visible:ring-[3px] focus-visible:ring-warning/40"
             >
               View diff
             </button>
             <button
               type="button"
               onClick={() => onUseProvider("claude")}
-              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-amber-200 transition-colors outline-none hover:bg-amber-500/15 focus-visible:ring-[3px] focus-visible:ring-amber-300/40"
+              className="cursor-pointer rounded-md px-2 py-0.5 text-[11px] font-medium text-warning-foreground transition-colors outline-none hover:bg-warning-muted focus-visible:ring-[3px] focus-visible:ring-warning/40"
             >
               Use Claude copy
             </button>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -519,6 +519,60 @@ export interface UpdateInstructionsRequest {
   content: string;
 }
 
+// ── Global custom agent settings ────────────────────────────────────
+
+export type CustomAgentProviderId = "claude" | "codex";
+export type CustomAgentStatus =
+  | "both"
+  | "claude_only"
+  | "codex_only"
+  | "invalid";
+
+export interface CustomAgentProviderState {
+  present: boolean;
+  path: string;
+  fileName?: string;
+  isSymlink?: boolean;
+  realPath?: string;
+  hash?: string;
+  updatedAt?: string;
+  error?: string;
+}
+
+export interface CustomAgentManifest {
+  name: string;
+  description?: string;
+  developerInstructions?: string;
+}
+
+export interface CustomAgentSummary {
+  id: string;
+  name: string;
+  description?: string;
+  status: CustomAgentStatus;
+  providers: Record<CustomAgentProviderId, CustomAgentProviderState>;
+  invalidReason?: string;
+  updatedAt?: string;
+}
+
+export interface CustomAgentDetail extends CustomAgentSummary {
+  contents: Partial<Record<CustomAgentProviderId, string>>;
+  manifests: Partial<Record<CustomAgentProviderId, CustomAgentManifest>>;
+}
+
+export interface CustomAgentListResponse {
+  agents: CustomAgentSummary[];
+}
+
+export interface CreateCustomAgentRequest {
+  provider: CustomAgentProviderId;
+  content: string;
+}
+
+export interface UpdateCustomAgentRequest {
+  content: string;
+}
+
 // ── Hub WebSocket protocol (multiplexed) ────────────────────────────
 
 /** Client -> Server (hub-level). */

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -135,6 +135,10 @@ vi.mock("@/pages/settings/AgentSettings", () => ({
   default: () => <div>agent settings</div>,
 }));
 
+vi.mock("@/pages/settings/CustomAgentsSettings", () => ({
+  default: () => <div>custom agents settings</div>,
+}));
+
 vi.mock("@/pages/settings/ProjectDetail", () => ({
   default: () => <div>project detail</div>,
 }));
@@ -263,6 +267,14 @@ describe("App", () => {
     renderApp();
 
     expect(screen.getByText("agent settings")).toBeInTheDocument();
+  });
+
+  it("renders custom agents settings route", async () => {
+    window.history.pushState({}, "", "/settings/custom-agents");
+
+    renderApp();
+
+    expect(await screen.findByText("custom agents settings")).toBeInTheDocument();
   });
 
   it("redirects /projects/:id to /home", () => {

--- a/frontend/tests/components/SettingsSidebar.test.tsx
+++ b/frontend/tests/components/SettingsSidebar.test.tsx
@@ -196,6 +196,25 @@ describe("SettingsSidebar", () => {
     });
   });
 
+  it("navigates to custom agents settings", async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <MemoryRouter initialEntries={["/settings/appearance"]}>
+        <Routes>
+          <Route path="/settings" element={<SettingsShell />}>
+            <Route path="appearance" element={<div>Appearance settings</div>} />
+            <Route path="custom-agents" element={<div>Custom agents settings</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole("link", { name: /Custom Agents/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Custom agents settings")).toBeInTheDocument();
+    });
+  });
+
   it("highlights the agents link when agents route is active", async () => {
     renderWithProviders(
       <MemoryRouter initialEntries={["/settings/agents"]}>
@@ -225,6 +244,7 @@ describe("SettingsSidebar", () => {
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Agents" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /CLI/i })).toHaveAttribute("href", "/settings/agents");
+    expect(screen.getByRole("link", { name: /Custom Agents/i })).toHaveAttribute("href", "/settings/custom-agents");
     expect(screen.getByRole("link", { name: /Instructions/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Prompts/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Skills/i })).toBeInTheDocument();

--- a/frontend/tests/hooks/useCustomAgents.test.ts
+++ b/frontend/tests/hooks/useCustomAgents.test.ts
@@ -1,0 +1,227 @@
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  useCreateCustomAgent,
+  useCreateCustomAgentCounterpart,
+  useCustomAgent,
+  useCustomAgents,
+  useDeleteCustomAgentProvider,
+  useUpdateCustomAgentProvider,
+} from "@/hooks/useCustomAgents";
+import { api } from "@/hooks/useApi";
+import type { CustomAgentDetail, CustomAgentSummary } from "@/types";
+import { createWrapper } from "../test-utils";
+
+vi.mock("@/hooks/useApi", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+function makeAgent(overrides: Partial<CustomAgentSummary> = {}): CustomAgentSummary {
+  return {
+    id: "reviewer",
+    name: "reviewer",
+    description: "Review code",
+    status: "claude_only",
+    providers: {
+      claude: { present: true, path: "/home/me/.claude/agents/reviewer.md", isSymlink: false },
+      codex: { present: false, path: "/home/me/.codex/agents/reviewer.toml" },
+    },
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<CustomAgentDetail> = {}): CustomAgentDetail {
+  const summary = makeAgent(overrides);
+  return {
+    ...summary,
+    contents: {
+      claude: "---\nname: reviewer\n---\n# Reviewer\n",
+    },
+    manifests: {
+      claude: {
+        name: "reviewer",
+        description: "Review code",
+        developerInstructions: "# Reviewer",
+      },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useCustomAgents", () => {
+  it("fetches custom agents from the settings API", async () => {
+    const response = { agents: [makeAgent()] };
+    vi.mocked(api.get).mockResolvedValueOnce(response);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCustomAgents(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(response);
+    });
+
+    expect(api.get).toHaveBeenCalledWith("/api/settings/custom-agents");
+  });
+});
+
+describe("useCustomAgent", () => {
+  it("fetches one custom agent by id", async () => {
+    const detail = makeDetail();
+    vi.mocked(api.get).mockResolvedValueOnce(detail);
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCustomAgent("reviewer"), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(detail);
+    });
+
+    expect(api.get).toHaveBeenCalledWith("/api/settings/custom-agents/reviewer");
+  });
+});
+
+describe("useCreateCustomAgent", () => {
+  it("posts a new provider-native custom agent", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce(makeDetail());
+
+    const { wrapper, queryClient } = createWrapper();
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+    const { result } = renderHook(() => useCreateCustomAgent(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        provider: "claude",
+        content: "---\nname: reviewer\n---\n# Reviewer\n",
+      });
+    });
+
+    expect(api.post).toHaveBeenCalledWith("/api/settings/custom-agents", {
+      provider: "claude",
+      content: "---\nname: reviewer\n---\n# Reviewer\n",
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["settings", "custom-agents"] }),
+    );
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: ["completions"] }),
+    );
+  });
+});
+
+describe("useUpdateCustomAgentProvider", () => {
+  it("keeps the old summary when renaming one provider from a two-provider agent", async () => {
+    const existing = makeAgent({
+      status: "both",
+      providers: {
+        claude: { present: true, path: "/home/me/.claude/agents/reviewer.md" },
+        codex: { present: true, path: "/home/me/.codex/agents/reviewer.toml" },
+      },
+    });
+    const renamed = makeDetail({
+      id: "auditor",
+      name: "auditor",
+      status: "claude_only",
+      providers: {
+        claude: { present: true, path: "/home/me/.claude/agents/auditor.md" },
+        codex: { present: false, path: "/home/me/.codex/agents/auditor.toml" },
+      },
+    });
+    vi.mocked(api.put).mockResolvedValueOnce(renamed);
+
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(["settings", "custom-agents"], { agents: [existing] });
+    const { result } = renderHook(() => useUpdateCustomAgentProvider(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        id: "reviewer",
+        provider: "claude",
+        content: "---\nname: auditor\n---\n# Auditor\n",
+      });
+    });
+
+    expect(api.put).toHaveBeenCalledWith(
+      "/api/settings/custom-agents/reviewer/providers/claude",
+      { content: "---\nname: auditor\n---\n# Auditor\n" },
+    );
+    expect(queryClient.getQueryData(["settings", "custom-agents"])).toEqual({
+      agents: [
+        expect.objectContaining({ id: "auditor", status: "claude_only" }),
+        expect.objectContaining({
+          id: "reviewer",
+          status: "codex_only",
+          providers: expect.objectContaining({
+            claude: expect.objectContaining({ present: false }),
+            codex: expect.objectContaining({ present: true }),
+          }),
+        }),
+      ],
+    });
+  });
+});
+
+describe("useDeleteCustomAgentProvider", () => {
+  it("keeps invalid status when deleting the valid side of an invalid two-provider agent", async () => {
+    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
+
+    const { wrapper, queryClient } = createWrapper();
+    queryClient.setQueryData(["settings", "custom-agents"], {
+      agents: [
+        makeAgent({
+          status: "invalid",
+          invalidReason: "developer_instructions is required",
+          providers: {
+            claude: { present: true, path: "/home/me/.claude/agents/reviewer.md" },
+            codex: {
+              present: true,
+              path: "/home/me/.codex/agents/reviewer.toml",
+              error: "developer_instructions is required",
+            },
+          },
+        }),
+      ],
+    });
+    const { result } = renderHook(() => useDeleteCustomAgentProvider(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "reviewer", provider: "claude" });
+    });
+
+    expect(api.delete).toHaveBeenCalledWith("/api/settings/custom-agents/reviewer/providers/claude");
+    expect(queryClient.getQueryData(["settings", "custom-agents"])).toEqual({
+      agents: [
+        expect.objectContaining({
+          id: "reviewer",
+          status: "invalid",
+          invalidReason: "developer_instructions is required",
+        }),
+      ],
+    });
+  });
+});
+
+describe("useCreateCustomAgentCounterpart", () => {
+  it("posts to the provider counterpart endpoint", async () => {
+    vi.mocked(api.post).mockResolvedValueOnce(makeDetail({ status: "both" }));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useCreateCustomAgentCounterpart(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ id: "reviewer", provider: "codex" });
+    });
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/settings/custom-agents/reviewer/providers/codex/counterpart",
+    );
+  });
+});

--- a/frontend/tests/pages/CustomAgentsSettings.test.tsx
+++ b/frontend/tests/pages/CustomAgentsSettings.test.tsx
@@ -1,0 +1,272 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import CustomAgentsSettings from "@/pages/settings/CustomAgentsSettings";
+import { ApiError, api } from "@/hooks/useApi";
+import type { CustomAgentDetail, CustomAgentSummary } from "@/types";
+import { createWrapper } from "../test-utils";
+
+vi.mock("@/components/AppLayout", () => ({
+  SettingsHeader: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="settings-header">{children}</div>
+  ),
+}));
+
+vi.mock("@/components/MarkdownEditor", () => ({
+  MarkdownEditor: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value: string;
+    onChange?: (value: string) => void;
+    ariaLabel?: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/components/CodeEditor", () => ({
+  CodeEditor: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value: string;
+    onChange?: (value: string) => void;
+    ariaLabel?: string;
+  }) => (
+    <textarea
+      aria-label={ariaLabel}
+      value={value}
+      onChange={(event) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      message: string,
+    ) {
+      super(message);
+    }
+  },
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+function makeAgent(overrides: Partial<CustomAgentSummary> = {}): CustomAgentSummary {
+  return {
+    id: "reviewer",
+    name: "reviewer",
+    description: "Review code",
+    status: "claude_only",
+    providers: {
+      claude: { present: true, path: "/home/me/.claude/agents/reviewer.md", isSymlink: false },
+      codex: { present: false, path: "/home/me/.codex/agents/reviewer.toml" },
+    },
+    ...overrides,
+  };
+}
+
+function makeDetail(overrides: Partial<CustomAgentDetail> = {}): CustomAgentDetail {
+  const summary = makeAgent(overrides);
+  return {
+    ...summary,
+    contents: {
+      claude: "---\nname: reviewer\n---\n# Reviewer\n",
+    },
+    manifests: {
+      claude: {
+        name: "reviewer",
+        description: "Review code",
+        developerInstructions: "# Reviewer",
+      },
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CustomAgentsSettings", () => {
+  it("lists custom agents and opens the first agent", async () => {
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [makeAgent()] });
+      if (url === "/api/settings/custom-agents/reviewer") return Promise.resolve(makeDetail());
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    expect(await screen.findByText("reviewer")).toBeInTheDocument();
+    expect(await screen.findByLabelText("reviewer Claude custom agent")).toHaveValue(
+      "---\nname: reviewer\n---\n# Reviewer\n",
+    );
+    expect(screen.getAllByText("Claude").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
+  });
+
+  it("saves edited provider content", async () => {
+    const user = userEvent.setup();
+    const both = makeDetail({
+      status: "both",
+      providers: {
+        claude: { present: true, path: "/home/me/.claude/agents/reviewer.md" },
+        codex: { present: true, path: "/home/me/.codex/agents/reviewer.toml" },
+      },
+      contents: {
+        claude: "---\nname: reviewer\n---\n# Reviewer\n",
+        codex: "name = \"reviewer\"\ndeveloper_instructions = \"Review.\"\n",
+      },
+      manifests: {
+        claude: { name: "reviewer", developerInstructions: "# Reviewer" },
+        codex: { name: "reviewer", developerInstructions: "Review." },
+      },
+    });
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [both] });
+      if (url === "/api/settings/custom-agents/reviewer") return Promise.resolve(both);
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+    vi.mocked(api.put).mockResolvedValueOnce({
+      ...both,
+      contents: {
+        ...both.contents,
+        codex: "name = \"reviewer\"\ndeveloper_instructions = \"Updated.\"\n",
+      },
+    });
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    await screen.findByLabelText("reviewer Claude custom agent");
+    await user.click(screen.getByRole("button", { name: /^Codex$/ }));
+    const editor = await screen.findByLabelText("reviewer Codex custom agent");
+    await user.clear(editor);
+    await user.type(editor, "name = \"reviewer\"\ndeveloper_instructions = \"Updated.\"\n");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.put).toHaveBeenCalledWith(
+        "/api/settings/custom-agents/reviewer/providers/codex",
+        { content: "name = \"reviewer\"\ndeveloper_instructions = \"Updated.\"\n" },
+      );
+    });
+  });
+
+  it("creates a missing provider counterpart explicitly", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [makeAgent()] });
+      if (url === "/api/settings/custom-agents/reviewer") return Promise.resolve(makeDetail());
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+    vi.mocked(api.post).mockResolvedValueOnce(
+      makeDetail({
+        status: "both",
+        providers: {
+          claude: { present: true, path: "/home/me/.claude/agents/reviewer.md" },
+          codex: { present: true, path: "/home/me/.codex/agents/reviewer.toml" },
+        },
+      }),
+    );
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    await screen.findByLabelText("reviewer Claude custom agent");
+    await user.click(screen.getByRole("button", { name: /^Codex$/ }));
+    await user.click(screen.getByRole("button", { name: "Create Codex version" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith(
+        "/api/settings/custom-agents/reviewer/providers/codex/counterpart",
+      );
+    });
+  });
+
+  it("creates a new Codex custom agent draft", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [] });
+      if (url === "/api/settings/custom-agents/reviewer") return Promise.resolve(makeDetail());
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+    vi.mocked(api.post).mockResolvedValueOnce(makeDetail());
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    await user.click(await screen.findByRole("button", { name: "New Agent" }));
+    await user.click(screen.getByRole("button", { name: "Codex" }));
+    const editor = screen.getByLabelText("New custom agent");
+    const content = "name = \"reviewer\"\ndeveloper_instructions = \"Review changes.\"\n";
+    await user.clear(editor);
+    await user.type(editor, content);
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(api.post).toHaveBeenCalledWith("/api/settings/custom-agents", {
+        provider: "codex",
+        content,
+      });
+    });
+  });
+
+  it("shows a duplicate-name error after a create conflict", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [] });
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+    vi.mocked(api.post).mockRejectedValueOnce(new ApiError(409, "Custom agent already exists"));
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    await user.click(await screen.findByRole("button", { name: "New Agent" }));
+    const editor = screen.getByLabelText("New custom agent");
+    await user.clear(editor);
+    await user.type(editor, "---\nname: reviewer\n---\n# Reviewer\n");
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Custom agent already exists");
+  });
+
+  it("deletes a provider copy after confirmation", async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.get).mockImplementation((url: string) => {
+      if (url === "/api/settings/custom-agents") return Promise.resolve({ agents: [makeAgent()] });
+      if (url === "/api/settings/custom-agents/reviewer") return Promise.resolve(makeDetail());
+      return Promise.reject(new Error(`Unexpected GET ${url}`));
+    });
+    vi.mocked(api.delete).mockResolvedValueOnce(undefined);
+
+    const { wrapper } = createWrapper();
+    render(<CustomAgentsSettings />, { wrapper });
+
+    await screen.findByLabelText("reviewer Claude custom agent");
+    await user.click(screen.getByRole("button", { name: "Delete Claude" }));
+    const dialog = await screen.findByRole("alertdialog");
+    expect(within(dialog).getByText(/Claude version/i)).toBeInTheDocument();
+    await user.click(within(dialog).getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(api.delete).toHaveBeenCalledWith("/api/settings/custom-agents/reviewer/providers/claude");
+    });
+  });
+});

--- a/frontend/tests/pages/SkillsSettings.test.tsx
+++ b/frontend/tests/pages/SkillsSettings.test.tsx
@@ -93,7 +93,7 @@ Describe the workflow, rules, and context this skill should provide.
 `;
 
 describe("SkillsSettings", () => {
-  it("lists skills with provider badges and opens the first skill", async () => {
+  it("lists skills and opens the first skill with provider state", async () => {
     vi.mocked(api.get).mockImplementation((url: string) => {
       if (url === "/api/settings/skills") return Promise.resolve({ skills: [makeSkill()] });
       if (url === "/api/settings/skills/reviewer") return Promise.resolve(makeDetail());
@@ -104,11 +104,11 @@ describe("SkillsSettings", () => {
     render(<SkillsSettings />, { wrapper });
 
     expect(await screen.findByText("reviewer")).toBeInTheDocument();
-    expect(screen.getAllByText("Claude").length).toBeGreaterThan(0);
-    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
     expect(await screen.findByLabelText("reviewer SKILL.md")).toHaveValue(
       "---\nname: reviewer\n---\n# Reviewer\n",
     );
+    expect(screen.getAllByText("Claude").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Codex").length).toBeGreaterThan(0);
   });
 
   it("saves edited SKILL.md content", async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "nanoid": "^3.3.11",
         "node-pty": "^1.1.0",
         "sharp": "^0.34.5",
+        "smol-toml": "^1.6.1",
         "ws": "^8.19.0"
       },
       "devDependencies": {
@@ -15784,6 +15785,18 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/smol-toml": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+      "integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/cyyynthia"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "4.2.1",


### PR DESCRIPTION
## Summary
- add provider-native global custom agent CRUD for Claude Markdown and Codex TOML
- add Settings > Custom Agents with provider tabs, Markdown/TOML editor support, and explicit counterpart creation
- reuse custom agent manifest parsing for completions and map Claude custom agent mentions to native @agent-name invocation

## Tests
- npm run lint --workspace @hive/backend
- npm run lint --workspace @hive/frontend
- npm run typecheck --workspace @hive/backend
- npm run typecheck --workspace @hive/frontend
- npm run test --workspace @hive/backend -- src/state/custom-agents.test.ts src/api/custom-agents.test.ts src/utils/completion-scanner.test.ts src/index.test.ts
- npm run test --workspace @hive/frontend -- tests/pages/CustomAgentsSettings.test.tsx tests/components/SettingsSidebar.test.tsx tests/App.test.tsx
- backend full test suite via npm test
- npm run test --workspace @hive/frontend
- git diff --check
- browser smoke test for /settings/custom-agents with agent-browser