### PR TITLE
Fix GitHub repo creation flow

### DIFF
--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -133,6 +133,70 @@ describe("initProject", () => {
     expect(loaded?.url).toBeUndefined();
   });
 
+  it("creates a GitHub repo and stores its SSH URL", async () => {
+    const githubModule = await import("../utils/github.js");
+    const gitModule = await import("../utils/git.js");
+    const originalGit = gitModule.git;
+
+    const ghSpy = vi.spyOn(githubModule, "gh").mockImplementation(async (args) => {
+      if (args.join(" ") === "api user --jq .login") {
+        return { stdout: "octocat", stderr: "" };
+      }
+      if (args.join(" ") === "repo create octocat/remote-repo --private") {
+        return { stdout: "", stderr: "" };
+      }
+      if (args.join(" ") === "repo view octocat/remote-repo --json sshUrl --jq .sshUrl") {
+        return { stdout: "git@github.com:octocat/remote-repo.git", stderr: "" };
+      }
+      throw new Error(`Unexpected gh call: ${args.join(" ")}`);
+    });
+
+    const gitSpy = vi.spyOn(gitModule, "git").mockImplementation(async (args, cwd) => {
+      if (args.join(" ") === "push --all origin") {
+        return { stdout: "", stderr: "" };
+      }
+      return originalGit(args, cwd);
+    });
+
+    try {
+      const { state, warning } = await initProject(
+        "remote-repo",
+        { visibility: "private" },
+        dataDir,
+      );
+
+      expect(warning).toBeUndefined();
+      expect(state.url).toBe("git@github.com:octocat/remote-repo.git");
+      expect(ghSpy).toHaveBeenCalledWith(["api", "user", "--jq", ".login"]);
+      expect(ghSpy).toHaveBeenCalledWith([
+        "repo",
+        "create",
+        "octocat/remote-repo",
+        "--private",
+      ]);
+      expect(ghSpy).toHaveBeenCalledWith([
+        "repo",
+        "view",
+        "octocat/remote-repo",
+        "--json",
+        "sshUrl",
+        "--jq",
+        ".sshUrl",
+      ]);
+      expect(gitSpy).toHaveBeenCalledWith([
+        "remote",
+        "add",
+        "origin",
+        "git@github.com:octocat/remote-repo.git",
+      ], expect.any(String));
+
+      const loaded = await getProject(state.id, dataDir);
+      expect(loaded?.url).toBe("git@github.com:octocat/remote-repo.git");
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
   it("rejects empty name", async () => {
     await expect(initProject("", {}, dataDir)).rejects.toThrow("Repository name is required");
   });

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -74,29 +74,40 @@ async function createGitHubRepo(
     throw new Error("Invalid visibility");
   }
 
-  const { stdout } = await gh([
+  const { stdout: login } = await gh(["api", "user", "--jq", ".login"]);
+  const owner = login.trim();
+  if (!owner) throw new Error("Unable to determine GitHub user");
+
+  const repo = `${owner}/${name}`;
+  await gh([
     "repo",
     "create",
-    name,
+    repo,
     `--${visibility}`,
-    "--json",
-    "sshUrl",
-    "--jq",
-    ".sshUrl",
   ]);
-  const url = stdout.trim();
 
   // Point the bare repo at the new remote and push the initial commit.
-  // If push fails, delete the GitHub repo so we don't leave orphans.
+  // If any post-create step fails, delete the GitHub repo so we don't leave orphans.
   try {
+    const { stdout } = await gh([
+      "repo",
+      "view",
+      repo,
+      "--json",
+      "sshUrl",
+      "--jq",
+      ".sshUrl",
+    ]);
+    const url = stdout.trim();
+    if (!url) throw new Error("Unable to determine GitHub SSH URL");
+
     await git(["remote", "add", "origin", url], bare);
     await git(["push", "--all", "origin"], bare);
+    return url;
   } catch (err) {
-    await gh(["repo", "delete", name, "--yes"]).catch(() => {});
+    await gh(["repo", "delete", repo, "--yes"]).catch(() => {});
     throw err;
   }
-
-  return url;
 }
 
 // ── Init a brand-new project (optionally on GitHub) ─────────────────


### PR DESCRIPTION
## Summary
- create GitHub repos with supported gh repo create flags
- fetch the SSH URL via gh repo view after creation
- cover the remote creation path with a backend test

## Verification
- npm run test --workspace @hive/backend -- src/projects/project-manager.test.ts
- npm run typecheck --workspace @hive/backend
- npm run lint --workspace @hive/backend -- src/projects/project-manager.ts src/projects/project-manager.test.ts