### PR TITLE
Fix stale default branch diff stats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,7 +127,7 @@ One session is active per workspace, but multiple sessions can coexist (max 4) a
 - On first message, a lightweight Claude subprocess generates a branch name and session title (`naming.ts`), then renames the branch via `git branch -m`.
 - Workspace merge is executed in a temporary worktree on default branch, then default-branch ref is updated.
 - `archiveWorkspace()` removes worktree and moves matching session folders under `archive/<ws-id>/sessions`.
-- Git sync pushes cached `branch_info` + `diff_stats` snapshots to new WS clients. PR status is no longer polled here — moved to on-demand REST endpoints.
+- Git sync pushes cached `branch_info` + `diff_stats` snapshots to new WS clients. Before computing diff stats, Hive refreshes the local default branch from `origin/<defaultBranch>` with a fast-forward-only update, throttled per project, so branch diffs do not include already-merged default-branch changes. PR status is no longer polled here — moved to on-demand REST endpoints.
 - WS uses a single multiplexed hub endpoint (`/ws/hub`). Clients send `sync_workspaces` with workspace ID lists to subscribe/unsubscribe. All outgoing messages are wrapped in `HubOutgoing` envelopes (`{ workspaceId, event }`). Bootstrap (status, history, branch_info, diff_stats, script_status) is sent per workspace on subscribe.
 - Preflight checks run at startup and exit with clear errors if git/claude/gh are missing. Codex and Gemini are optional.
 - Notification system supports 5 event types: turn complete (with duration + summary), needs input, proposed plan, agent failed, automation run complete. Events dispatched to Telegram and/or APNs channels.

--- a/backend/src/services/git-sync.test.ts
+++ b/backend/src/services/git-sync.test.ts
@@ -6,7 +6,7 @@ import { createProject } from "../projects/project-manager.js";
 import { createWorkspace } from "../workspaces/workspace-manager.js";
 import { git } from "../utils/git.js";
 import { loadProject } from "../state/state.js";
-import { workspacesDir } from "../utils/paths.js";
+import { bareRepoPath, workspacesDir } from "../utils/paths.js";
 import { getBranchName, GitSyncService } from "./git-sync.js";
 import type { BranchInfo, DiffStatResponse } from "../types.js";
 
@@ -14,6 +14,21 @@ let tempDir: string;
 let dataDir: string;
 let fixtureRepoUrl: string;
 let projectId: string;
