### PR TITLE
Fix Codex app-server ghost turns from sub-agent thread turn lifecycle

### DIFF
--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1266,6 +1266,53 @@ describe("CodexAppServerSession normalized events", () => {
     expect(lateChild).toEqual(expect.objectContaining({ parentToolUseId: "collab-1" }));
   });
 
+  it("keeps live receiver-thread tools under a fallback closeAgent card when spawn was missed", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: Array<{ message: { content: Array<Record<string, unknown>> } }> = [];
+    session.on("assistant", (event) => assistantEvents.push(event as never));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-close-1",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
+    const read = await waitForMethod(proc, "thread/read");
+    proc._stdout.push(appServerResponse(read.id, { thread: { id: "thread-child", turns: [] } }));
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-late",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "inProgress",
+        },
+      },
+    }) + "\n");
+
+    await waitForCondition(() =>
+      assistantEvents.some((event) => event.message.content.some((block) => block.id === "child-cmd-late")),
+    );
+    const lateChild = assistantEvents
+      .flatMap((event) => event.message.content)
+      .find((block) => block.id === "child-cmd-late");
+    expect(lateChild).toEqual(expect.objectContaining({ parentToolUseId: "collab-close-1" }));
+  });
+
   it("preserves collab parent mapping across a turn boundary (goal continuation)", async () => {
     // With goals, a single prompt spans several autonomous turns. A sub-agent
     // spawned in one turn can emit live items in a later turn; the per-turn reset

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -552,6 +552,73 @@ describe("CodexAppServerSession normalized events", () => {
     }]);
   });
 
