### PR TITLE
Persist chat settings per session

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -3229,15 +3229,27 @@ describe("ConversationSession", () => {
   it("locks provider on first sendMessage based on model prefix", () => {
     const session = createSession({ sessionId: "lock-test" });
 
-    session.sendMessage("Hello", { model: "codex:gpt-5.3-codex" });
+    session.sendMessage("Hello", { model: "codex:gpt-5.3-codex", thinkingLevel: "low" });
     expect(session.metadata.lockedProvider).toBe("codex");
+    expect(session.metadata.lastRunOptions).toEqual({
+      model: "codex:gpt-5.3-codex",
+      planMode: false,
+      thinkingLevel: "low",
+      fastMode: false,
+    });
   });
 
   it("defaults to claude provider when model has no prefix", () => {
     const session = createSession({ sessionId: "lock-default" });
 
-    session.sendMessage("Hello", { model: "opus-4-7" });
+    session.sendMessage("Hello", { model: "opus-4-7", thinkingLevel: "low", fastMode: true });
     expect(session.metadata.lockedProvider).toBe("claude");
+    expect(session.metadata.lastRunOptions).toEqual({
+      model: "claude:opus-4-8",
+      planMode: false,
+      thinkingLevel: "low",
+      fastMode: true,
+    });
   });
 
   it("defaults to claude provider when no model specified", () => {
@@ -3310,6 +3322,12 @@ describe("ConversationSession", () => {
     const raw = await readFile(metaPath, "utf-8");
     const meta = JSON.parse(raw);
     expect(meta.lockedProvider).toBe("claude");
+    expect(meta.lastRunOptions).toEqual({
+      model: "claude:opus-4-8",
+      planMode: false,
+      thinkingLevel: "high",
+      fastMode: false,
+    });
   });
 
   // ── ExitPlanMode dismiss and reject responses ──────────────────────

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -202,6 +202,35 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     };
   }
 
+  private normalizeRunOptions(
+    msgOptions: MessageOptions | undefined,
+    resolved: { provider: AgentProvider; modelId: string },
+  ): MessageOptions {
+    const { provider, modelId } = resolved;
+    const model = provider.models.find((m) => m.id === modelId)
+      ?? provider.models.find((m) => m.isDefault)
+      ?? provider.models[0];
+    const thinkingLevels = provider.capabilities.thinkingLevels;
+    const thinkingLevel = thinkingLevels.length > 0
+      ? (msgOptions?.thinkingLevel && thinkingLevels.includes(msgOptions.thinkingLevel)
+          ? msgOptions.thinkingLevel
+          : (thinkingLevels.includes("high") ? "high" : thinkingLevels[0]))
+      : undefined;
+
+    return {
+      model: `${provider.id}:${model?.id ?? modelId}`,
+      planMode: provider.capabilities.planMode ? msgOptions?.planMode === true : false,
+      ...(thinkingLevel ? { thinkingLevel } : {}),
+      fastMode: !!msgOptions?.fastMode && !!model?.supportsFastMode,
+    };
+  }
+
+  private enqueueMetadataPersist(): void {
+    this.persistQueue = this.persistQueue
+      .then(() => this.saveMetadata())
+      .catch((err) => console.error("[session] Persist metadata failed:", err));
+  }
+
   /** Load a session from disk. Returns the session in idle state with history available. */
   static async load(config: ConversationSessionConfig): Promise<ConversationSession> {
     const session = new ConversationSession(config);
@@ -262,6 +291,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       } else if (this._metadata.lockedProvider !== resolved.provider.id) {
         throw new Error(`Provider mismatch: session locked to "${this._metadata.lockedProvider}"`);
       }
+      this._metadata.lastRunOptions = this.normalizeRunOptions(msgOptions, resolved);
+      this._metadata.updatedAt = new Date().toISOString();
+      this.enqueueMetadataPersist();
     }
 
     this._status = "streaming";
@@ -948,9 +980,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
     this._metadata.messageCount = this.messageCount;
     this._metadata.updatedAt = new Date().toISOString();
-    this.persistQueue = this.persistQueue
-      .then(() => this.saveMetadata())
-      .catch((err) => console.error("[session] Persist metadata failed:", err));
+    this.enqueueMetadataPersist();
 
     const unansweredBlockingTools = killedForBlockingTool
       ? this._streamToolCalls.filter((tc) => blockingToolNames.has(tc.name))
@@ -1081,9 +1111,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   setTitle(title: string): void {
     this._metadata.title = title;
     this._metadata.updatedAt = new Date().toISOString();
-    this.persistQueue = this.persistQueue
-      .then(() => this.saveMetadata())
-      .catch((err) => console.error("[session] Persist metadata failed:", err));
+    this.enqueueMetadataPersist();
   }
 
   private async appendMessage(msg: ChatMessage): Promise<void> {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -198,6 +198,8 @@ export interface SessionMetadata {
   messageCount: number;
   /** Provider ID locked on first message (e.g. "claude" or "codex"). */
   lockedProvider?: string;
+  /** Options from the last user message accepted for execution. */
+  lastRunOptions?: MessageOptions;
 }
 
 export interface ToolCall {

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -35,6 +35,10 @@ interface ChatInputProps {
   wsId?: string;
   sessionId?: string;
   lockedProvider?: string;
+  /** Run options of the session's last sent message, used to seed the input
+   *  controls. Read once at mount — the parent remounts this component
+   *  (key={wsId:sessionId}) on session switch, so each session seeds cleanly. */
+  lastRunOptions?: MessageOptions;
   onSend: (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]) => boolean;
   onStop: () => void;
   disabled: boolean;
@@ -88,6 +92,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   wsId,
   sessionId,
   lockedProvider,
+  lastRunOptions,
   onSend,
   onStop,
   disabled,
@@ -100,9 +105,12 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   agentPlanMode,
 }, ref) {
   const [value, setValue] = useState("");
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(DEFAULT_THINKING_LEVEL);
-  const [planMode, setPlanMode] = useState(false);
-  const [fastMode, setFastMode] = useState(false);
+  // Seeded once at mount from the session's last run (see lastRunOptions prop).
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
+    () => lastRunOptions?.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
+  );
+  const [planMode, setPlanMode] = useState(() => lastRunOptions?.planMode ?? false);
+  const [fastMode, setFastMode] = useState(() => lastRunOptions?.fastMode ?? false);
   const [fileCount, setFileCount] = useState(0);
   const [autocomplete, setAutocomplete] = useState<AutocompleteState | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -122,7 +130,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   const isInputDisabled = disabled || isDisconnected || hasQueuedMessage;
   const canSubmit = !isInputDisabled && (value.trim().length > 0 || fileCount > 0);
 
-  const { models, defaultModelId, selectedModelId, selectedModel, setSelectedModelId, capabilities } = useModels(lockedProvider);
+  const { models, selectedModelId, selectedModel, setSelectedModelId, capabilities } = useModels(lockedProvider, lastRunOptions?.model);
   const contextUsage = useContextUsage(messages, selectedModel);
   const completionProvider = lockedProvider ?? (selectedModelId ? selectedModelId.split(":")[0] : undefined);
 
@@ -147,18 +155,9 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     wsId,
     sessionId,
     value,
-    planMode,
-    selectedModelId,
-    defaultModelId,
-    thinkingLevel,
-    fastMode,
     attachmentsRef,
     fileMentions,
     setValue,
-    setPlanMode,
-    setSelectedModelId,
-    setThinkingLevel,
-    setFastMode,
     setFileCount,
     setFileMentions,
   });

