### PR TITLE
Fix Brain PDF file previews

### DIFF
--- a/frontend/src/components/FileViewer.tsx
+++ b/frontend/src/components/FileViewer.tsx
@@ -8,7 +8,6 @@ import {
 } from "react";
 import {
   AlertTriangleIcon,
-  FileTextIcon,
   ImageOffIcon,
   Loader2Icon,
   MusicIcon,
@@ -20,7 +19,7 @@ import { MessageResponse } from "@/components/ai-elements/message";
 import { Skeleton } from "@/components/ui/skeleton";
 import { useThemeType } from "@/hooks/useThemeType";
 import { useFileContent } from "@/hooks/useFileContent";
-import { resolveImageSrc } from "@/lib/image-url";
+import { resolveApiResourceSrc, resolveImageSrc } from "@/lib/image-url";
 import { getFilePreviewKind, isMarkdownFilePath, workspaceFileRawPath } from "@/lib/file-preview";
 import { cn } from "@/lib/utils";
 
@@ -141,23 +140,16 @@ function ImageFilePreview({ wsId, filePath }: { wsId: string; filePath: string }
 }
 
 function PdfFilePreview({ wsId, filePath }: { wsId: string; filePath: string }) {
-  const src = `${workspaceFileRawPath(wsId, filePath)}#navpanes=0`;
+  const src = `${resolveApiResourceSrc(workspaceFileRawPath(wsId, filePath))}#navpanes=0`;
 
   return (
     <div className="flex min-h-0 flex-1 bg-muted/20">
-      <object
-        data={src}
-        type="application/pdf"
+      <iframe
+        src={src}
+        title={`${basename(filePath)} PDF preview`}
         className="min-h-0 flex-1 border-0 bg-background"
         aria-label={`${basename(filePath)} PDF preview`}
-      >
-        <div className="flex flex-1 items-center justify-center p-4">
-          <div className="flex w-full max-w-sm items-center gap-2 rounded-md border border-border/50 bg-background/70 px-4 py-3 text-sm text-muted-foreground">
-            <FileTextIcon className="size-4 shrink-0" />
-            <span>PDF preview is not available in this environment.</span>
-          </div>
-        </div>
-      </object>
+      />
     </div>
   );
 }
@@ -171,7 +163,7 @@ function MediaFilePreview({
   filePath: string;
   kind: "audio" | "video";
 }) {
-  const src = workspaceFileRawPath(wsId, filePath);
+  const src = resolveApiResourceSrc(workspaceFileRawPath(wsId, filePath));
   const name = basename(filePath);
   const Icon = kind === "audio" ? MusicIcon : VideoIcon;
 

--- a/frontend/src/lib/image-url.ts
+++ b/frontend/src/lib/image-url.ts
@@ -1,12 +1,18 @@
 import { getServerUrl } from "@/hooks/useServerUrl";
 
-/** Resolve an image dataUrl to a renderable src.
- *  - `data:` URIs (legacy base64) are returned as-is.
- *  - `/api/...` paths are prefixed with the server URL + auth token query param. */
-export function resolveImageSrc(dataUrl: string): string {
+/** Resolve an API-backed media path to a browser-loadable src. */
+export function resolveApiResourceSrc(dataUrl: string): string {
   if (!dataUrl || dataUrl.startsWith("data:")) return dataUrl;
   const base = getServerUrl();
   const token = import.meta.env.VITE_HIVE_AUTH_TOKEN?.trim();
-  const sep = dataUrl.includes("?") ? "&" : "?";
-  return `${base}${dataUrl}${token ? `${sep}token=${encodeURIComponent(token)}` : ""}`;
+  const hashIndex = dataUrl.indexOf("#");
+  const path = hashIndex >= 0 ? dataUrl.slice(0, hashIndex) : dataUrl;
+  const hash = hashIndex >= 0 ? dataUrl.slice(hashIndex) : "";
+  const sep = path.includes("?") ? "&" : "?";
+  return `${base}${path}${token ? `${sep}token=${encodeURIComponent(token)}` : ""}${hash}`;
+}
+
+/** Resolve an image dataUrl to a renderable src. */
+export function resolveImageSrc(dataUrl: string): string {
+  return resolveApiResourceSrc(dataUrl);
 }

--- a/frontend/tests/components/FileViewer.test.tsx
+++ b/frontend/tests/components/FileViewer.test.tsx
@@ -56,6 +56,7 @@ async function getHighlightMock() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
 });
 
 describe("FileViewer", () => {
@@ -102,6 +103,23 @@ describe("FileViewer", () => {
       "/api/workspaces/ws-1/file/raw?path=assets%2Flogo.png",
     );
     expect(screen.getByText("Loading preview...")).toBeInTheDocument();
+    expect(apiMock).not.toHaveBeenCalled();
+    expect(highlightMock).not.toHaveBeenCalled();
+  });
+
+  it("renders PDF files in an iframe with the configured server URL", async () => {
+    const apiMock = await getApiMock();
+    const highlightMock = await getHighlightMock();
+    localStorage.setItem("hive-server-url", "http://127.0.0.1:9420");
+
+    renderFileViewer({ wsId: "brain", filePath: "crypto/bitcoin/bitcoin-whitepaper.pdf" });
+
+    const frame = screen.getByTitle("bitcoin-whitepaper.pdf PDF preview");
+    expect(frame.tagName).toBe("IFRAME");
+    expect(frame).toHaveAttribute(
+      "src",
+      "http://127.0.0.1:9420/api/brain/file/raw?path=crypto%2Fbitcoin%2Fbitcoin-whitepaper.pdf#navpanes=0",
+    );
     expect(apiMock).not.toHaveBeenCalled();
     expect(highlightMock).not.toHaveBeenCalled();
   });

--- a/frontend/tests/lib/image-url.test.ts
+++ b/frontend/tests/lib/image-url.test.ts
@@ -5,9 +5,7 @@ vi.mock("@/hooks/useServerUrl", () => ({
   getServerUrl: vi.fn(() => "http://192.168.1.10:3000"),
 }));
 
-const originalEnv = { ...import.meta.env };
-
-import { resolveImageSrc } from "@/lib/image-url";
+import { resolveApiResourceSrc, resolveImageSrc } from "@/lib/image-url";
 
 beforeEach(() => {
   import.meta.env.VITE_HIVE_AUTH_TOKEN = "";
@@ -40,5 +38,16 @@ describe("resolveImageSrc", () => {
     import.meta.env.VITE_HIVE_AUTH_TOKEN = "";
     const path = "/api/workspaces/ws1/sessions/s1/attachments/abc.png";
     expect(resolveImageSrc(path)).not.toContain("token=");
+  });
+});
+
+describe("resolveApiResourceSrc", () => {
+  it("adds auth tokens before URL fragments", () => {
+    import.meta.env.VITE_HIVE_AUTH_TOKEN = "secret token";
+    const path = "/api/brain/file/raw?path=docs%2Fspec.pdf#navpanes=0";
+
+    expect(resolveApiResourceSrc(path)).toBe(
+      "http://192.168.1.10:3000/api/brain/file/raw?path=docs%2Fspec.pdf&token=secret%20token#navpanes=0",
+    );
   });
 });


### PR DESCRIPTION
## Summary
- resolve raw media preview URLs through the configured backend server URL
- render PDF previews with an iframe instead of the fragile object fallback
- cover raw media URL fragments and Brain PDF previews in tests

## Tests
- npm --prefix frontend test -- tests/lib/image-url.test.ts tests/components/FileViewer.test.tsx
- npm --prefix frontend run typecheck
- npm --prefix frontend run lint
- git diff --check