### PR TITLE
Fix script tab overflow layout

### DIFF
--- a/frontend/src/components/ScriptPanel.tsx
+++ b/frontend/src/components/ScriptPanel.tsx
@@ -215,6 +215,37 @@ export default function ScriptPanel({
     }
   };
 
+  const renderTabButton = (tab: TabInfo) => {
+    const tabStatus: ScriptStatusInfo = status[tab.key] ?? { state: "idle" };
+    const isActive = effectiveTab === tab.key;
+
+    return (
+      <button
+        key={tab.key}
+        type="button"
+        aria-label={tab.label}
+        title={tab.label}
+        className={cn(
+          "flex h-full shrink-0 items-center gap-1.5 whitespace-nowrap text-xs uppercase tracking-wide transition-colors",
+          isActive ? "font-semibold text-foreground" : "font-normal text-muted-foreground hover:text-foreground",
+        )}
+        onClick={() => setActiveTab(tab.key)}
+      >
+        {tab.isTerminal ? (
+          <>
+            {tabStatus.state === "running" && <ActivityWave size="small" decorative />}
+            <span>T1</span>
+          </>
+        ) : (
+          <>
+            <StatusIndicator status={tabStatus} isSetup={tab.isSetup} />
+            <span className="block max-w-28 truncate">{tab.label}</span>
+          </>
+        )}
+      </button>
+    );
+  };
+
   if (tabs.length === 0) {
     return (
       <div className="flex h-full min-h-0 flex-col">
@@ -238,42 +269,23 @@ export default function ScriptPanel({
     );
   }
 
+  const terminalTab = tabs.find((tab) => tab.isTerminal);
+  const scriptTabs = tabs.filter((tab) => !tab.isTerminal);
+
   return (
     <div className="flex h-full min-h-0 flex-col">
       {/* Tab bar */}
-      <div className="flex h-9 items-center gap-3 border-t border-border/50 px-3">
-        {tabs.map((tab) => {
-          const tabStatus: ScriptStatusInfo = status[tab.key] ?? { state: "idle" };
-          return (
-            <button
-              key={tab.key}
-              type="button"
-              aria-label={tab.label}
-              className={cn(
-                "flex items-center gap-1.5 text-xs uppercase tracking-wide transition-colors",
-                effectiveTab === tab.key
-                  ? "font-semibold text-foreground"
-                  : "font-normal text-muted-foreground hover:text-foreground",
-              )}
-              onClick={() => setActiveTab(tab.key)}
-            >
-              {tab.isTerminal ? (
-                <>
-                  {tabStatus.state === "running" && <ActivityWave size="small" decorative />}
-                  <span>T1</span>
-                </>
-              ) : (
-                <>
-                  <StatusIndicator status={tabStatus} isSetup={tab.isSetup} />
-                  {tab.label}
-                </>
-              )}
-            </button>
-          );
-        })}
+      <div className="flex h-9 min-w-0 items-center border-t border-border/50">
+        <div className="min-w-0 flex-1 self-stretch overflow-x-auto overflow-y-hidden">
+          <div className="flex h-full w-max min-w-full items-center gap-3 px-3">
+            {scriptTabs.map(renderTabButton)}
+          </div>
+        </div>
 
         {/* Action button */}
-        <div className="ml-auto">
+        <div className="flex h-full shrink-0 items-center gap-3 px-3">
+          <div className="h-4 w-px bg-border/70" aria-hidden="true" />
+          {terminalTab && renderTabButton(terminalTab)}
           {currentStatus.state === "running" ? (
             <Button variant="ghost" size="icon-xs" onClick={handleAction} title="Stop">
               <SquareIcon className="size-3 text-destructive" />

--- a/frontend/tests/components/ScriptPanel.test.tsx
+++ b/frontend/tests/components/ScriptPanel.test.tsx
@@ -339,6 +339,38 @@ describe("ScriptPanel", () => {
     expect(screen.getByRole("button", { name: "Terminal" })).toBeInTheDocument();
   });
 
+  it("keeps scripts scrollable while terminal controls stay fixed", () => {
+    renderPanel({
+      config: {
+        scripts: {
+          setup: "npm ci",
+          run: {
+            front: "npm run dev:front",
+            back: "npm run dev:back",
+            "back-full-dev": "npm run dev:back:full",
+            "reset-dev": "npm run reset:dev",
+          },
+        },
+      },
+      status: {},
+    });
+
+    const setupButton = screen.getByRole("button", { name: "Setup" });
+    const scrollContent = setupButton.parentElement;
+    const scrollContainer = scrollContent?.parentElement;
+    expect(scrollContainer).toHaveClass("min-w-0", "flex-1", "overflow-x-auto", "overflow-y-hidden");
+    expect(scrollContent?.firstElementChild).toBe(setupButton);
+
+    const longLabel = screen.getByText("Back-full-dev");
+    expect(longLabel).toHaveClass("block", "max-w-28", "truncate");
+
+    const fixedControls = scrollContainer?.nextElementSibling;
+    expect(fixedControls).toHaveClass("shrink-0");
+    expect(fixedControls?.querySelector('[aria-hidden="true"]')).toHaveClass("w-px");
+    expect(fixedControls).toContainElement(screen.getByRole("button", { name: "Terminal" }));
+    expect(fixedControls).toContainElement(screen.getByTitle("Run setup"));
+  });
+
   it("starts a named run script when selected", async () => {
     const { onStart } = renderPanel({
       config: {


### PR DESCRIPTION
## Summary
- Move setup into the scrollable script tab list so it remains first without reserving fixed left space
- Keep terminal and run action controls fixed on the right with a compact separator
- Truncate long script labels with full names available via title tooltips

## Tests
- npm --prefix frontend test -- ScriptPanel.test.tsx
- npm --prefix frontend run typecheck