+
+async function pushRemoteMainFile(
+  cloneName: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const pushClone = join(tempDir, cloneName);
+  await git(["clone", fixtureRepoUrl, pushClone]);
+  await git(["config", "user.email", "test@hive.dev"], pushClone);
+  await git(["config", "user.name", "Test"], pushClone);
+  await writeFile(join(pushClone, fileName), content);
+  await git(["add", "."], pushClone);
+  await git(["commit", "-m", `add ${fileName}`], pushClone);
+  await git(["push", "origin", "main"], pushClone);
+}
 
 beforeEach(async () => {
   tempDir = await createTempDir("hive-git-sync-test-");
@@ -248,6 +263,30 @@ describe("GitSyncService", () => {
 
     const updatedDiff = service.getCachedDiffStats(ws.id);
     expect(updatedDiff?.uncommitted.some((f) => f.file === "bootstrap.txt")).toBe(true);
+  });
+
+  it("refreshes the default branch before broadcasting diff stats", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(workspacesDir(dataDir, projectId), ws.name);
+    const bare = bareRepoPath(dataDir, projectId);
+
+    await pushRemoteMainFile("push-clone-stale-main", "main-only.txt", "from main\n");
+
+    await git(["fetch", "origin", "main:refs/hive-test/main-update"], bare);
+    await git(["merge", "--ff-only", "refs/hive-test/main-update"], wsPath);
+
+    await writeFile(join(wsPath, "branch-only.txt"), "from branch\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "add branch-only file"], wsPath);
+
+    await service.poll();
+
+    const committed = service.getCachedDiffStats(ws.id)?.committed ?? [];
+    const files = committed.map((s) => s.file);
+    expect(files).toContain("branch-only.txt");
+    expect(files).not.toContain("main-only.txt");
   });
 
   it("returns undefined from getCachedBranchInfo/getCachedDiffStats for unknown workspace", async () => {

--- a/backend/src/services/git-sync.ts
+++ b/backend/src/services/git-sync.ts
@@ -7,6 +7,7 @@ import {
   withProjectStateLock,
 } from "../state/state.js";
 import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/paths.js";
+import { refreshDefaultBranchFromOrigin } from "../utils/git-default-branch.js";
 import { computeDiffStat } from "../workspaces/workspace-manager.js";
 import type { BranchInfo, DiffStatResponse, Workspace } from "../types.js";
 
@@ -14,6 +15,7 @@ type BranchChangeCallback = (wsId: string, info: BranchInfo) => void;
 type DiffStatsChangeCallback = (wsId: string, stats: DiffStatResponse) => void;
 
 const GIT_SYNC_CONCURRENCY = 6;
+const DEFAULT_BRANCH_REFRESH_TTL_MS = 60_000;
 
 async function withConcurrency<T>(
   items: T[],
@@ -44,6 +46,7 @@ export class GitSyncService {
   private diffStatsCache = new Map<string, string>();
   private latestBranchInfo = new Map<string, BranchInfo>();
   private latestDiffStats = new Map<string, DiffStatResponse>();
+  private defaultBranchRefreshCache = new Map<string, { branch: string; at: number }>();
   private syncing = false;
 
   constructor(private readonly dataDir: string) {}
@@ -93,6 +96,8 @@ export class GitSyncService {
           // Bare repo inaccessible — skip entire project
           continue;
         }
+
+        await this.refreshDefaultBranch(project.id, bare, defaultBranch);
 
         await withConcurrency(
           project.workspaces,
@@ -168,6 +173,24 @@ export class GitSyncService {
     }
   }
 
+  private async refreshDefaultBranch(
+    projectId: string,
+    bare: string,
+    defaultBranch: string,
+  ): Promise<void> {
+    const now = Date.now();
+    const cached = this.defaultBranchRefreshCache.get(projectId);
+    if (
+      cached?.branch === defaultBranch &&
+      now - cached.at < DEFAULT_BRANCH_REFRESH_TTL_MS
+    ) {
+      return;
+    }
+
+    await refreshDefaultBranchFromOrigin(bare, defaultBranch);
+    this.defaultBranchRefreshCache.set(projectId, { branch: defaultBranch, at: now });
+  }
+
   _clearForTests(): void {
     this.stop();
     this.branchCallbacks = [];
@@ -176,6 +199,7 @@ export class GitSyncService {
     this.diffStatsCache.clear();
     this.latestBranchInfo.clear();
     this.latestDiffStats.clear();
+    this.defaultBranchRefreshCache.clear();
     this.syncing = false;
   }
 }

--- a/backend/src/utils/git-default-branch.ts
+++ b/backend/src/utils/git-default-branch.ts
@@ -1,0 +1,17 @@
+import { git } from "./git.js";
+
+export async function refreshDefaultBranchFromOrigin(
+  bareRepo: string,
+  defaultBranch: string,
+): Promise<void> {
+  try {
+    await git(["fetch", "origin", defaultBranch], bareRepo);
+    await git(
+      ["merge-base", "--is-ancestor", `refs/heads/${defaultBranch}`, "FETCH_HEAD"],
+      bareRepo,
+    );
+    await git(["update-ref", `refs/heads/${defaultBranch}`, "FETCH_HEAD"], bareRepo);
+  } catch {
+    // Local-only repos, missing remotes, and diverged default branches keep their current ref.
+  }
+}

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -26,6 +26,21 @@ let dataDir: string;
 let fixtureRepoUrl: string;
 let projectId: string;
 
+async function pushRemoteMainFile(
+  cloneName: string,
+  fileName: string,
+  content: string,
+): Promise<void> {
+  const pushClone = join(tempDir, cloneName);
+  await git(["clone", fixtureRepoUrl, pushClone]);
+  await git(["config", "user.email", "test@hive.dev"], pushClone);
+  await git(["config", "user.name", "Test"], pushClone);
+  await writeFile(join(pushClone, fileName), content);
+  await git(["add", "."], pushClone);
+  await git(["commit", "-m", `add ${fileName}`], pushClone);
+  await git(["push", "origin", "main"], pushClone);
+}
+
 beforeEach(async () => {
   clearWorkspaceIndexForTests();
   tempDir = await createTempDir("hive-ws-test-");
@@ -103,16 +118,7 @@ describe("createWorkspace", () => {
   });
 
   it("picks up new files pushed to remote after project creation", async () => {
-    // Clone from fixture bare to simulate a collaborator pushing changes
-    const pushClone = join(tempDir, "push-clone");
-    await git(["clone", fixtureRepoUrl, pushClone]);
-    await git(["config", "user.email", "test@hive.dev"], pushClone);
-    await git(["config", "user.name", "Test"], pushClone);
-
-    await writeFile(join(pushClone, "new-remote-file.txt"), "from remote\n");
-    await git(["add", "."], pushClone);
-    await git(["commit", "-m", "add new file on remote"], pushClone);
-    await git(["push", "origin", "main"], pushClone);
+    await pushRemoteMainFile("push-clone", "new-remote-file.txt", "from remote\n");
 
     // Workspace should fetch and contain the new file
     const ws = await createWorkspace(projectId, dataDir);
@@ -145,15 +151,7 @@ describe("createWorkspace", () => {
     const ws1Path = join(dataDir, projectId, "workspaces", ws1.name);
     expect(existsSync(join(ws1Path, "round2.txt"))).toBe(false);
 
-    // Push a new commit to the remote
-    const pushClone = join(tempDir, "push-clone-multi");
-    await git(["clone", fixtureRepoUrl, pushClone]);
-    await git(["config", "user.email", "test@hive.dev"], pushClone);
-    await git(["config", "user.name", "Test"], pushClone);
-    await writeFile(join(pushClone, "round2.txt"), "second round\n");
-    await git(["add", "."], pushClone);
-    await git(["commit", "-m", "second round"], pushClone);
-    await git(["push", "origin", "main"], pushClone);
+    await pushRemoteMainFile("push-clone-multi", "round2.txt", "second round\n");
 
     // Second workspace should have the new file
     const ws2 = await createWorkspace(projectId, dataDir);
@@ -578,6 +576,32 @@ describe("getWorkspaceDiffStat", () => {
     const readme = committed.find((s) => s.file === "README.md");
     expect(readme).toBeDefined();
     expect(readme!.status).toBe("modified");
+  });
+
+  it("refreshes the default branch before committed stats", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+    const bare = bareRepoPath(dataDir, projectId);
+
+    await pushRemoteMainFile("push-clone-stale-main", "main-only.txt", "from main\n");
+
+    await git(["fetch", "origin", "main:refs/hive-test/main-update"], bare);
+    await git(["merge", "--ff-only", "refs/hive-test/main-update"], wsPath);
+
+    await writeFile(join(wsPath, "branch-only.txt"), "from branch\n");
+    await git(["add", "."], wsPath);
+    await git(["config", "user.email", "test@hive.dev"], wsPath);
+    await git(["config", "user.name", "Test"], wsPath);
+    await git(["commit", "-m", "add branch-only file"], wsPath);
+
+    const beforeRefresh = await git(["diff", "--name-only", `main...${ws.branch}`], bare);
+    expect(beforeRefresh.stdout.split("\n")).toContain("main-only.txt");
+
+    const { committed } = await getWorkspaceDiffStat(ws.id, dataDir);
+    const files = committed.map((s) => s.file);
+
+    expect(files).toContain("branch-only.txt");
+    expect(files).not.toContain("main-only.txt");
   });
 
   it("returns uncommitted stats for unstaged changes", async () => {

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -8,6 +8,7 @@ import {
   removeWorktreeOrDeleteDirectory,
 } from "../utils/git-worktree.js";
 import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/paths.js";
+import { refreshDefaultBranchFromOrigin } from "../utils/git-default-branch.js";
 import { pickCityName } from "../utils/city-names.js";
 import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
 import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
@@ -137,24 +138,7 @@ export async function createWorkspace(
 
       const defaultBranch = await resolveDefaultBranch(bare);
 
-      // Pull the remote default branch into FETCH_HEAD, then fast-forward
-      // the local ref only when the remote is strictly ahead.  This avoids
-      // overwriting local merges that haven't been pushed yet while still
-      // ensuring new workspaces start from the latest remote content.
-      try {
-        await git(["fetch", "origin", defaultBranch], bare);
-        // Safe to fast-forward when the local ref is an ancestor of FETCH_HEAD
-        await git(
-          ["merge-base", "--is-ancestor", `refs/heads/${defaultBranch}`, "FETCH_HEAD"],
-          bare,
-        );
-        await git(
-          ["update-ref", `refs/heads/${defaultBranch}`, "FETCH_HEAD"],
-          bare,
-        );
-      } catch {
-        // Fetch failed, local is ahead, or branches diverged — proceed with local state
-      }
+      await refreshDefaultBranchFromOrigin(bare, defaultBranch);
 
       // Create worktree from the default branch
       await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranch);
@@ -368,6 +352,7 @@ export async function getWorkspaceDiff(
   // Keep these scopes aligned with the modified-file UX: branch commits,
   // working tree changes, or a combined review against the default branch.
   if (scope === "committed") {
+    await refreshDefaultBranchFromOrigin(bare, defaultBranch);
     return git(["diff", "--find-renames", `${defaultBranch}...${workspace.branch}`], bare)
       .then((r) => r.stdout)
       .catch(() => "");
@@ -381,6 +366,7 @@ export async function getWorkspaceDiff(
     return [trackedDiff, untrackedDiff].filter(Boolean).join("\n");
   }
 
+  await refreshDefaultBranchFromOrigin(bare, defaultBranch);
   const mergeBase = await git(
     ["merge-base", defaultBranch, workspace.branch],
     wsPath,
@@ -522,6 +508,7 @@ export async function getWorkspaceDiffStat(
 ): Promise<DiffStatResponse> {
   const { bare, wsPath, defaultBranch, workspace } =
     await resolveWorkspacePaths(wsId, dataDir);
+  await refreshDefaultBranchFromOrigin(bare, defaultBranch);
   return computeDiffStat(bare, wsPath, defaultBranch, workspace.branch);
 }
 


### PR DESCRIPTION
## Summary
- refresh the local default branch from origin with a fast-forward-only update before branch diff calculations
- throttle default branch refreshes in GitSyncService per project to avoid repeated fetches
- add regression coverage for stale local main after a branch has merged current main
- document the diff stats refresh behavior

## Tests
- npm run lint --workspace @hive/backend
- npm run typecheck --workspace @hive/backend
- npm test --workspace @hive/backend -- workspace-manager.test.ts
- npm test --workspace @hive/backend -- git-sync.test.ts
- npm test --workspace @hive/backend