+  it("keeps sub-agent image views and generations out of the main stream", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect assets",
+        },
+      },
+    }) + "\n");
+    // The sub-agent views the same image the parent will also view: without
+    // the parent filter both rendered as identical top-level tiles.
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "imageView",
+          id: "child-image-1",
+          path: "/tmp/project/assets/logo.png",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "imageGeneration",
+          id: "child-gen-1",
+          status: "completed",
+          savedPath: "/tmp/project/assets/generated.png",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "imageView",
+          id: "main-image-1",
+          path: "/tmp/project/assets/logo.png",
+        },
+      },
+    }) + "\n");
+
+    const imageEvents = events.filter((event) =>
+      ["image_view_updated", "image_generation_updated"].includes((event as { type: string }).type),
+    );
+    expect(imageEvents).toEqual([
+      expect.objectContaining({ type: "image_view_updated", id: "main-image-1" }),
+    ]);
+  });
+
   it("flags image views outside the workspace without a relative path", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -65,6 +65,24 @@ async function waitForMethod(proc: ReturnType<typeof createMockProcess>, method:
   throw new Error(`Timed out waiting for ${method}`);
 }
 
+async function waitForNthMethod(
+  proc: ReturnType<typeof createMockProcess>,
+  method: string,
+  occurrence: number,
+): Promise<{ id: number }> {
+  const deadline = Date.now() + 1000;
+  while (Date.now() < deadline) {
+    const writes = parseWrites(proc).filter(
+      (write): write is { id: number; method: string } => write.method === method && typeof write.id === "number",
+    );
+    if (writes.length >= occurrence) {
+      return { id: writes[occurrence - 1].id };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`Timed out waiting for ${method} occurrence ${occurrence}`);
+}
+
 async function waitForResponse(proc: ReturnType<typeof createMockProcess>, id: number): Promise<Record<string, unknown>> {
   const deadline = Date.now() + 1000;
   while (Date.now() < deadline) {
@@ -1079,6 +1097,111 @@ describe("CodexAppServerSession normalized events", () => {
     // and nothing nests under the Close Agent card.
     expect(blocks.filter((block) => block.id === "child-cmd-1")).toHaveLength(1);
     expect(blocks.filter((block) => block.parentToolUseId === "collab-close-1")).toHaveLength(0);
+  });
+
+  it("does not re-emit a previous user turn's sub-agent tools when closeAgent replays later", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: Array<{ message: { content: Array<Record<string, unknown>> } }> = [];
+    const resultEvents: unknown[] = [];
+    session.on("assistant", (event) => assistantEvents.push(event as never));
+    session.on("result", (event) => resultEvents.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+    }) + "\n");
+    await waitForCondition(() => resultEvents.length === 1);
+
+    const secondStarted = session.startTurn({
+      cwd: "/tmp/project",
+      content: "follow up",
+      model: "gpt-5.5",
+    });
+    const secondTurnStart = await waitForNthMethod(proc, "turn/start", 2);
+    expect(parseWrites(proc).filter((write) => write.method === "thread/start")).toHaveLength(1);
+    proc._stdout.push(appServerResponse(secondTurnStart.id, { turn: { id: "turn-2" } }));
+    await secondStarted;
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-close-1",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
+    const read = await waitForMethod(proc, "thread/read");
+    proc._stdout.push(appServerResponse(read.id, {
+      thread: {
+        id: "thread-child",
+        turns: [{
+          id: "turn-child",
+          items: [{
+            type: "commandExecution",
+            id: "child-cmd-1",
+            command: "npm test",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "ok",
+            exitCode: 0,
+          }, {
+            type: "commandExecution",
+            id: "child-cmd-2",
+            command: "npm run lint",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "clean",
+            exitCode: 0,
+          }],
+        }],
+      },
+    }));
+
+    await waitForCondition(() =>
+      assistantEvents.some((event) => event.message.content.some((block) => block.id === "child-cmd-2")),
+    );
+    const toolUseBlocks = assistantEvents
+      .flatMap((event) => event.message.content)
+      .filter((block) => block.type === "tool_use");
+    expect(toolUseBlocks.filter((block) => block.id === "child-cmd-1")).toHaveLength(1);
+    expect(toolUseBlocks.filter((block) => block.id === "child-cmd-2")).toHaveLength(1);
   });
 
   it("keeps live receiver-thread tools under the spawning Agent card after a wait completes", async () => {

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -176,6 +176,62 @@ describe("CodexAppServerSession request handling", () => {
     expect(session.capturedTurnId).toBe("turn-2");
   });
 
+  it("ignores turn lifecycle notifications from sub-agent threads", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const turnStartedEvents: unknown[] = [];
+    const resultEvents: Array<Record<string, unknown>> = [];
+    session.on("turn_started", (event) => turnStartedEvents.push(event));
+    session.on("result", (event) => resultEvents.push(event as unknown as Record<string, unknown>));
+    await initializeSession(session, proc);
+
+    // The App Server auto-attaches the client to spawned sub-agent threads and
+    // forwards their turn lifecycle too. Those must never hijack active-turn
+    // tracking: before this guard, the sub-thread's turn/started overwrote
+    // activeTurnId and the main turn/completed was dropped as stale (ghost turn).
+    proc._stdout.push(JSON.stringify({
+      method: "turn/started",
+      params: { threadId: "thread-child", turn: { id: "turn-child" } },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: { threadId: "thread-child", turn: { id: "turn-child", status: "completed" } },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed", durationMs: 42 } },
+    }) + "\n");
+
+    await waitForCondition(() => resultEvents.length === 1);
+    expect(turnStartedEvents).toEqual([]);
+    expect(session.capturedThreadId).toBe("thread-1");
+    expect(resultEvents).toEqual([
+      expect.objectContaining({
+        type: "result",
+        status: "completed",
+        turn_id: "turn-1",
+        session_id: "thread-1",
+        duration_ms: 42,
+      }),
+    ]);
+  });
+
+  it("does not adopt foreign thread ids from thread/started notifications", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/started",
+      params: { thread: { id: "thread-child" } },
+    }) + "\n");
+
+    await waitForCondition(() => parseWrites(proc).length > 0);
+    expect(session.capturedThreadId).toBe("thread-1");
+  });
+
   it("rejects known unsupported request paths with clear errors", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1411,6 +1411,19 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-wait-1",
+          tool: "wait",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
 
     const read = await waitForMethod(proc, "thread/read");
     proc._stdout.push(appServerResponse(read.id, {
@@ -1460,6 +1473,13 @@ describe("CodexAppServerSession normalized events", () => {
       expect.objectContaining({
         message: expect.objectContaining({
           content: [
+            expect.objectContaining({ type: "tool_use", id: "collab-wait-1", name: "Agent" }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [
             expect.objectContaining({
               type: "tool_use",
               id: "child-cmd-1",
@@ -1473,6 +1493,39 @@ describe("CodexAppServerSession normalized events", () => {
     expect(resultEvents).toEqual([
       expect.objectContaining({ type: "result", status: "completed", duration_ms: 123 }),
     ]);
+  });
+
+  it("does not replay receiver threads when spawnAgent completes", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const resultEvents: unknown[] = [];
+    session.on("result", (event) => resultEvents.push(event));
+    await initializeSession(session, proc);
+
+    // spawnAgent completes at thread creation; the child has no history yet,
+    // so reading it is useless and races Codex's rollout flush.
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: { turn: { id: "turn-1", status: "completed" } },
+    }) + "\n");
+
+    await waitForCondition(() => resultEvents.length === 1);
+    expect(parseWrites(proc).filter((write) => write.method === "thread/read")).toHaveLength(0);
   });
 
   it("emits context-window usage from token usage updates", async () => {
@@ -1529,7 +1582,7 @@ describe("CodexAppServerSession normalized events", () => {
     });
   });
 
-  it("does not surface unmaterialized receiver-thread replay errors", async () => {
+  it("does not surface benign too-young-thread replay errors", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const session = new CodexAppServerSession();
@@ -1545,19 +1598,39 @@ describe("CodexAppServerSession normalized events", () => {
         threadId: "thread-1",
         item: {
           type: "collabAgentToolCall",
-          id: "collab-1",
-          tool: "spawnAgent",
+          id: "collab-wait-1",
+          tool: "wait",
           status: "completed",
           receiverThreadIds: ["thread-child"],
-          prompt: "Inspect auth",
         },
       },
     }) + "\n");
-
-    const read = await waitForMethod(proc, "thread/read");
+    const firstRead = await waitForMethod(proc, "thread/read");
     proc._stdout.push(appServerError(
-      read.id,
+      firstRead.id,
       "thread thread-child is not materialized yet; includeTurns is unavailable before first user message",
+    ));
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-close-1",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
+    await waitForCondition(() =>
+      parseWrites(proc).filter((write) => write.method === "thread/read").length === 2,
+    );
+    const secondRead = parseWrites(proc).filter((write) => write.method === "thread/read")[1] as { id: number };
+    proc._stdout.push(appServerError(
+      secondRead.id,
+      "failed to read thread: thread-store internal error: failed to read thread /tmp/rollout-x.jsonl: rollout at /tmp/rollout-x.jsonl is empty",
     ));
     proc._stdout.push(JSON.stringify({
       method: "turn/completed",

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -912,6 +912,170 @@ describe("CodexAppServerSession normalized events", () => {
     ]);
   });
 
+  it("does not re-emit a previous turn's sub-agent tools when closeAgent replays later", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: Array<{ message: { content: Array<Record<string, unknown>> } }> = [];
+    session.on("assistant", (event) => assistantEvents.push(event as never));
+    await initializeSession(session, proc);
+
+    // Turn 1: spawn a sub-agent and stream one of its commands live.
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+    }) + "\n");
+
+    // Turn 2: the model closes the sub-agent; Hive replays the child thread.
+    proc._stdout.push(JSON.stringify({
+      method: "turn/started",
+      params: { threadId: "thread-1", turn: { id: "turn-2" } },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-close-1",
+          tool: "closeAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
+    const read = await waitForMethod(proc, "thread/read");
+    proc._stdout.push(appServerResponse(read.id, {
+      thread: {
+        id: "thread-child",
+        turns: [{
+          id: "turn-child",
+          items: [{
+            type: "commandExecution",
+            id: "child-cmd-1",
+            command: "npm test",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "ok",
+            exitCode: 0,
+          }, {
+            type: "commandExecution",
+            id: "child-cmd-2",
+            command: "npm run lint",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "clean",
+            exitCode: 0,
+          }],
+        }],
+      },
+    }));
+
+    // The never-seen item is caught up, nested under the ORIGINAL Agent card.
+    await waitForCondition(() =>
+      assistantEvents.some((event) => event.message.content.some((block) => block.id === "child-cmd-2")),
+    );
+    const blocks = assistantEvents.flatMap((event) => event.message.content);
+    expect(blocks.find((block) => block.id === "child-cmd-2")).toEqual(
+      expect.objectContaining({ parentToolUseId: "collab-1" }),
+    );
+    // The previous turn's tool is NOT re-emitted (it used to duplicate here),
+    // and nothing nests under the Close Agent card.
+    expect(blocks.filter((block) => block.id === "child-cmd-1")).toHaveLength(1);
+    expect(blocks.filter((block) => block.parentToolUseId === "collab-close-1")).toHaveLength(0);
+  });
+
+  it("keeps live receiver-thread tools under the spawning Agent card after a wait completes", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: Array<{ message: { content: Array<Record<string, unknown>> } }> = [];
+    session.on("assistant", (event) => assistantEvents.push(event as never));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    // A completed wait used to re-parent thread-child onto the Wait card.
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-wait-1",
+          tool: "wait",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+        },
+      },
+    }) + "\n");
+    const read = await waitForMethod(proc, "thread/read");
+    proc._stdout.push(appServerResponse(read.id, { thread: { id: "thread-child", turns: [] } }));
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-late",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "inProgress",
+        },
+      },
+    }) + "\n");
+
+    await waitForCondition(() =>
+      assistantEvents.some((event) => event.message.content.some((block) => block.id === "child-cmd-late")),
+    );
+    const lateChild = assistantEvents
+      .flatMap((event) => event.message.content)
+      .find((block) => block.id === "child-cmd-late");
+    expect(lateChild).toEqual(expect.objectContaining({ parentToolUseId: "collab-1" }));
+  });
+
   it("preserves collab parent mapping across a turn boundary (goal continuation)", async () => {
     // With goals, a single prompt spans several autonomous turns. A sub-agent
     // spawned in one turn can emit live items in a later turn; the per-turn reset

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1752,6 +1752,71 @@ describe("CodexAppServerSession normalized events", () => {
     });
   });
 
+  it("ignores foreign-thread token usage updates when completing the main turn", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const resultEvents: unknown[] = [];
+    session.on("result", (event) => resultEvents.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        tokenUsage: {
+          last: {
+            totalTokens: 42_000,
+            inputTokens: 36_000,
+            cachedInputTokens: 5_000,
+            outputTokens: 900,
+            reasoningOutputTokens: 100,
+          },
+          modelContextWindow: 400_000,
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "thread/tokenUsage/updated",
+      params: {
+        threadId: "thread-child",
+        turnId: "turn-child",
+        tokenUsage: {
+          last: {
+            totalTokens: 1_000,
+            inputTokens: 800,
+            cachedInputTokens: 10,
+            outputTokens: 50,
+            reasoningOutputTokens: 5,
+          },
+          modelContextWindow: 10_000,
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/completed",
+      params: {
+        threadId: "thread-1",
+        turn: {
+          id: "turn-1",
+          status: "completed",
+        },
+      },
+    }) + "\n");
+
+    await waitForCondition(() => resultEvents.length === 1);
+    expect(resultEvents[0]).toMatchObject({
+      usage: {
+        input_tokens: 36_000,
+        cache_read_input_tokens: 5_000,
+        output_tokens: 900,
+        context_used_tokens: 42_000,
+        context_window: 400_000,
+      },
+    });
+  });
+
   it("does not surface benign too-young-thread replay errors", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1956,6 +1956,43 @@ describe("CodexAppServerSession normalized events", () => {
     ]);
   });
 
