### PR TITLE
Fix Codex usage percentage parsing

### DIFF
--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -163,6 +163,18 @@ describe("provider usage", () => {
         resetsAt: 1781542800,
       },
     ]);
+
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      primary: {
+        usedPercent: 1,
+        windowDurationMins: 300,
+      },
+    })).toMatchObject([
+      {
+        id: "codex",
+        usedPercent: 1,
+      },
+    ]);
   });
 
   it("reads Codex usage through the App Server JSON-RPC endpoint", async () => {
@@ -190,7 +202,7 @@ describe("provider usage", () => {
           limitId: "primary",
           limitName: "Primary",
           primary: {
-            usedPercent: 0.25,
+            usedPercent: 25,
             windowDurationMins: 300,
             resetsAt: 1781110800,
           },

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -360,7 +360,7 @@ function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): Provide
   return {
     id,
     label: asString(bucket.limitName),
-    usedPercent: normalizePercent(primary.usedPercent ?? primary.usagePercent),
+    usedPercent: normalizeCodexPercent(primary),
     windowDurationMins: asNumber(primary.windowDurationMins),
     resetsAt: parseResetTimestamp(primary.resetsAt ?? primary.resetAt),
     planType: asString(bucket.planType),
@@ -369,17 +369,27 @@ function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): Provide
   };
 }
 
-function normalizePercent(value: unknown): number | null {
-  const num = asNumber(value);
-  if (num === null) return null;
-  const percent = num <= 1 ? num * 100 : num;
-  return Math.max(0, Math.min(100, Math.round(percent)));
+function normalizeCodexPercent(window: CodexRateLimitWindow): number | null {
+  if (window.usedPercent !== undefined) {
+    return normalizeWholePercent(window.usedPercent);
+  }
+  return normalizeFractionOrPercent(window.usagePercent);
 }
 
-function normalizeClaudePercent(value: unknown): number | null {
+function normalizeWholePercent(value: unknown): number | null {
   const num = asNumber(value);
   if (num === null) return null;
   return Math.max(0, Math.min(100, Math.round(num)));
+}
+
+function normalizeFractionOrPercent(value: unknown): number | null {
+  const num = asNumber(value);
+  if (num === null) return null;
+  return normalizeWholePercent(num <= 1 ? num * 100 : num);
+}
+
+function normalizeClaudePercent(value: unknown): number | null {
+  return normalizeWholePercent(value);
 }
 
 function parseResetTimestamp(value: unknown): number | null {


### PR DESCRIPTION
## Summary
- Treat Codex `usedPercent` as an already-normalized percentage
- Keep fractional handling only for the older/fallback `usagePercent` field
- Add a regression test for Codex `usedPercent: 1` staying at 1%

## Tests
- `cd backend && npm test -- provider-usage`
- `cd backend && npm run typecheck`