### PR TITLE
Upgrade Claude Opus default to 4.8

### DIFF
--- a/backend/src/agents/providers/claude.test.ts
+++ b/backend/src/agents/providers/claude.test.ts
@@ -38,7 +38,7 @@ describe("ClaudeProvider", () => {
 
   it("includes opus, sonnet, and haiku", () => {
     const ids = provider.models.map((m) => m.id);
-    expect(ids).toContain("opus-4-7");
+    expect(ids).toContain("opus-4-8");
     expect(ids).toContain("sonnet-4-6");
     expect(ids).toContain("haiku-4-5");
   });
@@ -99,6 +99,12 @@ describe("ClaudeProvider", () => {
     const args = provider.buildArgs("Hello", { model: "sonnet-4-6" }, baseSession());
     expect(args).toContain("--model");
     expect(args).toContain("claude-sonnet-4-6");
+  });
+
+  it("maps persisted Opus 4.7 selections to Opus 4.8", () => {
+    const args = provider.buildArgs("Hello", { model: "opus-4-7" }, baseSession());
+    expect(args).toContain("--model");
+    expect(args).toContain("claude-opus-4-8[1m]");
   });
 
   it("omits --model when model is not in the list", () => {

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -9,10 +9,14 @@ import type {
 } from "./types.js";
 
 const CLAUDE_MODELS: ModelDefinition[] = [
-  { id: "opus-4-7", label: "Opus 4.7", cliValue: "claude-opus-4-7[1m]", isDefault: true, contextWindow: 1_000_000 },
+  { id: "opus-4-8", label: "Opus 4.8", cliValue: "claude-opus-4-8[1m]", isDefault: true, contextWindow: 1_000_000 },
   { id: "sonnet-4-6", label: "Sonnet 4.6", cliValue: "claude-sonnet-4-6", contextWindow: 200_000 },
   { id: "haiku-4-5", label: "Haiku 4.5", cliValue: "claude-haiku-4-5", contextWindow: 200_000 },
 ];
+
+const MODEL_ALIASES = new Map<string, string>([
+  ["opus-4-7", "opus-4-8"],
+]);
 
 const CLAUDE_CAPABILITIES: ProviderCapabilities = {
   thinkingLevels: ["low", "medium", "high", "xhigh", "max"],
@@ -32,7 +36,8 @@ export class ClaudeProvider implements AgentProvider {
     options: ProviderMessageOptions,
     session: ProviderSessionState,
   ): string[] {
-    const model = this.models.find((m) => m.id === options.model);
+    const requestedModel = options.model ? MODEL_ALIASES.get(options.model) ?? options.model : undefined;
+    const model = this.models.find((m) => m.id === requestedModel);
     return [
       "--print",
       "--output-format", "stream-json",

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -54,9 +54,9 @@ describe("resolveProvider", () => {
   });
 
   it("assumes claude provider for unprefixed model ID", () => {
-    const { provider, modelId } = resolveProvider("opus-4-7");
+    const { provider, modelId } = resolveProvider("opus-4-8");
     expect(provider.id).toBe("claude");
-    expect(modelId).toBe("opus-4-7");
+    expect(modelId).toBe("opus-4-8");
   });
 
   it("resolves claude:model-id correctly", () => {
@@ -365,7 +365,7 @@ describe("contextWindow in catalog", () => {
     const catalog = getModelCatalog();
     const claudeModels = catalog.models.filter((m) => m.provider === "claude");
 
-    const opus = claudeModels.find((m) => m.id === "claude:opus-4-7");
+    const opus = claudeModels.find((m) => m.id === "claude:opus-4-8");
     expect(opus?.contextWindow).toBe(1_000_000);
     const sonnet = claudeModels.find((m) => m.id === "claude:sonnet-4-6");
     expect(sonnet?.contextWindow).toBe(200_000);


### PR DESCRIPTION
## Summary
- replace the Claude Opus default catalog entry with Opus 4.8 using the 1M Claude Code model selector
- keep the context window at 1,000,000 tokens based on Anthropic's current model docs
- map persisted Opus 4.7 selections to Opus 4.8 so older drafts/automations keep working

## Verification
- npm --prefix backend test -- src/agents/providers/claude.test.ts src/agents/providers/registry.test.ts
- npm --prefix backend run typecheck