### PR TITLE
Fix project favicon cache updates

### DIFF
--- a/backend/src/api/projects.test.ts
+++ b/backend/src/api/projects.test.ts
@@ -250,6 +250,7 @@ describe("GET /api/projects", () => {
     const res = await app.inject({ method: "GET", url: "/api/projects" });
     const [project] = res.json();
     expect(project.hasFavicon).toBe(true);
+    expect(project.faviconVersion).toMatch(/^[0-9a-f]{40}$/);
   });
 });
 

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -17,22 +17,22 @@ import type { CreateProjectRequest, ProjectState } from "../types.js";
 
 const FAVICON_NAMES = new Set(["favicon.ico", "favicon.png", "favicon.svg"]);
 
-/** Find the first favicon path in the repo tree (recursive). */
-async function findFavicon(bare: string): Promise<string | null> {
-  const { stdout: tree } = await git(["ls-tree", "-r", "--name-only", "HEAD"], bare);
-  for (const line of tree.split("\n")) {
-    const basename = line.split("/").pop() ?? "";
-    if (FAVICON_NAMES.has(basename)) return line;
-  }
-  return null;
+interface FaviconMetadata {
+  path: string;
+  version: string;
 }
 
-async function hasFaviconFlag(dir: string, projectId: string): Promise<boolean> {
-  try {
-    return (await findFavicon(bareRepoPath(dir, projectId))) !== null;
-  } catch {
-    return false;
+/** Find the first favicon path in the repo tree (recursive). */
+async function findFavicon(bare: string): Promise<FaviconMetadata | null> {
+  const { stdout: tree } = await git(["ls-tree", "-r", "HEAD"], bare);
+  for (const line of tree.split("\n")) {
+    const match = line.match(/^[0-7]+ \w+ ([0-9a-f]+)\t(.+)$/);
+    if (!match) continue;
+    const [, version, path] = match;
+    const basename = path.split("/").pop() ?? "";
+    if (FAVICON_NAMES.has(basename)) return { path, version };
   }
+  return null;
 }
 
 interface WorkspaceSessionSummary {
@@ -76,15 +76,16 @@ async function summarizeSessionsPerWorkspace(
 }
 
 async function enrichProject(project: ProjectState, dir: string) {
-  const [hasFavicon, sessionSummaries] = await Promise.all([
-    hasFaviconFlag(dir, project.id),
+  const [favicon, sessionSummaries] = await Promise.all([
+    findFavicon(bareRepoPath(dir, project.id)).catch(() => null),
     summarizeSessionsPerWorkspace(dir, project.id),
   ]);
   return {
     ...project,
     repoPath: bareRepoPath(dir, project.id),
     workspacesPath: workspacesDir(dir, project.id),
-    hasFavicon,
+    hasFavicon: favicon !== null,
+    faviconVersion: favicon?.version,
     workspaces: project.workspaces.map((ws) => ({
       ...ws,
       projectName: project.name,
@@ -175,10 +176,10 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
     const bare = bareRepoPath(dir, project.id);
 
     try {
-      const path = await findFavicon(bare);
-      if (path) {
-        const ext = path.slice(path.lastIndexOf("."));
-        const buf = await gitBuffer(["show", `HEAD:${path}`], bare);
+      const favicon = await findFavicon(bare);
+      if (favicon) {
+        const ext = favicon.path.slice(favicon.path.lastIndexOf("."));
+        const buf = await gitBuffer(["show", `HEAD:${favicon.path}`], bare);
         return reply
           .header("Content-Type", EXT_MIME[ext] ?? "application/octet-stream")
           .header("Cache-Control", "public, max-age=3600")

--- a/frontend/src/components/ProjectAvatar.tsx
+++ b/frontend/src/components/ProjectAvatar.tsx
@@ -7,22 +7,26 @@ interface ProjectAvatarProps {
   name: string;
   projectId?: string;
   hasFavicon?: boolean;
+  faviconVersion?: string;
   className?: string;
 }
 
-export function ProjectAvatar({ name, projectId, hasFavicon, className }: ProjectAvatarProps) {
-  const [imgFailed, setImgFailed] = useState(false);
+export function ProjectAvatar({ name, projectId, hasFavicon, faviconVersion, className }: ProjectAvatarProps) {
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
 
   const size = "h-5 w-5";
   const sizeClass = className?.includes("h-") ? "" : size;
+  let faviconUrl = hasFavicon && projectId
+    ? `${getServerUrl()}/api/projects/${projectId}/favicon`
+    : undefined;
+  if (faviconUrl && faviconVersion) faviconUrl += `?v=${encodeURIComponent(faviconVersion)}`;
 
-  if (hasFavicon && projectId && !imgFailed) {
-    const faviconUrl = `${getServerUrl()}/api/projects/${projectId}/favicon`;
+  if (faviconUrl && failedUrl !== faviconUrl) {
     return (
       <img
         src={faviconUrl}
         alt={name}
-        onError={() => setImgFailed(true)}
+        onError={() => setFailedUrl(faviconUrl)}
         className={cn(
           "shrink-0 rounded object-cover",
           sizeClass,

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -239,6 +239,7 @@ function RepositoryNavItem({
         name={project.name}
         projectId={project.id}
         hasFavicon={project.hasFavicon}
+        faviconVersion={project.faviconVersion}
       />
       <span className="min-w-0 flex-1 truncate">{project.name}</span>
       {isActive && (

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -99,6 +99,7 @@ export function SidebarProjectItem({
                 name={project.name}
                 projectId={project.id}
                 hasFavicon={project.hasFavicon}
+                faviconVersion={project.faviconVersion}
                 className="h-[18px] w-[18px]"
               />
               <SidebarActivityDot state={projectActivity} dimmed={isExpanded} />

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -71,7 +71,12 @@ export default function ProjectDetail() {
     <div className="flex h-full flex-col overflow-auto">
       <SettingsHeader>
         <div className="flex items-center gap-2.5">
-          <ProjectAvatar name={project.name} projectId={project.id} hasFavicon={project.hasFavicon} />
+          <ProjectAvatar
+            name={project.name}
+            projectId={project.id}
+            hasFavicon={project.hasFavicon}
+            faviconVersion={project.faviconVersion}
+          />
           <h1 className="text-sm font-medium">{project.name}</h1>
         </div>
       </SettingsHeader>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,7 @@ export interface Project {
   repoPath?: string;
   workspacesPath?: string;
   hasFavicon?: boolean;
+  faviconVersion?: string;
   /** Present when GitHub repo creation failed (project degraded to local-only). */
   warning?: string;
 }

--- a/frontend/tests/components/ProjectAvatar.test.tsx
+++ b/frontend/tests/components/ProjectAvatar.test.tsx
@@ -25,6 +25,15 @@ describe("ProjectAvatar", () => {
     expect(img.className).toContain("w-5");
   });
 
+  it("adds the favicon version to the image URL", () => {
+    render(<ProjectAvatar name="Alpha" projectId="p1" hasFavicon faviconVersion="abc123" />);
+
+    expect(screen.getByRole("img", { name: "Alpha" })).toHaveAttribute(
+      "src",
+      "http://127.0.0.1:4000/api/projects/p1/favicon?v=abc123",
+    );
+  });
+
   it("falls back to the initial letter when favicon image fails", () => {
     render(<ProjectAvatar name="Alpha" projectId="p1" hasFavicon />);
 


### PR DESCRIPTION
## Summary
- expose a Git blob-based faviconVersion for project favicons
- append faviconVersion to ProjectAvatar image URLs so merged favicon changes bust browser cache
- propagate faviconVersion through sidebar and settings avatars

## Tests
- npm run test --workspace @hive/backend -- projects.test.ts
- npm run test --workspace @hive/frontend -- ProjectAvatar.test.tsx
- npm run typecheck
- npm run lint