### PR TITLE
Align iOS image activity UI

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -141,7 +141,7 @@ struct ChatInputBar: View {
         ScrollView(.horizontal) {
             HStack(spacing: 8) {
                 ForEach(attachedImages) { item in
-                    AttachmentChip(image: item.image) {
+                    AttachmentChip(source: item.attachment.dataUrl) {
                         withAnimation(.spring(duration: 0.25)) {
                             attachedImages.removeAll { $0.id == item.id }
                         }
@@ -237,7 +237,7 @@ struct ChatInputBar: View {
                     guard let attachment = ImageAttachment.makeFromDraftImage(uiImage) else { return }
                     DispatchQueue.main.async {
                         withAnimation(.spring(duration: 0.25)) {
-                            attachedImages.append(AttachedImage(image: uiImage, attachment: attachment))
+                            attachedImages.append(AttachedImage(attachment: attachment))
                         }
                         onDraftAttachmentsChange(attachedImages.map(\.attachment))
                     }
@@ -252,8 +252,8 @@ struct ChatInputBar: View {
         guard normalized != current else { return }
 
         attachedImages = attachments.compactMap { attachment in
-            guard let uiImage = attachment.decodedImage else { return nil }
-            return AttachedImage(image: uiImage, attachment: attachment)
+            guard attachment.decodedImage != nil else { return nil }
+            return AttachedImage(attachment: attachment)
         }
         if attachedImages.count != attachments.count {
             onDraftAttachmentsChange(attachedImages.map(\.attachment))
@@ -265,7 +265,6 @@ struct ChatInputBar: View {
 
 private struct AttachedImage: Identifiable {
     let id = UUID()
-    let image: UIImage
     let attachment: ImageAttachment
 }
 
@@ -330,16 +329,18 @@ private struct LevelCycleButton: View {
 // MARK: - Attachment Chip
 
 private struct AttachmentChip: View {
-    let image: UIImage
+    private static let size = CGSize(width: 52, height: 52)
+
+    let source: String
     let onRemove: () -> Void
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            Image(uiImage: image)
-                .resizable()
-                .scaledToFill()
-                .frame(width: 52, height: 52)
-                .clipShape(RoundedRectangle(cornerRadius: 8))
+            ChatImageTile(
+                source: source,
+                size: Self.size,
+                cornerRadius: 8
+            )
 
             Button {
                 onRemove()

--- a/ios/HiveMobile/Views/Chat/ImageActivity.swift
+++ b/ios/HiveMobile/Views/Chat/ImageActivity.swift
@@ -2,12 +2,10 @@ import SwiftUI
 
 private let outsideWorkspaceMessage = "Image is outside the workspace and cannot be previewed."
 
-/// `image_view` activity: a small thumbnail beside a "View image" toggle.
+/// `image_view` activity: a "View image" toggle with the thumbnail below.
 /// Mirrors `ImageViewActivity` in `frontend/src/components/chat/ImageActivity.tsx`.
 struct ImageViewActivityRow: View {
     let activity: AgentActivity.ImageView
-
-    private static let tileSize = CGSize(width: 48, height: 48)
 
     private var name: String { imageActivityFileName(activity.path) }
     private var source: String? { activity.resolvedSource }
@@ -20,16 +18,11 @@ struct ImageViewActivityRow: View {
     }
 
     var body: some View {
-        ActivityDisclosureRow(
+        ImageActivityShell(
             title: "View image",
             detail: name,
-            leading: AnyView(
-                ChatImageTileWithLightbox(
-                    source: source,
-                    size: Self.tileSize,
-                    noPreviewMessage: activity.outsideWorkspace == true ? outsideWorkspaceMessage : nil
-                )
-            ),
+            source: source,
+            noPreviewMessage: activity.outsideWorkspace == true ? outsideWorkspaceMessage : nil,
             expanded: expandedContent
         )
     }
@@ -42,8 +35,6 @@ struct ImageGenerationActivityRow: View {
     let activity: AgentActivity.ImageGeneration
     var showExecutingState = false
 
-    private static let tileSize = CGSize(width: 80, height: 80)
-
     private var source: String? { activity.resolvedSource }
     private var pending: Bool { activity.isPending(showExecutingState: showExecutingState) }
     private var promptDetail: String? { imagePromptPreview(activity.revisedPrompt) }
@@ -54,17 +45,39 @@ struct ImageGenerationActivityRow: View {
     }
 
     var body: some View {
-        ActivityDisclosureRow(
-            icon: "photo",
+        ImageActivityShell(
             title: "Proposed image",
             detail: promptDetail,
+            source: source,
             executing: pending,
-            expanded: expandedContent,
+            expanded: expandedContent
+        )
+    }
+}
+
+private struct ImageActivityShell: View {
+    private static let tileSize = CGSize(width: 80, height: 80)
+
+    let title: String
+    var detail: String?
+    let source: String?
+    var executing = false
+    var noPreviewMessage: String?
+    var expanded: AnyView?
+
+    var body: some View {
+        ActivityDisclosureRow(
+            icon: "photo",
+            title: title,
+            detail: detail,
+            executing: executing,
+            expanded: expanded,
             below: AnyView(
                 ChatImageTileWithLightbox(
                     source: source,
-                    pending: pending,
-                    size: Self.tileSize
+                    pending: executing,
+                    size: Self.tileSize,
+                    noPreviewMessage: noPreviewMessage
                 )
                 .padding(.top, 6)
             )


### PR DESCRIPTION
## Summary
- Align iOS image_view activities with the unified frontend image activity layout
- Share the iOS image activity shell between viewed and generated image rows
- Reuse the shared chat image tile for draft attachment previews in the input bar
- Render viewed image thumbnails below the activity row at the same size as generated images

## Testing
- git diff --check
- Not run: Swift/iOS build or tests because swift and xcodebuild are unavailable in this environment