### PR TITLE
Suppress Codex thread settings notification

### DIFF
--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -343,6 +343,19 @@ describe("CodexAppServerSession normalized events", () => {
       method: "turn/diff/updated",
       params: { threadId: "thread-1", turnId: "turn-1", diff: "diff --git a/app.ts b/app.ts" },
     }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "thread/settings/updated",
+      params: {
+        threadId: "thread-1",
+        threadSettings: {
+          cwd: "/tmp/workspace",
+          approvalPolicy: "never",
+          sandboxPolicy: { type: "dangerFullAccess" },
+          model: "gpt-5.5",
+          effort: "high",
+        },
+      },
+    }) + "\n");
 
     expect(events).toEqual([]);
   });

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -454,6 +454,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       case "remoteControl/status/changed":
       case "account/rateLimits/updated":
       case "turn/diff/updated":
+      case "thread/settings/updated":
         break;
       case "mcpServer/startupStatus/updated":
         if (isNotificationStatus(data, "failed", "cancelled")) {


### PR DESCRIPTION
## Summary
- Treat Codex App Server thread/settings/updated as an internal status notification
- Cover the notification in the existing silent-status notification test

## Test
- npm test -- codex-app-server.test.ts