+  it("ignores plan updates from sub-agent threads", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    // A sub-agent maintaining its own plan must not surface as a parasitic card
+    // in the main task tracker; only the main thread's plan is emitted.
+    proc._stdout.push(JSON.stringify({
+      method: "turn/plan/updated",
+      params: {
+        threadId: "thread-child",
+        turnId: "turn-child",
+        plan: [{ step: "Child step", status: "inProgress" }],
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/plan/updated",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        plan: [{ step: "Run tests", status: "completed" }],
+      },
+    }) + "\n");
+
+    const planEvents = events.filter((event) => (event as { type: string }).type === "plan_updated");
+    expect(planEvents).toEqual([
+      {
+        type: "plan_updated",
+        id: "codex-plan-turn-1",
+        steps: [{ text: "Run tests", status: "completed" }],
+      },
+    ]);
+  });
+
   it("emits an interrupted result instead of an error when closed mid-turn", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -430,9 +430,16 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     const data = asRecord(params);
     switch (method) {
       case "thread/started":
-        this.threadId = asString(asRecord(data?.thread)?.id) ?? this.threadId;
+        // Only adopt a thread id when we do not own one yet: the App Server
+        // auto-attaches this connection to spawned sub-agent threads, and a
+        // foreign id here would corrupt turn tracking for the main thread.
+        this.threadId ??= asString(asRecord(data?.thread)?.id);
         break;
       case "turn/started": {
+        // Sub-agent (collab) threads emit their own turn lifecycle. Tracking
+        // them as the active turn would make the main thread's turn/completed
+        // look stale and get dropped, leaving the session streaming forever.
+        if (this.isForeignThread(asString(data?.threadId))) break;
         const turn = asRecord(data?.turn);
         const threadId = asString(data?.threadId) ?? this.threadId;
         const turnId = asString(turn?.id);
@@ -792,6 +799,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     return Boolean(threadId && collabAgentReceiverThreadIds(item).includes(threadId));
   }
 
+  /** True when a notification belongs to another thread (a spawned sub-agent
+   *  thread the App Server auto-attached us to), not the session's own thread. */
+  private isForeignThread(threadId: string | undefined): boolean {
+    return Boolean(threadId && this.threadId && threadId !== this.threadId);
+  }
+
   private parentToolUseIdForThread(threadId: string | undefined): string | undefined {
     return threadId ? this.collabParentByThreadId.get(threadId) : undefined;
   }
@@ -838,6 +851,9 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private handleTurnCompleted(data: JsonObject | null): void {
+    // Turn completions for sub-agent threads end that sub-thread's turn, not
+    // ours; only the main thread's turn/completed may finalize the session turn.
+    if (this.isForeignThread(asString(data?.threadId))) return;
     const turn = asRecord(data?.turn);
     const turnId = asString(turn?.id);
     if (turnId && this.completedTurnIds.has(turnId)) return;

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -545,6 +545,9 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "turn/plan/updated":
+        // Sub-agent threads maintain their own plan; without this filter their
+        // steps would surface as a parasitic card in the main task tracker.
+        if (this.isForeignThread(asString(data?.threadId))) break;
         this.emitPlanUpdate(data);
         break;
       case "thread/goal/updated":

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -226,9 +226,14 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
 
   async startTurn(options: CodexAppServerTurnOptions): Promise<void> {
     await this.ensureInitialized(options.env);
-    this.resetTurnState();
+    const previousThreadId = this.threadId;
+    this.resetForUserTurn();
     this.currentCwd = options.cwd;
-    this.threadId = await this.ensureThread(options);
+    const threadId = await this.ensureThread(options);
+    if (threadId !== previousThreadId) {
+      this.resetForThreadBoundary();
+    }
+    this.threadId = threadId;
     const input: UserInput[] = [
       { type: "text", text: options.content, text_elements: [] },
       ...(options.imagePaths ?? []).map((path) => ({ type: "localImage" as const, path })),
@@ -268,6 +273,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.initialized = null;
     this.activeTurnId = undefined;
     this.threadId = undefined;
+    this.resetForThreadBoundary();
     rpc?.close(new Error("Codex app-server closed"));
     if (interruptedTurnId) {
       // Closing with a live turn is a cancellation, not an error: emit a
@@ -343,9 +349,13 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     return started.thread.id;
   }
 
-  /** Full reset, including cross-turn parent maps. Used at process init/teardown. */
-  private resetTurnState(): void {
+  private resetForUserTurn(): void {
     this.resetForNewTurn();
+    this.collabParentByThreadId.clear();
+    this.toolParentByItemId.clear();
+  }
+
+  private resetForThreadBoundary(): void {
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
     this.completedCollabItemIds.clear();
@@ -1139,6 +1149,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.initialized = null;
     this.activeTurnId = undefined;
     this.threadId = undefined;
+    this.resetForThreadBoundary();
   }
 }
 

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -758,7 +758,13 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         this.emitToolUse(collabItem.id, "Agent", JSON.stringify(collabAgentToolInput(collabItem)), parentToolUseId);
         if (phase === "completed") {
           this.emitToolResult(collabItem.id, collabAgentToolResult(collabItem));
-          this.queueCollabAgentReplay(collabItem);
+          // spawnAgent completes at thread creation: the child has no history
+          // yet, and reading it races Codex's rollout flush ("rollout is
+          // empty"). Catch-up replays only make sense once the child has run,
+          // i.e. when a wait/closeAgent on it completes.
+          if (collabItem.tool !== "spawnAgent") {
+            this.queueCollabAgentReplay(collabItem);
+          }
         }
         break;
       }
@@ -1327,10 +1333,16 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
+/** Both variants mean the child thread is too young to be read: it was created
+ *  but has not run (or Codex has not flushed its rollout to disk) yet. Nothing
+ *  to catch up — not worth a user-facing warning. */
 function isUnmaterializedThreadReadError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return message.includes("not materialized yet") &&
-    message.includes("includeTurns is unavailable before first user message");
+  return (
+    (message.includes("not materialized yet") &&
+      message.includes("includeTurns is unavailable before first user message")) ||
+    (message.includes("rollout") && message.includes("is empty"))
+  );
 }
 
 function diagnosticId(prefix: string, method: string): string {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -771,6 +771,10 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "imageView": {
+        // Sub-agent image views stay out of the main stream (like sub-agent
+        // text/reasoning); otherwise they render as unattributed top-level
+        // duplicates of the parent's own views.
+        if (parentToolUseId) break;
         const imageItem = item as Extract<ThreadItem, { type: "imageView" }>;
         if (!imageItem.path) break;
         this.emit("agent_event", {
@@ -782,6 +786,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "imageGeneration": {
+        if (parentToolUseId) break;
         const generationItem = item as Extract<ThreadItem, { type: "imageGeneration" }>;
         const savedPath = generationItem.savedPath ?? undefined;
         const result = generationItem.result;

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -19,6 +19,8 @@ import {
 
 /** Cap for long-lived per-session turn-id dedup Sets to avoid unbounded growth. */
 const MAX_TRACKED_TURN_IDS = 256;
+/** Cap for the cross-turn sub-agent item dedup Set (items are far more numerous than turns). */
+const MAX_TRACKED_COLLAB_ITEM_IDS = 1024;
 
 type CodexAppServerEvent = StreamParserEvent & {
   agent_event: [event: NormalizedAgentEvent];
@@ -191,6 +193,11 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private completedTurnIds = new Set<string>();
   private collabParentByThreadId = new Map<string, string>();
   private toolParentByItemId = new Map<string, string>();
+  /** Sub-agent item ids already rendered, across turns. Collab replays on
+   *  wait/closeAgent re-deliver a child thread's full history; once the
+   *  per-turn dedup sets are reset (next turn), only this set prevents the
+   *  previous turn's child tools from re-emitting as duplicates. */
+  private completedCollabItemIds = new Set<string>();
   private pendingCollabReplays = new Set<Promise<void>>();
   private lastUsage: TokenUsage | undefined;
   private lastProtocolError: string | undefined;
@@ -341,6 +348,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.resetForNewTurn();
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
+    this.completedCollabItemIds.clear();
   }
 
   /**
@@ -629,6 +637,16 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   ): void {
     if (!item?.type || !item.id) return;
     const parentToolUseId = context.parentToolUseId ?? this.parentToolUseIdForThread(context.threadId);
+    if (parentToolUseId) {
+      // Cross-turn dedup: a child item completed in an earlier turn (per-turn
+      // emitted sets reset since) must not re-emit when a later wait/closeAgent
+      // replay re-delivers it. Same-turn re-delivery still flows through and is
+      // handled by the per-turn dedup sets.
+      if (this.completedCollabItemIds.has(item.id) && !this.emittedToolIds.has(item.id)) return;
+      if (phase === "completed") {
+        addBounded(this.completedCollabItemIds, item.id, MAX_TRACKED_COLLAB_ITEM_IDS);
+      }
+    }
 
     switch (item.type) {
       case "agentMessage": {
@@ -731,7 +749,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         if (parentToolUseId && this.isCollabAgentSelfReference(collabItem, context.threadId)) {
           break;
         }
-        this.rememberCollabAgentReceivers(collabItem);
+        // Only spawnAgent owns its receiver threads. wait/closeAgent reference
+        // the same threads but must not steal the children: their live items
+        // and replay catch-ups belong under the original Agent card.
+        if (collabItem.tool === "spawnAgent") {
+          this.rememberCollabAgentReceivers(collabItem);
+        }
         this.emitToolUse(collabItem.id, "Agent", JSON.stringify(collabAgentToolInput(collabItem)), parentToolUseId);
         if (phase === "completed") {
           this.emitToolResult(collabItem.id, collabAgentToolResult(collabItem));
@@ -818,7 +841,11 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private queueCollabAgentReplay(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
     const threadIds = collabAgentReceiverThreadIds(item);
     if (threadIds.length === 0) return;
-    const replay = Promise.all(threadIds.map((threadId) => this.replayCollabAgentThread(threadId, item.id)))
+    // Catch-up items nest under the spawning Agent card when known; the
+    // triggering wait/closeAgent card is only a fallback for threads whose
+    // spawn was never observed (e.g. resumed session).
+    const replay = Promise.all(threadIds.map((threadId) =>
+      this.replayCollabAgentThread(threadId, this.collabParentByThreadId.get(threadId) ?? item.id)))
       .then(() => undefined)
       .catch((err: unknown) => {
         if (isUnmaterializedThreadReadError(err)) return;

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -474,6 +474,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "thread/tokenUsage/updated":
+        if (this.isForeignThread(asString(data?.threadId))) break;
         this.lastUsage = asRecord(data?.tokenUsage) as TokenUsage | undefined;
         break;
       case "remoteControl/status/changed":

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -759,11 +759,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         if (parentToolUseId && this.isCollabAgentSelfReference(collabItem, context.threadId)) {
           break;
         }
-        // Only spawnAgent owns its receiver threads. wait/closeAgent reference
-        // the same threads but must not steal the children: their live items
-        // and replay catch-ups belong under the original Agent card.
+        // spawnAgent owns receiver threads when observed. wait/closeAgent only
+        // become fallback owners for threads whose spawn was missed.
         if (collabItem.tool === "spawnAgent") {
           this.rememberCollabAgentReceivers(collabItem);
+        } else {
+          this.rememberFallbackCollabAgentReceivers(collabItem);
         }
         this.emitToolUse(collabItem.id, "Agent", JSON.stringify(collabAgentToolInput(collabItem)), parentToolUseId);
         if (phase === "completed") {
@@ -856,6 +857,14 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private rememberCollabAgentReceivers(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
     for (const threadId of collabAgentReceiverThreadIds(item)) {
       this.collabParentByThreadId.set(threadId, item.id);
+    }
+  }
+
+  private rememberFallbackCollabAgentReceivers(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
+    for (const threadId of collabAgentReceiverThreadIds(item)) {
+      if (!this.collabParentByThreadId.has(threadId)) {
+        this.collabParentByThreadId.set(threadId, item.id);
+      }
     }
   }
 


### PR DESCRIPTION
## Problem

Turn end was still sometimes not detected for Codex app-server chats (session stuck "streaming" forever after the final message), despite #231. It reliably reproduced on turns that spawned sub-agents. Related symptom: sub-agent tool calls duplicated over time (3 → 6 → 9…), often under a "Close Agent" card in the next turn.

## Root cause (verified against openai/codex sources)

The App Server auto-attaches every initialized connection to spawned sub-agent (collab) threads (`notify_thread_created` → `try_attach_thread_listener`) and forwards their **turn lifecycle notifications too** — `turn/started` / `turn/completed` carry a `threadId` and that is the only discriminator.

### Commit 1 — ghost turns

Our bridge did not filter turn lifecycle by thread:

1. Main turn `turn-main` active on `thread-main`.
2. Sub-agent starts → `turn/started` (`threadId: thread-child`) → bridge overwrote `this.threadId` **and** `this.activeTurnId`, and ran `resetForNewTurn()` mid-turn.
3. Main `turn/completed` arrives → id ≠ `activeTurnId` → dropped by the stale-turn guard from #231 → no result, ghost turn.

Fix: ignore `turn/started` / `turn/completed` from foreign threads; `thread/started` only adopts a thread id when none is owned yet.

### Commit 2 — duplicated sub-agent tools / Wait & Close Agent cards stealing children

Collab replays (`thread/read` on every completed collab item — `spawnAgent`, `wait`, `closeAgent` alike) re-delivered a child thread's full history. Within a turn the per-turn dedup sets suppressed duplicates, but once the next turn reset them, the previous turn's child tools re-emitted as new (3 → 6 → 9), nested under the triggering `wait`/`closeAgent` card (which also re-parented the child thread away from its original Agent card).

Fix:
- Cross-turn bounded set of already-rendered sub-agent item ids: replays only emit items never shown (also stops recursive replay cascades).
- Only `spawnAgent` re-parents its receiver threads; `wait`/`closeAgent` are plain markers again.
- Replay catch-ups nest under the spawning Agent card (fallback to the triggering card only when the spawn was never observed, e.g. resumed session).

## Tests

- 4 new regression tests: sub-thread lifecycle does not hijack the active turn; foreign `thread/started` ignored; `closeAgent` replay in a later turn does not duplicate and catch-ups nest under the original Agent card; a completed `wait` no longer steals live child items.
- Backend 1547 tests, frontend 1361 tests, lint + typecheck all green.