### PR TITLE
Align Brain chat with workspace chat

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -232,7 +232,7 @@ describe("ConversationSession", () => {
     providerRegistry.markProviderAvailable("codex", { appServer: true, goals: true });
   });
 
-  function createSession(opts?: { sessionId?: string; command?: string; skipPermissions?: boolean; sessionKind?: "chat" | "automation" }) {
+  function createSession(opts?: { sessionId?: string; command?: string; skipPermissions?: boolean; sessionKind?: "chat" | "automation" | "brain" }) {
     return new ConversationSession({
       cwd: "/tmp/test",
       dataDir: tempDir,
@@ -1363,6 +1363,26 @@ describe("ConversationSession", () => {
       sessionKind: "chat",
     });
 
+    expect(selection.debug).toEqual({
+      command: "codex",
+      args: ["app-server", "--enable", "goals", "--listen", "stdio://"],
+    });
+  });
+
+  it("uses Codex app-server for Brain chat sessions", () => {
+    const resolved = providerRegistry.resolveProvider("codex:gpt-5.5");
+
+    const selection = createAgentRunner({
+      cwd: "/tmp/brain",
+      content: "Hello Brain",
+      msgOptions: { model: "codex:gpt-5.5" },
+      resolved,
+      isFirstMessage: true,
+      skipPermissions: true,
+      sessionKind: "brain",
+    });
+
+    expect(selection.protocol).toBe("codex_app_server");
     expect(selection.debug).toEqual({
       command: "codex",
       args: ["app-server", "--enable", "goals", "--listen", "stdio://"],

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -87,6 +87,10 @@ function normalizeActivityFiles(
 
 type SessionKind = "chat" | "automation" | "brain";
 
+function isInteractiveSessionKind(sessionKind: SessionKind): boolean {
+  return sessionKind !== "automation";
+}
+
 export interface ConversationSessionConfig {
   cwd: string;
   dataDir: string;
@@ -278,7 +282,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         const useNativeCodexImages =
           !this.testCommand &&
           resolved?.provider.id === "codex" &&
-          this.sessionKind === "chat";
+          isInteractiveSessionKind(this.sessionKind);
         this.emitUserMessage(content, urlImages, fileMentions, isCodexGoalCommand(content, resolved?.provider.id));
         this.startAgentTurn(
           useNativeCodexImages ? promptContent : this.buildPromptWithImages(promptContent, imagePaths),

--- a/backend/src/agents/runners/factory.ts
+++ b/backend/src/agents/runners/factory.ts
@@ -10,6 +10,10 @@ import { ProcessAgentRunner } from "./process-agent-runner.js";
 
 type SessionKind = "chat" | "automation" | "brain";
 
+function usesInteractiveRunner(sessionKind: SessionKind): boolean {
+  return sessionKind !== "automation";
+}
+
 export interface CreateAgentRunnerInput {
   cwd: string;
   content: string;
@@ -62,7 +66,7 @@ export function createAgentRunner(input: CreateAgentRunnerInput): CreatedAgentRu
   const useCodexAppServer =
     !input.testCommand &&
     provider!.id === "codex" &&
-    input.sessionKind === "chat" &&
+    usesInteractiveRunner(input.sessionKind) &&
     providerSupportsAppServer(provider!.id);
   const supportsBlockingTools = provider?.capabilities.blockingTools ?? false;
 

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -72,6 +72,7 @@ const ChatMessage = memo(function ChatMessage({
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const inlineAgentActivities = getInlineAgentActivities(message.agentActivities ?? []);
+  const showAssistantActions = !isUser && (message.durationMs != null || Boolean(message.content));
 
   if (!isUser) {
     const hasAssistantContent = Boolean(
@@ -177,11 +178,11 @@ const ChatMessage = memo(function ChatMessage({
               )}
             </div>
           )}
-          {message.durationMs != null && (
+          {showAssistantActions && (
             <div className="mt-2 flex items-center gap-1.5 text-[11px] text-muted-foreground">
-              <span>{formatElapsed(message.durationMs)}</span>
-              <span>·</span>
-              <CopyButton content={message.content} className="mb-0.5" />
+              {message.durationMs != null && <span>{formatElapsed(message.durationMs)}</span>}
+              {message.durationMs != null && message.content && <span>·</span>}
+              {message.content && <CopyButton content={message.content} className="mb-0.5" />}
             </div>
           )}
         </div>

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -170,6 +170,8 @@ export default function BrainView() {
     tasks,
     currentTask,
     taskCounts,
+    taskTrackerStatus,
+    goal,
     backgroundAgents,
     backgroundRunningCount: bgRunningCount,
     // Queue + scroll
@@ -396,9 +398,11 @@ export default function BrainView() {
               queuedMessage={queuedMessage}
               onClearQueue={() => setQueuedMessage(null)}
               scrollToBottomTrigger={scrollToBottomTrigger}
+              goal={goal}
               tasks={tasks}
               currentTask={currentTask}
               taskCounts={taskCounts}
+              taskTrackerStatus={taskTrackerStatus}
               backgroundAgents={backgroundAgents}
               backgroundRunningCount={bgRunningCount}
               onBatchAnswerQuestions={batchAnswerQuestions}

--- a/frontend/tests/components/ChatMessage.test.tsx
+++ b/frontend/tests/components/ChatMessage.test.tsx
@@ -249,14 +249,14 @@ describe("ChatMessage", () => {
 
   // ── Additional assistant message coverage ───────────────────────────
 
-  it("does not show duration or copy button when durationMs is absent", () => {
+  it("shows copy button when durationMs is absent", () => {
     render(
       <ChatMessage
         message={assistantMessage({ durationMs: undefined })}
       />,
     );
 
-    expect(screen.queryByTestId("copy-button")).not.toBeInTheDocument();
+    expect(screen.getByTestId("copy-button")).toHaveAttribute("data-content", "Assistant text");
   });
 
   it("shows duration and copy button when durationMs is set", () => {

--- a/ios/HiveMobile/Models/ConversationSurfaceModels.swift
+++ b/ios/HiveMobile/Models/ConversationSurfaceModels.swift
@@ -22,6 +22,19 @@ func isBrainWorkspaceId(_ workspaceId: String) -> Bool {
     workspaceId == BRAIN_WORKSPACE_ID
 }
 
+func makeBrainWorkspace(from state: BrainState?) -> Workspace {
+    Workspace(
+        id: BRAIN_WORKSPACE_ID,
+        name: "Brain",
+        branch: "main",
+        status: .idle,
+        createdAt: state?.createdAt ?? "",
+        activeSessionId: nil,
+        projectName: "Brain",
+        defaultBranch: nil
+    )
+}
+
 func brainSaveFailureMessage(
     result: BrainSaveResponse? = nil,
     fallbackErrorDescription: String? = nil

--- a/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
+++ b/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
@@ -25,16 +25,7 @@ struct BrainConversationsView: View {
     private let api = APIClient()
 
     private var brainWorkspace: Workspace {
-        Workspace(
-            id: BRAIN_WORKSPACE_ID,
-            name: "Brain",
-            branch: "main",
-            status: .idle,
-            createdAt: brainState?.createdAt ?? "",
-            activeSessionId: nil,
-            projectName: "Brain",
-            defaultBranch: nil
-        )
+        makeBrainWorkspace(from: brainState)
     }
 
     private var pendingCount: Int {

--- a/ios/Tests/ChatDraftStoreTests/ConversationSurfaceModelsTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationSurfaceModelsTests.swift
@@ -1,0 +1,35 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+@Suite("Conversation surface models")
+struct ConversationSurfaceModelsTests {
+    @Test("Brain workspace uses the shared workspace conversation surface")
+    func brainWorkspaceUsesSharedWorkspaceSurface() {
+        let state = BrainState(
+            exists: true,
+            repoUrl: "https://github.com/example/brain",
+            createdAt: "2026-06-09T15:00:00.000Z",
+            lastSyncedAt: "2026-06-09T15:05:00.000Z"
+        )
+
+        let workspace = makeBrainWorkspace(from: state)
+
+        #expect(workspace.id == BRAIN_WORKSPACE_ID)
+        #expect(isBrainWorkspaceId(workspace.id))
+        #expect(workspace.name == "Brain")
+        #expect(workspace.projectName == "Brain")
+        #expect(workspace.branch == "main")
+        #expect(workspace.status == .idle)
+        #expect(workspace.createdAt == state.createdAt)
+        #expect(workspace.activeSessionId == nil)
+        #expect(workspace.defaultBranch == nil)
+    }
+
+    @Test("Brain workspace tolerates missing state while loading")
+    func brainWorkspaceToleratesMissingState() {
+        let workspace = makeBrainWorkspace(from: nil)
+
+        #expect(workspace.id == BRAIN_WORKSPACE_ID)
+        #expect(workspace.createdAt == "")
+    }
+}


### PR DESCRIPTION
## Summary
- Route Brain Codex sessions through the same interactive app-server runner used by workspace chats
- Keep assistant copy actions visible even when a provider omits duration metadata
- Pass shared goal/task tracker state through the Brain conversation pane

## Tests
- npm run test --workspace @hive/backend -- src/agents/conversation-session.test.ts src/agents/providers/codex-stream-adapter.test.ts
- npm run typecheck --workspace @hive/frontend
- npm run typecheck --workspace @hive/backend
- npm run lint