### PR TITLE
Add provider account usage display

### DIFF
--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -1,4 +1,3 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   commandExecutionActivityToToolCall,
@@ -10,31 +9,15 @@ import type { StreamParserEvent } from "../stream-parser.js";
 import type { ThinkingLevel } from "./types.js";
 import { buildWorkspaceEnv } from "../../utils/env.js";
 import { addBounded } from "../../utils/bounded-set.js";
+import {
+  JsonRpcStdioClient,
+  type JsonObject,
+  type JsonRpcId,
+  type JsonRpcRequest,
+} from "./json-rpc-stdio.js";
 
 /** Cap for long-lived per-session turn-id dedup Sets to avoid unbounded growth. */
 const MAX_TRACKED_TURN_IDS = 256;
-
-type JsonObject = Record<string, unknown>;
-type JsonRpcId = number;
-
-interface JsonRpcResponse {
-  id: JsonRpcId;
-  result?: unknown;
-  error?: { code?: number; message?: string; data?: unknown };
-}
-
-interface JsonRpcRequest {
-  id: JsonRpcId;
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcNotification {
-  method: string;
-  params?: unknown;
-}
-
-type JsonRpcMessage = JsonRpcResponse | JsonRpcRequest | JsonRpcNotification;
 
 type CodexAppServerEvent = StreamParserEvent & {
   agent_event: [event: NormalizedAgentEvent];
@@ -182,15 +165,8 @@ export function buildCodexAppServerArgs(enableGoals: boolean): string[] {
  */
 export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private readonly enableGoals: boolean;
-  private proc: ChildProcessWithoutNullStreams | null = null;
+  private rpc: JsonRpcStdioClient | null = null;
   private initialized: Promise<void> | null = null;
-  private buffer = "";
-  private nextId = 1;
-  private readonly pending = new Map<JsonRpcId, {
-    method: string;
-    resolve: (value: unknown) => void;
-    reject: (err: Error) => void;
-  }>();
   private threadId: string | undefined;
   private activeTurnId: string | undefined;
   private emittedToolIds = new Set<string>();
@@ -258,15 +234,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
 
   close(): void {
     const hadActiveTurn = Boolean(this.activeTurnId);
-    for (const { reject } of this.pending.values()) {
-      reject(new Error("Codex app-server closed"));
-    }
-    this.pending.clear();
-    this.proc?.kill("SIGTERM");
-    this.proc = null;
+    const rpc = this.rpc;
+    this.rpc = null;
     this.initialized = null;
     this.activeTurnId = undefined;
     this.threadId = undefined;
+    rpc?.close(new Error("Codex app-server closed"));
     if (hadActiveTurn) {
       queueMicrotask(() => this.emit("error", new Error("Codex app-server closed")));
     }
@@ -275,19 +248,18 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private async ensureInitialized(env: Record<string, string> | undefined): Promise<void> {
     if (this.initialized) return this.initialized;
     this.initialized = (async () => {
-      this.proc = spawn("codex", buildCodexAppServerArgs(this.enableGoals), {
-        stdio: ["pipe", "pipe", "pipe"],
+      const rpc = new JsonRpcStdioClient({
+        command: "codex",
+        args: buildCodexAppServerArgs(this.enableGoals),
         env: buildWorkspaceEnv(env),
       });
-      this.proc.stdout.on("data", (chunk: Buffer) => this.onStdout(chunk.toString("utf-8")));
-      this.proc.stderr.on("data", (chunk: Buffer) => {
-        const text = chunk.toString("utf-8").trim();
-        if (text) this.emit("system", { type: "system", message: text, level: "debug" });
-      });
-      this.proc.on("error", (err) => this.rejectAll(err));
-      this.proc.on("close", (code) => {
-        this.rejectAll(new Error(`Codex app-server exited with code ${code ?? 1}`));
-      });
+      this.rpc = rpc;
+      rpc.on("stderr", (text) => this.emit("system", { type: "system", message: text, level: "debug" }));
+      rpc.on("error", (err) => this.emit("error", err));
+      rpc.on("close", (err) => this.onRpcClosed(err));
+      rpc.on("request", (request) => this.handleServerRequest(request));
+      rpc.on("notification", (notification) => this.handleNotification(notification.method, notification.params));
+      rpc.start();
 
       await this.request("initialize", {
         clientInfo: CLIENT_INFO,
@@ -353,68 +325,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private request<T = unknown>(method: string, params?: unknown): Promise<T> {
-    const proc = this.proc;
-    if (!proc || !proc.stdin.writable) {
-      return Promise.reject(new Error("Codex app-server is not running"));
-    }
-
-    const id = this.nextId++;
-    const payload: JsonRpcRequest = { id, method, params };
-    return new Promise<T>((resolve, reject) => {
-      this.pending.set(id, {
-        method,
-        resolve: (value) => resolve(value as T),
-        reject,
-      });
-      proc.stdin.write(`${JSON.stringify(payload)}\n`);
-    });
+    return this.rpc?.request<T>(method, params)
+      ?? Promise.reject(new Error("Codex app-server is not running"));
   }
 
   private notify(method: string, params?: unknown): void {
-    this.proc?.stdin.write(`${JSON.stringify({ method, ...(params !== undefined ? { params } : {}) })}\n`);
-  }
-
-  private onStdout(chunk: string): void {
-    this.buffer += chunk;
-    const lines = this.buffer.split("\n");
-    this.buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      this.handleMessage(trimmed);
-    }
-  }
-
-  private handleMessage(line: string): void {
-    let message: JsonRpcMessage;
-    try {
-      message = JSON.parse(line) as JsonRpcMessage;
-    } catch {
-      this.emit("error", new Error(`Malformed Codex app-server JSON line: ${line.slice(0, 200)}`));
-      return;
-    }
-
-    if ("id" in message && "method" in message) {
-      this.handleServerRequest(message);
-      return;
-    }
-
-    if ("id" in message) {
-      const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      if ("error" in message && message.error) {
-        pending.reject(new Error(message.error.message ?? `${pending.method} failed`));
-      } else {
-        pending.resolve(message.result);
-      }
-      return;
-    }
-
-    if ("method" in message) {
-      this.handleNotification(message.method, message.params);
-    }
+    this.rpc?.notify(method, params);
   }
 
   private handleServerRequest(request: JsonRpcRequest): void {
@@ -450,11 +366,11 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private respond(id: JsonRpcId, result: unknown): void {
-    this.proc?.stdin.write(`${JSON.stringify({ id, result })}\n`);
+    this.rpc?.respond(id, result);
   }
 
   private respondError(id: JsonRpcId, message: string): void {
-    this.proc?.stdin.write(`${JSON.stringify({ id, error: { code: -32603, message } })}\n`);
+    this.rpc?.respondError(id, message);
   }
 
   private rejectUnsupportedRequest(request: JsonRpcRequest, message: string): void {
@@ -1078,22 +994,14 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private resolvePendingByMethod(method: string, result: unknown): void {
-    for (const [id, pending] of this.pending) {
-      if (pending.method !== method) continue;
-      this.pending.delete(id);
-      pending.resolve(result);
-    }
+    this.rpc?.resolvePendingByMethod(method, result);
   }
 
-  private rejectAll(err: Error): void {
-    for (const { reject } of this.pending.values()) {
-      reject(err);
-    }
-    this.pending.clear();
+  private onRpcClosed(err: Error): void {
     if (this.activeTurnId) {
       this.emit("error", err);
     }
-    this.proc = null;
+    this.rpc = null;
     this.initialized = null;
     this.activeTurnId = undefined;
     this.threadId = undefined;

--- a/backend/src/agents/providers/json-rpc-stdio.ts
+++ b/backend/src/agents/providers/json-rpc-stdio.ts
@@ -1,0 +1,197 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { EventEmitter } from "node:events";
+
+export type JsonRpcId = number;
+export type JsonObject = Record<string, unknown>;
+
+export interface JsonRpcResponse {
+  id: JsonRpcId;
+  result?: unknown;
+  error?: { code?: number; message?: string; data?: unknown };
+}
+
+export interface JsonRpcRequest {
+  id: JsonRpcId;
+  method: string;
+  params?: unknown;
+}
+
+export interface JsonRpcNotification {
+  method: string;
+  params?: unknown;
+}
+
+export type JsonRpcMessage = JsonRpcResponse | JsonRpcRequest | JsonRpcNotification;
+
+type JsonRpcStdioClientEvent = {
+  request: [request: JsonRpcRequest];
+  notification: [notification: JsonRpcNotification];
+  stderr: [text: string];
+  error: [err: Error];
+  close: [err: Error];
+};
+
+interface PendingRequest {
+  method: string;
+  timer: NodeJS.Timeout | null;
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+}
+
+interface JsonRpcStdioClientOptions {
+  command: string;
+  args: string[];
+  env?: NodeJS.ProcessEnv;
+  requestTimeoutMs?: number;
+  closeOnRequestTimeout?: boolean;
+}
+
+export class JsonRpcStdioClient extends EventEmitter<JsonRpcStdioClientEvent> {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<JsonRpcId, PendingRequest>();
+
+  constructor(private readonly options: JsonRpcStdioClientOptions) {
+    super();
+  }
+
+  start(): void {
+    if (this.proc) return;
+    this.proc = spawn(this.options.command, this.options.args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: this.options.env,
+    });
+    this.proc.stdout.on("data", (chunk: Buffer) => this.onStdout(chunk.toString("utf-8")));
+    this.proc.stderr.on("data", (chunk: Buffer) => {
+      const text = chunk.toString("utf-8").trim();
+      if (text) this.emit("stderr", text);
+    });
+    this.proc.on("error", (err) => this.closeWithError(err));
+    this.proc.on("close", (code) => {
+      this.closeWithError(new Error(`${this.options.command} exited with code ${code ?? 1}`), false);
+    });
+  }
+
+  request<T = unknown>(method: string, params?: unknown): Promise<T> {
+    const proc = this.proc;
+    if (!proc || !proc.stdin.writable) {
+      return Promise.reject(new Error(`${this.options.command} is not running`));
+    }
+
+    const id = this.nextId++;
+    const payload: JsonRpcRequest = { id, method, ...(params !== undefined ? { params } : {}) };
+    return new Promise<T>((resolve, reject) => {
+      const pending: PendingRequest = {
+        method,
+        timer: null,
+        resolve: (value) => resolve(value as T),
+        reject,
+      };
+      if (this.options.requestTimeoutMs) {
+        pending.timer = setTimeout(() => {
+          this.pending.delete(id);
+          const err = new Error(`${method} timed out`);
+          reject(err);
+          if (this.options.closeOnRequestTimeout) {
+            this.close(err);
+          }
+        }, this.options.requestTimeoutMs);
+      }
+      this.pending.set(id, pending);
+      proc.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+
+  notify(method: string, params?: unknown): void {
+    this.proc?.stdin.write(`${JSON.stringify({ method, ...(params !== undefined ? { params } : {}) })}\n`);
+  }
+
+  respond(id: JsonRpcId, result: unknown): void {
+    this.proc?.stdin.write(`${JSON.stringify({ id, result })}\n`);
+  }
+
+  respondError(id: JsonRpcId, message: string): void {
+    this.proc?.stdin.write(`${JSON.stringify({ id, error: { code: -32603, message } })}\n`);
+  }
+
+  resolvePendingByMethod(method: string, result: unknown): void {
+    for (const [id, pending] of this.pending) {
+      if (pending.method !== method) continue;
+      this.pending.delete(id);
+      this.clearPendingTimer(pending);
+      pending.resolve(result);
+    }
+  }
+
+  close(err = new Error(`${this.options.command} closed`)): void {
+    this.closeWithError(err, true);
+  }
+
+  private onStdout(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      this.handleLine(trimmed);
+    }
+  }
+
+  private handleLine(line: string): void {
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      this.emit("error", new Error(`Malformed JSON-RPC line: ${line.slice(0, 200)}`));
+      return;
+    }
+
+    if ("id" in message && "method" in message) {
+      this.emit("request", message);
+      return;
+    }
+
+    if ("id" in message) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      this.clearPendingTimer(pending);
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? `${pending.method} failed`));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if ("method" in message) {
+      this.emit("notification", message);
+    }
+  }
+
+  private closeWithError(err: Error, killProcess = true): void {
+    const proc = this.proc;
+    if (!proc && this.pending.size === 0) return;
+    this.proc = null;
+    this.buffer = "";
+    for (const pending of this.pending.values()) {
+      this.clearPendingTimer(pending);
+      pending.reject(err);
+    }
+    this.pending.clear();
+    if (killProcess) {
+      proc?.kill("SIGTERM");
+    }
+    this.emit("close", err);
+  }
+
+  private clearPendingTimer(pending: PendingRequest): void {
+    if (pending.timer) {
+      clearTimeout(pending.timer);
+      pending.timer = null;
+    }
+  }
+}

--- a/backend/src/api/provider-usage.ts
+++ b/backend/src/api/provider-usage.ts
@@ -1,0 +1,11 @@
+import type { FastifyInstance } from "fastify";
+import {
+  getProviderUsageSnapshot,
+  type ProviderUsageResponse,
+} from "../services/provider-usage.js";
+
+export async function providerUsageRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/api/provider-usage", async (): Promise<ProviderUsageResponse> => {
+    return getProviderUsageSnapshot();
+  });
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -19,6 +19,7 @@ import { type SessionOptions, rebuildNotifier, stopAllSessions } from "./agents/
 import { GitSyncService } from "./services/git-sync.js";
 import { settingsRoutes } from "./api/settings.js";
 import { agentSettingsRoutes } from "./api/agents-settings.js";
+import { providerUsageRoutes } from "./api/provider-usage.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
@@ -320,6 +321,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
   );
   await app.register((instance: FastifyInstance) => settingsRoutes(instance));
   await app.register((instance: FastifyInstance) => agentSettingsRoutes(instance));
+  await app.register((instance: FastifyInstance) => providerUsageRoutes(instance));
   await app.register((instance: FastifyInstance) => accountRoutes(instance));
   await app.register((instance: FastifyInstance) => scriptRoutes(instance));
   await app.register((instance: FastifyInstance) =>

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -20,6 +20,7 @@ import { GitSyncService } from "./services/git-sync.js";
 import { settingsRoutes } from "./api/settings.js";
 import { agentSettingsRoutes } from "./api/agents-settings.js";
 import { providerUsageRoutes } from "./api/provider-usage.js";
+import { stopProviderUsagePolling } from "./services/provider-usage.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
@@ -401,6 +402,7 @@ async function main() {
   app.addHook("onClose", () => {
     gitSync.stop();
     scheduler.stop();
+    stopProviderUsagePolling();
   });
   gitSync.start(BRANCH_SYNC_INTERVAL_MS);
   await scheduler.start();

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -1,9 +1,16 @@
+import { EventEmitter } from "node:events";
+import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   getAllProviderInfo: vi.fn(),
   providerSupportsAppServer: vi.fn(),
   readFile: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: mocks.spawn,
 }));
 
 vi.mock("../agents/providers/registry.js", () => ({
@@ -19,6 +26,64 @@ import {
   __providerUsageTestHooks,
   getProviderUsageSnapshot,
 } from "./provider-usage.js";
+
+function createMockStream(): EventEmitter & { push(data: string): void } {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    push(data: string) {
+      emitter.emit("data", Buffer.from(data));
+    },
+  });
+}
+
+function createMockProcess() {
+  const proc = new EventEmitter() as ChildProcessWithoutNullStreams & {
+    _stdout: ReturnType<typeof createMockStream>;
+    _stderr: ReturnType<typeof createMockStream>;
+    _stdinWrite: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  proc._stdout = createMockStream();
+  proc._stderr = createMockStream();
+  proc.stdout = proc._stdout as unknown as ChildProcessWithoutNullStreams["stdout"];
+  proc.stderr = proc._stderr as unknown as ChildProcessWithoutNullStreams["stderr"];
+  proc._stdinWrite = vi.fn();
+  proc.stdin = {
+    write: proc._stdinWrite,
+    writable: true,
+  } as unknown as ChildProcessWithoutNullStreams["stdin"];
+  proc.kill = vi.fn(() => true);
+  return proc;
+}
+
+function parseWrites(proc: ReturnType<typeof createMockProcess>): Array<Record<string, unknown>> {
+  return proc._stdinWrite.mock.calls.flatMap((call) => {
+    const raw = String(call[0]).trim();
+    if (!raw) return [];
+    try {
+      return [JSON.parse(raw) as Record<string, unknown>];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function findMethod(proc: ReturnType<typeof createMockProcess>, method: string): { id: number } {
+  const write = parseWrites(proc).find((entry) => entry.method === method);
+  if (!write || typeof write.id !== "number") {
+    throw new Error(`Expected ${method} request`);
+  }
+  return { id: write.id };
+}
+
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function appServerResponse(id: number, result: unknown): string {
+  return JSON.stringify({ id, result }) + "\n";
+}
 
 function mockFetchJson(status: number, body: unknown, headers: Record<string, string> = {}) {
   const response = {
@@ -38,8 +103,10 @@ describe("provider usage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
     vi.stubGlobal("fetch", vi.fn());
     __providerUsageTestHooks.resetProviderUsageCaches();
+    mocks.spawn.mockReset();
     mocks.providerSupportsAppServer.mockReturnValue(false);
     mocks.getAllProviderInfo.mockReturnValue([
       {
@@ -55,6 +122,183 @@ describe("provider usage", () => {
         accessToken: "test-token",
       },
     }));
+  });
+
+  it("parses Codex rate-limit payload variants", () => {
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      primary: {
+        usagePercent: 0.42,
+        windowDurationMins: 300,
+        resetAt: "2026-06-10T17:00:00Z",
+      },
+    })).toEqual([
+      {
+        id: "codex",
+        label: null,
+        usedPercent: 42,
+        windowDurationMins: 300,
+        resetsAt: 1781110800,
+        planType: null,
+        credits: undefined,
+        rateLimitReachedType: null,
+      },
+    ]);
+
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      rateLimitsByLimitId: {
+        weekly: {
+          limitId: "weekly",
+          limitName: "Weekly",
+          primary: {
+            usedPercent: 87,
+            resetsAt: 1781542800,
+          },
+        },
+      },
+    })).toMatchObject([
+      {
+        id: "weekly",
+        label: "Weekly",
+        usedPercent: 87,
+        resetsAt: 1781542800,
+      },
+    ]);
+  });
+
+  it("reads Codex usage through the App Server JSON-RPC endpoint", async () => {
+    const proc = createMockProcess();
+    mocks.spawn.mockReturnValue(proc);
+    mocks.providerSupportsAppServer.mockReturnValue(true);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const resultPromise = getProviderUsageSnapshot();
+    const init = findMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(init.id, {}));
+    await flushPromises();
+    const read = findMethod(proc, "account/rateLimits/read");
+    proc._stdout.push(appServerResponse(read.id, {
+      rateLimitsByLimitId: {
+        primary: {
+          limitId: "primary",
+          limitName: "Primary",
+          primary: {
+            usedPercent: 0.25,
+            windowDurationMins: 300,
+            resetsAt: 1781110800,
+          },
+        },
+      },
+    }));
+
+    const result = await resultPromise;
+
+    expect(mocks.spawn).toHaveBeenCalledWith("codex", ["app-server", "--listen", "stdio://"], expect.any(Object));
+    expect(result.providers).toMatchObject([
+      {
+        id: "codex",
+        status: "available",
+        buckets: [
+          {
+            id: "primary",
+            label: "Primary",
+            usedPercent: 25,
+            resetsAt: 1781110800,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("reports a Codex usage error instead of crashing on malformed App Server output", async () => {
+    const proc = createMockProcess();
+    mocks.spawn.mockReturnValue(proc);
+    mocks.providerSupportsAppServer.mockReturnValue(true);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const resultPromise = getProviderUsageSnapshot();
+    const init = findMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(init.id, {}));
+    await flushPromises();
+    expect(findMethod(proc, "account/rateLimits/read")).toBeTruthy();
+
+    proc._stdout.push("{not-json}\n");
+
+    const result = await resultPromise;
+
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(result.providers[0]).toMatchObject({
+      id: "codex",
+      status: "error",
+      message: expect.stringContaining("Malformed JSON-RPC line"),
+    });
+  });
+
+  it("resets the Codex App Server client after an initialize timeout", async () => {
+    vi.useFakeTimers();
+    const firstProc = createMockProcess();
+    const secondProc = createMockProcess();
+    mocks.spawn
+      .mockReturnValueOnce(firstProc)
+      .mockReturnValueOnce(secondProc);
+    mocks.providerSupportsAppServer.mockReturnValue(true);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const firstResultPromise = getProviderUsageSnapshot();
+    expect(findMethod(firstProc, "initialize")).toBeTruthy();
+    await vi.advanceTimersByTimeAsync(5_000);
+    const firstResult = await firstResultPromise;
+
+    expect(firstProc.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(firstResult.providers[0]).toMatchObject({
+      id: "codex",
+      status: "error",
+      message: "initialize timed out",
+    });
+
+    const secondResultPromise = getProviderUsageSnapshot();
+    const init = findMethod(secondProc, "initialize");
+    procRespond(secondProc, init.id, {});
+    await flushPromises();
+    const read = findMethod(secondProc, "account/rateLimits/read");
+    procRespond(secondProc, read.id, {
+      primary: {
+        usedPercent: 12,
+        resetsAt: 1781110800,
+      },
+    });
+
+    const secondResult = await secondResultPromise;
+
+    expect(mocks.spawn).toHaveBeenCalledTimes(2);
+    expect(secondResult.providers[0]).toMatchObject({
+      id: "codex",
+      status: "available",
+      buckets: [{ id: "codex", usedPercent: 12 }],
+    });
   });
 
   it("parses Claude OAuth usage windows", () => {
@@ -146,3 +390,7 @@ describe("provider usage", () => {
     });
   });
 });
+
+function procRespond(proc: ReturnType<typeof createMockProcess>, id: number, result: unknown): void {
+  proc._stdout.push(appServerResponse(id, result));
+}

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -301,6 +301,77 @@ describe("provider usage", () => {
     });
   });
 
+  it("closes the Codex usage App Server after the idle window", async () => {
+    vi.useFakeTimers();
+    const proc = createMockProcess();
+    mocks.spawn.mockReturnValue(proc);
+    mocks.providerSupportsAppServer.mockReturnValue(true);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const resultPromise = getProviderUsageSnapshot();
+    const init = findMethod(proc, "initialize");
+    procRespond(proc, init.id, {});
+    await flushPromises();
+    const read = findMethod(proc, "account/rateLimits/read");
+    procRespond(proc, read.id, { primary: { usedPercent: 12 } });
+
+    await resultPromise;
+    expect(proc.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(proc.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("keeps the Codex usage App Server warm while cached snapshots continue", async () => {
+    vi.useFakeTimers();
+    const proc = createMockProcess();
+    mocks.spawn.mockReturnValue(proc);
+    mocks.providerSupportsAppServer.mockReturnValue(true);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const firstResultPromise = getProviderUsageSnapshot();
+    const init = findMethod(proc, "initialize");
+    procRespond(proc, init.id, {});
+    await flushPromises();
+    const firstRead = findMethod(proc, "account/rateLimits/read");
+    procRespond(proc, firstRead.id, { primary: { usedPercent: 12 } });
+    await firstResultPromise;
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    const secondResult = await getProviderUsageSnapshot();
+    expect(secondResult.providers[0]).toMatchObject({
+      id: "codex",
+      buckets: [{ id: "codex", usedPercent: 12 }],
+    });
+    expect(parseWrites(proc).filter((entry) => entry.method === "account/rateLimits/read")).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(119_999);
+    expect(proc.kill).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(proc.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(mocks.spawn).toHaveBeenCalledTimes(1);
+  });
+
   it("parses Claude OAuth usage windows", () => {
     expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
       five_hour: { utilization: 42, resets_at: "2026-06-10T17:00:00Z" },

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -1,0 +1,140 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAllProviderInfo: vi.fn(),
+  providerSupportsAppServer: vi.fn(),
+  readFile: vi.fn(),
+}));
+
+vi.mock("../agents/providers/registry.js", () => ({
+  getAllProviderInfo: mocks.getAllProviderInfo,
+  providerSupportsAppServer: mocks.providerSupportsAppServer,
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: mocks.readFile,
+}));
+
+import {
+  __providerUsageTestHooks,
+  getProviderUsageSnapshot,
+} from "./provider-usage.js";
+
+function mockFetchJson(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name: string) {
+        return headers[name.toLowerCase()] ?? null;
+      },
+    },
+    json: async () => body,
+  } as Response;
+  vi.stubGlobal("fetch", vi.fn(async () => response));
+}
+
+describe("provider usage", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.stubGlobal("fetch", vi.fn());
+    __providerUsageTestHooks.resetProviderUsageCaches();
+    mocks.providerSupportsAppServer.mockReturnValue(false);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "claude",
+        label: "Claude Code",
+        npmPackage: "@anthropic-ai/claude-code",
+        installed: true,
+        version: "2.1.170",
+      },
+    ]);
+    mocks.readFile.mockResolvedValue(JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "test-token",
+      },
+    }));
+  });
+
+  it("parses Claude OAuth usage windows", () => {
+    expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
+      five_hour: { utilization: 0.42, resets_at: "2026-06-10T17:00:00Z" },
+      seven_day: { utilization: 61, resets_at: "2026-06-15T17:00:00Z" },
+      seven_day_opus: null,
+      extra_usage: { utilization: null },
+    })).toEqual([
+      {
+        id: "five_hour",
+        label: "5h",
+        usedPercent: 42,
+        windowDurationMins: 300,
+        resetsAt: 1781110800,
+      },
+      {
+        id: "seven_day",
+        label: "7d",
+        usedPercent: 61,
+        windowDurationMins: 10080,
+        resetsAt: 1781542800,
+      },
+    ]);
+  });
+
+  it("reads Claude usage from the OAuth usage endpoint", async () => {
+    mockFetchJson(200, {
+      five_hour: { utilization: 0.25, resets_at: "2026-06-10T17:00:00Z" },
+      seven_day_sonnet: { utilization: 0.04, resets_at: "2026-06-15T17:00:00Z" },
+    });
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers).toHaveLength(1);
+    expect(result.providers[0]).toMatchObject({
+      id: "claude",
+      status: "available",
+      buckets: [
+        { id: "five_hour", usedPercent: 25 },
+        { id: "seven_day_sonnet", usedPercent: 4 },
+      ],
+    });
+    expect(fetch).toHaveBeenCalledWith("https://api.anthropic.com/api/oauth/usage", expect.objectContaining({
+      headers: expect.objectContaining({
+        Authorization: "Bearer test-token",
+        "User-Agent": "claude-code/2.1.170",
+        "anthropic-beta": "oauth-2025-04-20",
+      }),
+    }));
+  });
+
+  it("reports unknown Claude usage when OAuth credentials are missing", async () => {
+    mocks.readFile.mockRejectedValue(new Error("missing"));
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers[0]).toMatchObject({
+      id: "claude",
+      status: "unknown",
+      buckets: [],
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("does not return stale Claude buckets when the usage endpoint fails", async () => {
+    mockFetchJson(429, {
+      error: {
+        message: "Rate limited. Please try again later.",
+        type: "rate_limit_error",
+      },
+    }, { "retry-after": "300" });
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers[0]).toMatchObject({
+      id: "claude",
+      status: "error",
+      buckets: [],
+      message: "Rate limited. Please try again later.",
+    });
+  });
+});

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -59,8 +59,9 @@ describe("provider usage", () => {
 
   it("parses Claude OAuth usage windows", () => {
     expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
-      five_hour: { utilization: 0.42, resets_at: "2026-06-10T17:00:00Z" },
+      five_hour: { utilization: 42, resets_at: "2026-06-10T17:00:00Z" },
       seven_day: { utilization: 61, resets_at: "2026-06-15T17:00:00Z" },
+      seven_day_sonnet: { utilization: 1, resets_at: "2026-06-15T17:00:00Z" },
       seven_day_opus: null,
       extra_usage: { utilization: null },
     })).toEqual([
@@ -78,13 +79,20 @@ describe("provider usage", () => {
         windowDurationMins: 10080,
         resetsAt: 1781542800,
       },
+      {
+        id: "seven_day_sonnet",
+        label: "7d Sonnet",
+        usedPercent: 1,
+        windowDurationMins: 10080,
+        resetsAt: 1781542800,
+      },
     ]);
   });
 
   it("reads Claude usage from the OAuth usage endpoint", async () => {
     mockFetchJson(200, {
-      five_hour: { utilization: 0.25, resets_at: "2026-06-10T17:00:00Z" },
-      seven_day_sonnet: { utilization: 0.04, resets_at: "2026-06-15T17:00:00Z" },
+      five_hour: { utilization: 25, resets_at: "2026-06-10T17:00:00Z" },
+      seven_day_sonnet: { utilization: 4, resets_at: "2026-06-15T17:00:00Z" },
     });
 
     const result = await getProviderUsageSnapshot();

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -71,8 +71,9 @@ interface ClaudeUsageWindow {
   resets_at?: unknown;
 }
 
-const CODEX_USAGE_CACHE_TTL_MS = 30_000;
+const CODEX_USAGE_CACHE_TTL_MS = 120_000;
 const CODEX_REQUEST_TIMEOUT_MS = 5_000;
+const CODEX_USAGE_IDLE_TIMEOUT_MS = 120_000;
 const CLAUDE_USAGE_CACHE_TTL_MS = 180_000;
 const CLAUDE_REQUEST_TIMEOUT_MS = 5_000;
 const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
@@ -127,6 +128,7 @@ async function getCodexUsage(label: string, installed: boolean): Promise<Provide
 
   const now = Date.now();
   if (codexUsageCache && codexUsageCache.expiresAt > now) {
+    codexClient?.deferIdleClose();
     return codexUsageCache.value;
   }
 
@@ -450,21 +452,47 @@ export const __providerUsageTestHooks = {
 class CodexUsageClient {
   private rpc: JsonRpcStdioClient | null = null;
   private initialized: Promise<void> | null = null;
+  private idleTimer: ReturnType<typeof setTimeout> | null = null;
 
   async readRateLimits(): Promise<unknown> {
-    await this.ensureInitialized();
-    return this.rpc?.request("account/rateLimits/read")
-      ?? Promise.reject(new Error("Codex app-server is not running"));
+    this.clearIdleTimer();
+    try {
+      await this.ensureInitialized();
+      return await (this.rpc?.request("account/rateLimits/read")
+        ?? Promise.reject(new Error("Codex app-server is not running")));
+    } finally {
+      this.scheduleIdleClose();
+    }
   }
 
   close(): void {
     this.closeWithError(new Error("Codex usage polling stopped"));
   }
 
+  deferIdleClose(): void {
+    this.scheduleIdleClose();
+  }
+
   private closeWithError(err: Error): void {
+    this.clearIdleTimer();
     this.rpc?.close(err);
     this.rpc = null;
     this.initialized = null;
+  }
+
+  private scheduleIdleClose(): void {
+    if (!this.rpc) return;
+    this.clearIdleTimer();
+    this.idleTimer = setTimeout(() => {
+      this.idleTimer = null;
+      this.closeWithError(new Error("Codex usage polling idle timeout"));
+    }, CODEX_USAGE_IDLE_TIMEOUT_MS);
+  }
+
+  private clearIdleTimer(): void {
+    if (!this.idleTimer) return;
+    clearTimeout(this.idleTimer);
+    this.idleTimer = null;
   }
 
   private async ensureInitialized(): Promise<void> {

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -330,7 +330,7 @@ function parseClaudeUsageBucket(
   window: ClaudeUsageWindow | null,
 ): ProviderUsageBucket | null {
   if (!window) return null;
-  const usedPercent = normalizePercent(window.utilization);
+  const usedPercent = normalizeClaudePercent(window.utilization);
   if (usedPercent === null) return null;
   return {
     id,
@@ -376,6 +376,12 @@ function normalizePercent(value: unknown): number | null {
   if (num === null) return null;
   const percent = num <= 1 ? num * 100 : num;
   return Math.max(0, Math.min(100, Math.round(percent)));
+}
+
+function normalizeClaudePercent(value: unknown): number | null {
+  const num = asNumber(value);
+  if (num === null) return null;
+  return Math.max(0, Math.min(100, Math.round(num)));
 }
 
 function parseResetTimestamp(value: unknown): number | null {

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -1,0 +1,577 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { buildCodexAppServerArgs } from "../agents/providers/codex-app-server.js";
+import {
+  getAllProviderInfo,
+  providerSupportsAppServer,
+} from "../agents/providers/registry.js";
+import { buildWorkspaceEnv } from "../utils/env.js";
+
+type UsageStatus = "available" | "unavailable" | "unknown" | "error";
+
+export interface ProviderUsageBucket {
+  id: string;
+  label: string | null;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+  planType?: string | null;
+  credits?: unknown;
+  rateLimitReachedType?: string | null;
+}
+
+export interface ProviderUsageEntry {
+  id: string;
+  label: string;
+  status: UsageStatus;
+  buckets: ProviderUsageBucket[];
+  lastUpdatedAt: string | null;
+  message?: string;
+}
+
+export interface ProviderUsageResponse {
+  providers: ProviderUsageEntry[];
+  generatedAt: string;
+}
+
+interface JsonRpcResponse {
+  id: number;
+  result?: unknown;
+  error?: { message?: string };
+}
+
+interface JsonRpcRequest {
+  id: number;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcNotification {
+  method: string;
+  params?: unknown;
+}
+
+type JsonRpcMessage = JsonRpcResponse | JsonRpcRequest | JsonRpcNotification;
+
+interface CodexRateLimitWindow {
+  usedPercent?: unknown;
+  windowDurationMins?: unknown;
+  resetsAt?: unknown;
+}
+
+interface CodexRateLimitBucket {
+  limitId?: unknown;
+  limitName?: unknown;
+  primary?: CodexRateLimitWindow | null;
+  secondary?: CodexRateLimitWindow | null;
+  planType?: unknown;
+  credits?: unknown;
+  rateLimitReachedType?: unknown;
+}
+
+interface ClaudeCredentials {
+  claudeAiOauth?: {
+    accessToken?: unknown;
+    expiresAt?: unknown;
+  };
+  accessToken?: unknown;
+  expiresAt?: unknown;
+}
+
+interface ClaudeUsageWindow {
+  utilization?: unknown;
+  resets_at?: unknown;
+}
+
+const CODEX_USAGE_CACHE_TTL_MS = 30_000;
+const CODEX_REQUEST_TIMEOUT_MS = 5_000;
+const CLAUDE_USAGE_CACHE_TTL_MS = 180_000;
+const CLAUDE_REQUEST_TIMEOUT_MS = 5_000;
+const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
+const CLAUDE_OAUTH_BETA_HEADER = "oauth-2025-04-20";
+const CLIENT_INFO = {
+  name: "hive",
+  title: "Hive",
+  version: "0.1.0",
+};
+
+let codexClient: CodexUsageClient | null = null;
+let codexUsageCache:
+  | { value: ProviderUsageEntry; expiresAt: number }
+  | null = null;
+let claudeUsageCache:
+  | { value: ProviderUsageEntry; expiresAt: number }
+  | null = null;
+let claudeBackoffUntil = 0;
+
+export async function getProviderUsageSnapshot(): Promise<ProviderUsageResponse> {
+  const providerInfo = getAllProviderInfo();
+  const generatedAt = new Date().toISOString();
+  const providers: ProviderUsageEntry[] = [];
+
+  const codex = providerInfo.find((provider) => provider.id === "codex");
+  if (codex) {
+    providers.push(await getCodexUsage(codex.label, codex.installed));
+  }
+
+  const claude = providerInfo.find((provider) => provider.id === "claude");
+  if (claude) {
+    providers.push(await getClaudeUsage(claude.label, claude.installed, claude.version));
+  }
+
+  return { providers, generatedAt };
+}
+
+async function getCodexUsage(label: string, installed: boolean): Promise<ProviderUsageEntry> {
+  if (!installed) {
+    return unavailableProvider("codex", label, "Codex CLI is not installed.");
+  }
+
+  if (!providerSupportsAppServer("codex")) {
+    return unavailableProvider("codex", label, "Installed Codex CLI does not support app-server account usage.");
+  }
+
+  const now = Date.now();
+  if (codexUsageCache && codexUsageCache.expiresAt > now) {
+    return codexUsageCache.value;
+  }
+
+  try {
+    const client = getCodexClient();
+    const result = await client.readRateLimits();
+    const entry = {
+      id: "codex",
+      label,
+      status: "available" as const,
+      buckets: parseCodexRateLimitBuckets(result),
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    codexUsageCache = { value: entry, expiresAt: now + CODEX_USAGE_CACHE_TTL_MS };
+    return entry;
+  } catch (err) {
+    return {
+      id: "codex",
+      label,
+      status: "error",
+      buckets: [],
+      lastUpdatedAt: codexUsageCache?.value.lastUpdatedAt ?? null,
+      message: err instanceof Error ? err.message : "Could not read Codex account usage.",
+    };
+  }
+}
+
+async function getClaudeUsage(label: string, installed: boolean, version: string | null): Promise<ProviderUsageEntry> {
+  if (!installed) {
+    return unavailableProvider("claude", label, "Claude Code CLI is not installed.");
+  }
+
+  const now = Date.now();
+  if (claudeUsageCache && claudeUsageCache.expiresAt > now) {
+    return claudeUsageCache.value;
+  }
+
+  if (claudeBackoffUntil > now) {
+    return {
+      id: "claude",
+      label,
+      status: "unknown",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: `Claude usage polling is backing off after a rate limit. Try again ${formatRetryTime(claudeBackoffUntil)}.`,
+    };
+  }
+
+  try {
+    const token = await readClaudeAccessToken();
+    if (!token) {
+      return {
+        id: "claude",
+        label,
+        status: "unknown",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Claude Code OAuth credentials were not found. Run `claude auth login`.",
+      };
+    }
+
+    const response = await fetchClaudeUsage(token, version);
+    const buckets = parseClaudeUsageBuckets(response.body);
+    if (buckets.length === 0) {
+      return {
+        id: "claude",
+        label,
+        status: "unknown",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Claude usage API returned no usage windows.",
+      };
+    }
+
+    const entry = {
+      id: "claude",
+      label,
+      status: "available" as const,
+      buckets,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    claudeUsageCache = { value: entry, expiresAt: now + CLAUDE_USAGE_CACHE_TTL_MS };
+    claudeBackoffUntil = 0;
+    return entry;
+  } catch (err) {
+    if (err instanceof ClaudeUsageHttpError && err.status === 429) {
+      claudeBackoffUntil = Date.now() + Math.max(err.retryAfterMs ?? 0, CLAUDE_USAGE_CACHE_TTL_MS);
+    }
+    return {
+      id: "claude",
+      label,
+      status: "error",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: err instanceof Error ? err.message : "Could not read Claude account usage.",
+    };
+  }
+}
+
+function unavailableProvider(id: string, label: string, message: string): ProviderUsageEntry {
+  return {
+    id,
+    label,
+    status: "unavailable",
+    buckets: [],
+    lastUpdatedAt: null,
+    message,
+  };
+}
+
+function getCodexClient(): CodexUsageClient {
+  codexClient ??= new CodexUsageClient();
+  return codexClient;
+}
+
+async function readClaudeAccessToken(): Promise<string | null> {
+  const credentialsPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), ".credentials.json");
+  let parsed: ClaudeCredentials;
+  try {
+    parsed = JSON.parse(await readFile(credentialsPath, "utf-8")) as ClaudeCredentials;
+  } catch {
+    return null;
+  }
+
+  const oauth = asRecord(parsed.claudeAiOauth) ?? parsed;
+  return asString(oauth.accessToken);
+}
+
+async function fetchClaudeUsage(token: string, version: string | null): Promise<{ body: unknown }> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), CLAUDE_REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(CLAUDE_USAGE_URL, {
+      headers: {
+        Accept: "application/json",
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+        "anthropic-beta": CLAUDE_OAUTH_BETA_HEADER,
+        "User-Agent": `claude-code/${version ?? "2.0"}`,
+      },
+      signal: controller.signal,
+    });
+
+    let body: unknown = null;
+    try {
+      body = await response.json();
+    } catch {
+      // Non-JSON failures are converted into the generic HTTP error below.
+    }
+
+    if (!response.ok) {
+      throw new ClaudeUsageHttpError(
+        response.status,
+        errorMessageFromBody(body) ?? `Claude usage API returned HTTP ${response.status}.`,
+        retryAfterMs(response.headers.get("retry-after")),
+      );
+    }
+
+    return { body };
+  } catch (err) {
+    if (err instanceof ClaudeUsageHttpError) throw err;
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new Error("Claude usage API timed out.");
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function parseClaudeUsageBuckets(result: unknown): ProviderUsageBucket[] {
+  const record = asRecord(result);
+  if (!record) return [];
+
+  return Object.entries(CLAUDE_USAGE_BUCKETS)
+    .map(([id, config]) => parseClaudeUsageBucket(id, config, asRecord(record[id]) as ClaudeUsageWindow | null))
+    .filter((bucket): bucket is ProviderUsageBucket => bucket !== null);
+}
+
+const CLAUDE_USAGE_BUCKETS: Record<string, { label: string; windowDurationMins: number | null }> = {
+  five_hour: { label: "5h", windowDurationMins: 300 },
+  seven_day: { label: "7d", windowDurationMins: 10_080 },
+  seven_day_sonnet: { label: "7d Sonnet", windowDurationMins: 10_080 },
+  seven_day_opus: { label: "7d Opus", windowDurationMins: 10_080 },
+  seven_day_oauth_apps: { label: "7d OAuth apps", windowDurationMins: 10_080 },
+  seven_day_cowork: { label: "7d cowork", windowDurationMins: 10_080 },
+  seven_day_omelette: { label: "7d omelette", windowDurationMins: 10_080 },
+};
+
+function parseClaudeUsageBucket(
+  id: string,
+  config: { label: string; windowDurationMins: number | null },
+  window: ClaudeUsageWindow | null,
+): ProviderUsageBucket | null {
+  if (!window) return null;
+  const usedPercent = normalizePercent(window.utilization);
+  if (usedPercent === null) return null;
+  return {
+    id,
+    label: config.label,
+    usedPercent,
+    windowDurationMins: config.windowDurationMins,
+    resetsAt: parseResetTimestamp(window.resets_at),
+  };
+}
+
+function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
+  const record = asRecord(result);
+  const byLimitId = asRecord(record?.rateLimitsByLimitId);
+  const source = byLimitId && Object.keys(byLimitId).length > 0
+    ? Object.values(byLimitId)
+    : [record?.rateLimits];
+
+  return source
+    .map((value) => parseCodexRateLimitBucket(asRecord(value) as CodexRateLimitBucket | null))
+    .filter((bucket): bucket is ProviderUsageBucket => bucket !== null);
+}
+
+function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): ProviderUsageBucket | null {
+  if (!bucket) return null;
+  const primary = asRecord(bucket.primary) as CodexRateLimitWindow | null;
+  const id = asString(bucket.limitId) ?? asString(bucket.limitName);
+  if (!id || !primary) return null;
+
+  return {
+    id,
+    label: asString(bucket.limitName),
+    usedPercent: normalizePercent(primary.usedPercent),
+    windowDurationMins: asNumber(primary.windowDurationMins),
+    resetsAt: asNumber(primary.resetsAt),
+    planType: asString(bucket.planType),
+    credits: bucket.credits,
+    rateLimitReachedType: asString(bucket.rateLimitReachedType),
+  };
+}
+
+function normalizePercent(value: unknown): number | null {
+  const num = asNumber(value);
+  if (num === null) return null;
+  const percent = num <= 1 ? num * 100 : num;
+  return Math.max(0, Math.min(100, Math.round(percent)));
+}
+
+function parseResetTimestamp(value: unknown): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value > 10_000_000_000 ? Math.round(value / 1000) : Math.round(value);
+  }
+  if (typeof value !== "string" || !value.trim()) return null;
+  const millis = Date.parse(value);
+  return Number.isFinite(millis) ? Math.round(millis / 1000) : null;
+}
+
+function errorMessageFromBody(body: unknown): string | null {
+  const record = asRecord(body);
+  const error = asRecord(record?.error);
+  return asString(error?.message) ?? asString(record?.message);
+}
+
+function retryAfterMs(value: string | null): number | null {
+  if (!value) return null;
+  const seconds = Number(value);
+  if (Number.isFinite(seconds) && seconds >= 0) return seconds * 1000;
+  const millis = Date.parse(value) - Date.now();
+  return Number.isFinite(millis) && millis > 0 ? millis : null;
+}
+
+function formatRetryTime(timestampMs: number): string {
+  const seconds = Math.max(1, Math.ceil((timestampMs - Date.now()) / 1000));
+  if (seconds < 60) return `in ${seconds}s`;
+  const minutes = Math.ceil(seconds / 60);
+  return `in ${minutes}m`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null;
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function asNumber(value: unknown): number | null {
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  return value;
+}
+
+class ClaudeUsageHttpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+    readonly retryAfterMs: number | null,
+  ) {
+    super(message);
+  }
+}
+
+export const __providerUsageTestHooks = {
+  parseClaudeUsageBuckets,
+  parseResetTimestamp,
+  resetProviderUsageCaches() {
+    codexUsageCache = null;
+    claudeUsageCache = null;
+    claudeBackoffUntil = 0;
+  },
+};
+
+class CodexUsageClient {
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private initialized: Promise<void> | null = null;
+  private buffer = "";
+  private nextId = 1;
+  private readonly pending = new Map<number, {
+    method: string;
+    timer: NodeJS.Timeout;
+    resolve: (value: unknown) => void;
+    reject: (err: Error) => void;
+  }>();
+
+  async readRateLimits(): Promise<unknown> {
+    await this.ensureInitialized();
+    return this.request("account/rateLimits/read");
+  }
+
+  private async ensureInitialized(): Promise<void> {
+    if (this.initialized) return this.initialized;
+
+    this.initialized = (async () => {
+      this.proc = spawn("codex", buildCodexAppServerArgs(false), {
+        stdio: ["pipe", "pipe", "pipe"],
+        env: buildWorkspaceEnv(),
+      });
+      this.proc.stdout.on("data", (chunk: Buffer) => this.onStdout(chunk.toString("utf8")));
+      this.proc.stderr.on("data", () => {
+        // Account usage is best-effort. Stderr is intentionally not surfaced unless a request fails.
+      });
+      this.proc.on("error", (err) => this.rejectAll(err));
+      this.proc.on("close", (code) => {
+        this.rejectAll(new Error(`Codex app-server exited with code ${code ?? 1}`));
+        this.proc = null;
+        this.initialized = null;
+      });
+
+      await this.request("initialize", {
+        clientInfo: CLIENT_INFO,
+        capabilities: { experimentalApi: true },
+      });
+      this.notify("initialized");
+    })();
+
+    return this.initialized;
+  }
+
+  private request(method: string, params?: unknown): Promise<unknown> {
+    const proc = this.proc;
+    if (!proc || !proc.stdin.writable) {
+      return Promise.reject(new Error("Codex app-server is not running"));
+    }
+
+    const id = this.nextId++;
+    const payload = { id, method, ...(params !== undefined ? { params } : {}) };
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`${method} timed out`));
+      }, CODEX_REQUEST_TIMEOUT_MS);
+      this.pending.set(id, { method, timer, resolve, reject });
+      proc.stdin.write(`${JSON.stringify(payload)}\n`);
+    });
+  }
+
+  private notify(method: string, params?: unknown): void {
+    this.proc?.stdin.write(`${JSON.stringify({ method, ...(params !== undefined ? { params } : {}) })}\n`);
+  }
+
+  private onStdout(chunk: string): void {
+    this.buffer += chunk;
+    const lines = this.buffer.split("\n");
+    this.buffer = lines.pop() ?? "";
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      this.handleMessage(trimmed);
+    }
+  }
+
+  private handleMessage(line: string): void {
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch {
+      return;
+    }
+
+    if ("id" in message && "method" in message) {
+      this.respondError(message.id, `${message.method} is not supported by Hive usage polling`);
+      return;
+    }
+
+    if ("id" in message) {
+      const pending = this.pending.get(message.id);
+      if (!pending) return;
+      this.pending.delete(message.id);
+      clearTimeout(pending.timer);
+      if (message.error) {
+        pending.reject(new Error(message.error.message ?? `${pending.method} failed`));
+      } else {
+        pending.resolve(message.result);
+      }
+      return;
+    }
+
+    if ("method" in message && message.method === "account/rateLimits/updated") {
+      const entry = {
+        id: "codex",
+        label: "Codex",
+        status: "available" as const,
+        buckets: parseCodexRateLimitBuckets(message.params),
+        lastUpdatedAt: new Date().toISOString(),
+      };
+      if (entry.buckets.length > 0) {
+        codexUsageCache = { value: entry, expiresAt: Date.now() + CODEX_USAGE_CACHE_TTL_MS };
+      }
+    }
+  }
+
+  private respondError(id: number, message: string): void {
+    this.proc?.stdin.write(`${JSON.stringify({ id, error: { code: -32603, message } })}\n`);
+  }
+
+  private rejectAll(err: Error): void {
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(err);
+    }
+    this.pending.clear();
+  }
+}

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -1,8 +1,11 @@
-import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { buildCodexAppServerArgs } from "../agents/providers/codex-app-server.js";
+import {
+  JsonRpcStdioClient,
+  type JsonRpcRequest,
+} from "../agents/providers/json-rpc-stdio.js";
 import {
   getAllProviderInfo,
   providerSupportsAppServer,
@@ -36,29 +39,12 @@ export interface ProviderUsageResponse {
   generatedAt: string;
 }
 
-interface JsonRpcResponse {
-  id: number;
-  result?: unknown;
-  error?: { message?: string };
-}
-
-interface JsonRpcRequest {
-  id: number;
-  method: string;
-  params?: unknown;
-}
-
-interface JsonRpcNotification {
-  method: string;
-  params?: unknown;
-}
-
-type JsonRpcMessage = JsonRpcResponse | JsonRpcRequest | JsonRpcNotification;
-
 interface CodexRateLimitWindow {
   usedPercent?: unknown;
+  usagePercent?: unknown;
   windowDurationMins?: unknown;
   resetsAt?: unknown;
+  resetAt?: unknown;
 }
 
 interface CodexRateLimitBucket {
@@ -109,19 +95,25 @@ let claudeBackoffUntil = 0;
 export async function getProviderUsageSnapshot(): Promise<ProviderUsageResponse> {
   const providerInfo = getAllProviderInfo();
   const generatedAt = new Date().toISOString();
-  const providers: ProviderUsageEntry[] = [];
+  const providerTasks: Array<Promise<ProviderUsageEntry>> = [];
 
   const codex = providerInfo.find((provider) => provider.id === "codex");
   if (codex) {
-    providers.push(await getCodexUsage(codex.label, codex.installed));
+    providerTasks.push(getCodexUsage(codex.label, codex.installed));
   }
 
   const claude = providerInfo.find((provider) => provider.id === "claude");
   if (claude) {
-    providers.push(await getClaudeUsage(claude.label, claude.installed, claude.version));
+    providerTasks.push(getClaudeUsage(claude.label, claude.installed, claude.version));
   }
 
+  const providers = await Promise.all(providerTasks);
   return { providers, generatedAt };
+}
+
+export function stopProviderUsagePolling(): void {
+  codexClient?.close();
+  codexClient = null;
 }
 
 async function getCodexUsage(label: string, installed: boolean): Promise<ProviderUsageEntry> {
@@ -346,7 +338,11 @@ function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
   const byLimitId = asRecord(record?.rateLimitsByLimitId);
   const source = byLimitId && Object.keys(byLimitId).length > 0
     ? Object.values(byLimitId)
-    : [record?.rateLimits];
+    : [
+        record?.rateLimits,
+        record?.rateLimit,
+        record,
+      ];
 
   return source
     .map((value) => parseCodexRateLimitBucket(asRecord(value) as CodexRateLimitBucket | null))
@@ -356,15 +352,15 @@ function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
 function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): ProviderUsageBucket | null {
   if (!bucket) return null;
   const primary = asRecord(bucket.primary) as CodexRateLimitWindow | null;
-  const id = asString(bucket.limitId) ?? asString(bucket.limitName);
+  const id = asString(bucket.limitId) ?? asString(bucket.limitName) ?? (primary ? "codex" : null);
   if (!id || !primary) return null;
 
   return {
     id,
     label: asString(bucket.limitName),
-    usedPercent: normalizePercent(primary.usedPercent),
+    usedPercent: normalizePercent(primary.usedPercent ?? primary.usagePercent),
     windowDurationMins: asNumber(primary.windowDurationMins),
-    resetsAt: asNumber(primary.resetsAt),
+    resetsAt: parseResetTimestamp(primary.resetsAt ?? primary.resetAt),
     planType: asString(bucket.planType),
     credits: bucket.credits,
     rateLimitReachedType: asString(bucket.rateLimitReachedType),
@@ -440,144 +436,102 @@ class ClaudeUsageHttpError extends Error {
 }
 
 export const __providerUsageTestHooks = {
+  parseCodexRateLimitBuckets,
   parseClaudeUsageBuckets,
   parseResetTimestamp,
   resetProviderUsageCaches() {
     codexUsageCache = null;
     claudeUsageCache = null;
     claudeBackoffUntil = 0;
+    stopProviderUsagePolling();
   },
 };
 
 class CodexUsageClient {
-  private proc: ChildProcessWithoutNullStreams | null = null;
+  private rpc: JsonRpcStdioClient | null = null;
   private initialized: Promise<void> | null = null;
-  private buffer = "";
-  private nextId = 1;
-  private readonly pending = new Map<number, {
-    method: string;
-    timer: NodeJS.Timeout;
-    resolve: (value: unknown) => void;
-    reject: (err: Error) => void;
-  }>();
 
   async readRateLimits(): Promise<unknown> {
     await this.ensureInitialized();
-    return this.request("account/rateLimits/read");
+    return this.rpc?.request("account/rateLimits/read")
+      ?? Promise.reject(new Error("Codex app-server is not running"));
+  }
+
+  close(): void {
+    this.closeWithError(new Error("Codex usage polling stopped"));
+  }
+
+  private closeWithError(err: Error): void {
+    this.rpc?.close(err);
+    this.rpc = null;
+    this.initialized = null;
   }
 
   private async ensureInitialized(): Promise<void> {
     if (this.initialized) return this.initialized;
 
     this.initialized = (async () => {
-      this.proc = spawn("codex", buildCodexAppServerArgs(false), {
-        stdio: ["pipe", "pipe", "pipe"],
+      const rpc = new JsonRpcStdioClient({
+        command: "codex",
+        args: buildCodexAppServerArgs(false),
         env: buildWorkspaceEnv(),
+        requestTimeoutMs: CODEX_REQUEST_TIMEOUT_MS,
+        closeOnRequestTimeout: true,
       });
-      this.proc.stdout.on("data", (chunk: Buffer) => this.onStdout(chunk.toString("utf8")));
-      this.proc.stderr.on("data", () => {
+      this.rpc = rpc;
+      rpc.on("stderr", () => {
         // Account usage is best-effort. Stderr is intentionally not surfaced unless a request fails.
       });
-      this.proc.on("error", (err) => this.rejectAll(err));
-      this.proc.on("close", (code) => {
-        this.rejectAll(new Error(`Codex app-server exited with code ${code ?? 1}`));
-        this.proc = null;
-        this.initialized = null;
+      rpc.on("error", (err) => {
+        if (this.rpc === rpc) {
+          this.closeWithError(err);
+        }
       });
+      rpc.on("close", () => {
+        if (this.rpc === rpc) {
+          this.rpc = null;
+          this.initialized = null;
+        }
+      });
+      rpc.on("request", (request) => this.rejectUnsupportedRequest(request));
+      rpc.on("notification", (notification) => {
+        if (notification.method === "account/rateLimits/updated") {
+          this.cacheRateLimits(notification.params);
+        }
+      });
+      rpc.start();
 
-      await this.request("initialize", {
-        clientInfo: CLIENT_INFO,
-        capabilities: { experimentalApi: true },
-      });
-      this.notify("initialized");
+      try {
+        await rpc.request("initialize", {
+          clientInfo: CLIENT_INFO,
+          capabilities: { experimentalApi: true },
+        });
+        rpc.notify("initialized");
+      } catch (err) {
+        if (this.rpc === rpc) {
+          this.close();
+        }
+        throw err;
+      }
     })();
 
     return this.initialized;
   }
 
-  private request(method: string, params?: unknown): Promise<unknown> {
-    const proc = this.proc;
-    if (!proc || !proc.stdin.writable) {
-      return Promise.reject(new Error("Codex app-server is not running"));
-    }
-
-    const id = this.nextId++;
-    const payload = { id, method, ...(params !== undefined ? { params } : {}) };
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        this.pending.delete(id);
-        reject(new Error(`${method} timed out`));
-      }, CODEX_REQUEST_TIMEOUT_MS);
-      this.pending.set(id, { method, timer, resolve, reject });
-      proc.stdin.write(`${JSON.stringify(payload)}\n`);
-    });
+  private rejectUnsupportedRequest(request: JsonRpcRequest): void {
+    this.rpc?.respondError(request.id, `${request.method} is not supported by Hive usage polling`);
   }
 
-  private notify(method: string, params?: unknown): void {
-    this.proc?.stdin.write(`${JSON.stringify({ method, ...(params !== undefined ? { params } : {}) })}\n`);
-  }
-
-  private onStdout(chunk: string): void {
-    this.buffer += chunk;
-    const lines = this.buffer.split("\n");
-    this.buffer = lines.pop() ?? "";
-
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      this.handleMessage(trimmed);
+  private cacheRateLimits(params: unknown): void {
+    const entry = {
+      id: "codex",
+      label: "Codex",
+      status: "available" as const,
+      buckets: parseCodexRateLimitBuckets(params),
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    if (entry.buckets.length > 0) {
+      codexUsageCache = { value: entry, expiresAt: Date.now() + CODEX_USAGE_CACHE_TTL_MS };
     }
-  }
-
-  private handleMessage(line: string): void {
-    let message: JsonRpcMessage;
-    try {
-      message = JSON.parse(line) as JsonRpcMessage;
-    } catch {
-      return;
-    }
-
-    if ("id" in message && "method" in message) {
-      this.respondError(message.id, `${message.method} is not supported by Hive usage polling`);
-      return;
-    }
-
-    if ("id" in message) {
-      const pending = this.pending.get(message.id);
-      if (!pending) return;
-      this.pending.delete(message.id);
-      clearTimeout(pending.timer);
-      if (message.error) {
-        pending.reject(new Error(message.error.message ?? `${pending.method} failed`));
-      } else {
-        pending.resolve(message.result);
-      }
-      return;
-    }
-
-    if ("method" in message && message.method === "account/rateLimits/updated") {
-      const entry = {
-        id: "codex",
-        label: "Codex",
-        status: "available" as const,
-        buckets: parseCodexRateLimitBuckets(message.params),
-        lastUpdatedAt: new Date().toISOString(),
-      };
-      if (entry.buckets.length > 0) {
-        codexUsageCache = { value: entry, expiresAt: Date.now() + CODEX_USAGE_CACHE_TTL_MS };
-      }
-    }
-  }
-
-  private respondError(id: number, message: string): void {
-    this.proc?.stdin.write(`${JSON.stringify({ id, error: { code: -32603, message } })}\n`);
-  }
-
-  private rejectAll(err: Error): void {
-    for (const pending of this.pending.values()) {
-      clearTimeout(pending.timer);
-      pending.reject(err);
-    }
-    this.pending.clear();
   }
 }

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -1,0 +1,124 @@
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useProviderUsage, type ProviderUsageBucket, type ProviderUsageEntry } from "@/hooks/useProviderUsage";
+import { usageStrokeColor } from "@/lib/format-usage";
+import { cn } from "@/lib/utils";
+
+interface ProviderUsageSummary {
+  provider: ProviderUsageEntry;
+  bucket: ProviderUsageBucket | null;
+  percent: number | null;
+}
+
+export function ProviderUsage() {
+  const { data } = useProviderUsage();
+  const summaries = (data?.providers ?? [])
+    .filter((provider) => provider.status !== "unavailable")
+    .map((provider) => {
+      const bucket = pickPrimaryBucket(provider.buckets);
+      return {
+        provider,
+        bucket,
+        percent: bucket?.usedPercent ?? null,
+      };
+    });
+
+  if (summaries.length === 0) return null;
+
+  const tooltip = summaries.map(formatTooltipLine).join("\n");
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div className="flex cursor-default items-center gap-2 overflow-hidden">
+            {summaries.map((summary) => (
+              <ProviderUsageRow
+                key={summary.provider.id}
+                summary={summary}
+              />
+            ))}
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-72 whitespace-pre-line">
+          {tooltip}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function ProviderUsageRow({ summary }: { summary: ProviderUsageSummary }) {
+  const { provider, percent } = summary;
+  const color = percent === null ? undefined : usageStrokeColor(percent / 100);
+  const label = provider.id === "claude" ? "Claude" : provider.label;
+  const value = percent === null ? statusLabel(provider.status) : `${percent}%`;
+
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <span
+        className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
+        style={{ backgroundColor: color }}
+      />
+      <span className="truncate text-[10px] font-medium text-muted-foreground">
+        {label}
+      </span>
+      <span
+        className={cn(
+          "shrink-0 text-[10px] font-medium",
+          provider.status === "error" ? "text-red-400" : "text-muted-foreground",
+        )}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function pickPrimaryBucket(buckets: ProviderUsageBucket[]): ProviderUsageBucket | null {
+  if (buckets.length === 0) return null;
+  return [...buckets].sort((a, b) => (b.usedPercent ?? -1) - (a.usedPercent ?? -1))[0] ?? null;
+}
+
+function statusLabel(status: ProviderUsageEntry["status"]): string {
+  if (status === "error") return "err";
+  return "n/a";
+}
+
+function formatTooltipLine(summary: ProviderUsageSummary): string {
+  const { provider, bucket, percent } = summary;
+  const bucketDetails = provider.buckets.length > 1
+    ? provider.buckets.map(formatBucketDetail).join(" · ")
+    : null;
+  const details = [
+    bucketDetails,
+    bucketDetails ? null : percent === null ? statusLabel(provider.status) : `${percent}% used`,
+    bucketDetails ? null : bucket?.resetsAt ? `resets ${formatReset(bucket.resetsAt)}` : null,
+    bucketDetails ? null : bucket?.windowDurationMins ? `${bucket.windowDurationMins}m window` : null,
+    bucket?.planType ? bucket.planType : null,
+    provider.message,
+  ].filter(Boolean);
+
+  return `${provider.label}: ${details.join(" · ") || "usage unavailable"}`;
+}
+
+function formatBucketDetail(bucket: ProviderUsageBucket): string {
+  const label = bucket.label ?? bucket.id;
+  const percent = bucket.usedPercent === null ? "n/a" : `${bucket.usedPercent}%`;
+  const reset = bucket.resetsAt ? ` resets ${formatReset(bucket.resetsAt)}` : "";
+  return `${label} ${percent}${reset}`;
+}
+
+function formatReset(resetsAtSeconds: number): string {
+  const deltaMs = resetsAtSeconds * 1000 - Date.now();
+  if (deltaMs <= 0) return "now";
+  const minutes = Math.round(deltaMs / 60_000);
+  if (minutes < 60) return `in ${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  const rest = minutes % 60;
+  return rest === 0 ? `in ${hours}h` : `in ${hours}h ${rest}m`;
+}

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -6,7 +6,6 @@ import {
 } from "@/components/ui/tooltip";
 import { useProviderUsage, type ProviderUsageBucket, type ProviderUsageEntry } from "@/hooks/useProviderUsage";
 import { usageStrokeColor } from "@/lib/format-usage";
-import { cn } from "@/lib/utils";
 
 interface ProviderUsageSummary {
   provider: ProviderUsageEntry;
@@ -29,13 +28,11 @@ export function ProviderUsage() {
 
   if (summaries.length === 0) return null;
 
-  const tooltip = summaries.map(formatTooltipLine).join("\n");
-
   return (
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex cursor-default items-center gap-2 overflow-hidden">
+          <div className="grid w-full cursor-default grid-cols-3 items-center gap-2.5">
             {summaries.map((summary) => (
               <ProviderUsageRow
                 key={summary.provider.id}
@@ -44,8 +41,18 @@ export function ProviderUsage() {
             ))}
           </div>
         </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-72 whitespace-pre-line">
-          {tooltip}
+        <TooltipContent
+          side="top"
+          className="w-64 max-w-[calc(100vw-2rem)] bg-zinc-950 px-2.5 py-2 text-zinc-100 shadow-lg [&>svg]:!bg-zinc-950 [&>svg]:!fill-zinc-950"
+        >
+          <div className="grid gap-1.5">
+            {summaries.map((summary) => (
+              <ProviderUsageDetails
+                key={summary.provider.id}
+                summary={summary}
+              />
+            ))}
+          </div>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -56,24 +63,99 @@ function ProviderUsageRow({ summary }: { summary: ProviderUsageSummary }) {
   const { provider, percent } = summary;
   const color = percent === null ? undefined : usageStrokeColor(percent / 100);
   const label = provider.id === "claude" ? "Claude" : provider.label;
-  const value = percent === null ? statusLabel(provider.status) : `${percent}%`;
 
   return (
     <div className="flex min-w-0 items-center gap-1">
-      <span
-        className="h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground/40"
-        style={{ backgroundColor: color }}
-      />
-      <span className="truncate text-[10px] font-medium text-muted-foreground">
+      <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
         {label}
       </span>
-      <span
-        className={cn(
-          "shrink-0 text-[10px] font-medium",
-          provider.status === "error" ? "text-red-400" : "text-muted-foreground",
-        )}
-      >
-        {value}
+      <div className="h-1 min-w-8 flex-1 overflow-hidden rounded-full bg-border dark:bg-muted/40">
+        <div
+          className="h-full rounded-full transition-[width] duration-700 ease-out"
+          style={{
+            width: percent === null ? "0%" : `${percent}%`,
+            backgroundColor: color,
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function ProviderUsageDetails({ summary }: { summary: ProviderUsageSummary }) {
+  const { provider } = summary;
+  const buckets = provider.buckets.length > 0 ? sortProviderBuckets(provider) : [null];
+
+  return (
+    <div className="grid gap-1.5">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-zinc-500">
+        {provider.id === "claude" ? "Claude" : provider.label}
+      </div>
+      <div className="grid gap-1">
+        {buckets.map((bucket, index) => (
+          <ProviderUsageBucketDetail
+            key={bucket?.id ?? `${provider.id}-${index}`}
+            provider={provider}
+            bucket={bucket}
+          />
+        ))}
+      </div>
+      {provider.message ? (
+        <div className="max-w-full truncate text-[10px] leading-snug text-zinc-400">
+          {provider.message}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ProviderUsageBucketDetail({
+  provider,
+  bucket,
+}: {
+  provider: ProviderUsageEntry;
+  bucket: ProviderUsageBucket | null;
+}) {
+  if (!bucket) {
+    return (
+      <div className="grid grid-cols-[5.5rem_1fr_2.25rem] items-center gap-2 text-[10px]">
+        <span className="truncate font-medium text-zinc-200">
+          {provider.id === "claude" ? "Claude" : provider.label}
+        </span>
+        <div className="h-1 overflow-hidden rounded-full bg-zinc-700" />
+        <span className="text-right tabular-nums text-zinc-400">
+          {statusLabel(provider.status)}
+        </span>
+      </div>
+    );
+  }
+
+  const percent = bucket.usedPercent === null ? null : bucket.usedPercent;
+  const color = percent === null ? undefined : usageStrokeColor(percent / 100);
+  const providerLabel = provider.id === "claude" ? "Claude" : provider.label;
+  const bucketLabel = bucket.label ?? (bucket.id === provider.id ? null : bucket.id);
+  const label = provider.buckets.length > 1 && bucketLabel
+    ? `${providerLabel} ${bucketLabel}`
+    : providerLabel;
+  const reset = bucket.resetsAt ? formatCompactReset(bucket.resetsAt) : null;
+
+  return (
+    <div className="grid grid-cols-[5.5rem_1fr_4rem] items-center gap-2 text-[10px]">
+      <span className="min-w-0 truncate font-medium text-zinc-200">
+        {label}
+      </span>
+      <div className="h-1 overflow-hidden rounded-full bg-zinc-700">
+        <div
+          className="h-full rounded-full"
+          style={{
+            width: percent === null ? "0%" : `${percent}%`,
+            backgroundColor: color,
+          }}
+        />
+      </div>
+      <span className="text-right tabular-nums text-zinc-400">
+        {percent === null ? "n/a" : `${percent}%`}
+        {reset ? ` ${reset}` : ""}
       </span>
     </div>
   );
@@ -84,41 +166,23 @@ function pickPrimaryBucket(buckets: ProviderUsageBucket[]): ProviderUsageBucket 
   return [...buckets].sort((a, b) => (b.usedPercent ?? -1) - (a.usedPercent ?? -1))[0] ?? null;
 }
 
+function sortProviderBuckets(provider: ProviderUsageEntry): ProviderUsageBucket[] {
+  return [...provider.buckets].sort((a, b) => {
+    if (a.id === provider.id && b.id !== provider.id) return -1;
+    if (b.id === provider.id && a.id !== provider.id) return 1;
+    return 0;
+  });
+}
+
 function statusLabel(status: ProviderUsageEntry["status"]): string {
   if (status === "error") return "err";
   return "n/a";
 }
 
-function formatTooltipLine(summary: ProviderUsageSummary): string {
-  const { provider, bucket, percent } = summary;
-  const bucketDetails = provider.buckets.length > 1
-    ? provider.buckets.map(formatBucketDetail).join(" · ")
-    : null;
-  const details = [
-    bucketDetails,
-    bucketDetails ? null : percent === null ? statusLabel(provider.status) : `${percent}% used`,
-    bucketDetails ? null : bucket?.resetsAt ? `resets ${formatReset(bucket.resetsAt)}` : null,
-    bucketDetails ? null : bucket?.windowDurationMins ? `${bucket.windowDurationMins}m window` : null,
-    bucket?.planType ? bucket.planType : null,
-    provider.message,
-  ].filter(Boolean);
-
-  return `${provider.label}: ${details.join(" · ") || "usage unavailable"}`;
-}
-
-function formatBucketDetail(bucket: ProviderUsageBucket): string {
-  const label = bucket.label ?? bucket.id;
-  const percent = bucket.usedPercent === null ? "n/a" : `${bucket.usedPercent}%`;
-  const reset = bucket.resetsAt ? ` resets ${formatReset(bucket.resetsAt)}` : "";
-  return `${label} ${percent}${reset}`;
-}
-
-function formatReset(resetsAtSeconds: number): string {
+function formatCompactReset(resetsAtSeconds: number): string {
   const deltaMs = resetsAtSeconds * 1000 - Date.now();
   if (deltaMs <= 0) return "now";
   const minutes = Math.round(deltaMs / 60_000);
-  if (minutes < 60) return `in ${minutes}m`;
-  const hours = Math.floor(minutes / 60);
-  const rest = minutes % 60;
-  return rest === 0 ? `in ${hours}h` : `in ${hours}h ${rest}m`;
+  if (minutes < 60) return `${minutes}m`;
+  return `${Math.round(minutes / 60)}h`;
 }

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -32,7 +32,10 @@ export function ProviderUsage() {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="grid w-full cursor-default grid-cols-3 items-center gap-2.5">
+          <div
+            className="grid w-full cursor-default items-center gap-2.5"
+            style={{ gridTemplateColumns: `repeat(${summaries.length}, minmax(0, 1fr))` }}
+          >
             {summaries.map((summary) => (
               <ProviderUsageRow
                 key={summary.provider.id}

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -32,10 +32,7 @@ export function ProviderUsage() {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div
-            className="grid w-full cursor-default items-center gap-2.5"
-            style={{ gridTemplateColumns: `repeat(${summaries.length}, minmax(0, 1fr))` }}
-          >
+          <div className="grid w-full grid-cols-3 items-center gap-2.5 cursor-default">
             {summaries.map((summary) => (
               <ProviderUsageRow
                 key={summary.provider.id}
@@ -69,10 +66,10 @@ function ProviderUsageRow({ summary }: { summary: ProviderUsageSummary }) {
 
   return (
     <div className="flex min-w-0 items-center gap-1">
-      <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+      <span className="w-9 shrink-0 truncate text-[10px] font-medium text-muted-foreground">
         {label}
       </span>
-      <div className="h-1 min-w-8 flex-1 overflow-hidden rounded-full bg-border dark:bg-muted/40">
+      <div className="h-1 min-w-0 flex-1 overflow-hidden rounded-full bg-border dark:bg-muted/40">
         <div
           className="h-full rounded-full transition-[width] duration-700 ease-out"
           style={{

--- a/frontend/src/components/ServerMetrics.tsx
+++ b/frontend/src/components/ServerMetrics.tsx
@@ -15,11 +15,11 @@ interface MetricBarProps {
 function MetricBar({ label, percent }: MetricBarProps) {
   const color = usageStrokeColor(percent / 100);
   return (
-    <div className="flex flex-1 items-center gap-1">
-      <span className="shrink-0 text-[10px] font-medium text-muted-foreground">
+    <div className="flex min-w-0 items-center gap-1">
+      <span className="w-9 shrink-0 truncate text-[10px] font-medium text-muted-foreground">
         {label}
       </span>
-      <div className="h-1 flex-1 rounded-full bg-border dark:bg-muted/40">
+      <div className="h-1 min-w-0 flex-1 rounded-full bg-border dark:bg-muted/40">
         <div
           className="h-full rounded-full transition-[width] duration-700 ease-out"
           style={{ width: `${percent}%`, backgroundColor: color }}
@@ -44,7 +44,7 @@ export function ServerMetrics() {
     <TooltipProvider delayDuration={300}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <div className="flex items-center gap-2.5 cursor-default">
+          <div className="grid w-full grid-cols-3 items-center gap-2.5 cursor-default">
             <MetricBar label="CPU" percent={metrics.cpuPercent} />
             <MetricBar label="MEM" percent={metrics.memPercent} />
             <MetricBar label="DSK" percent={metrics.diskPercent} />

--- a/frontend/src/components/SidebarShell.tsx
+++ b/frontend/src/components/SidebarShell.tsx
@@ -19,12 +19,8 @@ export function SidebarShell({ children, footerActions }: SidebarShellProps) {
 
       <div className="shrink-0 border-t border-border">
         {footerActions}
-        <div className="mx-2 border-t border-border" />
-        <div className="px-3 pt-1.5">
+        <div className="grid gap-2 border-t border-border px-3 py-2">
           <ProviderUsage />
-        </div>
-        <div className="mx-2 mt-1.5 border-t border-border" />
-        <div className="px-3 pb-2 pt-1.5">
           <ServerMetrics />
         </div>
       </div>

--- a/frontend/src/components/SidebarShell.tsx
+++ b/frontend/src/components/SidebarShell.tsx
@@ -1,4 +1,5 @@
 import { ServerMetrics } from "@/components/ServerMetrics";
+import { ProviderUsage } from "@/components/ProviderUsage";
 
 interface SidebarShellProps {
   children: React.ReactNode;
@@ -19,6 +20,10 @@ export function SidebarShell({ children, footerActions }: SidebarShellProps) {
       <div className="shrink-0 border-t border-border">
         {footerActions}
         <div className="mx-2 border-t border-border" />
+        <div className="px-3 pt-1.5">
+          <ProviderUsage />
+        </div>
+        <div className="mx-2 mt-1.5 border-t border-border" />
         <div className="px-3 pb-2 pt-1.5">
           <ServerMetrics />
         </div>

--- a/frontend/src/hooks/useProviderUsage.ts
+++ b/frontend/src/hooks/useProviderUsage.ts
@@ -30,8 +30,8 @@ export function useProviderUsage() {
   return useQuery({
     queryKey: ["provider-usage"],
     queryFn: () => api.get<ProviderUsageResponse>("/api/provider-usage"),
-    refetchInterval: 60_000,
-    staleTime: 30_000,
+    refetchInterval: 120_000,
+    staleTime: 120_000,
     retry: 0,
   });
 }

--- a/frontend/src/hooks/useProviderUsage.ts
+++ b/frontend/src/hooks/useProviderUsage.ts
@@ -1,0 +1,37 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/hooks/useApi";
+
+export interface ProviderUsageBucket {
+  id: string;
+  label: string | null;
+  usedPercent: number | null;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+  planType?: string | null;
+  credits?: unknown;
+  rateLimitReachedType?: string | null;
+}
+
+export interface ProviderUsageEntry {
+  id: string;
+  label: string;
+  status: "available" | "unavailable" | "unknown" | "error";
+  buckets: ProviderUsageBucket[];
+  lastUpdatedAt: string | null;
+  message?: string;
+}
+
+export interface ProviderUsageResponse {
+  providers: ProviderUsageEntry[];
+  generatedAt: string;
+}
+
+export function useProviderUsage() {
+  return useQuery({
+    queryKey: ["provider-usage"],
+    queryFn: () => api.get<ProviderUsageResponse>("/api/provider-usage"),
+    refetchInterval: 60_000,
+    staleTime: 30_000,
+    retry: 0,
+  });
+}

--- a/frontend/tests/components/ProviderUsage.test.tsx
+++ b/frontend/tests/components/ProviderUsage.test.tsx
@@ -44,9 +44,7 @@ describe("ProviderUsage", () => {
     render(<ProviderUsage />);
 
     expect(screen.getByText("Codex")).toBeInTheDocument();
-    expect(screen.getByText("42%")).toBeInTheDocument();
     expect(screen.getByText("Claude")).toBeInTheDocument();
-    expect(screen.getByText("n/a")).toBeInTheDocument();
   });
 
   it("renders nothing when every provider is unavailable", () => {

--- a/frontend/tests/components/ProviderUsage.test.tsx
+++ b/frontend/tests/components/ProviderUsage.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProviderUsage } from "@/components/ProviderUsage";
+
+const mocks = vi.hoisted(() => ({
+  useProviderUsage: vi.fn(),
+}));
+
+vi.mock("@/hooks/useProviderUsage", () => ({
+  useProviderUsage: mocks.useProviderUsage,
+}));
+
+describe("ProviderUsage", () => {
+  it("renders compact usage rows for available providers", () => {
+    mocks.useProviderUsage.mockReturnValue({
+      data: {
+        generatedAt: "2026-06-10T00:00:00.000Z",
+        providers: [
+          {
+            id: "codex",
+            label: "Codex",
+            status: "available",
+            lastUpdatedAt: "2026-06-10T00:00:00.000Z",
+            buckets: [{
+              id: "codex",
+              label: null,
+              usedPercent: 42,
+              windowDurationMins: 60,
+              resetsAt: 1780000000,
+            }],
+          },
+          {
+            id: "claude",
+            label: "Claude Code",
+            status: "unknown",
+            lastUpdatedAt: null,
+            buckets: [],
+            message: "Claude Code OAuth credentials were not found. Run `claude auth login`.",
+          },
+        ],
+      },
+    });
+
+    render(<ProviderUsage />);
+
+    expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(screen.getByText("42%")).toBeInTheDocument();
+    expect(screen.getByText("Claude")).toBeInTheDocument();
+    expect(screen.getByText("n/a")).toBeInTheDocument();
+  });
+
+  it("renders nothing when every provider is unavailable", () => {
+    mocks.useProviderUsage.mockReturnValue({
+      data: {
+        generatedAt: "2026-06-10T00:00:00.000Z",
+        providers: [
+          {
+            id: "codex",
+            label: "Codex",
+            status: "unavailable",
+            lastUpdatedAt: null,
+            buckets: [],
+          },
+        ],
+      },
+    });
+
+    const { container } = render(<ProviderUsage />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});


### PR DESCRIPTION
## Summary
- add a provider usage API and sidebar display for Codex and Claude Code account usage
- read Claude Code OAuth usage from api.anthropic.com/api/oauth/usage with Claude Code headers and no rate_limit_event fallback
- add backend and frontend tests for provider usage rendering and parsing

## Tests
- npm --workspace @hive/backend test -- provider-usage stream-parser
- npm --workspace @hive/backend run typecheck
- npm --workspace @hive/backend run lint
- npm --workspace @hive/frontend test -- ProviderUsage
- npm --workspace @hive/frontend run typecheck
- npm --workspace @hive/frontend run lint