### PR TITLE
Polish Brain sync, file previews, and question handling

### DIFF
--- a/backend/src/agents/chat-context.test.ts
+++ b/backend/src/agents/chat-context.test.ts
@@ -26,7 +26,12 @@ describe("resolveChatCwd", () => {
 
   it("returns the Brain repo path when a Brain is connected", async () => {
     await saveBrainState(
-      { exists: true, repoUrl: "git@github.com:test/brain.git", createdAt: "2026-06-05T00:00:00.000Z" },
+      {
+        exists: true,
+        repoUrl: "git@github.com:test/brain.git",
+        createdAt: "2026-06-05T00:00:00.000Z",
+        repoPath: brainRepoPath(dataDir),
+      },
       dataDir,
     );
     expect(await resolveChatCwd("brain", dataDir)).toBe(brainRepoPath(dataDir));

--- a/backend/src/api/brain.test.ts
+++ b/backend/src/api/brain.test.ts
@@ -55,6 +55,7 @@ describe("brain routes", () => {
       exists: true,
       repoUrl: origin,
       createdAt: expect.any(String),
+      repoPath: brainRepoPath(dataDir),
     });
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
   });

--- a/backend/src/api/brain.test.ts
+++ b/backend/src/api/brain.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import Fastify from "fastify";
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { brainRoutes } from "./brain.js";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
@@ -55,6 +55,7 @@ describe("brain routes", () => {
       exists: true,
       repoUrl: origin,
       createdAt: expect.any(String),
+      lastSyncedAt: expect.any(String),
       repoPath: brainRepoPath(dataDir),
     });
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
@@ -142,7 +143,11 @@ describe("brain routes", () => {
       url: "/api/brain/save",
       payload: { message: "Add idea" },
     });
-    expect(saveRes.json()).toEqual({ committed: true, pushed: true });
+    expect(saveRes.json()).toEqual({
+      committed: true,
+      pushed: true,
+      lastSyncedAt: expect.any(String),
+    });
 
     // Nothing left to commit afterwards.
     const cleanStatus = await app.inject({ method: "GET", url: "/api/brain/status" });
@@ -156,6 +161,54 @@ describe("brain routes", () => {
     expect(saveAgain.json()).toEqual({ committed: false, pushed: false });
 
     await app.close();
+  });
+
+  it("streams raw Brain PDFs for file previews", async () => {
+    const fixtureDir = join(tempDir, "fixtures");
+    await mkdir(fixtureDir, { recursive: true });
+    const origin = await createFixtureRepo(fixtureDir);
+    const app = await buildTestApp();
+
+    await app.inject({
+      method: "POST",
+      url: "/api/brain",
+      payload: { mode: "connect", url: origin },
+    });
+    const pdf = Buffer.from("%PDF-1.4\n%%EOF\n", "utf-8");
+    await mkdir(join(brainRepoPath(dataDir), "docs"), { recursive: true });
+    await writeFile(join(brainRepoPath(dataDir), "docs", "spec.pdf"), pdf);
+
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/brain/file/raw?path=docs/spec.pdf",
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.headers["content-disposition"]).toBe('inline; filename="spec.pdf"');
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(res.rawPayload).toEqual(pdf);
+  });
+
+  it("rejects Brain raw file directory traversal attempts", async () => {
+    const fixtureDir = join(tempDir, "fixtures");
+    await mkdir(fixtureDir, { recursive: true });
+    const origin = await createFixtureRepo(fixtureDir);
+    const app = await buildTestApp();
+
+    await app.inject({
+      method: "POST",
+      url: "/api/brain",
+      payload: { mode: "connect", url: origin },
+    });
+    const res = await app.inject({
+      method: "GET",
+      url: "/api/brain/file/raw?path=../../etc/passwd",
+    });
+    await app.close();
+
+    expect(res.statusCode).toBe(400);
   });
 
   it("DELETE /api/brain removes state and clone", async () => {

--- a/backend/src/api/brain.ts
+++ b/backend/src/api/brain.ts
@@ -1,6 +1,8 @@
 import type { FastifyInstance } from "fastify";
+import { createReadStream } from "node:fs";
 import { createBrain, connectBrain, deleteBrain } from "../brain/brain-repo.js";
 import {
+  getBrainFileEntry,
   listBrainFiles,
   readBrainFile,
   writeBrainFile,
@@ -9,6 +11,7 @@ import { getBrainDiff, getBrainStatus, saveBrain } from "../brain/brain-git.js";
 import { loadBrainState } from "../state/brain.js";
 import { getDataDir } from "../state/state.js";
 import { BadRequestError, errorMessage, errorStatus } from "../utils/errors.js";
+import { headerFilename, rawFileContentType } from "../utils/raw-file.js";
 
 type BrainRequest =
   | { mode: "create"; name?: string }
@@ -72,6 +75,24 @@ export async function brainRoutes(app: FastifyInstance, dataDir?: string) {
     try {
       if (!req.query.path) throw new BadRequestError("Missing 'path' query parameter");
       return reply.send(await readBrainFile(req.query.path, dir));
+    } catch (err: unknown) {
+      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed to read Brain file") });
+    }
+  });
+
+  app.get<{ Querystring: { path?: string } }>("/api/brain/file/raw", async (req, reply) => {
+    const dir = dataDir ?? getDataDir();
+    try {
+      if (!req.query.path) throw new BadRequestError("Missing 'path' query parameter");
+
+      const file = await getBrainFileEntry(req.query.path, dir);
+      reply.header("Cache-Control", "no-store");
+      reply.header("Content-Type", rawFileContentType(file.path));
+      reply.header("Content-Length", file.stat.size);
+      reply.header("Content-Disposition", `inline; filename="${headerFilename(file.path)}"`);
+      reply.header("X-Content-Type-Options", "nosniff");
+
+      return reply.send(createReadStream(file.absolutePath));
     } catch (err: unknown) {
       return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed to read Brain file") });
     }

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -489,6 +489,29 @@ describe("GET /api/workspaces/:wsId/file", () => {
     expect(res.rawPayload).toEqual(image);
   });
 
+  it("streams raw workspace PDFs for file previews", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const ws = createRes.json();
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+    const pdf = Buffer.from("%PDF-1.4\n%%EOF\n", "utf-8");
+
+    await mkdir(join(wsPath, "docs"), { recursive: true });
+    await writeFile(join(wsPath, "docs", "spec.pdf"), pdf);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${ws.id}/file/raw?path=docs/spec.pdf`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.headers["content-type"]).toBe("application/pdf");
+    expect(res.headers["content-disposition"]).toBe('inline; filename="spec.pdf"');
+    expect(res.rawPayload).toEqual(pdf);
+  });
+
   it("returns 404 for non-existent file", async () => {
     const createRes = await app.inject({
       method: "POST",

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -16,7 +16,7 @@ import { git } from "../utils/git.js";
 import { endSession } from "../agents/agent-manager.js";
 import { resolveChatCwd } from "../agents/chat-context.js";
 import { createReadStream } from "node:fs";
-import { basename, join } from "node:path";
+import { join } from "node:path";
 import { bareRepoPath, resolveDefaultBranch, workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
 import { BadRequestError, errorMessage, errorStatus } from "../utils/errors.js";
@@ -25,47 +25,10 @@ import { getBranchName } from "../services/git-sync.js";
 import { readHiveConfig } from "../utils/hive-config.js";
 import { startScript } from "../services/script-runner.js";
 import { broadcastToWorkspace } from "../ws/stream.js";
+import { headerFilename, rawFileContentType } from "../utils/raw-file.js";
 import type { BulkPrStatusResponse, DiffScope, PrStatusResponse } from "../types.js";
 
 const DIFF_SCOPES = new Set<DiffScope>(["combined", "committed", "uncommitted"]);
-
-const RAW_FILE_MIME_BY_EXT: Record<string, string> = {
-  apng: "image/apng",
-  avif: "image/avif",
-  avifs: "image/avif",
-  bmp: "image/bmp",
-  cur: "image/x-icon",
-  gif: "image/gif",
-  heic: "image/heic",
-  heics: "image/heic-sequence",
-  heif: "image/heif",
-  heifs: "image/heif-sequence",
-  ico: "image/x-icon",
-  jfif: "image/jpeg",
-  jif: "image/jpeg",
-  jp2: "image/jp2",
-  jpe: "image/jpeg",
-  jpeg: "image/jpeg",
-  jpg: "image/jpeg",
-  jxl: "image/jxl",
-  png: "image/png",
-  psd: "image/vnd.adobe.photoshop",
-  svg: "image/svg+xml",
-  svgz: "image/svg+xml",
-  tif: "image/tiff",
-  tiff: "image/tiff",
-  webp: "image/webp",
-  xcf: "image/x-xcf",
-};
-
-function rawFileContentType(path: string): string {
-  const ext = path.split(".").pop()?.toLowerCase() ?? "";
-  return RAW_FILE_MIME_BY_EXT[ext] ?? "application/octet-stream";
-}
-
-function headerFilename(path: string): string {
-  return basename(path).replace(/[\r\n"]/g, "_");
-}
 
 function parseDiffScope(scope: unknown): DiffScope {
   if (scope === undefined) return "combined";

--- a/backend/src/brain/brain-files.ts
+++ b/backend/src/brain/brain-files.ts
@@ -9,6 +9,12 @@ import { brainRepoPath } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
 import { loadBrainState } from "../state/brain.js";
 
+export interface BrainFileEntry {
+  absolutePath: string;
+  path: string;
+  stat: Stats;
+}
+
 /**
  * Resolve the Brain repository path, asserting the Brain exists.
  * Throws {@link ConflictError} (409) when no Brain is connected.
@@ -34,6 +40,34 @@ export async function readBrainFile(
   relPath: string,
   dataDir = getDataDir(),
 ): Promise<BrainFileContent> {
+  const file = await getBrainFileEntry(relPath, dataDir);
+
+  // The agent can write notes directly to disk (its own Write tool bypasses the
+  // size-checked write path), so any finite cap can be exceeded. Rather than
+  // making such a note unviewable, return a bounded prefix and flag it as
+  // truncated; the UI renders truncated files read-only so a save can never
+  // overwrite the dropped tail.
+  if (file.stat.size > MAX_TEXT_FILE_SIZE) {
+    const handle = await open(file.absolutePath, "r");
+    try {
+      const buffer = Buffer.alloc(MAX_TEXT_FILE_SIZE);
+      const { bytesRead } = await handle.read(buffer, 0, MAX_TEXT_FILE_SIZE, 0);
+      const content = buffer.subarray(0, bytesRead).toString("utf-8");
+      return { path: file.path, content, truncated: true };
+    } finally {
+      await handle.close();
+    }
+  }
+
+  const content = await readFile(file.absolutePath, "utf-8");
+  return { path: file.path, content };
+}
+
+/** Resolve a Brain working-tree file for raw streaming routes. */
+export async function getBrainFileEntry(
+  relPath: string,
+  dataDir = getDataDir(),
+): Promise<BrainFileEntry> {
   const repoPath = await requireBrainRepo(dataDir);
   const absolutePath = await resolveSafeRepoFilePath(repoPath, relPath);
 
@@ -47,25 +81,7 @@ export async function readBrainFile(
     throw new BadRequestError("Path is not a file");
   }
 
-  // The agent can write notes directly to disk (its own Write tool bypasses the
-  // size-checked write path), so any finite cap can be exceeded. Rather than
-  // making such a note unviewable, return a bounded prefix and flag it as
-  // truncated; the UI renders truncated files read-only so a save can never
-  // overwrite the dropped tail.
-  if (fileStat.size > MAX_TEXT_FILE_SIZE) {
-    const handle = await open(absolutePath, "r");
-    try {
-      const buffer = Buffer.alloc(MAX_TEXT_FILE_SIZE);
-      const { bytesRead } = await handle.read(buffer, 0, MAX_TEXT_FILE_SIZE, 0);
-      const content = buffer.subarray(0, bytesRead).toString("utf-8");
-      return { path: relPath, content, truncated: true };
-    } finally {
-      await handle.close();
-    }
-  }
-
-  const content = await readFile(absolutePath, "utf-8");
-  return { path: relPath, content };
+  return { absolutePath, path: relPath, stat: fileStat };
 }
 
 /**

--- a/backend/src/brain/brain-git.test.ts
+++ b/backend/src/brain/brain-git.test.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createFixtureRepo, createTempDir } from "../utils/test-helpers.js";
 import { git } from "../utils/git.js";
 import { brainRepoPath } from "../utils/paths.js";
+import { loadBrainState } from "../state/brain.js";
 import { connectBrain } from "./brain-repo.js";
 import { writeBrainFile } from "./brain-files.js";
 import { getBrainDiff, getBrainStatus, saveBrain } from "./brain-git.js";
@@ -38,6 +39,8 @@ describe("getBrainStatus", () => {
     const status = await getBrainStatus(dataDir);
     expect(status.files).toEqual([]);
     expect(status.count).toBe(0);
+    expect(status.lastSyncedAt).toBeTruthy();
+    expect(status.unpushedCommitCount).toBe(0);
     // A fresh clone tracks origin.
     expect(status.upstream).toMatch(/^origin\//);
   });
@@ -53,6 +56,7 @@ describe("getBrainStatus", () => {
     expect(byPath["README.md"]).toBe("modified");
     expect(byPath["new-note.md"]).toBe("untracked");
     expect(status.count).toBe(2);
+    expect(status.unpushedCommitCount).toBe(0);
   });
 });
 
@@ -111,14 +115,26 @@ describe("saveBrain", () => {
     await connectFixtureBrain();
     await writeBrainFile("saved.md", "to be saved\n", dataDir);
 
-    const result = await saveBrain("Add saved note", dataDir);
-    expect(result).toEqual({ committed: true, pushed: true });
+    const result = await saveBrain("Add saved note", dataDir, {
+      now: () => new Date("2026-06-06T10:00:00.000Z"),
+    });
+    expect(result).toEqual({
+      committed: true,
+      pushed: true,
+      lastSyncedAt: "2026-06-06T10:00:00.000Z",
+    });
 
     // The commit landed on the origin bare repo.
     const { stdout } = await git(["log", "-1", "--pretty=%s", "main"], origin);
     expect(stdout).toBe("Add saved note");
     // Working tree is clean again.
-    expect((await getBrainStatus(dataDir)).count).toBe(0);
+    const status = await getBrainStatus(dataDir);
+    expect(status.count).toBe(0);
+    expect(status.unpushedCommitCount).toBe(0);
+    await expect(loadBrainState(dataDir)).resolves.toMatchObject({
+      exists: true,
+      lastSyncedAt: "2026-06-06T10:00:00.000Z",
+    });
   });
 
   it("uses a default commit message when none is provided", async () => {
@@ -126,24 +142,55 @@ describe("saveBrain", () => {
     await writeBrainFile("auto.md", "auto\n", dataDir);
     const result = await saveBrain(undefined, dataDir);
     expect(result.committed).toBe(true);
+    expect(result.pushed).toBe(true);
+    expect(result.lastSyncedAt).toBeTruthy();
     const { stdout } = await git(["log", "-1", "--pretty=%s"], brainRepoPath(dataDir));
     expect(stdout).toMatch(/^Brain update /);
   });
 
   it("keeps the commit but reports pushed:false when push fails", async () => {
     await connectFixtureBrain();
+    const before = await loadBrainState(dataDir);
     // Break the remote so push fails but the local commit still succeeds.
     await rm(origin, { recursive: true, force: true });
     await writeBrainFile("note.md", "content\n", dataDir);
 
-    const result = await saveBrain("Will not push", dataDir);
+    const result = await saveBrain("Will not push", dataDir, {
+      now: () => new Date("2026-06-06T11:00:00.000Z"),
+    });
     expect(result.committed).toBe(true);
     expect(result.pushed).toBe(false);
     expect(result.error).toBeTruthy();
+    expect(result.lastSyncedAt).toBeUndefined();
+    await expect(loadBrainState(dataDir)).resolves.toEqual(before);
 
     // The commit exists locally.
     const { stdout } = await git(["log", "-1", "--pretty=%s"], brainRepoPath(dataDir));
     expect(stdout).toBe("Will not push");
+    expect((await getBrainStatus(dataDir)).unpushedCommitCount).toBe(1);
+  });
+
+  it("pushes existing local commits when there are no working-tree changes", async () => {
+    await connectFixtureBrain();
+    const repoPath = brainRepoPath(dataDir);
+    await writeBrainFile("local.md", "local commit\n", dataDir);
+    await git(["add", "local.md"], repoPath);
+    await git(["commit", "-m", "Local only"], repoPath);
+
+    expect((await getBrainStatus(dataDir)).unpushedCommitCount).toBe(1);
+
+    const result = await saveBrain(undefined, dataDir, {
+      now: () => new Date("2026-06-06T12:00:00.000Z"),
+    });
+
+    expect(result).toEqual({
+      committed: false,
+      pushed: true,
+      lastSyncedAt: "2026-06-06T12:00:00.000Z",
+    });
+    expect((await getBrainStatus(dataDir)).unpushedCommitCount).toBe(0);
+    const { stdout } = await git(["log", "-1", "--pretty=%s", "main"], origin);
+    expect(stdout).toBe("Local only");
   });
 
   it("throws 409 when the Brain is not connected", async () => {

--- a/backend/src/brain/brain-git.test.ts
+++ b/backend/src/brain/brain-git.test.ts
@@ -35,7 +35,11 @@ async function connectFixtureBrain(): Promise<void> {
 describe("getBrainStatus", () => {
   it("returns no changes for a clean tree", async () => {
     await connectFixtureBrain();
-    expect(await getBrainStatus(dataDir)).toEqual({ files: [], count: 0 });
+    const status = await getBrainStatus(dataDir);
+    expect(status.files).toEqual([]);
+    expect(status.count).toBe(0);
+    // A fresh clone tracks origin.
+    expect(status.upstream).toMatch(/^origin\//);
   });
 
   it("reports modified, added (untracked), and deleted files", async () => {

--- a/backend/src/brain/brain-git.ts
+++ b/backend/src/brain/brain-git.ts
@@ -30,7 +30,14 @@ export async function getBrainStatus(
   const repoPath = await requireBrainRepo(dataDir);
   // -z gives NUL-delimited records; renames emit an extra NUL-separated old path.
   // -uall lists individual untracked files instead of collapsing directories.
-  const { stdout } = await git(["status", "--porcelain", "-z", "-uall"], repoPath);
+  // Fetch the upstream tracking ref alongside the change set; the lookup throws
+  // when no tracking ref is set (normalized to null).
+  const [{ stdout }, upstream] = await Promise.all([
+    git(["status", "--porcelain", "-z", "-uall"], repoPath),
+    git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], repoPath)
+      .then((r) => r.stdout || null)
+      .catch(() => null),
+  ]);
 
   const files: BrainFileStatus[] = [];
   const records = stdout.split("\0");
@@ -56,7 +63,7 @@ export async function getBrainStatus(
     files.push({ path, status });
   }
 
-  return { files, count: files.length };
+  return { files, count: files.length, upstream };
 }
 
 /**

--- a/backend/src/brain/brain-git.ts
+++ b/backend/src/brain/brain-git.ts
@@ -8,6 +8,7 @@ import type {
 import { git } from "../utils/git.js";
 import { buildDiffResponse, getUntrackedDiff } from "../utils/git-diff.js";
 import { getDataDir } from "../state/state.js";
+import { loadBrainState, saveBrainState } from "../state/brain.js";
 import { requireBrainRepo } from "./brain-files.js";
 
 /** Map a `git status --porcelain` XY code pair to a Brain status kind. */
@@ -17,6 +18,25 @@ function porcelainToStatus(x: string, y: string): BrainFileStatusKind {
   if (x === "A" || y === "A") return "added";
   if (x === "D" || y === "D") return "deleted";
   return "modified";
+}
+
+async function getUnpushedCommitCount(repoPath: string): Promise<number | null> {
+  try {
+    const { stdout } = await git(["rev-list", "--count", "@{u}..HEAD"], repoPath);
+    const count = Number.parseInt(stdout, 10);
+    return Number.isFinite(count) ? count : null;
+  } catch {
+    return null;
+  }
+}
+
+async function markBrainSynced(dataDir: string, now: () => Date): Promise<string> {
+  const lastSyncedAt = now().toISOString();
+  const state = await loadBrainState(dataDir);
+  if (state.exists) {
+    await saveBrainState({ ...state, lastSyncedAt }, dataDir);
+  }
+  return lastSyncedAt;
 }
 
 /**
@@ -32,11 +52,13 @@ export async function getBrainStatus(
   // -uall lists individual untracked files instead of collapsing directories.
   // Fetch the upstream tracking ref alongside the change set; the lookup throws
   // when no tracking ref is set (normalized to null).
-  const [{ stdout }, upstream] = await Promise.all([
+  const [{ stdout }, upstream, unpushedCommitCount, state] = await Promise.all([
     git(["status", "--porcelain", "-z", "-uall"], repoPath),
     git(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"], repoPath)
       .then((r) => r.stdout || null)
       .catch(() => null),
+    getUnpushedCommitCount(repoPath),
+    loadBrainState(dataDir),
   ]);
 
   const files: BrainFileStatus[] = [];
@@ -63,7 +85,13 @@ export async function getBrainStatus(
     files.push({ path, status });
   }
 
-  return { files, count: files.length, upstream };
+  return {
+    files,
+    count: files.length,
+    upstream,
+    lastSyncedAt: state.exists ? state.lastSyncedAt : undefined,
+    unpushedCommitCount,
+  };
 }
 
 /**
@@ -102,11 +130,24 @@ export async function getBrainDiff(
 export async function saveBrain(
   message: string | undefined,
   dataDir = getDataDir(),
+  options: { now?: () => Date } = {},
 ): Promise<BrainSaveResponse> {
   const repoPath = await requireBrainRepo(dataDir);
 
   const { count } = await getBrainStatus(dataDir);
   if (count === 0) {
+    const unpushedCommitCount = await getUnpushedCommitCount(repoPath);
+    if ((unpushedCommitCount ?? 0) > 0) {
+      try {
+        await git(["push"], repoPath);
+      } catch (err: unknown) {
+        const detail = err instanceof Error ? err.message : "Push failed";
+        return { committed: false, pushed: false, error: detail };
+      }
+
+      const lastSyncedAt = await markBrainSynced(dataDir, options.now ?? (() => new Date()));
+      return { committed: false, pushed: true, lastSyncedAt };
+    }
     return { committed: false, pushed: false };
   }
 
@@ -121,5 +162,6 @@ export async function saveBrain(
     return { committed: true, pushed: false, error: detail };
   }
 
-  return { committed: true, pushed: true };
+  const lastSyncedAt = await markBrainSynced(dataDir, options.now ?? (() => new Date()));
+  return { committed: true, pushed: true, lastSyncedAt };
 }

--- a/backend/src/brain/brain-repo.test.ts
+++ b/backend/src/brain/brain-repo.test.ts
@@ -72,6 +72,7 @@ describe("createBrain", () => {
       exists: true,
       repoUrl: origin,
       createdAt: "2026-06-05T12:00:00.000Z",
+      repoPath: brainRepoPath(dataDir),
     });
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
 

--- a/backend/src/brain/brain-repo.test.ts
+++ b/backend/src/brain/brain-repo.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { existsSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { git } from "../utils/git.js";
@@ -72,6 +72,7 @@ describe("createBrain", () => {
       exists: true,
       repoUrl: origin,
       createdAt: "2026-06-05T12:00:00.000Z",
+      lastSyncedAt: "2026-06-05T12:00:00.000Z",
       repoPath: brainRepoPath(dataDir),
     });
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
@@ -94,6 +95,8 @@ describe("connectBrain", () => {
     });
 
     expect(state.repoUrl).toBe(origin);
+    expect(state.createdAt).toBe("2026-06-05T13:00:00.000Z");
+    expect(state.lastSyncedAt).toBe("2026-06-05T13:00:00.000Z");
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
     const { stdout } = await git(["remote", "get-url", "origin"], brainRepoPath(dataDir));
     expect(stdout).toBe(origin);
@@ -106,6 +109,29 @@ describe("connectBrain", () => {
 
     await connectBrain(origin, dataDir);
     await expect(connectBrain(origin, dataDir)).rejects.toThrow("Brain already exists");
+  });
+});
+
+describe("loadBrainState", () => {
+  it("hydrates legacy state with createdAt as lastSyncedAt", async () => {
+    const createdAt = "2026-06-05T14:00:00.000Z";
+    await mkdir(join(dataDir, "brain"), { recursive: true });
+    await writeFile(
+      join(dataDir, "brain", "state.json"),
+      JSON.stringify({
+        exists: true,
+        repoUrl: "git@example.com:octocat/brain.git",
+        createdAt,
+      }),
+      "utf-8",
+    );
+
+    await expect(loadBrainState(dataDir)).resolves.toMatchObject({
+      exists: true,
+      createdAt,
+      lastSyncedAt: createdAt,
+      repoPath: brainRepoPath(dataDir),
+    });
   });
 });
 

--- a/backend/src/brain/brain-repo.ts
+++ b/backend/src/brain/brain-repo.ts
@@ -51,10 +51,12 @@ function assertPathInsideBrain(dataDir: string, target: string): void {
 }
 
 async function persistBrain(repoUrl: string, dataDir: string, now: () => Date): Promise<PersistedBrainState> {
+  const timestamp = now().toISOString();
   const state: PersistedBrainState = {
     exists: true,
     repoUrl,
-    createdAt: now().toISOString(),
+    createdAt: timestamp,
+    lastSyncedAt: timestamp,
     repoPath: brainRepoPath(dataDir),
   };
   await saveBrainState(state, dataDir);

--- a/backend/src/brain/brain-repo.ts
+++ b/backend/src/brain/brain-repo.ts
@@ -55,6 +55,7 @@ async function persistBrain(repoUrl: string, dataDir: string, now: () => Date): 
     exists: true,
     repoUrl,
     createdAt: now().toISOString(),
+    repoPath: brainRepoPath(dataDir),
   };
   await saveBrainState(state, dataDir);
   return state;

--- a/backend/src/state/brain.ts
+++ b/backend/src/state/brain.ts
@@ -1,7 +1,7 @@
 import { readFile, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { BrainState } from "../types.js";
-import { brainDir } from "../utils/paths.js";
+import { brainDir, brainRepoPath } from "../utils/paths.js";
 import { getDataDir, writeJsonAtomic } from "./state.js";
 
 function brainStateFile(dataDir: string): string {
@@ -12,7 +12,11 @@ function brainStateFile(dataDir: string): string {
 export async function loadBrainState(dataDir = getDataDir()): Promise<BrainState> {
   try {
     const raw = await readFile(brainStateFile(dataDir), "utf-8");
-    return JSON.parse(raw) as BrainState;
+    const state = JSON.parse(raw) as BrainState;
+    // Re-derive the local clone path on every read so it always reflects the
+    // current data dir (and is present even for states persisted before the
+    // field existed) — the persisted value is never trusted.
+    return state.exists ? { ...state, repoPath: brainRepoPath(dataDir) } : state;
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") return { exists: false };

--- a/backend/src/state/brain.ts
+++ b/backend/src/state/brain.ts
@@ -15,8 +15,16 @@ export async function loadBrainState(dataDir = getDataDir()): Promise<BrainState
     const state = JSON.parse(raw) as BrainState;
     // Re-derive the local clone path on every read so it always reflects the
     // current data dir (and is present even for states persisted before the
-    // field existed) — the persisted value is never trusted.
-    return state.exists ? { ...state, repoPath: brainRepoPath(dataDir) } : state;
+    // field existed) — the persisted value is never trusted. Older Brain states
+    // predate lastSyncedAt; createdAt is the best available successful-sync
+    // timestamp because create/connect leave the clone aligned with upstream.
+    return state.exists
+      ? {
+          ...state,
+          lastSyncedAt: state.lastSyncedAt ?? state.createdAt,
+          repoPath: brainRepoPath(dataDir),
+        }
+      : state;
   } catch (err: unknown) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") return { exists: false };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -89,6 +89,8 @@ export type BrainState =
       exists: true;
       repoUrl: string;
       createdAt: string;
+      /** Last successful push timestamp for the Brain clone. */
+      lastSyncedAt?: string;
       /** Absolute local clone path. Derived from the data dir on every read. */
       repoPath: string;
     };
@@ -116,12 +118,18 @@ export interface BrainStatusResponse {
   count: number;
   /** Upstream tracking ref (e.g. "origin/main"), or null when none is set. */
   upstream: string | null;
+  /** Last successful Brain push timestamp, when known. */
+  lastSyncedAt?: string;
+  /** Local commits not yet pushed to upstream, or null when no upstream exists. */
+  unpushedCommitCount: number | null;
 }
 
 /** Response of `POST /api/brain/save`: outcome of commit + push. */
 export interface BrainSaveResponse {
   committed: boolean;
   pushed: boolean;
+  /** Present when this save completed a successful push. */
+  lastSyncedAt?: string;
   error?: string;
 }
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -89,6 +89,8 @@ export type BrainState =
       exists: true;
       repoUrl: string;
       createdAt: string;
+      /** Absolute local clone path. Derived from the data dir on every read. */
+      repoPath: string;
     };
 
 /** Working-tree change status for a single Brain file, relative to HEAD. */
@@ -107,10 +109,13 @@ export interface BrainFileStatus {
   renamedFrom?: string;
 }
 
-/** Response of `GET /api/brain/status`: the set of changes awaiting save. */
+/** Response of `GET /api/brain/status`: the set of changes awaiting save plus
+ *  the upstream tracking ref for the header. */
 export interface BrainStatusResponse {
   files: BrainFileStatus[];
   count: number;
+  /** Upstream tracking ref (e.g. "origin/main"), or null when none is set. */
+  upstream: string | null;
 }
 
 /** Response of `POST /api/brain/save`: outcome of commit + push. */

--- a/backend/src/utils/raw-file.ts
+++ b/backend/src/utils/raw-file.ts
@@ -1,0 +1,52 @@
+import { basename } from "node:path";
+
+const RAW_FILE_MIME_BY_EXT: Record<string, string> = {
+  apng: "image/apng",
+  avif: "image/avif",
+  avifs: "image/avif",
+  bmp: "image/bmp",
+  cur: "image/x-icon",
+  gif: "image/gif",
+  heic: "image/heic",
+  heics: "image/heic-sequence",
+  heif: "image/heif",
+  heifs: "image/heif-sequence",
+  ico: "image/x-icon",
+  jfif: "image/jpeg",
+  jif: "image/jpeg",
+  jp2: "image/jp2",
+  jpe: "image/jpeg",
+  jpeg: "image/jpeg",
+  jpg: "image/jpeg",
+  jxl: "image/jxl",
+  png: "image/png",
+  psd: "image/vnd.adobe.photoshop",
+  svg: "image/svg+xml",
+  svgz: "image/svg+xml",
+  tif: "image/tiff",
+  tiff: "image/tiff",
+  webp: "image/webp",
+  xcf: "image/x-xcf",
+  pdf: "application/pdf",
+  m4a: "audio/mp4",
+  mp3: "audio/mpeg",
+  oga: "audio/ogg",
+  ogg: "audio/ogg",
+  opus: "audio/ogg",
+  wav: "audio/wav",
+  weba: "audio/webm",
+  m4v: "video/mp4",
+  mov: "video/quicktime",
+  mp4: "video/mp4",
+  ogv: "video/ogg",
+  webm: "video/webm",
+};
+
+export function rawFileContentType(path: string): string {
+  const ext = path.split(".").pop()?.toLowerCase() ?? "";
+  return RAW_FILE_MIME_BY_EXT[ext] ?? "application/octet-stream";
+}
+
+export function headerFilename(path: string): string {
+  return basename(path).replace(/[\r\n"]/g, "_");
+}

--- a/frontend/src/components/FileViewer.tsx
+++ b/frontend/src/components/FileViewer.tsx
@@ -6,7 +6,14 @@ import {
   useRef,
   useState,
 } from "react";
-import { AlertTriangleIcon, ImageOffIcon, Loader2Icon } from "lucide-react";
+import {
+  AlertTriangleIcon,
+  FileTextIcon,
+  ImageOffIcon,
+  Loader2Icon,
+  MusicIcon,
+  VideoIcon,
+} from "lucide-react";
 import { highlightCode } from "@/lib/shiki";
 import { MarkdownEditor } from "@/components/MarkdownEditor";
 import { MessageResponse } from "@/components/ai-elements/message";
@@ -14,7 +21,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useThemeType } from "@/hooks/useThemeType";
 import { useFileContent } from "@/hooks/useFileContent";
 import { resolveImageSrc } from "@/lib/image-url";
-import { isImageFilePath, isMarkdownFilePath, workspaceFileRawPath } from "@/lib/file-preview";
+import { getFilePreviewKind, isMarkdownFilePath, workspaceFileRawPath } from "@/lib/file-preview";
 import { cn } from "@/lib/utils";
 
 /** Debounce (ms) before flushing edits to disk via the `onWriteToDisk` callback. */
@@ -133,6 +140,62 @@ function ImageFilePreview({ wsId, filePath }: { wsId: string; filePath: string }
   );
 }
 
+function PdfFilePreview({ wsId, filePath }: { wsId: string; filePath: string }) {
+  const src = `${workspaceFileRawPath(wsId, filePath)}#navpanes=0`;
+
+  return (
+    <div className="flex min-h-0 flex-1 bg-muted/20">
+      <object
+        data={src}
+        type="application/pdf"
+        className="min-h-0 flex-1 border-0 bg-background"
+        aria-label={`${basename(filePath)} PDF preview`}
+      >
+        <div className="flex flex-1 items-center justify-center p-4">
+          <div className="flex w-full max-w-sm items-center gap-2 rounded-md border border-border/50 bg-background/70 px-4 py-3 text-sm text-muted-foreground">
+            <FileTextIcon className="size-4 shrink-0" />
+            <span>PDF preview is not available in this environment.</span>
+          </div>
+        </div>
+      </object>
+    </div>
+  );
+}
+
+function MediaFilePreview({
+  wsId,
+  filePath,
+  kind,
+}: {
+  wsId: string;
+  filePath: string;
+  kind: "audio" | "video";
+}) {
+  const src = workspaceFileRawPath(wsId, filePath);
+  const name = basename(filePath);
+  const Icon = kind === "audio" ? MusicIcon : VideoIcon;
+
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto bg-muted/20 p-4">
+      <div className="flex w-full max-w-3xl flex-col gap-3 rounded-md border border-border/50 bg-background p-4 shadow-sm dark:shadow-none">
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Icon className="size-4 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 truncate">{name}</span>
+        </div>
+        {kind === "audio" ? (
+          <audio controls className="w-full" src={src}>
+            Audio preview is not available in this environment.
+          </audio>
+        ) : (
+          <video controls className="max-h-[70vh] w-full rounded-md bg-black" src={src}>
+            Video preview is not available in this environment.
+          </video>
+        )}
+      </div>
+    </div>
+  );
+}
+
 export const FileViewer = forwardRef<FileViewerHandle, FileViewerProps>(function FileViewer({
   wsId,
   filePath,
@@ -142,7 +205,8 @@ export const FileViewer = forwardRef<FileViewerHandle, FileViewerProps>(function
 }, ref) {
   const theme = useThemeType();
   const shikiTheme = theme === "dark" ? "github-dark" : "github-light";
-  const isImageFile = isImageFilePath(filePath);
+  const previewKind = getFilePreviewKind(filePath);
+  const isRawPreviewFile = previewKind === "image" || previewKind === "pdf" || previewKind === "audio" || previewKind === "video";
   const isMarkdown = isMarkdownFilePath(filePath);
   const showRendered = renderMode === "rendered" && isMarkdown;
   const editableRef = useRef<EditableRawFileHandle>(null);
@@ -156,8 +220,8 @@ export const FileViewer = forwardRef<FileViewerHandle, FileViewerProps>(function
   );
 
   const { content, isLoading: contentLoading, error: contentError, truncated } = useFileContent(
-    isImageFile ? undefined : wsId,
-    isImageFile ? null : filePath,
+    isRawPreviewFile ? undefined : wsId,
+    isRawPreviewFile ? null : filePath,
   );
 
   // A truncated file holds only a prefix of the on-disk content, so it must
@@ -165,7 +229,7 @@ export const FileViewer = forwardRef<FileViewerHandle, FileViewerProps>(function
   const effectiveEditable = editable && !truncated;
 
   // Shiki HTML for the read-only raw view. Skipped when editing or rendering.
-  const skipHtml = isImageFile || showRendered || effectiveEditable;
+  const skipHtml = isRawPreviewFile || showRendered || effectiveEditable;
   const [html, setHtml] = useState("");
   useEffect(() => {
     if (skipHtml || content === undefined) {
@@ -181,8 +245,14 @@ export const FileViewer = forwardRef<FileViewerHandle, FileViewerProps>(function
     };
   }, [content, filePath, skipHtml, shikiTheme]);
 
-  if (isImageFile) {
+  if (previewKind === "image") {
     return <ImageFilePreview wsId={wsId} filePath={filePath} />;
+  }
+  if (previewKind === "pdf") {
+    return <PdfFilePreview wsId={wsId} filePath={filePath} />;
+  }
+  if (previewKind === "audio" || previewKind === "video") {
+    return <MediaFilePreview wsId={wsId} filePath={filePath} kind={previewKind} />;
   }
 
   const error = contentError?.message ?? null;

--- a/frontend/src/components/PathCopyButton.tsx
+++ b/frontend/src/components/PathCopyButton.tsx
@@ -3,15 +3,21 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { useClipboardCopy } from "@/hooks/useClipboardCopy";
 
-interface WorkspacePathCopyButtonProps {
+interface PathCopyButtonProps {
   path: string;
   disabledReason: string;
+  /** What the path refers to, used in the aria-labels (e.g. "Workspace path"). */
+  label?: string;
 }
 
-export function WorkspacePathCopyButton({
+/** Ghost icon button that copies an absolute path to the clipboard, with a
+ *  tooltip showing the path (or a disabled reason when unavailable). Reused by
+ *  the Workspace and Brain headers. */
+export function PathCopyButton({
   path,
   disabledReason,
-}: WorkspacePathCopyButtonProps) {
+  label = "Path",
+}: PathCopyButtonProps) {
   const { copy, isCopied } = useClipboardCopy();
   const canCopy = path.length > 0;
   const copied = canCopy && isCopied(path);
@@ -27,7 +33,7 @@ export function WorkspacePathCopyButton({
               className="size-5 text-muted-foreground/70 hover:text-foreground"
               onClick={() => { if (canCopy) void copy(path); }}
               disabled={!canCopy}
-              aria-label={copied ? "Workspace path copied" : "Copy workspace path"}
+              aria-label={copied ? `${label} copied` : `Copy ${label.toLowerCase()}`}
             >
               {copied ? (
                 <CheckIcon className="size-3 text-green-500" />

--- a/frontend/src/components/chat/QuestionPanel.tsx
+++ b/frontend/src/components/chat/QuestionPanel.tsx
@@ -117,8 +117,12 @@ export default function QuestionPanel({
   };
 
   const answeredCount = flatQuestions.filter(hasAnswer).length;
+  const total = flatQuestions.length;
+  const canSubmit = total > 1 ? answeredCount === total : answeredCount > 0;
 
   const handleSubmit = useCallback(() => {
+    if (!canSubmit) return;
+
     const grouped = new Map<string, QuestionAnswer[]>();
     for (const fq of flatQuestions) {
       const d = drafts.get(draftKey(fq));
@@ -135,22 +139,19 @@ export default function QuestionPanel({
       answers,
     }));
     onBatchSubmit(responses);
-  }, [flatQuestions, drafts, onBatchSubmit]);
+  }, [canSubmit, flatQuestions, drafts, onBatchSubmit]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey && answeredCount > 0) {
+      if (e.key === "Enter" && !e.shiftKey && canSubmit) {
         e.preventDefault();
         handleSubmit();
       }
     },
-    [answeredCount, handleSubmit],
+    [canSubmit, handleSubmit],
   );
 
   if (flatQuestions.length === 0) return null;
-
-  const total = flatQuestions.length;
-  const canSubmit = total > 1 ? answeredCount === total : answeredCount > 0;
 
   return (
     <div className="border-t border-border/30 px-3 py-3">

--- a/frontend/src/components/chat/QuestionPanel.tsx
+++ b/frontend/src/components/chat/QuestionPanel.tsx
@@ -67,8 +67,6 @@ export default function QuestionPanel({
   const currentDraft =
     currentQuestion ? (drafts.get(draftKey(currentQuestion)) ?? emptyDraft()) : emptyDraft();
 
-  const hasCustomText = currentDraft.customText.trim().length > 0;
-
   const updateDraft = useCallback(
     (patch: Partial<AnswerDraft>) => {
       if (!currentQuestion) return;
@@ -174,32 +172,37 @@ export default function QuestionPanel({
 
         {/* Options */}
         {currentQuestion.question.options.length > 0 && (
-          <div className="px-4 py-2 space-y-0.5">
+          <div className="space-y-1 px-4 py-2">
             {currentQuestion.question.options.map((opt, i) => {
               const isSelected = currentDraft.selectedOptions.includes(i);
+              const description = opt.description?.trim();
               return (
                 <button
                   key={i}
                   type="button"
                   onClick={() => toggleOption(i)}
                   className={cn(
-                    "flex w-full items-center gap-3 rounded-md px-2 py-1.5 text-left text-[13px] transition-colors",
+                    "block w-full rounded-md border px-2.5 py-2 text-left text-[13px] outline-none transition-colors focus-visible:ring-[3px] focus-visible:ring-ring/50",
                     isSelected
-                      ? "text-foreground bg-muted/60"
-                      : "text-foreground/80 hover:bg-muted/40",
+                      ? "border-primary/35 bg-primary/10 text-foreground"
+                      : "border-transparent text-foreground/85 hover:border-border/50 hover:bg-muted/35",
                   )}
                 >
-                  <span
-                    className={cn(
-                      "flex size-5 shrink-0 items-center justify-center rounded text-xs tabular-nums",
-                      isSelected
-                        ? "text-foreground font-medium"
-                        : "text-muted-foreground",
+                  <span className="min-w-0 flex-1 space-y-1">
+                    <span
+                      className={cn(
+                        "block text-[13px] font-medium leading-snug",
+                        isSelected ? "text-primary" : "text-foreground",
+                      )}
+                    >
+                      {opt.label}
+                    </span>
+                    {description && (
+                      <span className="block text-[12px] leading-snug text-muted-foreground">
+                        {description}
+                      </span>
                     )}
-                  >
-                    {i + 1}
                   </span>
-                  <span className="min-w-0 flex-1">{opt.label}</span>
                 </button>
               );
             })}
@@ -208,14 +211,6 @@ export default function QuestionPanel({
 
         {/* Custom text input + submit */}
         <div className="flex items-center gap-3 px-6 pt-1 pb-3">
-          <span
-            className={cn(
-              "flex size-5 shrink-0 items-center justify-center rounded text-xs tabular-nums",
-              hasCustomText ? "text-foreground font-medium" : "text-muted-foreground/30",
-            )}
-          >
-            0
-          </span>
           <input
             ref={inputRef}
             type="text"

--- a/frontend/src/components/diff/InlineDiffViewer.tsx
+++ b/frontend/src/components/diff/InlineDiffViewer.tsx
@@ -24,7 +24,7 @@ import { useThemeType } from "@/hooks/useThemeType";
 import { useDiff } from "@/hooks/useDiff";
 import { FileDiffCard } from "@/components/diff/FileDiffCard";
 import { FileViewer } from "@/components/FileViewer";
-import { isImageFilePath } from "@/lib/file-preview";
+import { isBinaryPreviewFilePath } from "@/lib/file-preview";
 import type { DiffScope } from "@/types";
 
 // ---------- Types ----------
@@ -123,12 +123,12 @@ const CommentInputBar = memo(function CommentInputBar({
   );
 });
 
-interface ImageDiffFallbackProps {
+interface BinaryPreviewDiffFallbackProps {
   wsId: string;
   filePath: string;
 }
 
-function ImageDiffFallback({ wsId, filePath }: ImageDiffFallbackProps) {
+function BinaryPreviewDiffFallback({ wsId, filePath }: BinaryPreviewDiffFallbackProps) {
   return (
     <div className="flex min-h-0 flex-1 flex-col">
       <div
@@ -139,7 +139,7 @@ function ImageDiffFallback({ wsId, filePath }: ImageDiffFallbackProps) {
           <ImageIcon className="size-3.5" />
         </span>
         <span className="text-xs leading-5">
-          Image files do not have text diffs. Previewing the current file.
+          This file does not have a text diff. Previewing the current file.
         </span>
       </div>
       <FileViewer wsId={wsId} filePath={filePath} />
@@ -171,13 +171,13 @@ export const InlineDiffViewer = forwardRef<InlineDiffViewerHandle, InlineDiffVie
     onCommentCountChange,
     onPasteToPrompt,
   }, ref) {
-  const isImageFile = isImageFilePath(filePath);
+  const isBinaryPreviewFile = isBinaryPreviewFilePath(filePath);
   const {
     patchFiles,
     omittedFileCount = 0,
     loading: isLoading,
     error,
-  } = useDiff(wsId, diffScope, !isImageFile);
+  } = useDiff(wsId, diffScope, !isBinaryPreviewFile);
   const themeType = useThemeType();
 
   const [comments, setComments] = useState<DiffComment[]>([]);
@@ -329,8 +329,8 @@ export const InlineDiffViewer = forwardRef<InlineDiffViewerHandle, InlineDiffVie
     ) ?? null;
   }, [flattenedFiles, filePath]);
 
-  if (isImageFile) {
-    return <ImageDiffFallback wsId={wsId} filePath={filePath} />;
+  if (isBinaryPreviewFile) {
+    return <BinaryPreviewDiffFallback wsId={wsId} filePath={filePath} />;
   }
 
   // Loading

--- a/frontend/src/lib/file-preview.ts
+++ b/frontend/src/lib/file-preview.ts
@@ -1,38 +1,15 @@
-const IMAGE_FILE_EXTENSIONS = new Set([
-  "ai",
+import { BRAIN_WORKSPACE_ID } from "@/lib/brain";
+
+export type FilePreviewKind = "text" | "markdown" | "image" | "pdf" | "audio" | "video";
+
+const BROWSER_IMAGE_FILE_EXTENSIONS = new Set([
   "apng",
-  "ari",
-  "arw",
   "avif",
   "avifs",
-  "bay",
   "bmp",
-  "braw",
-  "cr2",
-  "cr3",
-  "crw",
   "cur",
-  "dcm",
-  "dcr",
-  "dds",
-  "dng",
-  "emf",
-  "erf",
-  "fff",
-  "fit",
-  "fits",
-  "fts",
-  "exr",
   "gif",
-  "gpr",
-  "hdr",
-  "heic",
-  "heics",
-  "heif",
-  "heifs",
-  "icns",
   "ico",
-  "iiq",
   "jfif",
   "jif",
   "jp2",
@@ -40,45 +17,16 @@ const IMAGE_FILE_EXTENSIONS = new Set([
   "jpeg",
   "jpg",
   "jxl",
-  "k25",
-  "kdc",
-  "ktx",
-  "ktx2",
-  "mef",
-  "mos",
-  "mrw",
-  "nef",
-  "nrw",
-  "orf",
-  "pbm",
-  "pcx",
-  "pef",
-  "pgm",
   "pjp",
   "pjpeg",
   "png",
-  "pnm",
-  "ppm",
-  "psb",
-  "psd",
-  "qoi",
-  "raf",
-  "raw",
-  "rw2",
-  "rwl",
-  "sr2",
-  "srf",
-  "srw",
   "svg",
   "svgz",
-  "tga",
-  "tif",
-  "tiff",
   "webp",
-  "wmf",
-  "xcf",
-  "x3f",
 ]);
+
+const AUDIO_FILE_EXTENSIONS = new Set(["m4a", "mp3", "oga", "ogg", "opus", "wav", "weba"]);
+const VIDEO_FILE_EXTENSIONS = new Set(["m4v", "mov", "mp4", "ogv", "webm"]);
 
 export function fileExtension(filePath: string): string {
   const name = filePath.split("/").pop() ?? filePath;
@@ -88,7 +36,7 @@ export function fileExtension(filePath: string): string {
 }
 
 export function isImageFilePath(filePath: string): boolean {
-  return IMAGE_FILE_EXTENSIONS.has(fileExtension(filePath));
+  return getFilePreviewKind(filePath) === "image";
 }
 
 const MARKDOWN_FILE_EXTENSIONS = new Set(["md", "markdown"]);
@@ -101,6 +49,24 @@ export function isMarkdownFilePath(filePath: string): boolean {
   return MARKDOWN_FILE_EXTENSIONS.has(fileExtension(filePath));
 }
 
+export function getFilePreviewKind(filePath: string): FilePreviewKind {
+  const ext = fileExtension(filePath);
+  if (MARKDOWN_FILE_EXTENSIONS.has(ext)) return "markdown";
+  if (BROWSER_IMAGE_FILE_EXTENSIONS.has(ext)) return "image";
+  if (ext === "pdf") return "pdf";
+  if (AUDIO_FILE_EXTENSIONS.has(ext)) return "audio";
+  if (VIDEO_FILE_EXTENSIONS.has(ext)) return "video";
+  return "text";
+}
+
+export function isBinaryPreviewFilePath(filePath: string): boolean {
+  const kind = getFilePreviewKind(filePath);
+  return kind === "image" || kind === "pdf" || kind === "audio" || kind === "video";
+}
+
 export function workspaceFileRawPath(wsId: string, filePath: string): string {
+  if (wsId === BRAIN_WORKSPACE_ID) {
+    return `/api/brain/file/raw?path=${encodeURIComponent(filePath)}`;
+  }
   return `/api/workspaces/${encodeURIComponent(wsId)}/file/raw?path=${encodeURIComponent(filePath)}`;
 }

--- a/frontend/src/lib/time.ts
+++ b/frontend/src/lib/time.ts
@@ -7,3 +7,27 @@ export function formatElapsed(ms: number): string {
     : sec.toFixed(1);
   return min > 0 ? `${min}m ${secStr}s` : `${sec.toFixed(1)}s`;
 }
+
+export function formatRelativeTime(iso: string): string {
+  const timestamp = new Date(iso).getTime();
+  if (!Number.isFinite(timestamp)) return "unknown";
+
+  const diff = Date.now() - timestamp;
+  const seconds = Math.floor(Math.max(0, diff) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export function formatAbsoluteTime(iso: string): string {
+  const date = new Date(iso);
+  if (!Number.isFinite(date.getTime())) return "Unknown time";
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}

--- a/frontend/src/pages/AutomationDetail.tsx
+++ b/frontend/src/pages/AutomationDetail.tsx
@@ -35,6 +35,7 @@ import { usePromptTemplates } from "@/hooks/usePromptTemplates";
 import { useProjects } from "@/hooks/useProjects";
 import { ApiError } from "@/hooks/useApi";
 import { getNextRun, formatTimeUntil } from "@/lib/cron";
+import { formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import type { AutomationRun } from "@/types";
 
@@ -323,18 +324,6 @@ function NextRunRow({ expression, isRunning }: { expression: string; isRunning: 
   const value = diffMs <= 0 ? "due now" : formatTimeUntil(diffMs);
 
   return <ConfigRow label="Next Run" value={value} />;
-}
-
-function formatRelativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 function RunRow({ run, onViewLog }: { run: AutomationRun; onViewLog: (run: AutomationRun) => void }) {

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -29,6 +29,7 @@ import { Badge } from "@/components/ui/badge";
 import { wsTransport } from "@/lib/ws-transport";
 import { BRAIN_WORKSPACE_ID, brainFileQueryKey } from "@/lib/brain";
 import { isMarkdownFilePath } from "@/lib/file-preview";
+import { formatAbsoluteTime, formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 import type {
   DiffFileStat,
@@ -88,6 +89,8 @@ export default function BrainView() {
   const { save, isSaving } = useBrainSave();
 
   const pendingCount = statusQuery.data?.count ?? 0;
+  const unpushedCommitCount = statusQuery.data?.unpushedCommitCount ?? 0;
+  const lastSyncedAt = statusQuery.data?.lastSyncedAt ?? (brain.exists ? brain.lastSyncedAt : undefined);
   const brainTree = useMemo(() => fileTreeQuery.data ?? [], [fileTreeQuery.data]);
   const fileTreeError = fileTreeQuery.error?.message ?? null;
 
@@ -262,6 +265,7 @@ export default function BrainView() {
     statusError: statusQuery.isError,
     saveIndicator,
     pendingCount,
+    unpushedCommitCount,
   });
 
   // ── File-tree actions ──
@@ -531,6 +535,8 @@ export default function BrainView() {
             {/* Sync: commit + push the whole working tree directly. */}
             <BrainSyncSection
               pendingCount={pendingCount}
+              unpushedCommitCount={unpushedCommitCount}
+              lastSyncedAt={lastSyncedAt}
               syncState={syncState}
               isSaving={isSaving}
               onSave={handleSave}
@@ -579,6 +585,7 @@ type BrainSyncState =
   | "push-failed"
   | "saved"
   | "pending"
+  | "unpushed"
   | "synced";
 
 /**
@@ -592,14 +599,16 @@ function deriveBrainSyncState(args: {
   statusError: boolean;
   saveIndicator: BrainSaveIndicator;
   pendingCount: number;
+  unpushedCommitCount: number | null;
 }): BrainSyncState {
-  const { statusLoading, statusError, saveIndicator, pendingCount } = args;
+  const { statusLoading, statusError, saveIndicator, pendingCount, unpushedCommitCount } = args;
   if (saveIndicator === "saving") return "saving";
   if (saveIndicator === "push-failed") return "push-failed";
   if (statusError) return "error";
   if (statusLoading) return "loading";
   if (saveIndicator === "saved") return "saved";
   if (pendingCount > 0) return "pending";
+  if ((unpushedCommitCount ?? 0) > 0) return "unpushed";
   return "synced";
 }
 
@@ -644,6 +653,11 @@ const BRAIN_SYNC_STATE_META: Record<
     dotClass: "bg-warning",
     textClass: "text-warning-foreground",
   },
+  unpushed: {
+    label: "Not pushed",
+    dotClass: "bg-warning",
+    textClass: "text-warning-foreground",
+  },
   synced: {
     label: "Up to date",
     dotClass: "bg-muted-foreground/60",
@@ -653,6 +667,8 @@ const BRAIN_SYNC_STATE_META: Record<
 
 interface BrainSyncSectionProps {
   pendingCount: number;
+  unpushedCommitCount: number | null;
+  lastSyncedAt?: string;
   syncState: BrainSyncState;
   isSaving: boolean;
   onSave: () => void;
@@ -664,35 +680,58 @@ interface BrainSyncSectionProps {
  * on the right — mirrors the workspace PR status line. Disabled while a save is
  * in flight or when there is nothing to commit.
  */
-function BrainSyncSection({ pendingCount, syncState, isSaving, onSave }: BrainSyncSectionProps) {
+function BrainSyncSection({
+  pendingCount,
+  unpushedCommitCount,
+  lastSyncedAt,
+  syncState,
+  isSaving,
+  onSave,
+}: BrainSyncSectionProps) {
   const meta = BRAIN_SYNC_STATE_META[syncState];
+  const canSave = pendingCount > 0 || (unpushedCommitCount ?? 0) > 0;
+  const lastSyncLabel = lastSyncedAt
+    ? `Last synced ${formatRelativeTime(lastSyncedAt)}`
+    : "Never synced";
+  const lastSyncTitle = lastSyncedAt
+    ? `Last successful sync: ${formatAbsoluteTime(lastSyncedAt)}`
+    : "No successful Brain sync recorded yet";
+
   return (
-    <div className="flex shrink-0 items-center gap-2 border-t border-border/50 px-3 py-2.5">
-      <span role="status" className={cn("flex items-center gap-1.5 text-xs font-medium", meta.textClass)}>
-        <span
-          className={cn("size-1.5 shrink-0 rounded-full", meta.dotClass, meta.pulse && "animate-pulse")}
-          aria-hidden="true"
-        />
-        {meta.label}
-      </span>
-      <button
-        type="button"
-        onClick={onSave}
-        disabled={pendingCount === 0 || isSaving}
-        className={cn(
-          "ml-auto flex shrink-0 cursor-pointer items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground",
-          // Dim the whole button (icon + label + count badge) together when disabled.
-          "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-muted-foreground",
-        )}
+    <div className="flex shrink-0 flex-col border-t border-border/50 px-3 py-2">
+      <div className="flex items-center gap-2">
+        <span role="status" className={cn("flex min-w-0 items-center gap-1.5 text-xs font-medium", meta.textClass)}>
+          <span
+            className={cn("size-1.5 shrink-0 rounded-full", meta.dotClass, meta.pulse && "animate-pulse")}
+            aria-hidden="true"
+          />
+          <span className="truncate">{meta.label}</span>
+        </span>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={!canSave || isSaving}
+          className={cn(
+            "ml-auto flex shrink-0 cursor-pointer items-center gap-1 text-xs text-muted-foreground transition-colors hover:text-foreground",
+            // Dim the whole button (icon + label + count badge) together when disabled.
+            "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:text-muted-foreground",
+          )}
+        >
+          <CloudUploadIcon className="size-3.5 shrink-0" aria-hidden="true" />
+          Save
+          {pendingCount > 0 && (
+            <Badge variant="secondary" className="ml-0.5 px-1.5 py-0 text-[10px]">
+              {pendingCount}
+            </Badge>
+          )}
+        </button>
+      </div>
+      <div
+        className="mt-1 min-w-0 truncate pl-3 text-[11px] leading-none text-muted-foreground"
+        title={lastSyncTitle}
       >
-        <CloudUploadIcon className="size-3.5 shrink-0" aria-hidden="true" />
-        Save
-        {pendingCount > 0 && (
-          <Badge variant="secondary" className="ml-0.5 px-1.5 py-0 text-[10px]">
-            {pendingCount}
-          </Badge>
-        )}
-      </button>
+        {lastSyncLabel}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -246,7 +246,7 @@ export default function BrainView() {
       await fileViewerRef.current?.flushPendingWrite();
       // No message → backend uses its default `Brain update <timestamp>`.
       const result = await save(undefined);
-      if (result.committed && !result.pushed) {
+      if (result.error || (result.committed && !result.pushed)) {
         setSaveIndicator("push-failed");
       } else {
         setSaveIndicator("saved");

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -20,6 +20,8 @@ import { BrainWelcome } from "@/components/BrainWelcome";
 import { FileViewer, type FileViewerHandle } from "@/components/FileViewer";
 import { FileContentToolbar } from "@/components/FileContentToolbar";
 import { FileTree, renderFileTreeNodes } from "@/components/ai-elements/file-tree";
+import { PathCopyButton } from "@/components/PathCopyButton";
+import { BranchLabel } from "@/components/BranchLabel";
 import { InlineDiffViewer, type InlineDiffViewerHandle } from "@/components/diff/InlineDiffViewer";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
 import { ResizeHandle } from "@/components/ResizeHandle";
@@ -108,6 +110,8 @@ export default function BrainView() {
 
   const notesCount = useMemo(() => countFiles(brainTree), [brainTree]);
   const repoUrl = brain.exists ? brain.repoUrl : undefined;
+  const repoPath = brain.exists ? brain.repoPath : undefined;
+  const brainUpstream = statusQuery.data?.upstream ?? null;
 
   const onLastSessionDeleted = useCallback(() => {
     wsTransport.clearCachedData(BRAIN_WORKSPACE_ID);
@@ -337,7 +341,7 @@ export default function BrainView() {
   if (!loading && !brainConnected) {
     return (
       <div className="flex h-full min-h-0 flex-col bg-background">
-        <BrainHeader />
+        <BrainHeader path={repoPath} upstream={brainUpstream} />
         <div className="flex flex-1 items-center justify-center px-6">
           <p className="text-sm text-muted-foreground">No Brain repository connected.</p>
         </div>
@@ -355,7 +359,7 @@ export default function BrainView() {
       >
         <Panel id="brain-main" minSize="40%">
           <div className="flex min-w-0 h-full flex-col overflow-hidden">
-            <BrainHeader />
+            <BrainHeader path={repoPath} upstream={brainUpstream} />
             <ConversationPane
               sessions={sessions}
               activeSessionId={sessionId}
@@ -538,12 +542,31 @@ export default function BrainView() {
   );
 }
 
-/** Slim Brain header: just the title bar (Save moved to the Sync section). */
-function BrainHeader() {
+/**
+ * Slim Brain header: title + the upstream tracking ref (e.g. "origin/main") +
+ * copy-path action. Save lives in the Sync section, not here.
+ */
+function BrainHeader({
+  path,
+  upstream,
+}: {
+  path?: string;
+  upstream?: string | null;
+}) {
   return (
     <div className="flex h-12 items-center gap-2 border-b border-border/50 px-4" data-tauri-drag-region>
       <BrainIcon className="size-4 text-primary" aria-hidden="true" />
-      <span className="text-sm font-semibold text-foreground">Brain</span>
+      <span className="shrink-0 text-sm font-semibold text-foreground">Brain</span>
+      <div className="flex min-w-0 items-center gap-1">
+        {upstream && (
+          <BranchLabel branch={upstream} showIcon={false} className="text-xs text-muted-foreground" />
+        )}
+        <PathCopyButton
+          path={path ?? ""}
+          disabledReason="Brain path unavailable. Connect a Brain repository first."
+          label="Brain path"
+        />
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -37,7 +37,7 @@ import { useTerminalApps } from "@/hooks/useTerminalApps";
 import { openTerminalSsh } from "@/lib/terminal";
 import { useLayoutContext } from "@/components/AppLayout";
 import { ResizeHandle } from "@/components/ResizeHandle";
-import { WorkspacePathCopyButton } from "@/components/WorkspacePathCopyButton";
+import { PathCopyButton } from "@/components/PathCopyButton";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent } from "@/lib/plan-state";
@@ -507,9 +507,10 @@ export default function WorkspaceView() {
               {workspace?.defaultBranch && (
                 <span className="truncate text-xs text-muted-foreground/60">{"> origin/"}{workspace.defaultBranch}</span>
               )}
-              <WorkspacePathCopyButton
+              <PathCopyButton
                 path={workspacePath}
                 disabledReason={copyWorkspacePathDisabledReason}
+                label="Workspace path"
               />
             </div>
             <div className="ml-auto" />

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -41,7 +41,7 @@ import { PathCopyButton } from "@/components/PathCopyButton";
 import { cn } from "@/lib/utils";
 import { wsTransport } from "@/lib/ws-transport";
 import { hasPendingExitPlanModeInput, isPlanAwaitingUserInput, findPlanContent } from "@/lib/plan-state";
-import { isImageFilePath, isMarkdownFilePath } from "@/lib/file-preview";
+import { isBinaryPreviewFilePath, isMarkdownFilePath } from "@/lib/file-preview";
 import { PlanActionBar } from "@/components/chat/PlanActionBar";
 import { useScripts } from "@/hooks/useScripts";
 import type { DiffFileStat, DiffScope, DiffStatResponse, FileMention, ImageAttachment, MessageOptions, Workspace, WorkspaceFileTreeNode } from "@/types";
@@ -255,7 +255,7 @@ export default function WorkspaceView() {
     handleDeleteSession,
   } = useConversationColumn(wsId, { onActivateSession, onLastSessionDeleted });
 
-  const openFileIsImage = openFile ? isImageFilePath(openFile) : false;
+  const openFileIsBinaryPreview = openFile ? isBinaryPreviewFilePath(openFile) : false;
   const supportsRendered = openFile ? isMarkdownFilePath(openFile) : false;
   const [renderMode, setRenderMode] = useState<"raw" | "rendered">("raw");
 
@@ -662,8 +662,8 @@ export default function WorkspaceView() {
                 onDiffStyleChange={handleDiffStyleChange}
                 commentCount={diffCommentCount}
                 onPasteToPrompt={handlePasteToPrompt}
-                sourceLabel={openFileIsImage ? "Preview" : "Source"}
-                supportsTextDiff={!openFileIsImage}
+                sourceLabel={openFileIsBinaryPreview ? "Preview" : "Source"}
+                supportsTextDiff={!openFileIsBinaryPreview}
                 renderMode={renderMode}
                 onRenderModeChange={setRenderMode}
                 supportsRendered={supportsRendered}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,8 @@ export type BrainState =
       exists: true;
       repoUrl: string;
       createdAt: string;
+      /** Absolute local clone path on the backend host (for the copy-path action). */
+      repoPath: string;
     };
 
 /** Working-tree change status for a single Brain file, relative to HEAD. */
@@ -39,10 +41,13 @@ export interface BrainFileStatus {
   renamedFrom?: string;
 }
 
-/** Response of `GET /api/brain/status`: the set of changes awaiting save. */
+/** Response of `GET /api/brain/status`: the set of changes awaiting save plus
+ *  the upstream tracking ref for the header. */
 export interface BrainStatusResponse {
   files: BrainFileStatus[];
   count: number;
+  /** Upstream tracking ref (e.g. "origin/main"), or null when none is set. */
+  upstream: string | null;
 }
 
 /** Response of `POST /api/brain/save`: outcome of commit + push. */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -22,6 +22,8 @@ export type BrainState =
       exists: true;
       repoUrl: string;
       createdAt: string;
+      /** Last successful push timestamp for the Brain clone. */
+      lastSyncedAt?: string;
       /** Absolute local clone path on the backend host (for the copy-path action). */
       repoPath: string;
     };
@@ -48,12 +50,18 @@ export interface BrainStatusResponse {
   count: number;
   /** Upstream tracking ref (e.g. "origin/main"), or null when none is set. */
   upstream: string | null;
+  /** Last successful Brain push timestamp, when known. */
+  lastSyncedAt?: string;
+  /** Local commits not yet pushed to upstream, or null when no upstream exists. */
+  unpushedCommitCount: number | null;
 }
 
 /** Response of `POST /api/brain/save`: outcome of commit + push. */
 export interface BrainSaveResponse {
   committed: boolean;
   pushed: boolean;
+  /** Present when this save completed a successful push. */
+  lastSyncedAt?: string;
   error?: string;
 }
 

--- a/frontend/tests/components/InlineDiffViewer.test.tsx
+++ b/frontend/tests/components/InlineDiffViewer.test.tsx
@@ -23,7 +23,7 @@ vi.mock("@/hooks/useThemeType", () => ({
 
 vi.mock("@/components/FileViewer", () => ({
   FileViewer: ({ filePath }: { filePath: string }) => (
-    <div data-testid="image-file-preview">{filePath}</div>
+    <div data-testid="file-preview">{filePath}</div>
   ),
 }));
 
@@ -284,14 +284,21 @@ describe("InlineDiffViewer", () => {
     expect(screen.getByText("Empty file")).toBeInTheDocument();
   });
 
-  it("renders an image diff fallback with the current image preview", () => {
+  it("renders a binary preview diff fallback with the current file preview", () => {
     renderViewer({ filePath: "assets/logo.png" });
 
     expect(mocks.useDiff).toHaveBeenCalledWith("ws-1", "uncommitted", false);
     expect(
-      screen.getByText("Image files do not have text diffs. Previewing the current file."),
+      screen.getByText("This file does not have a text diff. Previewing the current file."),
     ).toBeInTheDocument();
-    expect(screen.getByTestId("image-file-preview")).toHaveTextContent("assets/logo.png");
+    expect(screen.getByTestId("file-preview")).toHaveTextContent("assets/logo.png");
     expect(screen.queryByText("Click on line numbers to select code and add comments")).not.toBeInTheDocument();
+  });
+
+  it("uses the same fallback for PDF previews", () => {
+    renderViewer({ filePath: "docs/spec.pdf" });
+
+    expect(mocks.useDiff).toHaveBeenCalledWith("ws-1", "uncommitted", false);
+    expect(screen.getByTestId("file-preview")).toHaveTextContent("docs/spec.pdf");
   });
 });

--- a/frontend/tests/components/QuestionPanel.test.tsx
+++ b/frontend/tests/components/QuestionPanel.test.tsx
@@ -32,6 +32,40 @@ describe("QuestionPanel", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
+  it("shows option descriptions below their labels", () => {
+    render(
+      <QuestionPanel
+        pendingToolInputs={[
+          askInput("ask-1", [
+            {
+              question: "Choose an implementation",
+              options: [
+                {
+                  label: "Fast path",
+                  description: "Use the existing component and keep the change local.",
+                },
+                {
+                  label: "Larger refactor",
+                  description: "Move shared rendering into a reusable helper first.",
+                },
+              ],
+            },
+          ]),
+        ]}
+        onBatchSubmit={vi.fn()}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Choose an implementation")).toBeInTheDocument();
+    expect(screen.getByText("Fast path")).toBeInTheDocument();
+    expect(
+      screen.getByText("Use the existing component and keep the change local."),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Larger refactor")).toBeInTheDocument();
+    expect(screen.getByText("Move shared rendering into a reusable helper first.")).toBeInTheDocument();
+  });
+
   it("groups and submits answered questions by toolUseId", async () => {
     const user = userEvent.setup();
     const onBatchSubmit = vi.fn();

--- a/frontend/tests/components/QuestionPanel.test.tsx
+++ b/frontend/tests/components/QuestionPanel.test.tsx
@@ -149,6 +149,45 @@ describe("QuestionPanel", () => {
     expect(submit).toBeEnabled();
   });
 
+  it("requires every question to be answered before submitting a multi-question block", async () => {
+    const user = userEvent.setup();
+    const onBatchSubmit = vi.fn();
+    render(
+      <QuestionPanel
+        pendingToolInputs={[
+          askInput("ask-1", [
+            { question: "First question", options: [] },
+            { question: "Second question", options: [] },
+          ]),
+        ]}
+        onBatchSubmit={onBatchSubmit}
+        onDismiss={vi.fn()}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Type something..."), "first answer");
+
+    const partialSubmit = screen.getByRole("button", { name: "Submit (1/2)" });
+    expect(partialSubmit).toBeDisabled();
+
+    await user.keyboard("{Enter}");
+    expect(onBatchSubmit).not.toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "Question 2" }));
+    await user.type(screen.getByPlaceholderText("Type something..."), "second answer");
+    await user.click(screen.getByRole("button", { name: "Submit (2/2)" }));
+
+    expect(onBatchSubmit).toHaveBeenCalledWith([
+      {
+        toolUseId: "ask-1",
+        answers: [
+          { questionIndex: 0, selectedOptions: [], customText: "first answer" },
+          { questionIndex: 1, selectedOptions: [], customText: "second answer" },
+        ],
+      },
+    ]);
+  });
+
   it("calls dismiss handler", async () => {
     const user = userEvent.setup();
     const onDismiss = vi.fn();

--- a/frontend/tests/lib/file-preview.test.ts
+++ b/frontend/tests/lib/file-preview.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import {
   fileExtension,
+  getFilePreviewKind,
+  isBinaryPreviewFilePath,
   isImageFilePath,
   isMarkdownFilePath,
   workspaceFileRawPath,
@@ -39,6 +41,30 @@ describe("file-preview", () => {
   it("builds an encoded raw workspace file path", () => {
     expect(workspaceFileRawPath("ws 1", "assets/my logo.png")).toBe(
       "/api/workspaces/ws%201/file/raw?path=assets%2Fmy%20logo.png",
+    );
+  });
+
+  it("classifies browser-previewable files by kind", () => {
+    expect(getFilePreviewKind("README.md")).toBe("markdown");
+    expect(getFilePreviewKind("assets/logo.png")).toBe("image");
+    expect(getFilePreviewKind("docs/spec.PDF")).toBe("pdf");
+    expect(getFilePreviewKind("audio/voice.mp3")).toBe("audio");
+    expect(getFilePreviewKind("video/demo.webm")).toBe("video");
+    expect(getFilePreviewKind("src/app.tsx")).toBe("text");
+  });
+
+  it("classifies only non-text previews as binary preview files", () => {
+    expect(isBinaryPreviewFilePath("assets/logo.png")).toBe(true);
+    expect(isBinaryPreviewFilePath("docs/spec.pdf")).toBe(true);
+    expect(isBinaryPreviewFilePath("audio/voice.wav")).toBe(true);
+    expect(isBinaryPreviewFilePath("video/demo.mp4")).toBe(true);
+    expect(isBinaryPreviewFilePath("README.md")).toBe(false);
+    expect(isBinaryPreviewFilePath("src/app.ts")).toBe(false);
+  });
+
+  it("builds an encoded raw Brain file path", () => {
+    expect(workspaceFileRawPath("brain", "docs/spec.pdf")).toBe(
+      "/api/brain/file/raw?path=docs%2Fspec.pdf",
     );
   });
 });

--- a/frontend/tests/pages/BrainView.test.tsx
+++ b/frontend/tests/pages/BrainView.test.tsx
@@ -232,6 +232,24 @@ describe("BrainView", () => {
     expect(screen.queryByRole("button", { name: /Save & Push/i })).not.toBeInTheDocument();
   });
 
+  it("shows push failed when pushing existing local commits fails", async () => {
+    const user = userEvent.setup();
+    mocks.useBrainStatus.mockReturnValue({
+      data: {
+        files: [],
+        count: 0,
+        upstream: "origin/main",
+        unpushedCommitCount: 1,
+      },
+    });
+    mocks.save.mockResolvedValue({ committed: false, pushed: false, error: "Push failed" });
+    renderBrain();
+
+    await user.click(screen.getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => expect(screen.getByText("Push failed")).toBeInTheDocument());
+  });
+
   it("flushes an open raw file before saving", async () => {
     const user = userEvent.setup();
     const order: string[] = [];


### PR DESCRIPTION
## What

Polishes several related UX surfaces across Brain, file viewing, and agent questions so the branch is ready to review as one cohesive update.

## Changes

### Brain header + sync
- Reuses the shared `PathCopyButton` in Workspace and Brain headers.
- Shows the Brain upstream tracking ref in the header.
- Exposes Brain `repoPath`, `upstream`, `lastSyncedAt`, and `unpushedCommitCount` through the backend types/routes needed by the UI.
- Adds a Brain sync section that distinguishes unsaved changes, unpushed commits, successful saves, and push failures.
- Fixes the save UI so a failed push of existing local commits is shown as `Push failed`, not `Saved`.

### File previews
- Adds raw Brain file streaming for previews.
- Factors raw-file content type helpers for workspace + Brain routes.
- Adds preview support for PDF, audio, and video files alongside images.
- Uses a binary-preview diff fallback for files without text diffs.

### Question panel
- Shows option descriptions under labels.
- Requires every question in a multi-question block to be answered before submit.

### Tests and cleanup
- Adds/updates backend tests for Brain raw streaming, sync metadata, unpushed commits, and legacy Brain state hydration.
- Adds/updates frontend tests for Brain save failure state, binary preview fallback, file preview classification, and question panel behavior.
- Shares relative-time formatting instead of keeping a local duplicate in automation detail.

## Testing

- `npm run lint` ✅
- `npm run typecheck` ✅
- Targeted frontend tests ✅
  - `tests/pages/BrainView.test.tsx`
  - `tests/components/InlineDiffViewer.test.tsx`
  - `tests/lib/file-preview.test.ts`
- Targeted backend WS regression check ✅
  - `src/ws/stream.test.ts` filtered to `does not broadcast stale idle status when a session is replaced`

Note: during audit, the full `npm run test` run exposed a backend WS test that failed in the full suite but passed when rerun in isolation, consistent with a suite-order/timing flaky rather than a direct regression in this branch.