--- a/frontend/src/hooks/useChatInputDraftPersistence.ts
+++ b/frontend/src/hooks/useChatInputDraftPersistence.ts
@@ -1,13 +1,9 @@
 import { useCallback, useEffect, useRef, type MutableRefObject, type Dispatch, type SetStateAction } from "react";
 import type { AttachmentsContext } from "@/components/ai-elements/prompt-input";
-import type { FileMention, ThinkingLevel } from "@/types";
+import type { FileMention } from "@/types";
 
 interface DraftState {
   value: string;
-  planMode: boolean;
-  selectedModelId: string;
-  thinkingLevel: ThinkingLevel;
-  fastMode: boolean;
   files: AttachmentsContext["files"];
   fileMentions: FileMention[];
 }
@@ -16,18 +12,9 @@ interface UseChatInputDraftPersistenceParams {
   wsId?: string;
   sessionId?: string;
   value: string;
-  planMode: boolean;
-  selectedModelId: string;
-  defaultModelId: string;
-  thinkingLevel: ThinkingLevel;
-  fastMode: boolean;
   attachmentsRef: MutableRefObject<AttachmentsContext | null>;
   fileMentions: FileMention[];
   setValue: (value: string) => void;
-  setPlanMode: (value: boolean) => void;
-  setSelectedModelId: (value: string) => void;
-  setThinkingLevel: (value: ThinkingLevel) => void;
-  setFastMode: (value: boolean) => void;
   setFileCount: (count: number) => void;
   setFileMentions: Dispatch<SetStateAction<FileMention[]>>;
 }
@@ -69,10 +56,7 @@ function hasPersistableDraft(draft: DraftState): boolean {
   return (
     draft.value.trim().length > 0 ||
     draft.files.length > 0 ||
-    draft.fileMentions.length > 0 ||
-    draft.planMode ||
-    draft.fastMode ||
-    draft.thinkingLevel !== "high"
+    draft.fileMentions.length > 0
   );
 }
 
