### PR TITLE
Fix missing turn duration for process runners

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -2966,6 +2966,29 @@ describe("ConversationSession", () => {
     expect(assistantMsg.durationMs).toBe(2500);
   });
 
+  it("persists fallback durationMs when result event omits duration", async () => {
+    const session = createSession({ sessionId: "duration-fallback" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    mockProc._stdout.push(assistantLine("Reply"));
+    mockProc._stdout.push(resultLine("s1"));
+    mockProc._emitClose(0);
+
+    await new Promise((r) => setTimeout(r, 100));
+
+    const messagesPath = join(tempDir, "sessions", "duration-fallback", "messages.jsonl");
+    const raw = await readFile(messagesPath, "utf-8");
+    const lines = raw.split("\n").filter(Boolean);
+    expect(lines.length).toBe(2);
+    const assistantMsg = JSON.parse(lines[1]);
+    expect(assistantMsg.durationMs).toEqual(expect.any(Number));
+
+    const done = messages.find((msg) => msg.type === "done");
+    expect(done).toMatchObject({ type: "done", durationMs: expect.any(Number) });
+  });
+
   it("persists thinking content in assistant message", async () => {
     const session = createSession({ sessionId: "thinking-persist" });
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -909,6 +909,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     const cancellationErrorDetail = shouldSurfaceCancelled
       ? buildCancellationErrorDetail(exitCode, lastStderr)
       : undefined;
+    const effectiveDurationMs = resultDurationMs
+      ?? (capturedStreamingStart ? Date.now() - capturedStreamingStart : undefined);
 
     this._status = (exitCode === 0 || killedForBlockingTool) ? "idle" : "error";
     this._streamingStartedAt = null;
@@ -935,7 +937,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         timestamp: new Date().toISOString(),
         cancelled: shouldSurfaceCancelled || undefined,
         errorDetail: cancellationErrorDetail,
-        durationMs: resultDurationMs,
+        durationMs: effectiveDurationMs,
         inputTokens: resultInputTokens,
         outputTokens: resultOutputTokens,
         contextUsedTokens: resultContextUsedTokens,
@@ -964,14 +966,12 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       try {
         await this.persistQueue;
         if (shouldSurfaceCancelled) {
-          const cancelDurationMs = resultDurationMs
-            ?? (capturedStreamingStart ? Date.now() - capturedStreamingStart : undefined);
           this.emit("message", {
             type: "cancelled",
             sessionId: this.sessionId,
             errorDetail: cancellationErrorDetail,
             userInitiated: capturedStopReason === "user",
-            durationMs: cancelDurationMs,
+            durationMs: effectiveDurationMs,
           });
         } else if (failureDetail) {
           this.emit("message", {
@@ -983,7 +983,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           this.emit("message", {
             type: "done",
             sessionId: this.sessionId,
-            durationMs: resultDurationMs,
+            durationMs: effectiveDurationMs,
             inputTokens: resultInputTokens,
             outputTokens: resultOutputTokens,
             contextUsedTokens: resultContextUsedTokens,


### PR DESCRIPTION
## Summary
- compute one effective turn duration in ConversationSession using provider duration when available and a local wall-clock fallback otherwise
- use that effective duration for persisted assistant messages plus done/cancelled events
- add regression coverage for provider result events that omit duration_ms

## Tests
- npm --prefix backend test -- conversation-session.test.ts
- npm --prefix backend run typecheck