### PR TITLE
Fix visible PR status polling

### DIFF
--- a/backend/src/api/workspaces.pr-status.test.ts
+++ b/backend/src/api/workspaces.pr-status.test.ts
@@ -224,7 +224,7 @@ describe("GET /api/workspaces/:wsId/pr-status", () => {
       method: "GET",
       url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
     });
-    now += 60_001;
+    now += 15_001;
     const second = await app.inject({
       method: "GET",
       url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,

--- a/backend/src/api/workspaces.pr-status.test.ts
+++ b/backend/src/api/workspaces.pr-status.test.ts
@@ -224,7 +224,7 @@ describe("GET /api/workspaces/:wsId/pr-status", () => {
       method: "GET",
       url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
     });
-    now += 15_001;
+    now += 60_001;
     const second = await app.inject({
       method: "GET",
       url: `/api/workspaces/${WORKSPACE_ID}/pr-status`,
@@ -316,6 +316,39 @@ describe("GET /api/workspaces/:wsId/pr-status", () => {
 });
 
 describe("POST /api/workspaces/pr-status/bulk", () => {
+  it("limits concurrent GitHub PR status fetches", async () => {
+    const workspaces = Array.from({ length: 6 }, (_, index): Workspace => ({
+      ...workspace,
+      id: `ws-${index + 1}`,
+      name: `city-${index + 1}`,
+      branch: `workspace/city-${index + 1}`,
+    }));
+    mocks.getWorkspace.mockImplementation(async (wsId: string) => {
+      const found = workspaces.find((entry) => entry.id === wsId);
+      return found ? { workspace: found, projectState: { ...projectState, workspaces } } : null;
+    });
+
+    let active = 0;
+    let maxActive = 0;
+    mocks.fetchPrForBranch.mockImplementation(async () => {
+      active++;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      active--;
+      return { pr: makePr() };
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/workspaces/pr-status/bulk",
+      payload: { workspaceIds: workspaces.map((entry) => entry.id) },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.fetchPrForBranch).toHaveBeenCalledTimes(6);
+    expect(maxActive).toBeLessThanOrEqual(3);
+  });
+
   it("returns PR status for multiple workspaces", async () => {
     const ws2: Workspace = { ...workspace, id: "ws-2", name: "paris", branch: "workspace/paris" };
     const ps2: ProjectState = { ...projectState, workspaces: [ws2] };

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -29,6 +29,8 @@ import { headerFilename, rawFileContentType } from "../utils/raw-file.js";
 import type { BulkPrStatusResponse, DiffScope, PrStatusResponse } from "../types.js";
 
 const DIFF_SCOPES = new Set<DiffScope>(["combined", "committed", "uncommitted"]);
+const PR_TTL = 60_000;
+const PR_BULK_CONCURRENCY = 3;
 
 function parseDiffScope(scope: unknown): DiffScope {
   if (scope === undefined) return "combined";
@@ -36,6 +38,22 @@ function parseDiffScope(scope: unknown): DiffScope {
     return scope as DiffScope;
   }
   throw new BadRequestError("Invalid diff scope");
+}
+
+async function runWithConcurrency<T>(
+  items: T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  const executing = new Set<Promise<void>>();
+  for (const item of items) {
+    const task = fn(item).finally(() => executing.delete(task));
+    executing.add(task);
+    if (executing.size >= limit) {
+      await Promise.race(executing);
+    }
+  }
+  await Promise.allSettled([...executing]);
 }
 
 export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
@@ -134,12 +152,47 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
 
   // ── PR status (on-demand, cached) ─────────────────────────────────
   const prCache = new Map<string, { data: PrStatusResponse; at: number }>();
-  const PR_TTL = 15_000;
+
+  const fetchWorkspacePrStatus = async (
+    wsId: string,
+    loaded?: Awaited<ReturnType<typeof getWorkspace>>,
+  ): Promise<PrStatusResponse> => {
+    const cached = prCache.get(wsId);
+    if (cached && Date.now() - cached.at < PR_TTL) {
+      return cached.data;
+    }
+
+    const result = loaded ?? await getWorkspace(wsId, dataDir);
+    if (!result) throw new BadRequestError("Workspace not found");
+
+    const ghRepo = result.projectState.url ? parseGitHubRepo(result.projectState.url) : null;
+    if (!ghRepo) {
+      const data: PrStatusResponse = { pr: null };
+      prCache.set(wsId, { data, at: Date.now() });
+      return data;
+    }
+
+    const dir = dataDir ?? getDataDir();
+    const wsPath = join(workspacesDir(dir, result.projectState.id), result.workspace.name);
+    let branch: string;
+    try {
+      branch = await getBranchName(wsPath);
+    } catch {
+      branch = result.workspace.branch;
+    }
+
+    const prResult = await fetchPrForBranch(ghRepo.owner, ghRepo.repo, branch);
+    const data: PrStatusResponse = {
+      pr: prResult.pr,
+      ...(prResult.error ? { error: prResult.error } : {}),
+    };
+    prCache.set(wsId, { data, at: Date.now() });
+    return data;
+  };
 
   app.get<{ Params: { wsId: string } }>("/api/workspaces/:wsId/pr-status", async (req, reply) => {
     try {
       const { wsId } = req.params;
-
       const cached = prCache.get(wsId);
       if (cached && Date.now() - cached.at < PR_TTL) {
         return reply.send(cached.data);
@@ -147,30 +200,7 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
 
       const result = await getWorkspace(wsId, dataDir);
       if (!result) return reply.status(404).send({ error: "Workspace not found" });
-
-      const ghRepo = result.projectState.url ? parseGitHubRepo(result.projectState.url) : null;
-      if (!ghRepo) {
-        const data: PrStatusResponse = { pr: null };
-        prCache.set(wsId, { data, at: Date.now() });
-        return reply.send(data);
-      }
-
-      const dir = dataDir ?? getDataDir();
-      const wsPath = join(workspacesDir(dir, result.projectState.id), result.workspace.name);
-      let branch: string;
-      try {
-        branch = await getBranchName(wsPath);
-      } catch {
-        branch = result.workspace.branch;
-      }
-
-      const prResult = await fetchPrForBranch(ghRepo.owner, ghRepo.repo, branch);
-      const data: PrStatusResponse = {
-        pr: prResult.pr,
-        ...(prResult.error ? { error: prResult.error } : {}),
-      };
-      prCache.set(wsId, { data, at: Date.now() });
-      return reply.send(data);
+      return reply.send(await fetchWorkspacePrStatus(wsId, result));
     } catch (err: unknown) {
       return reply
         .status(errorStatus(err))
@@ -188,50 +218,21 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       }
 
       const results: Record<string, PrStatusResponse> = {};
+      const uniqueWorkspaceIds = [...new Set(workspaceIds)];
 
-      await Promise.allSettled(
-        workspaceIds.map(async (wsId) => {
-          const cached = prCache.get(wsId);
-          if (cached && Date.now() - cached.at < PR_TTL) {
-            results[wsId] = cached.data;
-            return;
-          }
-
+      await runWithConcurrency(
+        uniqueWorkspaceIds,
+        PR_BULK_CONCURRENCY,
+        async (wsId) => {
           try {
-            const result = await getWorkspace(wsId, dataDir);
-            if (!result) {
-              results[wsId] = { pr: null, error: "Workspace not found" };
-              return;
-            }
-
-            const ghRepo = result.projectState.url ? parseGitHubRepo(result.projectState.url) : null;
-            if (!ghRepo) {
-              const data: PrStatusResponse = { pr: null };
-              prCache.set(wsId, { data, at: Date.now() });
-              results[wsId] = data;
-              return;
-            }
-
-            const dir = dataDir ?? getDataDir();
-            const wsPath = join(workspacesDir(dir, result.projectState.id), result.workspace.name);
-            let branch: string;
-            try {
-              branch = await getBranchName(wsPath);
-            } catch {
-              branch = result.workspace.branch;
-            }
-
-            const prResult = await fetchPrForBranch(ghRepo.owner, ghRepo.repo, branch);
-            const data: PrStatusResponse = {
-              pr: prResult.pr,
-              ...(prResult.error ? { error: prResult.error } : {}),
-            };
-            prCache.set(wsId, { data, at: Date.now() });
-            results[wsId] = data;
-          } catch {
-            results[wsId] = { pr: null, error: "Failed to fetch PR status" };
+            results[wsId] = await fetchWorkspacePrStatus(wsId);
+          } catch (err) {
+            const message = err instanceof Error && err.message === "Workspace not found"
+              ? "Workspace not found"
+              : "Failed to fetch PR status";
+            results[wsId] = { pr: null, error: message };
           }
-        }),
+        },
       );
 
       const response: BulkPrStatusResponse = { results };

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -29,7 +29,7 @@ import { headerFilename, rawFileContentType } from "../utils/raw-file.js";
 import type { BulkPrStatusResponse, DiffScope, PrStatusResponse } from "../types.js";
 
 const DIFF_SCOPES = new Set<DiffScope>(["combined", "committed", "uncommitted"]);
-const PR_TTL = 60_000;
+const PR_TTL = 15_000;
 const PR_BULK_CONCURRENCY = 3;
 
 function parseDiffScope(scope: unknown): DiffScope {

--- a/backend/src/utils/github.test.ts
+++ b/backend/src/utils/github.test.ts
@@ -616,6 +616,32 @@ describe("fetchPrForBranch", () => {
     expect(error).toContain("API rate limit exceeded");
   });
 
+  it("pauses PR status refresh after a gh rate-limit error", async () => {
+    const execFileMock = await getExecFileMock();
+    let now = 100_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    execFileMock.mockImplementationOnce(
+      mockExecFileError({ stderr: "API rate limit exceeded" }),
+    );
+
+    const first = await fetchPrForBranch("acme", "widget", "rate-limited");
+    expect(first.error).toContain("API rate limit exceeded");
+
+    execFileMock.mockClear();
+    const second = await fetchPrForBranch("acme", "widget", "skipped");
+    expect(second.pr).toBeNull();
+    expect(second.error).toContain("GitHub rate limit reached");
+    expect(execFileMock).not.toHaveBeenCalled();
+
+    now += 5 * 60_000 + 1;
+    execFileMock.mockImplementationOnce(mockExecFileSuccess("[]"));
+    const third = await fetchPrForBranch("acme", "widget", "retry");
+    expect(third.error).toBeUndefined();
+    expect(execFileMock).toHaveBeenCalled();
+
+    nowSpy.mockRestore();
+  });
+
   it("keeps retrying after non-ENOENT errors (not permanently disabled)", async () => {
     const execFileMock = await getExecFileMock();
 

--- a/backend/src/utils/github.ts
+++ b/backend/src/utils/github.ts
@@ -5,11 +5,14 @@ import type { PullRequestInfo } from "../types.js";
 const execFile = promisify(execFileCb);
 
 const GH_RETRY_COOLDOWN_MS = 60_000;
+const GH_RATE_LIMIT_COOLDOWN_MS = 5 * 60_000;
+const GH_RATE_LIMIT_MESSAGE = "GitHub rate limit reached — PR status refresh is paused briefly";
 
 // After ENOENT, skip `gh` calls until cooldown expires.
 let ghAvailable: boolean | null = null;
 let ghUnavailableReason = "";
 let ghUnavailableAt = 0;
+let ghRateLimitedUntil = 0;
 
 export type RepositoryVisibility = "public" | "private";
 
@@ -48,6 +51,10 @@ function formatGhFailure(err: unknown): string {
     return "GitHub CLI is not authenticated. Run `gh auth login` and try again.";
   }
   return detail ? `GitHub CLI failed: ${detail}` : "GitHub CLI failed.";
+}
+
+function isGhRateLimitError(message: string | undefined): boolean {
+  return /\brate limit\b/i.test(message ?? "");
 }
 
 export function parseGitHubRepo(
@@ -263,6 +270,10 @@ export async function fetchPrForBranch(
     return { pr: null, error: ghUnavailableReason };
   }
 
+  if (Date.now() < ghRateLimitedUntil) {
+    return { pr: null, error: GH_RATE_LIMIT_MESSAGE };
+  }
+
   try {
     const { stdout } = await gh([
       "pr",
@@ -318,6 +329,9 @@ export async function fetchPrForBranch(
     if (stderr?.includes("auth login")) {
       return { pr: null, error: "gh not authenticated — run `gh auth login`" };
     }
+    if (isGhRateLimitError(stderr)) {
+      ghRateLimitedUntil = Date.now() + GH_RATE_LIMIT_COOLDOWN_MS;
+    }
 
     return { pr: null, error: `gh error: ${stderr}` };
   }
@@ -328,4 +342,5 @@ export function _resetGhState(): void {
   ghAvailable = null;
   ghUnavailableReason = "";
   ghUnavailableAt = 0;
+  ghRateLimitedUntil = 0;
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -28,7 +28,7 @@ import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext
 import { useProjects } from "@/hooks/useProjects";
 import { useBrain } from "@/hooks/useBrain";
 import { useBulkPrStatus, usePrStatusMap } from "@/hooks/usePrStatus";
-import { useSidebarProjectFolders } from "@/hooks/useSidebarProjectFolders";
+import { useSidebarProjectFolders, type SidebarProjectFolderView } from "@/hooks/useSidebarProjectFolders";
 import { api } from "@/hooks/useApi";
 import {
   automationSortKey,
@@ -72,6 +72,44 @@ type ProjectOrderDropTarget = {
   projectId: string;
   position: "before" | "after";
 };
+
+export function collectVisiblePrWorkspaceIds({
+  folders,
+  rootProjects,
+  expandedProjects,
+  activeProjectId,
+  activeWsId,
+  isFolderExpanded,
+}: {
+  folders: SidebarProjectFolderView[];
+  rootProjects: Project[];
+  expandedProjects: Record<string, boolean>;
+  activeProjectId?: string;
+  activeWsId?: string;
+  isFolderExpanded: (folderId: string) => boolean;
+}): string[] {
+  const visible = new Set<string>();
+  const isProjectExpanded = (projectId: string) => {
+    const expanded = expandedProjects[projectId];
+    if (typeof expanded === "boolean") return expanded;
+    return activeProjectId === projectId;
+  };
+  const addProjectWorkspaces = (project: Project) => {
+    if (!isProjectExpanded(project.id)) return;
+    for (const workspace of project.workspaces ?? []) {
+      visible.add(workspace.id);
+    }
+  };
+
+  for (const folder of folders) {
+    if (!isFolderExpanded(folder.id)) continue;
+    for (const project of folder.projects) addProjectWorkspaces(project);
+  }
+  for (const project of rootProjects) addProjectWorkspaces(project);
+  if (activeWsId) visible.add(activeWsId);
+
+  return [...visible];
+}
 
 const sidebarPanelScrollClassName =
   "[&_[data-slot=scroll-area-viewport]>div]:!block [&_[data-slot=scroll-area-viewport]>div]:!min-w-full [&_[data-slot=scroll-area-viewport]>div]:!w-full";
@@ -135,16 +173,6 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     (project.workspaces ?? []).some((workspace) => workspace.id === activeWsId),
   )?.id;
 
-  const allWsIds = useMemo(
-    () => projects.flatMap((p) => (p.workspaces ?? []).map((ws) => ws.id)),
-    [projects],
-  );
-  const { loading: prLoading } = useBulkPrStatus(allWsIds);
-  const prStatuses = usePrStatusMap(allWsIds);
-  const sortedAutomations = useMemo(() => {
-    if (!automations) return [];
-    return [...automations].sort((a, b) => automationSortKey(a) - automationSortKey(b));
-  }, [automations]);
   const {
     folders,
     rootProjects,
@@ -159,6 +187,23 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
     setFolderExpanded,
     getFolderIdForProject,
   } = useSidebarProjectFolders(projects, projectsReady);
+  const visiblePrWorkspaceIds = useMemo(
+    () => collectVisiblePrWorkspaceIds({
+      folders,
+      rootProjects,
+      expandedProjects,
+      activeProjectId,
+      activeWsId,
+      isFolderExpanded,
+    }),
+    [activeProjectId, activeWsId, expandedProjects, folders, isFolderExpanded, rootProjects],
+  );
+  const { loadingByWorkspace: prLoadingByWorkspace } = useBulkPrStatus(visiblePrWorkspaceIds);
+  const prStatuses = usePrStatusMap(visiblePrWorkspaceIds);
+  const sortedAutomations = useMemo(() => {
+    if (!automations) return [];
+    return [...automations].sort((a, b) => automationSortKey(a) - automationSortKey(b));
+  }, [automations]);
   const projectsAppearIncomplete = projectsReady
     && projects.length === 0
     && folders.some((folder) => folder.projectIds.length > folder.projects.length);
@@ -436,7 +481,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
         activeWsId={activeWsId}
         liveData={liveData}
         prStatuses={prStatuses}
-        prLoading={prLoading}
+        prLoadingByWorkspace={prLoadingByWorkspace}
         creatingProjectId={creatingProjectId}
         archivingWsId={archivingWsId}
         canReorder={hasInitialHydration}

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -33,7 +33,7 @@ interface SidebarProjectItemProps {
   activeWsId?: string;
   liveData: Record<string, WorkspaceLiveData>;
   prStatuses: Record<string, PrStatusResponse>;
-  prLoading: boolean;
+  prLoadingByWorkspace: Record<string, boolean>;
   creatingProjectId: string | null;
   archivingWsId: string | null;
   draggingProjectId: string | null;
@@ -67,7 +67,7 @@ export function SidebarProjectItem({
   activeWsId,
   liveData,
   prStatuses,
-  prLoading,
+  prLoadingByWorkspace,
   creatingProjectId,
   archivingWsId,
   draggingProjectId,
@@ -190,7 +190,7 @@ export function SidebarProjectItem({
                                   </span>
                                 );
                               })()
-                            ) : prLoading ? (
+                            ) : prLoadingByWorkspace[ws.id] ? (
                               <span className="text-muted-foreground">Loading…</span>
                             ) : prStatus?.error ? (
                               <span className="text-muted-foreground">Error fetching PR</span>

--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -12,6 +12,8 @@ import type { BulkPrStatusResponse, PrStatusResponse } from "@/types";
 export const prStatusKey = (wsId: string) => ["pr-status", wsId] as const;
 
 const PR_GC_TIME = 5 * 60_000;
+const PR_REFETCH_INTERVAL = 60_000;
+const PR_STALE_TIME = 45_000;
 
 function readPrStatusFromCache(
   queryClient: ReturnType<typeof useQueryClient>,
@@ -94,14 +96,25 @@ export function useBulkPrStatus(wsIds: string[]) {
       return data;
     },
     enabled: wsIds.length > 0,
-    refetchInterval: 15_000,
-    staleTime: 10_000,
+    refetchInterval: PR_REFETCH_INTERVAL,
+    staleTime: PR_STALE_TIME,
     gcTime: PR_GC_TIME,
     placeholderData: keepPreviousData,
   });
 
+  const loadingByWorkspace = useMemo(() => {
+    const loading: Record<string, boolean> = {};
+    if (query.isFetching) {
+      for (const wsId of wsIds) {
+        if (!readPrStatusFromCache(queryClient, wsId)) loading[wsId] = true;
+      }
+    }
+    return loading;
+  }, [query.isFetching, queryClient, wsIds]);
+
   return {
     results: query.data?.results ?? emptyResults,
     loading: query.isLoading,
+    loadingByWorkspace,
   };
 }

--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -12,8 +12,8 @@ import type { BulkPrStatusResponse, PrStatusResponse } from "@/types";
 export const prStatusKey = (wsId: string) => ["pr-status", wsId] as const;
 
 const PR_GC_TIME = 5 * 60_000;
-const PR_REFETCH_INTERVAL = 60_000;
-const PR_STALE_TIME = 45_000;
+const PR_REFETCH_INTERVAL = 15_000;
+const PR_STALE_TIME = 10_000;
 
 function readPrStatusFromCache(
   queryClient: ReturnType<typeof useQueryClient>,

--- a/frontend/tests/components/Sidebar.visible-pr.test.ts
+++ b/frontend/tests/components/Sidebar.visible-pr.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { collectVisiblePrWorkspaceIds } from "@/components/Sidebar";
+import type { Project } from "@/types";
+import type { SidebarProjectFolderView } from "@/hooks/useSidebarProjectFolders";
+
+function project(id: string, workspaceIds: string[]): Project {
+  return {
+    id,
+    name: id,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    workspaces: workspaceIds.map((wsId) => ({
+      id: wsId,
+      name: wsId,
+      branch: `workspace/${wsId}`,
+      status: "idle",
+      createdAt: "2026-01-01T00:00:00.000Z",
+    })),
+  };
+}
+
+function folder(id: string, projects: Project[]): SidebarProjectFolderView {
+  return {
+    id,
+    name: id,
+    projectIds: projects.map((entry) => entry.id),
+    projects,
+  };
+}
+
+describe("collectVisiblePrWorkspaceIds", () => {
+  it("includes only workspaces from expanded folders and expanded projects", () => {
+    const p1 = project("p1", ["ws-1"]);
+    const p2 = project("p2", ["ws-2"]);
+    const p3 = project("p3", ["ws-3"]);
+
+    expect(collectVisiblePrWorkspaceIds({
+      folders: [folder("folder-open", [p1, p2]), folder("folder-closed", [p3])],
+      rootProjects: [],
+      expandedProjects: { p1: true, p2: false, p3: true },
+      activeProjectId: undefined,
+      activeWsId: undefined,
+      isFolderExpanded: (folderId) => folderId === "folder-open",
+    })).toEqual(["ws-1"]);
+  });
+
+  it("always includes the active workspace even when its project is hidden", () => {
+    const p1 = project("p1", ["ws-1"]);
+    const p2 = project("p2", ["ws-2"]);
+
+    expect(collectVisiblePrWorkspaceIds({
+      folders: [folder("folder-closed", [p1])],
+      rootProjects: [p2],
+      expandedProjects: { p2: false },
+      activeProjectId: undefined,
+      activeWsId: "ws-1",
+      isFolderExpanded: () => false,
+    })).toEqual(["ws-1"]);
+  });
+
+  it("uses the active project as the default expanded project", () => {
+    const p1 = project("p1", ["ws-1"]);
+    const p2 = project("p2", ["ws-2"]);
+
+    expect(collectVisiblePrWorkspaceIds({
+      folders: [],
+      rootProjects: [p1, p2],
+      expandedProjects: {},
+      activeProjectId: "p2",
+      activeWsId: undefined,
+      isFolderExpanded: () => true,
+    })).toEqual(["ws-2"]);
+  });
+});

--- a/ios/HiveMobile/Stores/HubPrPollingSelection.swift
+++ b/ios/HiveMobile/Stores/HubPrPollingSelection.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum HubPrPollingSelection {
+    static func allWorkspaceIds(in sections: [HubSection]) -> [String] {
+        var ids: [String] = []
+        var seen = Set<String>()
+
+        for section in sections {
+            for node in section.projects {
+                for workspace in node.project.workspaces where !seen.contains(workspace.id) {
+                    seen.insert(workspace.id)
+                    ids.append(workspace.id)
+                }
+            }
+        }
+
+        return ids
+    }
+}

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -36,7 +36,7 @@ final class HubStatusMonitor {
     private var bulkPrPollTask: Task<Void, Never>?
     private var prPollingIds: Set<String> = []
     private let apiClient = APIClient()
-    private let prPollInterval: Duration = .seconds(60)
+    private let prPollInterval: Duration = .seconds(15)
     private let isoFormatter = ISO8601DateFormatter()
     private let fractionalIsoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -36,6 +36,7 @@ final class HubStatusMonitor {
     private var bulkPrPollTask: Task<Void, Never>?
     private var prPollingIds: Set<String> = []
     private let apiClient = APIClient()
+    private let prPollInterval: Duration = .seconds(60)
     private let isoFormatter = ISO8601DateFormatter()
     private let fractionalIsoFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -194,13 +195,8 @@ final class HubStatusMonitor {
 
     /// Start/stop PR status polling to match the given workspace IDs.
     /// Uses a single bulk request instead of per-workspace polling.
-    func syncPrPolling(visibleWorkspaceIds: [String]) {
-        let desired = Set(visibleWorkspaceIds)
-
-        // Clean up removed workspaces
-        for id in prPollingIds.subtracting(desired) {
-            workspacePrStatus.removeValue(forKey: id)
-        }
+    func syncPrPolling(workspaceIds: [String]) {
+        let desired = Set(workspaceIds)
 
         prPollingIds = desired
 
@@ -225,9 +221,13 @@ final class HubStatusMonitor {
                 } catch {
                     // Silently ignore — cards show stale or "No PR"
                 }
-                try? await Task.sleep(for: .seconds(15))
+                try? await Task.sleep(for: self.prPollInterval)
             }
         }
+    }
+
+    func syncPrPolling(visibleWorkspaceIds: [String]) {
+        syncPrPolling(workspaceIds: visibleWorkspaceIds)
     }
 
     // MARK: - Called by HubConnection

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -148,9 +148,8 @@ struct HubView: View {
                 sectionView(section)
             }
         }
-        .task(id: store.projects.flatMap { $0.workspaces.map(\.id) }) {
-            let ids = store.projects.flatMap { $0.workspaces.map(\.id) }
-            store.statusMonitor.syncPrPolling(visibleWorkspaceIds: ids)
+        .task(id: prPollingWorkspaceIds) {
+            store.statusMonitor.syncPrPolling(workspaceIds: prPollingWorkspaceIds)
         }
     }
 
@@ -159,6 +158,10 @@ struct HubView: View {
             projects: store.projects,
             preferences: store.uiPreferences.sidebar
         )
+    }
+
+    private var prPollingWorkspaceIds: [String] {
+        HubPrPollingSelection.allWorkspaceIds(in: baseSections)
     }
 
     private func sectionView(_ section: HubSection) -> some View {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -41,6 +41,7 @@ let package = Package(
                 "Stores/GoalDerivation.swift",
                 "Stores/GoalFormatting.swift",
                 "Stores/HubOrganization.swift",
+                "Stores/HubPrPollingSelection.swift",
                 "Stores/SubAgentStatus.swift",
                 "Stores/TaskDerivation.swift",
                 "Stores/TokenFormatting.swift"

--- a/ios/Tests/ChatDraftStoreTests/HubPrPollingSelectionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubPrPollingSelectionTests.swift
@@ -1,0 +1,95 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+struct HubPrPollingSelectionTests {
+    @Test
+    func returnsWorkspacesFromCollapsedSections() {
+        let projects = [
+            makeProject("p1", name: "alpha"),
+            makeProject("p2", name: "beta"),
+            makeProject("p3", name: "gamma")
+        ]
+        let preferences = SidebarProjectFoldersState(
+            folders: [
+                SidebarProjectFolder(id: "f-client", name: "Client", projectIds: ["p1", "p2"])
+            ],
+            folderOpenState: ["f-client": false]
+        )
+
+        let sections = HubOrganization.sections(projects: projects, preferences: preferences)
+        let ids = HubPrPollingSelection.allWorkspaceIds(in: sections)
+
+        #expect(sections[0].defaultExpanded == false)
+        #expect(ids == ["ws-p1", "ws-p2", "ws-p3"])
+    }
+
+    @Test
+    func returnsWorkspacesFromProjectsWithoutLiveAttention() {
+        let projects = [
+            makeProject("p1", name: "alpha"),
+            makeProject("p2", name: "beta")
+        ]
+
+        let sections = HubOrganization.sections(projects: projects, preferences: .empty)
+        let ids = HubPrPollingSelection.allWorkspaceIds(in: sections)
+
+        #expect(ids == ["ws-p1", "ws-p2"])
+    }
+
+    @Test
+    func dedupesWorkspaceIdsPreservingFirstSeenOrder() {
+        let projects = [
+            makeProject("p1", name: "alpha", workspaceIds: ["ws-shared", "ws-p1b"]),
+            makeProject("p2", name: "beta", workspaceIds: ["ws-shared", "ws-p2"]),
+            makeProject("p3", name: "gamma", workspaceIds: ["ws-p1b", "ws-p3"])
+        ]
+        let preferences = SidebarProjectFoldersState(
+            folders: [
+                SidebarProjectFolder(id: "f-client", name: "Client", projectIds: ["p1", "p2"])
+            ],
+            folderOpenState: [:]
+        )
+
+        let sections = HubOrganization.sections(projects: projects, preferences: preferences)
+        let ids = HubPrPollingSelection.allWorkspaceIds(in: sections)
+
+        #expect(ids == ["ws-shared", "ws-p1b", "ws-p2", "ws-p3"])
+    }
+
+    @Test
+    func returnsEmptyArrayForEmptySections() {
+        let ids = HubPrPollingSelection.allWorkspaceIds(in: [])
+
+        #expect(ids == [])
+    }
+
+    private func makeProject(
+        _ id: String,
+        name: String,
+        workspaceIds: [String]? = nil
+    ) -> Project {
+        let ids = workspaceIds ?? ["ws-\(id)"]
+        return Project(
+            id: id,
+            name: name,
+            url: "https://github.com/acme/\(name).git",
+            createdAt: "2026-01-01T00:00:00Z",
+            workspaces: ids.map { workspaceId in
+                Workspace(
+                    id: workspaceId,
+                    name: "\(name)-\(workspaceId)",
+                    branch: "main",
+                    status: .idle,
+                    createdAt: "2026-01-01T00:00:00Z",
+                    activeSessionId: nil,
+                    projectName: name,
+                    defaultBranch: "main",
+                    sessionCount: 1,
+                    projectId: id,
+                    hasFavicon: false
+                )
+            },
+            hasFavicon: false
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- limit desktop sidebar PR polling to visible workspace rows and show per-workspace loading state
- throttle backend bulk PR status fetches, extend cache/poll intervals, and pause after gh rate-limit errors
- keep iOS Hub PR attention discoverable by polling all Hub workspaces at the slower interval

## Tests
- npm test --workspace @hive/backend -- --run src/api/workspaces.pr-status.test.ts src/utils/github.test.ts
- npm test --workspace @hive/frontend -- --run tests/hooks/usePrStatus.test.ts tests/components/Sidebar.visible-pr.test.ts tests/components/Sidebar.test.tsx
- git diff --check

## Not run
- cd ios && swift test (swift not installed in this environment)
- cd ios && xcodebuild -project HiveMobile.xcodeproj -scheme HiveMobile -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build (xcodebuild not installed in this environment)\n