@@ -102,18 +86,9 @@ export function useChatInputDraftPersistence({
   wsId,
   sessionId,
   value,
-  planMode,
-  selectedModelId,
-  defaultModelId,
-  thinkingLevel,
-  fastMode,
   attachmentsRef,
   fileMentions,
   setValue,
-  setPlanMode,
-  setSelectedModelId,
-  setThinkingLevel,
-  setFastMode,
   setFileCount,
   setFileMentions,
 }: UseChatInputDraftPersistenceParams) {
@@ -121,16 +96,6 @@ export function useChatInputDraftPersistence({
   const prevWsIdRef = useRef<string | undefined>(undefined);
   const valueRef = useRef(value);
   valueRef.current = value;
-  const planModeRef = useRef(planMode);
-  planModeRef.current = planMode;
-  const selectedModelIdRef = useRef(selectedModelId);
-  selectedModelIdRef.current = selectedModelId;
-  const thinkingLevelRef = useRef(thinkingLevel);
-  thinkingLevelRef.current = thinkingLevel;
-  const fastModeRef = useRef(fastMode);
-  fastModeRef.current = fastMode;
-  const defaultModelIdRef = useRef(defaultModelId);
-  defaultModelIdRef.current = defaultModelId;
   const fileMentionsRef = useRef(fileMentions);
   fileMentionsRef.current = fileMentions;
   const wsIdRef = useRef(wsId);
@@ -144,10 +109,6 @@ export function useChatInputDraftPersistence({
     const files = attachmentsRef.current?.files ?? [];
     upsertDraft(options?.targetWsId ?? wsIdRef.current, targetSessionId, {
       value: valueRef.current,
-      planMode: planModeRef.current,
-      selectedModelId: selectedModelIdRef.current,
-      thinkingLevel: thinkingLevelRef.current,
-      fastMode: fastModeRef.current,
       files: [...files],
       fileMentions: [...fileMentionsRef.current],
     }, options?.allowDelete ?? true);
@@ -175,19 +136,11 @@ export function useChatInputDraftPersistence({
       const draft = getWorkspaceDrafts(wsId).get(sessionId);
       if (draft) {
         setValue(draft.value);
-        setPlanMode(draft.planMode);
-        setSelectedModelId(draft.selectedModelId);
-        setThinkingLevel(draft.thinkingLevel);
-        setFastMode(draft.fastMode ?? false);
         attachmentsRef.current?.restore([...draft.files]);
         setFileCount(draft.files.length);
         setFileMentions(draft.fileMentions ?? []);
       } else {
         setValue("");
-        setPlanMode(false);
-        setThinkingLevel("high");
-        setFastMode(false);
-        if (defaultModelIdRef.current) setSelectedModelId(defaultModelIdRef.current);
         attachmentsRef.current?.restore([]);
         setFileCount(0);
         setFileMentions([]);
@@ -202,10 +155,6 @@ export function useChatInputDraftPersistence({
     saveDraftForSession,
     attachmentsRef,
     setValue,
-    setPlanMode,
-    setSelectedModelId,
-    setThinkingLevel,
-    setFastMode,
     setFileCount,
     setFileMentions,
   ]);

--- a/frontend/src/hooks/useConversationColumn.ts
+++ b/frontend/src/hooks/useConversationColumn.ts
@@ -69,6 +69,9 @@ export interface ConversationColumn
   deleteSession: (sessionId: string) => Promise<boolean>;
   refreshSessions: () => void;
   effectiveLockedProvider: string | undefined;
+  activeSession: SessionMetadata | undefined;
+  /** True while the sessions list is still loading (no cached data yet). */
+  sessionsLoading: boolean;
 
   // Tasks + background agents
   tasks: TasksState["tasks"];
@@ -109,13 +112,14 @@ export function useConversationColumn(
     switchSession,
   } = conversation;
 
-  const { sessions, createSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
+  const { sessions, loading: sessionsLoading, createSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
 
   // Mirror iOS: fall back to session metadata when WS hasn't delivered
   // lockedProvider yet.
+  const activeSession = sessions.find((s) => s.sessionId === sessionId);
   const effectiveLockedProvider =
     conversation.lockedProvider ??
-    sessions.find((s) => s.sessionId === sessionId)?.lockedProvider;
+    activeSession?.lockedProvider;
 
   const tabs = useTabs(sessionId, wsId);
   const { activateTab } = tabs;
@@ -224,6 +228,8 @@ export function useConversationColumn(
     deleteSession,
     refreshSessions,
     effectiveLockedProvider,
+    activeSession,
+    sessionsLoading,
     // Tasks + background agents
     tasks,
     currentTask,

--- a/frontend/src/hooks/useModels.ts
+++ b/frontend/src/hooks/useModels.ts
@@ -20,34 +20,73 @@ const FALLBACK_CAPABILITIES: ProviderCapabilities = {
   goals: false,
 };
 
-export function useModels(lockedProvider?: string): UseModelsReturn {
-  const [models, setModels] = useState<ModelCatalogEntry[]>([]);
-  const [defaultModelId, setDefaultModelId] = useState("");
-  const [selectedModelId, setSelectedModelId] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
+// Module-level catalog cache. The model catalog is global and effectively
+// static for a session, so caching it lets ChatInput be remounted per session
+// (key={wsId:sessionId}) without re-fetching /api/models or flashing an empty
+// model selector — the states below seed synchronously from the cache.
+let catalogCache: ModelCatalogResponse | null = null;
+let catalogPromise: Promise<ModelCatalogResponse> | null = null;
 
-  // Track latest lockedProvider so the API callback reads the current value,
-  // not the one captured at mount time (which is often undefined).
+/** Test-only: clear the module-level catalog cache so cases stay isolated. */
+export function __resetModelCatalogCacheForTests(): void {
+  catalogCache = null;
+  catalogPromise = null;
+}
+
+function loadCatalog(): Promise<ModelCatalogResponse> {
+  if (!catalogPromise) {
+    catalogPromise = api.get<ModelCatalogResponse>("/api/models")
+      .then((data) => { catalogCache = data; return data; })
+      .catch((err) => { catalogPromise = null; throw err; });
+  }
+  return catalogPromise;
+}
+
+/** Pick the initial model: caller's preferred id (if valid for the locked
+ *  provider), else the locked provider's default, else the global default. */
+function seedModelId(
+  catalog: ModelCatalogResponse,
+  lockedProvider: string | undefined,
+  preferredModelId: string | undefined,
+): string {
+  if (preferredModelId) {
+    const match = catalog.models.find(
+      (m) => m.id === preferredModelId && (!lockedProvider || m.provider === lockedProvider),
+    );
+    if (match) return match.id;
+  }
+  if (lockedProvider) {
+    const providerDefault = catalog.models.find((m) => m.provider === lockedProvider && m.isDefault)
+      ?? catalog.models.find((m) => m.provider === lockedProvider);
+    if (providerDefault) return providerDefault.id;
+  }
+  return catalog.defaultModelId;
+}
+
+export function useModels(lockedProvider?: string, preferredModelId?: string): UseModelsReturn {
+  const [models, setModels] = useState<ModelCatalogEntry[]>(() => catalogCache?.models ?? []);
+  const [defaultModelId, setDefaultModelId] = useState(() => catalogCache?.defaultModelId ?? "");
+  const [selectedModelId, setSelectedModelId] = useState(() =>
+    catalogCache ? seedModelId(catalogCache, lockedProvider, preferredModelId) : "");
+  const [isLoading, setIsLoading] = useState(!catalogCache);
+
+  // Track latest values so the async seed reads current props, not the ones
+  // captured at mount time (lockedProvider is often undefined on first render).
   const lockedProviderRef = useRef(lockedProvider);
   lockedProviderRef.current = lockedProvider;
+  const preferredModelIdRef = useRef(preferredModelId);
+  preferredModelIdRef.current = preferredModelId;
 
   useEffect(() => {
+    if (catalogCache) return; // already seeded synchronously from cache
     let cancelled = false;
-    api.get<ModelCatalogResponse>("/api/models")
+    loadCatalog()
       .then((data) => {
         if (cancelled) return;
         setModels(data.models);
         setDefaultModelId(data.defaultModelId);
-        setSelectedModelId((prev) => {
-          if (prev) return prev;
-          const lp = lockedProviderRef.current;
-          if (lp) {
-            const providerDefault = data.models.find((m) => m.provider === lp && m.isDefault)
-              ?? data.models.find((m) => m.provider === lp);
-            if (providerDefault) return providerDefault.id;
-          }
-          return data.defaultModelId;
-        });
+        setSelectedModelId((prev) =>
+          prev || seedModelId(data, lockedProviderRef.current, preferredModelIdRef.current));
         setIsLoading(false);
       })
       .catch(() => {

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -166,6 +166,8 @@ export default function BrainView() {
     // Sessions
     sessions,
     effectiveLockedProvider,
+    activeSession,
+    sessionsLoading,
     // Tasks + background agents
     tasks,
     currentTask,
@@ -408,11 +410,17 @@ export default function BrainView() {
               onBatchAnswerQuestions={batchAnswerQuestions}
               onDismissQuestion={() => rejectToolInput("[question_dismissed]")}
               chatInput={
+                // Mount only once sessions have settled so lastRunOptions can
+                // seed the controls; key by session so each switch remounts and
+                // re-seeds cleanly (no syncing effect).
+                sessionsLoading ? null : (
                 <ChatInput
+                  key={`${BRAIN_WORKSPACE_ID}:${sessionId ?? "new"}`}
                   ref={chatInputRef}
                   wsId={BRAIN_WORKSPACE_ID}
                   sessionId={sessionId}
                   lockedProvider={effectiveLockedProvider}
+                  lastRunOptions={activeSession?.lastRunOptions}
                   onSend={handleSend}
                   onStop={stopStreaming}
                   disabled={false}
@@ -426,6 +434,7 @@ export default function BrainView() {
                   }}
                   agentPlanMode={agentPlanMode}
                 />
+                )
               }
             />
             {isFileTabActive && openFile && (

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -236,6 +236,8 @@ export default function WorkspaceView() {
     createSession,
     refreshSessions,
     effectiveLockedProvider,
+    activeSession,
+    sessionsLoading,
     // Tasks + background agents
     tasks,
     currentTask,
@@ -630,11 +632,17 @@ export default function WorkspaceView() {
               ) : undefined
             }
             chatInput={
+              // Mount only once the sessions list has settled so lastRunOptions
+              // is available to seed the controls; key by session so each
+              // switch remounts and re-seeds cleanly (no syncing effect).
+              sessionsLoading ? null : (
               <ChatInput
+                key={`${wsId}:${sessionId ?? "new"}`}
                 ref={chatInputRef}
                 wsId={wsId}
                 sessionId={sessionId}
                 lockedProvider={effectiveLockedProvider}
+                lastRunOptions={activeSession?.lastRunOptions}
                 onSend={handleSend}
                 onStop={stopStreaming}
                 disabled={false}
@@ -646,6 +654,7 @@ export default function WorkspaceView() {
                 onQueue={(msg) => { setQueuedMessage(msg); bumpScrollToBottom(); }}
                 agentPlanMode={agentPlanMode}
               />
+              )
             }
           />
           {isFileTabActive && openFile && wsId && (

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -210,6 +210,8 @@ export interface SessionMetadata {
   updatedAt: string;
   messageCount: number;
   lockedProvider?: string;
+  /** Options from the last user message accepted for execution. */
+  lastRunOptions?: MessageOptions;
 }
 
 export interface ToolCall {

--- a/frontend/tests/components/ChatInput.persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.persistence.test.tsx
@@ -194,32 +194,39 @@ describe("ChatInput draft persistence", () => {
     expect(inputValue()).toBe("draft from ws-a");
   });
 
-  it("persists thinking/plan toggles per session", async () => {
+  // Run options (plan/thinking/fast/model) are no longer drafted; they are
+  // seeded once at mount from the session's lastRunOptions. The parent remounts
+  // ChatInput per session (key={wsId:sessionId}), so each session seeds cleanly.
+  it("seeds plan mode and thinking level from lastRunOptions at mount", async () => {
     const user = userEvent.setup();
     const onSend = vi.fn(() => true);
-    const { a: sessionA, b: sessionB } = makeSessionIds();
-    const { rerender } = renderChatInput(sessionA, undefined, onSend);
+    render(
+      <ChatInput
+        {...chatInputProps({ sessionId: nextId("sess"), onSend })}
+        lastRunOptions={{ planMode: true, thinkingLevel: "xhigh", fastMode: false }}
+      />,
+    );
 
-    // Default "high" + one click -> "xhigh"
-    await user.click(screen.getByRole("button", { name: /^Thinking:/ }));
-    await user.click(screen.getByRole("button", { name: "Toggle plan mode" }));
-
-    rerenderChatInput(rerender, { sessionId: sessionB, onSend });
-    await user.type(getInput(), "session b");
+    await user.type(getInput(), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 
-    expect(onSend).toHaveBeenLastCalledWith("session b", undefined, {
-      planMode: false,
-      thinkingLevel: "high",
-    }, undefined);
-
-    rerenderChatInput(rerender, { sessionId: sessionA, onSend });
-    await user.type(getInput(), "session a");
-    await user.click(screen.getByRole("button", { name: "Send" }));
-
-    expect(onSend).toHaveBeenLastCalledWith("session a", undefined, {
+    expect(onSend).toHaveBeenLastCalledWith("hello", undefined, {
       planMode: true,
       thinkingLevel: "xhigh",
+    }, undefined);
+  });
+
+  it("seeds defaults when the session has no lastRunOptions", async () => {
+    const user = userEvent.setup();
+    const onSend = vi.fn(() => true);
+    render(<ChatInput {...chatInputProps({ sessionId: nextId("sess"), onSend })} />);
+
+    await user.type(getInput(), "hi");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(onSend).toHaveBeenLastCalledWith("hi", undefined, {
+      planMode: false,
+      thinkingLevel: "high",
     }, undefined);
   });
 

--- a/frontend/tests/hooks/useChatInputDraftPersistence.test.tsx
+++ b/frontend/tests/hooks/useChatInputDraftPersistence.test.tsx
@@ -3,7 +3,7 @@ import { useRef, useState, type MutableRefObject, type RefObject } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { FileUIPart } from "ai";
 import type { AttachmentsContext } from "@/components/ai-elements/prompt-input";
-import type { FileMention, ThinkingLevel } from "@/types";
+import type { FileMention } from "@/types";
 import { useChatInputDraftPersistence } from "@/hooks/useChatInputDraftPersistence";
 
 type AttachmentFile = FileUIPart & { id: string };
@@ -42,12 +42,11 @@ function createAttachmentsContext(initialFiles: AttachmentFile[] = []): Attachme
   return context;
 }
 
+// The draft hook only owns text, files, and file mentions. Run options
+// (model, plan mode, thinking level, fast mode) are seeded from the session's
+// lastRunOptions in ChatInput, not persisted as drafts.
 function useDraftHarness({ wsId, sessionId }: { wsId?: string; sessionId?: string }) {
   const [value, setValue] = useState("");
-  const [planMode, setPlanMode] = useState(false);
-  const [selectedModelId, setSelectedModelId] = useState("");
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("high");
-  const [fastMode, setFastMode] = useState(false);
   const [fileCount, setFileCount] = useState(0);
   const [fileMentions, setFileMentions] = useState<FileMention[]>([]);
   const attachmentsRef = useRef<AttachmentsContext | null>(null);
@@ -66,35 +65,18 @@ function useDraftHarness({ wsId, sessionId }: { wsId?: string; sessionId?: strin
     wsId,
     sessionId,
     value,
-    planMode,
-    selectedModelId,
-    defaultModelId: "claude:opus-4-7",
-    thinkingLevel,
-    fastMode,
     attachmentsRef: attachmentsRef as MutableRefObject<AttachmentsContext | null>,
     fileMentions,
     setValue,
-    setPlanMode,
-    setSelectedModelId,
-    setThinkingLevel,
-    setFastMode,
     setFileCount,
     setFileMentions,
   });
 
   return {
     value,
-    planMode,
-    selectedModelId,
-    thinkingLevel,
-    fastMode,
     fileCount,
     fileMentions,
     setValue,
-    setPlanMode,
-    setSelectedModelId,
-    setThinkingLevel,
-    setFastMode,
     setFileMentions,
     setFiles,
     attachments: attachmentsRef.current,
@@ -125,7 +107,7 @@ afterEach(() => {
 });
 
 describe("useChatInputDraftPersistence", () => {
-  it("restores text, toggles, and files when returning to a session", () => {
+  it("restores text and files when returning to a session", () => {
     const wsId = nextId("ws");
     const sessionA = nextId("sess-a");
     const sessionB = nextId("sess-b");
@@ -139,21 +121,15 @@ describe("useChatInputDraftPersistence", () => {
 
     act(() => {
       result.current.setValue("draft A");
-      result.current.setThinkingLevel("low");
-      result.current.setPlanMode(true);
       result.current.setFiles([fileA]);
     });
 
     rerender({ currentSessionId: sessionB });
     expect(result.current.value).toBe("");
-    expect(result.current.thinkingLevel).toBe("high");
-    expect(result.current.planMode).toBe(false);
     expect(result.current.fileCount).toBe(0);
 
     rerender({ currentSessionId: sessionA });
     expect(result.current.value).toBe("draft A");
-    expect(result.current.thinkingLevel).toBe("low");
-    expect(result.current.planMode).toBe(true);
     expect(result.current.fileCount).toBe(1);
     expect(result.current.attachments?.files).toEqual([fileA]);
   });
@@ -183,7 +159,9 @@ describe("useChatInputDraftPersistence", () => {
     expect(result.current.value).toBe("workspace A draft");
   });
 
-  it("persists toggle-only drafts when plan mode is enabled", () => {
+  it("does not persist a toggle-only intent (no text/files/mentions)", () => {
+    // Run options are no longer drafted, so an empty input never persists,
+    // regardless of any control toggles the user flipped without typing.
     const wsId = nextId("ws");
     const sessionA = nextId("sess-a");
     const sessionB = nextId("sess-b");
@@ -194,62 +172,14 @@ describe("useChatInputDraftPersistence", () => {
       { initialProps: { currentSessionId: sessionA } },
     );
 
-    act(() => {
-      result.current.setPlanMode(true);
-    });
-
+    // No text typed.
     rerender({ currentSessionId: sessionB });
-    expect(result.current.planMode).toBe(false);
-
     rerender({ currentSessionId: sessionA });
-    expect(result.current.planMode).toBe(true);
+    expect(result.current.value).toBe("");
+    expect(result.current.fileCount).toBe(0);
   });
 
-  it("persists toggle-only drafts when thinking level differs from default", () => {
-    const wsId = nextId("ws");
-    const sessionA = nextId("sess-a");
-    const sessionB = nextId("sess-b");
-
-    const { result, rerender } = renderHook(
-      ({ currentSessionId }: { currentSessionId?: string }) =>
-        useDraftHarness({ wsId, sessionId: currentSessionId }),
-      { initialProps: { currentSessionId: sessionA } },
-    );
-
-    act(() => {
-      result.current.setThinkingLevel("low");
-    });
-
-    rerender({ currentSessionId: sessionB });
-    expect(result.current.thinkingLevel).toBe("high");
-
-    rerender({ currentSessionId: sessionA });
-    expect(result.current.thinkingLevel).toBe("low");
-  });
-
-  it("persists and restores fast mode per session", () => {
-    const wsId = nextId("ws");
-    const sessionA = nextId("sess-a");
-    const sessionB = nextId("sess-b");
-
-    const { result, rerender } = renderHook(
-      ({ currentSessionId }: { currentSessionId?: string }) =>
-        useDraftHarness({ wsId, sessionId: currentSessionId }),
-      { initialProps: { currentSessionId: sessionA } },
-    );
-
-    act(() => {
-      result.current.setFastMode(true);
-    });
-
-    rerender({ currentSessionId: sessionB });
-    expect(result.current.fastMode).toBe(false);
-
-    rerender({ currentSessionId: sessionA });
-    expect(result.current.fastMode).toBe(true);
-  });
-
-  it("deletes empty drafts after a switch when defaults are restored", () => {
+  it("deletes empty drafts after a switch", () => {
     const wsId = nextId("ws");
     const sessionA = nextId("sess-a");
     const sessionB = nextId("sess-b");
@@ -270,8 +200,6 @@ describe("useChatInputDraftPersistence", () => {
 
     act(() => {
       result.current.setValue("");
-      result.current.setThinkingLevel("high");
-      result.current.setPlanMode(false);
       result.current.setFiles([]);
     });
 

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useModels } from "@/hooks/useModels";
+import { useModels, __resetModelCatalogCacheForTests } from "@/hooks/useModels";
 import { api } from "@/hooks/useApi";
 import type { ModelCatalogResponse } from "@/types";
 
@@ -44,6 +44,7 @@ const MOCK_CATALOG: ModelCatalogResponse = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetModelCatalogCacheForTests();
 });
 
 afterEach(() => {
@@ -207,5 +208,46 @@ describe("useModels", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
+  it("seeds preferredModelId when it exists in the catalog", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const { result } = renderHook(() => useModels(undefined, "claude:sonnet-4-6"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.selectedModelId).toBe("claude:sonnet-4-6");
+  });
+
+  it("ignores preferredModelId that conflicts with lockedProvider", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    // Prefer a claude model but the session is locked to codex.
+    const { result } = renderHook(() => useModels("codex", "claude:sonnet-4-6"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
+  it("falls back to default when preferredModelId is not in the catalog", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const { result } = renderHook(() => useModels(undefined, "claude:removed-model"));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
+  it("seeds synchronously from the cache on a remount (no second fetch)", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const first = renderHook(() => useModels());
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(mockApi.get).toHaveBeenCalledTimes(1);
+
+    // Simulate a fresh mount (e.g. ChatInput remounted on session switch).
+    const second = renderHook(() => useModels(undefined, "claude:sonnet-4-6"));
+    expect(second.result.current.isLoading).toBe(false);
+    expect(second.result.current.selectedModelId).toBe("claude:sonnet-4-6");
+    expect(mockApi.get).toHaveBeenCalledTimes(1); // still cached
   });
 });

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -177,8 +177,33 @@ struct SessionMetadata: Codable, Hashable, Identifiable {
     let updatedAt: String
     let messageCount: Int
     let lockedProvider: String?
+    let lastRunOptions: MessageOptions?
 
     var id: String { sessionId }
+
+    init(
+        sessionId: String,
+        providerSessionId: String?,
+        claudeSessionId: String?,
+        workspaceId: String,
+        title: String?,
+        createdAt: String,
+        updatedAt: String,
+        messageCount: Int,
+        lockedProvider: String?,
+        lastRunOptions: MessageOptions? = nil
+    ) {
+        self.sessionId = sessionId
+        self.providerSessionId = providerSessionId
+        self.claudeSessionId = claudeSessionId
+        self.workspaceId = workspaceId
+        self.title = title
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.messageCount = messageCount
+        self.lockedProvider = lockedProvider
+        self.lastRunOptions = lastRunOptions
+    }
 }
 
 struct ImageAttachment: Codable, Equatable {
@@ -440,7 +465,7 @@ enum ThinkingLevel: String, Codable, CaseIterable {
     }
 }
 
-struct MessageOptions: Codable {
+struct MessageOptions: Codable, Hashable {
     let planMode: Bool?
     let model: String?
     let thinkingLevel: ThinkingLevel?

--- a/ios/HiveMobile/Stores/ChatDraftStore.swift
+++ b/ios/HiveMobile/Stores/ChatDraftStore.swift
@@ -16,19 +16,11 @@ final class ChatDraftStore {
 
     struct Draft {
         var text: String
-        var planModeEnabled: Bool
-        var thinkingLevel: ThinkingLevel
-        var fastModeEnabled: Bool
-        var selectedModelId: String?
         var attachments: [Attachment]
 
         var hasMeaningfulContent: Bool {
             !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
                 || !attachments.isEmpty
-                || planModeEnabled
-                || fastModeEnabled
-                || thinkingLevel != .high
-                || selectedModelId != nil
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -41,6 +41,12 @@ struct ChatView: View {
     /// after the in-memory draft is gone (app relaunch). Mirrors the web's
     /// `useModels(lockedProvider)` seeding.
     private func initialModelId() -> String {
+        if let lastModelId = session.lastRunOptions?.model,
+           let match = modelCatalog.models.first(where: {
+               $0.id == lastModelId && (lockedProvider == nil || $0.provider == lockedProvider)
+           }) {
+            return match.id
+        }
         if let provider = lockedProvider {
             if let match = modelCatalog.models.first(where: { $0.provider == provider && $0.isDefault == true })
                 ?? modelCatalog.models.first(where: { $0.provider == provider }) {
@@ -48,6 +54,13 @@ struct ChatView: View {
             }
         }
         return modelCatalog.defaultModelId
+    }
+
+    private func applySessionRunOptions() {
+        selectedModelId = initialModelId()
+        planModeEnabled = session.lastRunOptions?.planMode ?? false
+        thinkingLevel = session.lastRunOptions?.thinkingLevel ?? .high
+        fastModeEnabled = session.lastRunOptions?.fastMode ?? false
     }
 
     private var selectedCapabilities: ProviderCapabilities? {
@@ -331,10 +344,6 @@ struct ChatView: View {
         let savedAttachments = draftAttachments
         let savedDraftState = ChatDraftStore.Draft(
             text: savedDraft,
-            planModeEnabled: planModeEnabled,
-            thinkingLevel: thinkingLevel,
-            fastModeEnabled: fastModeEnabled,
-            selectedModelId: selectedModelId.isEmpty ? nil : selectedModelId,
             attachments: savedAttachments.map(ChatDraftStore.Attachment.init)
         )
         draft = ""
@@ -433,10 +442,6 @@ struct ChatView: View {
             sessionId: session.sessionId,
             draft: .init(
                 text: draft,
-                planModeEnabled: planModeEnabled,
-                thinkingLevel: thinkingLevel,
-                fastModeEnabled: fastModeEnabled,
-                selectedModelId: selectedModelId.isEmpty ? nil : selectedModelId,
                 attachments: draftAttachments.map(ChatDraftStore.Attachment.init)
             )
         )
@@ -445,21 +450,12 @@ struct ChatView: View {
     private func restoreDraft(for sessionId: String) {
         if let saved = draftStore.restore(workspaceId: workspace.id, sessionId: sessionId) {
             draft = saved.text
-            planModeEnabled = saved.planModeEnabled
-            thinkingLevel = saved.thinkingLevel
-            fastModeEnabled = saved.fastModeEnabled
-            if let modelId = saved.selectedModelId {
-                selectedModelId = modelId
-            }
             draftAttachments = saved.attachments.map(ImageAttachment.init)
         } else {
             draft = ""
-            planModeEnabled = false
-            thinkingLevel = .high
-            fastModeEnabled = false
-            selectedModelId = initialModelId()
             draftAttachments = []
         }
+        applySessionRunOptions()
     }
 
     private static let bottomAnchorID = "chat-bottom-anchor"

--- a/ios/Tests/ChatDraftStoreTests/ChatDraftStoreTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ChatDraftStoreTests.swift
@@ -19,17 +19,12 @@ struct ChatDraftStoreTests {
             sessionId: sessionId,
             draft: .init(
                 text: "hello",
-                planModeEnabled: true,
-                thinkingLevel: .low,
-                selectedModelId: nil,
                 attachments: [attachment]
             )
         )
 
         let restored = ChatDraftStore.shared.restore(workspaceId: workspaceId, sessionId: sessionId)
         #expect(restored?.text == "hello")
-        #expect(restored?.thinkingLevel == .low)
-        #expect(restored?.planModeEnabled == true)
         #expect(restored?.attachments == [attachment])
 
         ChatDraftStore.shared.remove(workspaceId: workspaceId, sessionId: sessionId)
@@ -45,9 +40,6 @@ struct ChatDraftStoreTests {
             sessionId: sessionId,
             draft: .init(
                 text: "   ",
-                planModeEnabled: false,
-                thinkingLevel: .high,
-                selectedModelId: nil,
                 attachments: []
             )
         )
@@ -65,9 +57,6 @@ struct ChatDraftStoreTests {
             sessionId: sessionId,
             draft: .init(
                 text: "persist me",
-                planModeEnabled: false,
-                thinkingLevel: .high,
-                selectedModelId: nil,
                 attachments: []
             )
         )

--- a/ios/Tests/ChatDraftStoreTests/SessionMetadataDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/SessionMetadataDecodingTests.swift
@@ -15,7 +15,13 @@ struct SessionMetadataDecodingTests {
           "createdAt": "2026-01-01T00:00:00.000Z",
           "updatedAt": "2026-01-02T00:00:00.000Z",
           "messageCount": 7,
-          "lockedProvider": "codex"
+          "lockedProvider": "codex",
+          "lastRunOptions": {
+            "planMode": false,
+            "model": "codex:gpt-5.5",
+            "thinkingLevel": "low",
+            "fastMode": false
+          }
         }
         """.data(using: .utf8)!
 
@@ -30,6 +36,10 @@ struct SessionMetadataDecodingTests {
         #expect(metadata.updatedAt == "2026-01-02T00:00:00.000Z")
         #expect(metadata.messageCount == 7)
         #expect(metadata.lockedProvider == "codex")
+        #expect(metadata.lastRunOptions?.model == "codex:gpt-5.5")
+        #expect(metadata.lastRunOptions?.thinkingLevel == .low)
+        #expect(metadata.lastRunOptions?.planMode == false)
+        #expect(metadata.lastRunOptions?.fastMode == false)
         #expect(metadata.id == "session-1")
     }
 
@@ -52,5 +62,6 @@ struct SessionMetadataDecodingTests {
         #expect(metadata.claudeSessionId == nil)
         #expect(metadata.title == nil)
         #expect(metadata.lockedProvider == nil)
+        #expect(metadata.lastRunOptions == nil)
     }
 }


### PR DESCRIPTION
## Summary
- persist normalized last-run chat options in session metadata
- seed chat input controls from session metadata instead of draft storage
- update web and iOS draft persistence to keep only actual draft content

## Tests
- npm test -- src/agents/conversation-session.test.ts
- npm test -- tests/components/ChatInput.persistence.test.tsx tests/hooks/useChatInputDraftPersistence.test.tsx tests/hooks/useModels.test.ts
- swift test (not run: swift command not available in this environment)