### PR TITLE
Fix provider usage percentage normalization

### DIFF
--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -135,7 +135,7 @@ describe("provider usage", () => {
       {
         id: "codex",
         label: null,
-        usedPercent: 42,
+        usedPercent: 0.4,
         windowDurationMins: 300,
         resetsAt: 1781110800,
         planType: null,
@@ -173,6 +173,28 @@ describe("provider usage", () => {
       {
         id: "codex",
         usedPercent: 1,
+      },
+    ]);
+
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      primary: {
+        usagePercent: 1,
+      },
+    })).toMatchObject([
+      {
+        id: "codex",
+        usedPercent: 1,
+      },
+    ]);
+
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      primary: {
+        usageFraction: 0.42,
+      },
+    })).toMatchObject([
+      {
+        id: "codex",
+        usedPercent: 42,
       },
     ]);
   });
@@ -389,7 +411,7 @@ describe("provider usage", () => {
       five_hour: { utilization: 42, resets_at: "2026-06-10T17:00:00Z" },
       seven_day: { utilization: 61, resets_at: "2026-06-15T17:00:00Z" },
       seven_day_sonnet: { utilization: 1, resets_at: "2026-06-15T17:00:00Z" },
-      seven_day_opus: null,
+      seven_day_opus: { utilization: 0.42, resets_at: "2026-06-15T17:00:00Z" },
       extra_usage: { utilization: null },
     })).toEqual([
       {
@@ -410,6 +432,13 @@ describe("provider usage", () => {
         id: "seven_day_sonnet",
         label: "7d Sonnet",
         usedPercent: 1,
+        windowDurationMins: 10080,
+        resetsAt: 1781542800,
+      },
+      {
+        id: "seven_day_opus",
+        label: "7d Opus",
+        usedPercent: 0.4,
         windowDurationMins: 10080,
         resetsAt: 1781542800,
       },

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -13,6 +13,7 @@ import {
 import { buildWorkspaceEnv } from "../utils/env.js";
 
 type UsageStatus = "available" | "unavailable" | "unknown" | "error";
+type UsagePercentScale = "percent" | "fraction";
 
 export interface ProviderUsageBucket {
   id: string;
@@ -42,6 +43,8 @@ export interface ProviderUsageResponse {
 interface CodexRateLimitWindow {
   usedPercent?: unknown;
   usagePercent?: unknown;
+  usedFraction?: unknown;
+  usageFraction?: unknown;
   windowDurationMins?: unknown;
   resetsAt?: unknown;
   resetAt?: unknown;
@@ -371,25 +374,30 @@ function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): Provide
 
 function normalizeCodexPercent(window: CodexRateLimitWindow): number | null {
   if (window.usedPercent !== undefined) {
-    return normalizeWholePercent(window.usedPercent);
+    return normalizeUsagePercent(window.usedPercent, "percent");
   }
-  return normalizeFractionOrPercent(window.usagePercent);
-}
-
-function normalizeWholePercent(value: unknown): number | null {
-  const num = asNumber(value);
-  if (num === null) return null;
-  return Math.max(0, Math.min(100, Math.round(num)));
-}
-
-function normalizeFractionOrPercent(value: unknown): number | null {
-  const num = asNumber(value);
-  if (num === null) return null;
-  return normalizeWholePercent(num <= 1 ? num * 100 : num);
+  if (window.usagePercent !== undefined) {
+    return normalizeUsagePercent(window.usagePercent, "percent");
+  }
+  return normalizeUsagePercent(window.usedFraction ?? window.usageFraction, "fraction");
 }
 
 function normalizeClaudePercent(value: unknown): number | null {
-  return normalizeWholePercent(value);
+  return normalizeUsagePercent(value, "percent");
+}
+
+function normalizeUsagePercent(value: unknown, scale: UsagePercentScale): number | null {
+  const num = asNumber(value);
+  if (num === null) return null;
+  return normalizePercentNumber(scale === "fraction" ? num * 100 : num);
+}
+
+function normalizePercentNumber(value: number): number {
+  const clamped = Math.max(0, Math.min(100, value));
+  if (clamped > 0 && clamped < 10) {
+    return Math.round(clamped * 10) / 10;
+  }
+  return Math.round(clamped);
 }
 
 function parseResetTimestamp(value: unknown): number | null {


### PR DESCRIPTION
## Summary
- treat provider usage percent fields as explicit 0-100 percentages instead of guessing fractions
- support explicit Codex fraction fields separately
- centralize provider usage percentage normalization and add Claude/Codex edge-case coverage

## Tests
- npm --workspace @hive/backend test -- provider-usage.test.ts
- npm --workspace @hive/backend run typecheck