### PR TITLE
Fix Codex goal command handling

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1057,6 +1057,28 @@ describe("ConversationSession", () => {
     expect(session.metadata.providerSessionId).toBe("thread-goal-1");
   });
 
+  it("emits a single terminal event when stopped during a pending /goal request", async () => {
+    const session = createSession({ sessionId: "goal-stop-command-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("/goal Ship backend support", { model: "codex:gpt-5.5" });
+
+    await respondToAppServerThreadStart(mockProc, "thread-goal-stop");
+    // Wait until the goal request is in flight, then stop before it resolves.
+    await waitForStdinMethod(mockProc, "thread/goal/set");
+
+    session.stop();
+
+    const cancelled = await waitForMessages(messages, "cancelled");
+    // Let the rejected goal-request promise's .catch run: without the no-turn
+    // finalize guard it would finalize a second time and emit a ghost error.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(cancelled).toHaveLength(1);
+    expect(messages.filter((msg) => msg.type === "error")).toHaveLength(0);
+    expect(messages.filter((msg) => msg.type === "done")).toHaveLength(0);
+  });
+
   it("refuses fresh Codex /goal without creating a provider thread", async () => {
     await expectFreshGoalManagementCommandRejected("goal-fresh-get-command-session", "/goal");
   });

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1057,6 +1057,29 @@ describe("ConversationSession", () => {
     expect(session.metadata.providerSessionId).toBe("thread-goal-1");
   });
 
+  it("rejects overlong Codex /goal objectives before creating a thread", async () => {
+    const session = createSession({ sessionId: "goal-command-overlong-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage(`/goal ${"a".repeat(4001)}`, { model: "codex:gpt-5.5" });
+
+    const errors = await waitForMessages(messages, "error");
+    expect(errors).toEqual([
+      {
+        type: "error",
+        sessionId: "goal-command-overlong-session",
+        message: "Codex goal objective must be 4,000 characters or fewer.",
+      },
+    ]);
+    expect(countStdinMethod(mockProc, "thread/start")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/resume")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/set")).toBe(0);
+    expect(session.metadata.providerSessionId).toBeUndefined();
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    expect(userMessage?.goalCommand).toBe(true);
+  });
+
   it("emits a single terminal event when stopped during a pending /goal request", async () => {
     const session = createSession({ sessionId: "goal-stop-command-session" });
     const messages: WsOutgoing[] = [];

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -279,6 +279,82 @@ describe("ConversationSession", () => {
     });
   }
 
+  async function expectFreshGoalManagementCommandRejected(sessionId: string, command: string): Promise<void> {
+    const session = createSession({ sessionId });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage(command, { model: "codex:gpt-5.5" });
+
+    const errors = await waitForMessages(messages, "error");
+    expect(errors[0]).toMatchObject({
+      sessionId,
+      message: "No Codex thread exists yet. Send a message or set a goal objective first.",
+    });
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(countStdinMethod(mockProc, "thread/start")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/get")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/clear")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/set")).toBe(0);
+    expect(session.metadata.providerSessionId).toBeUndefined();
+
+    const userEvent = messages.find(
+      (msg): msg is Extract<WsOutgoing, { type: "user_message" }> => msg.type === "user_message",
+    );
+    expect(userEvent?.message.goalCommand).toBe(true);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    expect(userMessage?.goalCommand).toBe(true);
+  }
+
+  async function establishCodexThread(
+    session: ConversationSession,
+    messages: WsOutgoing[],
+    threadId: string,
+    turnId: string,
+  ): Promise<void> {
+    session.sendMessage("Start thread", { model: "codex:gpt-5.5" });
+    await completeAppServerTurn(mockProc, threadId, turnId);
+    await waitForMessages(messages, "done");
+    expect(session.metadata.providerSessionId).toBe(threadId);
+  }
+
+  async function resumeCodexGoalThread(threadId: string, occurrence = 1): Promise<void> {
+    const threadResume = await waitForStdinMethod(mockProc, "thread/resume", occurrence);
+    expect(threadResume.params).toMatchObject({ threadId });
+    mockProc._stdout.push(appServerResponse(threadResume.id, { thread: { id: threadId } }));
+  }
+
+  async function expectExistingGoalStatusCommand(
+    sessionId: string,
+    command: string,
+    expectedStatus: string,
+  ): Promise<void> {
+    const session = createSession({ sessionId });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+    const threadId = `${sessionId}-thread`;
+
+    await establishCodexThread(session, messages, threadId, `${sessionId}-turn`);
+
+    session.sendMessage(command, { model: "codex:gpt-5.5" });
+
+    await resumeCodexGoalThread(threadId);
+    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
+    expect(goalSet.params).toEqual({
+      threadId,
+      status: expectedStatus,
+    });
+    mockProc._stdout.push(appServerResponse(goalSet.id, {
+      goal: {
+        threadId,
+        status: expectedStatus,
+      },
+    }));
+
+    await waitForMessages(messages, "done", 2);
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(1);
+  }
+
   it("survives emit(\"error\") with no external listeners attached", () => {
     const session = createSession({ command: "bash" });
     // Node throws (and would crash the process) on an unhandled "error" event;
@@ -981,80 +1057,72 @@ describe("ConversationSession", () => {
     expect(session.metadata.providerSessionId).toBe("thread-goal-1");
   });
 
-  it("routes Codex /goal clear through thread/goal/clear without starting a turn", async () => {
+  it("refuses fresh Codex /goal without creating a provider thread", async () => {
+    await expectFreshGoalManagementCommandRejected("goal-fresh-get-command-session", "/goal");
+  });
+
+  it("refuses fresh Codex /goal clear without creating a provider thread", async () => {
+    await expectFreshGoalManagementCommandRejected("goal-fresh-clear-command-session", "/goal clear");
+  });
+
+  it("refuses fresh Codex /goal complete without treating complete as an objective", async () => {
+    await expectFreshGoalManagementCommandRejected("goal-fresh-complete-command-session", "/goal complete");
+  });
+
+  it("routes existing Codex /goal clear through thread/goal/clear without starting a turn", async () => {
     const session = createSession({ sessionId: "goal-clear-command-session" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
+    await establishCodexThread(session, messages, "thread-goal-clear", "turn-goal-clear");
+
     session.sendMessage("/goal clear", { model: "codex:gpt-5.5" });
 
-    await respondToAppServerThreadStart(mockProc, "thread-goal-clear");
+    await resumeCodexGoalThread("thread-goal-clear");
     const goalClear = await waitForStdinMethod(mockProc, "thread/goal/clear");
     expect(goalClear.params).toEqual({ threadId: "thread-goal-clear" });
     mockProc._stdout.push(appServerResponse(goalClear.id, {}));
 
-    await waitForMessages(messages, "done");
-    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
-    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    await waitForMessages(messages, "done", 2);
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(1);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user" && msg.content === "/goal clear");
     expect(userMessage?.goalCommand).toBe(true);
   });
 
-  it("routes Codex /goal pause through thread/goal/set with paused status", async () => {
-    const session = createSession({ sessionId: "goal-pause-command-session" });
-    const messages: WsOutgoing[] = [];
-    session.on("message", (msg) => messages.push(msg));
-
-    session.sendMessage("/goal pause", { model: "codex:gpt-5.5" });
-
-    await respondToAppServerThreadStart(mockProc, "thread-goal-pause");
-    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
-    expect(goalSet.params).toEqual({
-      threadId: "thread-goal-pause",
-      status: "paused",
-    });
-    mockProc._stdout.push(appServerResponse(goalSet.id, {
-      goal: {
-        threadId: "thread-goal-pause",
-        status: "paused",
-      },
-    }));
-
-    await waitForMessages(messages, "done");
-    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+  it("routes existing Codex /goal pause through thread/goal/set with paused status", async () => {
+    await expectExistingGoalStatusCommand("goal-pause-command-session", "/goal pause", "paused");
   });
 
-  it("routes Codex /goal resume through thread/goal/set with active status", async () => {
-    const session = createSession({ sessionId: "goal-resume-command-session" });
-    const messages: WsOutgoing[] = [];
-    session.on("message", (msg) => messages.push(msg));
-
-    session.sendMessage("/goal resume", { model: "codex:gpt-5.5" });
-
-    await respondToAppServerThreadStart(mockProc, "thread-goal-resume");
-    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
-    expect(goalSet.params).toEqual({
-      threadId: "thread-goal-resume",
-      status: "active",
-    });
-    mockProc._stdout.push(appServerResponse(goalSet.id, {
-      goal: {
-        threadId: "thread-goal-resume",
-        status: "active",
-      },
-    }));
-
-    await waitForMessages(messages, "done");
-    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+  it("routes existing Codex /goal resume through thread/goal/set with active status", async () => {
+    await expectExistingGoalStatusCommand("goal-resume-command-session", "/goal resume", "active");
   });
 
-  it("routes bare Codex /goal through thread/goal/get without starting a turn", async () => {
+  it("routes existing Codex /goal complete through thread/goal/set with complete status", async () => {
+    await expectExistingGoalStatusCommand("goal-complete-command-session", "/goal complete", "complete");
+  });
+
+  it("routes existing Codex /goal blocked through thread/goal/set with blocked status", async () => {
+    await expectExistingGoalStatusCommand("goal-blocked-command-session", "/goal blocked", "blocked");
+  });
+
+  it("routes existing Codex /goal usage-limited through thread/goal/set with usageLimited status", async () => {
+    await expectExistingGoalStatusCommand("goal-usage-limited-command-session", "/goal usage-limited", "usageLimited");
+  });
+
+  it("routes existing Codex /goal budget-limited through thread/goal/set with budgetLimited status", async () => {
+    await expectExistingGoalStatusCommand("goal-budget-limited-command-session", "/goal budget-limited", "budgetLimited");
+  });
+
+  it("routes existing bare Codex /goal through thread/goal/get without starting a turn", async () => {
     const session = createSession({ sessionId: "goal-get-command-session" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
+    await establishCodexThread(session, messages, "thread-goal-get", "turn-goal-get");
+
     session.sendMessage("/goal", { model: "codex:gpt-5.5" });
 
-    await respondToAppServerThreadStart(mockProc, "thread-goal-get");
+    await resumeCodexGoalThread("thread-goal-get");
     const goalGet = await waitForStdinMethod(mockProc, "thread/goal/get");
     expect(goalGet.params).toEqual({ threadId: "thread-goal-get" });
     mockProc._stdout.push(appServerResponse(goalGet.id, {
@@ -1065,9 +1133,9 @@ describe("ConversationSession", () => {
       },
     }));
 
-    await waitForMessages(messages, "done");
-    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
-    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    await waitForMessages(messages, "done", 2);
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(1);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user" && msg.content === "/goal");
     expect(userMessage?.goalCommand).toBe(true);
   });
 

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -180,6 +180,41 @@ function getStdinMethod(
   throw new Error(`Missing ${method}`);
 }
 
+async function respondToAppServerThreadStart(
+  proc: ReturnType<typeof createMockProcess>,
+  threadId: string,
+): Promise<void> {
+  const init = await waitForStdinMethod(proc, "initialize");
+  proc._stdout.push(appServerResponse(init.id, {
+    userAgent: "codex-test",
+    codexHome: "/tmp/codex",
+    platformFamily: "unix",
+    platformOs: "linux",
+  }));
+
+  const threadStart = await waitForStdinMethod(proc, "thread/start");
+  proc._stdout.push(appServerResponse(threadStart.id, {
+    thread: { id: threadId },
+  }));
+}
+
+async function completeAppServerTurn(
+  proc: ReturnType<typeof createMockProcess>,
+  threadId: string,
+  turnId: string,
+): Promise<{ id: number; method: string; params?: unknown }> {
+  await respondToAppServerThreadStart(proc, threadId);
+  const turnStart = await waitForStdinMethod(proc, "turn/start");
+  proc._stdout.push(appServerResponse(turnStart.id, {
+    turn: { id: turnId },
+  }));
+  proc._stdout.push(appServerNotification("turn/completed", {
+    threadId,
+    turn: { id: turnId, status: "completed" },
+  }));
+  return turnStart;
+}
+
 function geminiInitLine(sessionId: string, model = "gemini-3.1-pro-preview"): string {
   return JSON.stringify({ type: "init", session_id: sessionId, model }) + "\n";
 }
@@ -911,42 +946,127 @@ describe("ConversationSession", () => {
     ]);
   });
 
-  it("marks displayed Codex /goal user messages", async () => {
-    providerRegistry.markProviderAvailable("codex", { appServer: true, goals: true });
-    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
-    fakeRunner.start = vi.fn(() => {
-      fakeRunner.emit("result", { type: "result", session_id: "provider-goal-command" });
-      fakeRunner.emit("exit", 0, "provider-goal-command");
-    });
-    fakeRunner.stop = vi.fn(() => {});
-
-    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
-      runner: fakeRunner,
-      protocol: "process" as const,
-      providerId: "codex",
-      modelId: "gpt-5.5",
-      supportsBlockingTools: false,
-      providerSessionId: "provider-goal-command",
-      debug: { command: "fake", args: [] },
-      start: fakeRunner.start,
-    }));
-    const session = new ConversationSession({
-      cwd: "/tmp/test",
-      dataDir: tempDir,
-      workspaceId: "ws-test",
-      sessionId: "goal-command-session",
-      runnerFactory,
-    });
+  it("routes Codex /goal objectives through thread/goal/set without starting a turn", async () => {
+    const session = createSession({ sessionId: "goal-command-session" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
     session.sendMessage("  /goal Ship backend support", { model: "codex:gpt-5.5" });
 
+    await respondToAppServerThreadStart(mockProc, "thread-goal-1");
+
+    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
+    expect(goalSet.params).toEqual({
+      threadId: "thread-goal-1",
+      objective: "Ship backend support",
+      status: "active",
+    });
+    mockProc._stdout.push(appServerResponse(goalSet.id, {
+      goal: {
+        threadId: "thread-goal-1",
+        objective: "Ship backend support",
+        status: "active",
+      },
+    }));
+
     await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+
     const userEvent = messages.find(
       (msg): msg is Extract<WsOutgoing, { type: "user_message" }> => msg.type === "user_message",
     );
     expect(userEvent?.message.goalCommand).toBe(true);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    expect(userMessage?.goalCommand).toBe(true);
+    expect(session.metadata.providerSessionId).toBe("thread-goal-1");
+  });
+
+  it("routes Codex /goal clear through thread/goal/clear without starting a turn", async () => {
+    const session = createSession({ sessionId: "goal-clear-command-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("/goal clear", { model: "codex:gpt-5.5" });
+
+    await respondToAppServerThreadStart(mockProc, "thread-goal-clear");
+    const goalClear = await waitForStdinMethod(mockProc, "thread/goal/clear");
+    expect(goalClear.params).toEqual({ threadId: "thread-goal-clear" });
+    mockProc._stdout.push(appServerResponse(goalClear.id, {}));
+
+    await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    expect(userMessage?.goalCommand).toBe(true);
+  });
+
+  it("routes Codex /goal pause through thread/goal/set with paused status", async () => {
+    const session = createSession({ sessionId: "goal-pause-command-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("/goal pause", { model: "codex:gpt-5.5" });
+
+    await respondToAppServerThreadStart(mockProc, "thread-goal-pause");
+    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
+    expect(goalSet.params).toEqual({
+      threadId: "thread-goal-pause",
+      status: "paused",
+    });
+    mockProc._stdout.push(appServerResponse(goalSet.id, {
+      goal: {
+        threadId: "thread-goal-pause",
+        status: "paused",
+      },
+    }));
+
+    await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+  });
+
+  it("routes Codex /goal resume through thread/goal/set with active status", async () => {
+    const session = createSession({ sessionId: "goal-resume-command-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("/goal resume", { model: "codex:gpt-5.5" });
+
+    await respondToAppServerThreadStart(mockProc, "thread-goal-resume");
+    const goalSet = await waitForStdinMethod(mockProc, "thread/goal/set");
+    expect(goalSet.params).toEqual({
+      threadId: "thread-goal-resume",
+      status: "active",
+    });
+    mockProc._stdout.push(appServerResponse(goalSet.id, {
+      goal: {
+        threadId: "thread-goal-resume",
+        status: "active",
+      },
+    }));
+
+    await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
+  });
+
+  it("routes bare Codex /goal through thread/goal/get without starting a turn", async () => {
+    const session = createSession({ sessionId: "goal-get-command-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("/goal", { model: "codex:gpt-5.5" });
+
+    await respondToAppServerThreadStart(mockProc, "thread-goal-get");
+    const goalGet = await waitForStdinMethod(mockProc, "thread/goal/get");
+    expect(goalGet.params).toEqual({ threadId: "thread-goal-get" });
+    mockProc._stdout.push(appServerResponse(goalGet.id, {
+      goal: {
+        threadId: "thread-goal-get",
+        objective: "Ship backend support",
+        status: "active",
+      },
+    }));
+
+    await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(0);
     const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
     expect(userMessage?.goalCommand).toBe(true);
   });
@@ -1028,37 +1148,40 @@ describe("ConversationSession", () => {
     expect(userMessage?.goalCommand).toBeUndefined();
   });
 
-  it("does not mark Codex messages that only share the /goal prefix", async () => {
-    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
-    fakeRunner.start = vi.fn(() => {
-      fakeRunner.emit("result", { type: "result", session_id: "provider-goal-prefix" });
-      fakeRunner.emit("exit", 0, "provider-goal-prefix");
-    });
-    fakeRunner.stop = vi.fn(() => {});
-
-    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
-      runner: fakeRunner,
-      protocol: "process" as const,
-      providerId: "codex",
-      modelId: "gpt-5.5",
-      supportsBlockingTools: false,
-      providerSessionId: "provider-goal-prefix",
-      debug: { command: "fake", args: [] },
-      start: fakeRunner.start,
-    }));
-    const session = new ConversationSession({
-      cwd: "/tmp/test",
-      dataDir: tempDir,
-      workspaceId: "ws-test",
-      sessionId: "goal-prefix-session",
-      runnerFactory,
-    });
+  it("keeps /goalkeeper as a normal Codex turn", async () => {
+    const session = createSession({ sessionId: "goal-prefix-session" });
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
     session.sendMessage("/goalkeeper is not a command", { model: "codex:gpt-5.5" });
 
+    const turnStart = await completeAppServerTurn(mockProc, "thread-goal-prefix", "turn-goal-prefix");
+    expect(turnStart.params).toMatchObject({
+      threadId: "thread-goal-prefix",
+      input: [{ type: "text", text: "/goalkeeper is not a command", text_elements: [] }],
+    });
     await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "thread/goal/set")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/clear")).toBe(0);
+    const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
+    expect(userMessage?.goalCommand).toBeUndefined();
+  });
+
+  it("keeps /goal in the middle of a message as a normal Codex turn", async () => {
+    const session = createSession({ sessionId: "goal-middle-session" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Please check why /goal clear does not work", { model: "codex:gpt-5.5" });
+
+    const turnStart = await completeAppServerTurn(mockProc, "thread-goal-middle", "turn-goal-middle");
+    expect(turnStart.params).toMatchObject({
+      threadId: "thread-goal-middle",
+      input: [{ type: "text", text: "Please check why /goal clear does not work", text_elements: [] }],
+    });
+    await waitForMessages(messages, "done");
+    expect(countStdinMethod(mockProc, "thread/goal/set")).toBe(0);
+    expect(countStdinMethod(mockProc, "thread/goal/clear")).toBe(0);
     const userMessage = (await session.getMessages()).find((msg) => msg.role === "user");
     expect(userMessage?.goalCommand).toBeUndefined();
   });

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -559,6 +559,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let normalizer = new AgentEventNormalizer();
     const blockingToolNames = new Set(["AskUserQuestion", "ExitPlanMode"]);
     let killedForBlockingTool = false;
+    let finalized = false;
     let currentTurnId: string | undefined = options?.useCapturedTurnId === false
       ? undefined
       : (runner as { capturedTurnId?: string }).capturedTurnId;
@@ -572,6 +573,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       lastStderr = undefined;
       normalizer = new AgentEventNormalizer();
       killedForBlockingTool = false;
+      finalized = false;
     };
 
     const finish = (exitCode: number, failureDetail?: string, completedTurnId?: string) => {
@@ -579,7 +581,14 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       if (turnId) {
         if (this.finalizedCodexAppServerTurnIds.has(turnId)) return;
         addBounded(this.finalizedCodexAppServerTurnIds, turnId, MAX_FINALIZED_TURN_IDS);
+      } else if (finalized) {
+        // No turn id to dedup against (e.g. a /goal command that never starts a
+        // turn): the runner event handlers and the goal-request promise can both
+        // reach finish() — guard against a second finalizeTurn that would emit a
+        // duplicate terminal event (e.g. a ghost `error` after a `cancelled`).
+        return;
       }
+      finalized = true;
       this.finalizeTurn({
         exitCode,
         killedForBlockingTool,

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -6,6 +6,7 @@ import { workspaceFileRawPath } from "@hive/shared/workspace-files";
 import { nanoid } from "nanoid";
 import sharp from "sharp";
 import { AgentEventNormalizer, type NormalizedAgentEvent } from "./agent-event-normalizer.js";
+import type { CodexGoalResult, CodexGoalSetParams } from "./providers/codex-app-server.js";
 import { providerSupportsAppServerGoals, resolveProvider } from "./providers/registry.js";
 import type { AgentProvider } from "./providers/types.js";
 import { createAgentRunner, type AgentRunnerFactory } from "./runners/factory.js";
@@ -53,11 +54,57 @@ const MAX_FINALIZED_TURN_IDS = 256;
  */
 const MAX_GENERATED_IMAGE_COPY_BYTES = 25 * 1024 * 1024;
 
-function isCodexGoalCommand(content: string, providerId: string | undefined): boolean {
+type CodexGoalCommand =
+  | { type: "set"; objective: string }
+  | { type: "set_status"; status: "active" | "paused" }
+  | { type: "clear" }
+  | { type: "get" };
+
+type CodexGoalRunner = AgentRunner & {
+  setGoal(params: CodexGoalSetParams, options: CodexGoalRunnerOptions): Promise<CodexGoalResult>;
+  getGoal(options: CodexGoalRunnerOptions): Promise<CodexGoalResult>;
+  clearGoal(options: CodexGoalRunnerOptions): Promise<CodexGoalResult>;
+};
+
+type CodexGoalRunnerOptions = {
+  cwd: string;
+  model?: string;
+  systemPrompt?: string;
+  threadId?: string;
+  env?: Record<string, string>;
+};
+
+function parseCodexGoalCommand(content: string): CodexGoalCommand | null {
   const trimmed = content.trim();
-  return providerId === "codex"
-    && providerSupportsAppServerGoals(providerId)
-    && (trimmed === "/goal" || trimmed.startsWith("/goal "));
+  if (trimmed === "/goal") return { type: "get" };
+  if (!trimmed.startsWith("/goal ")) return null;
+
+  const argument = trimmed.slice("/goal ".length).trim();
+  if (!argument) return { type: "get" };
+  if (argument === "clear") return { type: "clear" };
+  if (argument === "pause") return { type: "set_status", status: "paused" };
+  if (argument === "resume") return { type: "set_status", status: "active" };
+  return { type: "set", objective: argument };
+}
+
+function canHandleCodexGoalCommand(
+  command: CodexGoalCommand | null,
+  providerId: string | undefined,
+  sessionKind: SessionKind,
+  testCommand: string | undefined,
+): command is CodexGoalCommand {
+  return command !== null
+    && !testCommand
+    && isInteractiveSessionKind(sessionKind)
+    && providerId === "codex"
+    && providerSupportsAppServerGoals(providerId);
+}
+
+function isCodexGoalRunner(runner: AgentRunner): runner is CodexGoalRunner {
+  const candidate = runner as Partial<CodexGoalRunner>;
+  return typeof candidate.setGoal === "function"
+    && typeof candidate.getGoal === "function"
+    && typeof candidate.clearGoal === "function";
 }
 
 function cloneAgentActivity(activity: AgentActivity): AgentActivity {
@@ -317,12 +364,22 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       this.enqueueMetadataPersist();
     }
 
+    const promptContent = cliContent ?? content;
+    const goalCommand = images?.length ? null : parseCodexGoalCommand(content);
+    if (resolved && canHandleCodexGoalCommand(goalCommand, resolved.provider.id, this.sessionKind, this.testCommand)) {
+      this._status = "streaming";
+      this._streamingStartedAt = Date.now();
+      this.stopReason = null;
+      this._lastPlanMode = false;
+      this.emitUserMessage(content, undefined, fileMentions, true);
+      this.startCodexGoalCommand(goalCommand, msgOptions, resolved);
+      return;
+    }
+
     this._status = "streaming";
     this._streamingStartedAt = Date.now();
     this.stopReason = null;
     this._lastPlanMode = msgOptions?.planMode ?? false;
-
-    const promptContent = cliContent ?? content;
 
     if (images?.length) {
       void this.saveImagesToDisk(images).then((saved) => {
@@ -336,7 +393,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           !this.testCommand &&
           resolved?.provider.id === "codex" &&
           isInteractiveSessionKind(this.sessionKind);
-        this.emitUserMessage(content, urlImages, fileMentions, isCodexGoalCommand(content, resolved?.provider.id));
+        this.emitUserMessage(content, urlImages, fileMentions);
         this.startAgentTurn(
           useNativeCodexImages ? promptContent : this.buildPromptWithImages(promptContent, imagePaths),
           msgOptions,
@@ -349,7 +406,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         this.emit("error", err instanceof Error ? err : new Error(String(err)));
       });
     } else {
-      this.emitUserMessage(content, undefined, fileMentions, isCodexGoalCommand(content, resolved?.provider.id));
+      this.emitUserMessage(content, undefined, fileMentions);
       this.startAgentTurn(promptContent, msgOptions, resolved);
     }
   }
@@ -463,6 +520,237 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     return true;
   }
 
+  private attachCodexAppServerRunnerHandlers(
+    runner: AgentRunner,
+    supportsBlockingTools: boolean,
+  ): { finishWithoutTurn: (exitCode: number, failureDetail?: string) => void; hasActiveTurn: () => boolean } {
+    this.resetStreamAccumulators();
+
+    let resultDurationMs: number | undefined;
+    let resultInputTokens: number | undefined;
+    let resultOutputTokens: number | undefined;
+    let resultContextUsedTokens: number | undefined;
+    let resultContextWindowTokens: number | undefined;
+    let lastStderr: string | undefined;
+
+    let normalizer = new AgentEventNormalizer();
+    const blockingToolNames = new Set(["AskUserQuestion", "ExitPlanMode"]);
+    let killedForBlockingTool = false;
+    let currentTurnId: string | undefined = (runner as { capturedTurnId?: string }).capturedTurnId;
+
+    const resetPerTurnState = () => {
+      resultDurationMs = undefined;
+      resultInputTokens = undefined;
+      resultOutputTokens = undefined;
+      resultContextUsedTokens = undefined;
+      resultContextWindowTokens = undefined;
+      lastStderr = undefined;
+      normalizer = new AgentEventNormalizer();
+      killedForBlockingTool = false;
+    };
+
+    const finish = (exitCode: number, failureDetail?: string, completedTurnId?: string) => {
+      const turnId = completedTurnId ?? currentTurnId;
+      if (turnId) {
+        if (this.finalizedCodexAppServerTurnIds.has(turnId)) return;
+        addBounded(this.finalizedCodexAppServerTurnIds, turnId, MAX_FINALIZED_TURN_IDS);
+      }
+      this.finalizeTurn({
+        exitCode,
+        killedForBlockingTool,
+        lastStderr,
+        failureDetail,
+        resultDurationMs,
+        resultInputTokens,
+        resultOutputTokens,
+        resultContextUsedTokens,
+        resultContextWindowTokens,
+        blockingToolNames,
+      });
+      currentTurnId = undefined;
+    };
+
+    runner.on("assistant", (data) => {
+      const blockTypes = data.message.content.map((b) => b.type);
+      if (DEBUG_AGENT_LOGS) {
+        console.log("[session] assistant blocks:", blockTypes, JSON.stringify(data.message.content).slice(0, 500));
+      }
+      for (const event of normalizer.handleAssistant(data)) {
+        const usage = this.handleNormalizedAgentEvent(event, { supportsBlockingTools, blockingToolNames });
+        if (usage) {
+          resultInputTokens = usage.inputTokens;
+          resultOutputTokens = usage.outputTokens;
+        }
+        if (
+          event.type === "tool_started" &&
+          supportsBlockingTools &&
+          blockingToolNames.has(event.rawName) &&
+          this.runner?.forceKill?.()
+        ) {
+          killedForBlockingTool = true;
+          this._lastBlockingToolUseId = event.id;
+        }
+      }
+    });
+
+    runner.on("user", (data) => {
+      for (const event of normalizer.handleUser(data)) {
+        this.handleNormalizedAgentEvent(event, { supportsBlockingTools, blockingToolNames });
+      }
+    });
+
+    runner.on("agent_event", (event) => {
+      const usage = this.handleNormalizedAgentEvent(event, { supportsBlockingTools, blockingToolNames });
+      if (usage) {
+        resultInputTokens = usage.inputTokens;
+        resultOutputTokens = usage.outputTokens;
+      }
+    });
+
+    runner.on("result", (data) => {
+      if (data.session_id && !this.cliSessionId) {
+        this.setProviderSessionId(data.session_id);
+      }
+      if (data.duration_ms != null) {
+        resultDurationMs = data.duration_ms;
+      }
+      if (data.usage && resultInputTokens === undefined) {
+        resultInputTokens =
+          data.usage.input_tokens +
+          (data.usage.cache_creation_input_tokens ?? 0) +
+          (data.usage.cache_read_input_tokens ?? 0);
+        resultOutputTokens = data.usage.output_tokens;
+      }
+      if (data.usage?.context_used_tokens != null) {
+        resultContextUsedTokens = data.usage.context_used_tokens;
+      }
+      if (data.usage?.context_window != null) {
+        resultContextWindowTokens = data.usage.context_window;
+      }
+
+      const completedTurnId = data.turn_id ?? currentTurnId;
+      const status = data.status ?? "completed";
+      if (status === "completed") {
+        finish(this.stopReason ? 1 : 0, undefined, completedTurnId);
+        return;
+      }
+      if (status === "interrupted") {
+        const failureDetail = this.stopReason
+          ? undefined
+          : (data.error ?? "Codex app-server turn was interrupted.");
+        finish(1, failureDetail, completedTurnId);
+        return;
+      }
+      finish(1, data.error ?? `Codex app-server turn ended with status "${status}".`, completedTurnId);
+    });
+
+    runner.on("system", () => {
+      // System messages — no action needed
+    });
+
+    runner.on("turn_started", (event) => {
+      if (event.turnId && this.finalizedCodexAppServerTurnIds.has(event.turnId)) return;
+      currentTurnId = event.turnId;
+      if (event.threadId && !this.cliSessionId) {
+        this.setProviderSessionId(event.threadId);
+      }
+      if (this.beginSpontaneousCodexAppServerTurn(runner, event)) {
+        resetPerTurnState();
+      }
+    });
+
+    runner.on("error", (err) => {
+      this.emit("error", err);
+      if (this._status !== "streaming" && !currentTurnId) return;
+      lastStderr = sanitizeErrorDetail(err.message);
+      finish(1);
+    });
+
+    return {
+      finishWithoutTurn: (exitCode, failureDetail) => finish(exitCode, failureDetail),
+      hasActiveTurn: () => Boolean(currentTurnId),
+    };
+  }
+
+  private startCodexGoalCommand(
+    command: CodexGoalCommand,
+    msgOptions: MessageOptions | undefined,
+    resolved: { provider: AgentProvider; modelId: string },
+  ): void {
+    const isFirstMessage = this.messageCount === 1;
+    const runnerSelection = this.runnerFactory({
+      cwd: this.cwd,
+      content: "",
+      msgOptions,
+      resolved,
+      testCommand: this.testCommand,
+      isFirstMessage,
+      systemPrompt: this.systemPrompt,
+      skipPermissions: this.skipPermissions,
+      browserEnv: this.browserEnv,
+      sessionKind: this.sessionKind,
+      providerSessionId: this.cliSessionId,
+      existingCodexAppServerRunner: this.codexAppServerRunner,
+    });
+    if (runnerSelection.cachedCodexAppServerRunner) {
+      this.codexAppServerRunner = runnerSelection.cachedCodexAppServerRunner;
+    }
+
+    const runner = runnerSelection.runner;
+    runner.removeAllListeners();
+    this.runner = runner;
+
+    const controller = this.attachCodexAppServerRunnerHandlers(runner, runnerSelection.supportsBlockingTools);
+    if (runnerSelection.protocol !== "codex_app_server" || !isCodexGoalRunner(runner)) {
+      controller.finishWithoutTurn(1, "Codex app-server goal commands are unavailable.");
+      return;
+    }
+
+    const model = resolved.provider.models.find((m) => m.id === resolved.modelId);
+    const env = {
+      ...(resolved.provider.buildEnv({ ...msgOptions, model: resolved.modelId }) ?? {}),
+      ...(this.browserEnv ?? {}),
+    };
+    const goalOptions: CodexGoalRunnerOptions = {
+      cwd: this.cwd,
+      model: model?.cliValue ?? resolved.modelId,
+      systemPrompt: this.systemPrompt,
+      threadId: this.cliSessionId,
+      env,
+    };
+
+    const execute = async (): Promise<CodexGoalResult> => {
+      switch (command.type) {
+        case "set":
+          return runner.setGoal({ objective: command.objective, status: "active" }, goalOptions);
+        case "set_status":
+          return runner.setGoal({ status: command.status }, goalOptions);
+        case "clear":
+          return runner.clearGoal(goalOptions);
+        case "get":
+          return runner.getGoal(goalOptions);
+      }
+    };
+
+    void execute()
+      .then((result) => {
+        if (result.threadId) {
+          this.setProviderSessionId(result.threadId);
+        }
+        if (!controller.hasActiveTurn()) {
+          controller.finishWithoutTurn(0);
+        }
+      })
+      .catch((err: unknown) => {
+        const detail = sanitizeErrorDetail(err instanceof Error ? err.message : String(err));
+        if (!controller.hasActiveTurn()) {
+          controller.finishWithoutTurn(1, detail);
+          return;
+        }
+        this.emit("error", err instanceof Error ? err : new Error(String(err)));
+      });
+  }
+
   /** Start a single agent turn, delegating protocol execution to the selected runner. */
   private startAgentTurn(
     content: string,
@@ -517,6 +805,12 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
     // Reset in-progress streaming accumulators
     this.resetStreamAccumulators();
+    if (useCodexAppServer) {
+      this.attachCodexAppServerRunnerHandlers(runner, supportsBlockingTools);
+      runnerSelection.start();
+      return;
+    }
+
     let resultDurationMs: number | undefined;
     let resultInputTokens: number | undefined;
     let resultOutputTokens: number | undefined;
@@ -525,20 +819,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let lastStderr: string | undefined;
     const emittedDiagnostics = new Set<string>();
 
-    let normalizer = new AgentEventNormalizer();
+    const normalizer = new AgentEventNormalizer();
     const blockingToolNames = new Set(["AskUserQuestion", "ExitPlanMode"]);
     let killedForBlockingTool = false;
-    const resetPerTurnState = () => {
-      resultDurationMs = undefined;
-      resultInputTokens = undefined;
-      resultOutputTokens = undefined;
-      resultContextUsedTokens = undefined;
-      resultContextWindowTokens = undefined;
-      lastStderr = undefined;
-      emittedDiagnostics.clear();
-      normalizer = new AgentEventNormalizer();
-      killedForBlockingTool = false;
-    };
 
     runner.on("assistant", (data) => {
       const blockTypes = data.message.content.map((b) => b.type);
@@ -615,68 +898,6 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       }
       this.emit("error", err);
     });
-
-    if (useCodexAppServer) {
-      let currentTurnId: string | undefined = (runner as { capturedTurnId?: string }).capturedTurnId;
-      const finish = (exitCode: number, failureDetail?: string, completedTurnId?: string) => {
-        const turnId = completedTurnId ?? currentTurnId;
-        if (turnId) {
-          if (this.finalizedCodexAppServerTurnIds.has(turnId)) return;
-          addBounded(this.finalizedCodexAppServerTurnIds, turnId, MAX_FINALIZED_TURN_IDS);
-        }
-        this.finalizeTurn({
-          exitCode,
-          killedForBlockingTool,
-          lastStderr,
-          failureDetail,
-          resultDurationMs,
-          resultInputTokens,
-          resultOutputTokens,
-          resultContextUsedTokens,
-          resultContextWindowTokens,
-          blockingToolNames,
-        });
-        currentTurnId = undefined;
-      };
-
-      runner.on("turn_started", (event) => {
-        if (event.turnId && this.finalizedCodexAppServerTurnIds.has(event.turnId)) return;
-        currentTurnId = event.turnId;
-        if (event.threadId && !this.cliSessionId) {
-          this.setProviderSessionId(event.threadId);
-        }
-        if (this.beginSpontaneousCodexAppServerTurn(runner, event)) {
-          resetPerTurnState();
-        }
-      });
-
-      runner.on("result", (data) => {
-        const completedTurnId = data.turn_id ?? currentTurnId;
-        const status = data.status ?? "completed";
-        if (data.session_id && !this.cliSessionId) {
-          this.setProviderSessionId(data.session_id);
-        }
-        if (status === "completed") {
-          finish(this.stopReason ? 1 : 0, undefined, completedTurnId);
-          return;
-        }
-        if (status === "interrupted") {
-          const failureDetail = this.stopReason
-            ? undefined
-            : (data.error ?? "Codex app-server turn was interrupted.");
-          finish(1, failureDetail, completedTurnId);
-          return;
-        }
-        finish(1, data.error ?? `Codex app-server turn ended with status "${status}".`, completedTurnId);
-      });
-      runner.on("error", (err) => {
-        if (this._status !== "streaming" && !currentTurnId) return;
-        lastStderr = sanitizeErrorDetail(err.message);
-        finish(1);
-      });
-      runnerSelection.start();
-      return;
-    }
 
     runner.on("stderr", ({ text, classification }) => {
       const stderrLine = `stderr: ${sanitizeErrorDetail(text)}`;

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -6,7 +6,7 @@ import { workspaceFileRawPath } from "@hive/shared/workspace-files";
 import { nanoid } from "nanoid";
 import sharp from "sharp";
 import { AgentEventNormalizer, type NormalizedAgentEvent } from "./agent-event-normalizer.js";
-import type { CodexGoalResult, CodexGoalSetParams } from "./providers/codex-app-server.js";
+import type { CodexGoalResult, CodexGoalSetParams, CodexGoalStatus } from "./providers/codex-app-server.js";
 import { providerSupportsAppServerGoals, resolveProvider } from "./providers/registry.js";
 import type { AgentProvider } from "./providers/types.js";
 import { createAgentRunner, type AgentRunnerFactory } from "./runners/factory.js";
@@ -56,7 +56,7 @@ const MAX_GENERATED_IMAGE_COPY_BYTES = 25 * 1024 * 1024;
 
 type CodexGoalCommand =
   | { type: "set"; objective: string }
-  | { type: "set_status"; status: "active" | "paused" }
+  | { type: "set_status"; status: CodexGoalStatus }
   | { type: "clear" }
   | { type: "get" };
 
@@ -81,10 +81,32 @@ function parseCodexGoalCommand(content: string): CodexGoalCommand | null {
 
   const argument = trimmed.slice("/goal ".length).trim();
   if (!argument) return { type: "get" };
-  if (argument === "clear") return { type: "clear" };
-  if (argument === "pause") return { type: "set_status", status: "paused" };
-  if (argument === "resume") return { type: "set_status", status: "active" };
+  switch (argument) {
+    case "clear":
+      return { type: "clear" };
+    case "pause":
+    case "paused":
+      return { type: "set_status", status: "paused" };
+    case "resume":
+    case "active":
+      return { type: "set_status", status: "active" };
+    case "blocked":
+      return { type: "set_status", status: "blocked" };
+    case "complete":
+    case "completed":
+      return { type: "set_status", status: "complete" };
+    case "usage-limited":
+    case "usageLimited":
+      return { type: "set_status", status: "usageLimited" };
+    case "budget-limited":
+    case "budgetLimited":
+      return { type: "set_status", status: "budgetLimited" };
+  }
   return { type: "set", objective: argument };
+}
+
+function goalCommandRequiresExistingThread(command: CodexGoalCommand): boolean {
+  return command.type === "get" || command.type === "clear" || command.type === "set_status";
 }
 
 function canHandleCodexGoalCommand(
@@ -523,6 +545,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private attachCodexAppServerRunnerHandlers(
     runner: AgentRunner,
     supportsBlockingTools: boolean,
+    options?: { useCapturedTurnId?: boolean },
   ): { finishWithoutTurn: (exitCode: number, failureDetail?: string) => void; hasActiveTurn: () => boolean } {
     this.resetStreamAccumulators();
 
@@ -536,7 +559,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let normalizer = new AgentEventNormalizer();
     const blockingToolNames = new Set(["AskUserQuestion", "ExitPlanMode"]);
     let killedForBlockingTool = false;
-    let currentTurnId: string | undefined = (runner as { capturedTurnId?: string }).capturedTurnId;
+    let currentTurnId: string | undefined = options?.useCapturedTurnId === false
+      ? undefined
+      : (runner as { capturedTurnId?: string }).capturedTurnId;
 
     const resetPerTurnState = () => {
       resultDurationMs = undefined;
@@ -677,6 +702,16 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     msgOptions: MessageOptions | undefined,
     resolved: { provider: AgentProvider; modelId: string },
   ): void {
+    if (goalCommandRequiresExistingThread(command) && !this.cliSessionId) {
+      this.finalizeTurn({
+        exitCode: 1,
+        killedForBlockingTool: false,
+        failureDetail: "No Codex thread exists yet. Send a message or set a goal objective first.",
+        blockingToolNames: new Set(),
+      });
+      return;
+    }
+
     const isFirstMessage = this.messageCount === 1;
     const runnerSelection = this.runnerFactory({
       cwd: this.cwd,
@@ -700,7 +735,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     runner.removeAllListeners();
     this.runner = runner;
 
-    const controller = this.attachCodexAppServerRunnerHandlers(runner, runnerSelection.supportsBlockingTools);
+    const controller = this.attachCodexAppServerRunnerHandlers(
+      runner,
+      runnerSelection.supportsBlockingTools,
+      { useCapturedTurnId: false },
+    );
     if (runnerSelection.protocol !== "codex_app_server" || !isCodexGoalRunner(runner)) {
       controller.finishWithoutTurn(1, "Codex app-server goal commands are unavailable.");
       return;

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -46,6 +46,7 @@ function formatNormalizedExitCode(exitCode: number | undefined): string {
 
 /** Cap for the per-session finalized-turn dedup Set to avoid unbounded growth. */
 const MAX_FINALIZED_TURN_IDS = 256;
+const CODEX_GOAL_OBJECTIVE_MAX_LENGTH = 4000;
 
 /**
  * Cap for copying a Codex-generated image into session attachments. Generated
@@ -711,6 +712,16 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     msgOptions: MessageOptions | undefined,
     resolved: { provider: AgentProvider; modelId: string },
   ): void {
+    if (command.type === "set" && command.objective.length > CODEX_GOAL_OBJECTIVE_MAX_LENGTH) {
+      this.finalizeTurn({
+        exitCode: 1,
+        killedForBlockingTool: false,
+        failureDetail: `Codex goal objective must be ${CODEX_GOAL_OBJECTIVE_MAX_LENGTH.toLocaleString("en-US")} characters or fewer.`,
+        blockingToolNames: new Set(),
+      });
+      return;
+    }
+
     if (goalCommandRequiresExistingThread(command) && !this.cliSessionId) {
       this.finalizeTurn({
         exitCode: 1,

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -358,6 +358,69 @@ describe("CodexAppServerSession request handling", () => {
     expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
   });
 
+  it("emits repeated explicit goal reads when the goal state is unchanged", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession({ enableGoals: true });
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    const goal = {
+      threadId: "thread-goal-repeat",
+      objective: "Keep the UI current",
+      status: "active",
+    };
+
+    const first = session.getGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+
+    const initialize = await waitForMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(initialize.id, {
+      userAgent: "codex-test",
+      codexHome: "/tmp/codex",
+      platformFamily: "unix",
+      platformOs: "linux",
+    }));
+    const threadStart = await waitForMethod(proc, "thread/start");
+    proc._stdout.push(appServerResponse(threadStart.id, { thread: { id: "thread-goal-repeat" } }));
+    const firstGoalGet = await waitForMethod(proc, "thread/goal/get");
+    proc._stdout.push(appServerResponse(firstGoalGet.id, { goal }));
+
+    await expect(first).resolves.toEqual({ threadId: "thread-goal-repeat", goal });
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/updated",
+      params: { goal },
+    }) + "\n");
+    expect(events).toHaveLength(1);
+
+    const second = session.getGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+    const secondGoalGet = await waitForNthMethod(proc, "thread/goal/get", 2);
+    proc._stdout.push(appServerResponse(secondGoalGet.id, { goal }));
+
+    await expect(second).resolves.toEqual({ threadId: "thread-goal-repeat", goal });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal-repeat",
+        objective: "Keep the UI current",
+        status: "active",
+      }),
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal-repeat",
+        objective: "Keep the UI current",
+        status: "active",
+      }),
+    ]);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/updated",
+      params: { goal },
+    }) + "\n");
+    expect(events).toHaveLength(2);
+    expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
+  });
+
   it("auto-accepts known command and file approval requests", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1214,6 +1214,68 @@ describe("CodexAppServerSession normalized events", () => {
     ]);
   });
 
+  it("parents live receiver-thread tools under documented Codex collab tool calls", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: unknown[] = [];
+    const diagnostics: unknown[] = [];
+    session.on("assistant", (event) => assistantEvents.push(event));
+    session.on("agent_event", (event) => diagnostics.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadId: "thread-child",
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "inProgress",
+        },
+      },
+    }) + "\n");
+
+    expect(assistantEvents).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({ type: "tool_use", id: "collab-1", name: "Agent" }),
+          ],
+        }),
+      }),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({
+              type: "tool_use",
+              id: "child-cmd-1",
+              name: "Bash",
+              parentToolUseId: "collab-1",
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({ method: "item/collabToolCall" }));
+  });
+
   it("does not re-emit a previous turn's sub-agent tools when closeAgent replays later", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
@@ -1880,6 +1942,88 @@ describe("CodexAppServerSession normalized events", () => {
     expect(resultEvents).toEqual([
       expect.objectContaining({ type: "result", status: "completed", duration_ms: 123 }),
     ]);
+  });
+
+  it("replays documented Codex collab tool call receiver-thread tools under the spawning parent", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: unknown[] = [];
+    const diagnostics: unknown[] = [];
+    session.on("assistant", (event) => assistantEvents.push(event));
+    session.on("agent_event", (event) => diagnostics.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadId: "thread-child",
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabToolCall",
+          id: "collab-wait-1",
+          tool: "wait",
+          status: "completed",
+          receiverThreadId: "thread-child",
+        },
+      },
+    }) + "\n");
+
+    const read = await waitForMethod(proc, "thread/read");
+    expect(parseWrites(proc).find((write) => write.id === read.id)).toMatchObject({
+      method: "thread/read",
+      params: { threadId: "thread-child", includeTurns: true },
+    });
+    proc._stdout.push(appServerResponse(read.id, {
+      thread: {
+        id: "thread-child",
+        turns: [{
+          id: "turn-child",
+          items: [{
+            type: "commandExecution",
+            id: "child-cmd-1",
+            command: "npm test",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "ok",
+            exitCode: 0,
+          }],
+        }],
+      },
+    }));
+
+    await waitForCondition(() =>
+      assistantEvents.some((event) =>
+        JSON.stringify(event).includes("child-cmd-1")),
+    );
+    expect(assistantEvents).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({
+              type: "tool_use",
+              id: "child-cmd-1",
+              name: "Bash",
+              parentToolUseId: "collab-1",
+            }),
+          ],
+        }),
+      }),
+    ]));
+    expect(diagnostics).not.toContainEqual(expect.objectContaining({ method: "item/collabToolCall" }));
   });
 
   it("does not replay receiver threads when spawnAgent completes", async () => {

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -421,6 +421,47 @@ describe("CodexAppServerSession request handling", () => {
     expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
   });
 
+  it("does not suppress a genuine identical-state goal notification after a new turn", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession({ enableGoals: true });
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    const goal = {
+      threadId: "thread-goal-turnreset",
+      objective: "Keep the UI current",
+      status: "active" as const,
+    };
+
+    const read = session.getGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+    const initialize = await waitForMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(initialize.id, {
+      userAgent: "codex-test",
+      codexHome: "/tmp/codex",
+      platformFamily: "unix",
+      platformOs: "linux",
+    }));
+    const threadStart = await waitForMethod(proc, "thread/start");
+    proc._stdout.push(appServerResponse(threadStart.id, { thread: { id: "thread-goal-turnreset" } }));
+    const goalGet = await waitForMethod(proc, "thread/goal/get");
+    proc._stdout.push(appServerResponse(goalGet.id, { goal }));
+    await expect(read).resolves.toEqual({ threadId: "thread-goal-turnreset", goal });
+    expect(events).toHaveLength(1);
+
+    // A new user turn is a context boundary: it must drop the read's pending
+    // echo key so the next genuine same-state notification is not swallowed.
+    const turn = session.startTurn({ cwd: "/tmp/project", content: "carry on", model: "gpt-5.5" });
+    const turnStart = await waitForMethod(proc, "turn/start");
+    proc._stdout.push(appServerResponse(turnStart.id, { turn: { id: "turn-after-read" } }));
+    await turn;
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/updated",
+      params: { goal },
+    }) + "\n");
+    expect(events).toHaveLength(2);
+  });
+
   it("auto-accepts known command and file approval requests", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -362,17 +362,27 @@ describe("CodexAppServerSession request handling", () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
     await initializeSession(session, proc);
 
     proc._stdout.push(appServerRequest(100, "item/commandExecution/requestApproval"));
+    await expect(waitForResponse(proc, 100)).resolves.toMatchObject({ id: 100, result: { decision: "accept" } });
+
+    proc._stdout.push(JSON.stringify({
+      method: "serverRequest/resolved",
+      params: { threadId: "thread-1", requestId: "100" },
+    }) + "\n");
+    expect(events).toEqual([]);
+
     proc._stdout.push(appServerRequest(101, "item/fileChange/requestApproval"));
     proc._stdout.push(appServerRequest(102, "execCommandApproval"));
     proc._stdout.push(appServerRequest(103, "applyPatchApproval"));
 
-    await expect(waitForResponse(proc, 100)).resolves.toMatchObject({ id: 100, result: { decision: "accept" } });
     await expect(waitForResponse(proc, 101)).resolves.toMatchObject({ id: 101, result: { decision: "accept" } });
     await expect(waitForResponse(proc, 102)).resolves.toMatchObject({ id: 102, result: { decision: "approved" } });
     await expect(waitForResponse(proc, 103)).resolves.toMatchObject({ id: 103, result: { decision: "approved" } });
+    expect(events).toEqual([]);
   });
 
   it("emits native turn_started events with thread and turn ids", async () => {
@@ -632,6 +642,10 @@ describe("CodexAppServerSession normalized events", () => {
           effort: "high",
         },
       },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "serverRequest/resolved",
+      params: { threadId: "thread-1", requestId: "req-1" },
     }) + "\n");
 
     expect(events).toEqual([]);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -213,12 +213,55 @@ describe("CodexAppServerSession request handling", () => {
         status: "active",
       }),
     ]);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/updated",
+      params: {
+        goal: {
+          threadId: "thread-goal",
+          objective: "Ship backend support",
+          status: "active",
+        },
+      },
+    }) + "\n");
+    expect(events).toHaveLength(1);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/updated",
+      params: {
+        goal: {
+          threadId: "thread-goal",
+          objective: "Ship backend support",
+          status: "active",
+          tokensUsed: 10,
+        },
+      },
+    }) + "\n");
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+      }),
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+        tokensUsed: 10,
+      }),
+    ]);
   });
 
   it("clears a goal on a materialized thread without starting a turn", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const session = new CodexAppServerSession({ enableGoals: true });
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
 
     const pending = session.clearGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
 
@@ -239,6 +282,79 @@ describe("CodexAppServerSession request handling", () => {
     proc._stdout.push(appServerResponse(goalClear.id, {}));
 
     await expect(pending).resolves.toEqual({ threadId: "thread-goal-clear", goal: null });
+    expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "goal_updated",
+        active: false,
+        threadId: "thread-goal-clear",
+      }),
+    ]);
+
+    proc._stdout.push(JSON.stringify({
+      method: "thread/goal/cleared",
+      params: {
+        threadId: "thread-goal-clear",
+      },
+    }) + "\n");
+    expect(events).toHaveLength(1);
+  });
+
+  it("emits goal state from get responses without waiting for notifications", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession({ enableGoals: true });
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+
+    const first = session.getGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+
+    const initialize = await waitForMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(initialize.id, {
+      userAgent: "codex-test",
+      codexHome: "/tmp/codex",
+      platformFamily: "unix",
+      platformOs: "linux",
+    }));
+    const threadStart = await waitForMethod(proc, "thread/start");
+    proc._stdout.push(appServerResponse(threadStart.id, { thread: { id: "thread-goal-get" } }));
+    const firstGoalGet = await waitForMethod(proc, "thread/goal/get");
+    proc._stdout.push(appServerResponse(firstGoalGet.id, {
+      goal: {
+        threadId: "thread-goal-get",
+        objective: "Keep the UI current",
+        status: "active",
+      },
+    }));
+
+    await expect(first).resolves.toEqual({
+      threadId: "thread-goal-get",
+      goal: {
+        threadId: "thread-goal-get",
+        objective: "Keep the UI current",
+        status: "active",
+      },
+    });
+
+    const second = session.getGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+    const secondGoalGet = await waitForNthMethod(proc, "thread/goal/get", 2);
+    proc._stdout.push(appServerResponse(secondGoalGet.id, { goal: null }));
+
+    await expect(second).resolves.toEqual({ threadId: "thread-goal-get", goal: null });
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal-get",
+        objective: "Keep the UI current",
+        status: "active",
+      }),
+      expect.objectContaining({
+        type: "goal_updated",
+        active: false,
+        threadId: "thread-goal-get",
+      }),
+    ]);
     expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
   });
 

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -155,6 +155,93 @@ describe("CodexAppServerSession request handling", () => {
     );
   });
 
+  it("sets a goal on a materialized thread without starting a turn", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession({ enableGoals: true });
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+
+    const pending = session.setGoal(
+      { objective: "Ship backend support", status: "active" },
+      { cwd: "/tmp/project", model: "gpt-5.5" },
+    );
+
+    const initialize = await waitForMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(initialize.id, {
+      userAgent: "codex-test",
+      codexHome: "/tmp/codex",
+      platformFamily: "unix",
+      platformOs: "linux",
+    }));
+
+    const threadStart = await waitForMethod(proc, "thread/start");
+    proc._stdout.push(appServerResponse(threadStart.id, { thread: { id: "thread-goal" } }));
+
+    const goalSet = await waitForMethod(proc, "thread/goal/set");
+    const goalSetWrite = parseWrites(proc).find((write) => write.method === "thread/goal/set");
+    expect(goalSetWrite).toMatchObject({
+      params: {
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+      },
+    });
+    proc._stdout.push(appServerResponse(goalSet.id, {
+      goal: {
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+      },
+    }));
+
+    await expect(pending).resolves.toEqual({
+      threadId: "thread-goal",
+      goal: {
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+      },
+    });
+    expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "goal_updated",
+        active: true,
+        threadId: "thread-goal",
+        objective: "Ship backend support",
+        status: "active",
+      }),
+    ]);
+  });
+
+  it("clears a goal on a materialized thread without starting a turn", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession({ enableGoals: true });
+
+    const pending = session.clearGoal({ cwd: "/tmp/project", model: "gpt-5.5" });
+
+    const initialize = await waitForMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(initialize.id, {
+      userAgent: "codex-test",
+      codexHome: "/tmp/codex",
+      platformFamily: "unix",
+      platformOs: "linux",
+    }));
+    const threadStart = await waitForMethod(proc, "thread/start");
+    proc._stdout.push(appServerResponse(threadStart.id, { thread: { id: "thread-goal-clear" } }));
+    const goalClear = await waitForMethod(proc, "thread/goal/clear");
+    const goalClearWrite = parseWrites(proc).find((write) => write.method === "thread/goal/clear");
+    expect(goalClearWrite).toMatchObject({
+      params: { threadId: "thread-goal-clear" },
+    });
+    proc._stdout.push(appServerResponse(goalClear.id, {}));
+
+    await expect(pending).resolves.toEqual({ threadId: "thread-goal-clear", goal: null });
+    expect(parseWrites(proc).filter((write) => write.method === "turn/start")).toHaveLength(0);
+  });
+
   it("auto-accepts known command and file approval requests", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -561,6 +561,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       case "account/rateLimits/updated":
       case "turn/diff/updated":
       case "thread/settings/updated":
+      case "serverRequest/resolved":
         break;
       case "mcpServer/startupStatus/updated":
         if (isNotificationStatus(data, "failed", "cancelled")) {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -458,6 +458,11 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.resetForNewTurn();
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
+    // A pending goal-echo key only exists to swallow the single notification that
+    // echoes a just-issued goal response. A new user turn is a context boundary:
+    // drop it so a later genuine identical-state thread/goal/updated (e.g. the
+    // goal cycling back to a previously-read state) is not silently suppressed.
+    this.pendingGoalNotificationEchoKeys.clear();
   }
 
   private resetForThreadBoundary(): void {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -43,6 +43,40 @@ type TurnStartResponse = {
   turn: { id: string };
 };
 
+export type CodexGoalStatus =
+  | "active"
+  | "paused"
+  | "blocked"
+  | "usageLimited"
+  | "budgetLimited"
+  | "complete";
+
+export type CodexGoal = {
+  threadId: string;
+  objective?: string;
+  status?: CodexGoalStatus;
+  tokenBudget?: number | null;
+  tokensUsed?: number;
+  timeUsedSeconds?: number;
+  createdAt?: number;
+  updatedAt?: number;
+};
+
+export type CodexGoalSetParams = {
+  objective?: string;
+  status?: CodexGoalStatus;
+  tokenBudget?: number | null;
+};
+
+export type CodexGoalResult = {
+  threadId: string;
+  goal?: CodexGoal | null;
+};
+
+type ThreadGoalResponse = {
+  goal?: CodexGoal | null;
+};
+
 type TurnStatus = "completed" | "interrupted" | "failed" | "inProgress";
 
 type TokenUsage = {
@@ -132,15 +166,18 @@ type FileUpdateChange = {
   kind?: unknown;
 };
 
-interface CodexAppServerTurnOptions {
+interface CodexAppServerThreadOptions {
   cwd: string;
-  content: string;
-  imagePaths?: string[];
   model?: string;
-  thinkingLevel?: ThinkingLevel;
   systemPrompt?: string;
   threadId?: string;
   env?: Record<string, string>;
+}
+
+interface CodexAppServerTurnOptions extends CodexAppServerThreadOptions {
+  content: string;
+  imagePaths?: string[];
+  thinkingLevel?: ThinkingLevel;
 }
 
 interface CodexAppServerSessionOptions {
@@ -250,6 +287,30 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.activeTurnId = response.turn.id;
   }
 
+  async setGoal(params: CodexGoalSetParams, options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
+    const threadId = await this.prepareGoalThread(options);
+    const response = await this.request<ThreadGoalResponse>("thread/goal/set", {
+      threadId,
+      ...params,
+    });
+    this.emitGoalResponse(threadId, response, true);
+    return { threadId, goal: response.goal };
+  }
+
+  async getGoal(options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
+    const threadId = await this.prepareGoalThread(options);
+    const response = await this.request<ThreadGoalResponse>("thread/goal/get", { threadId });
+    this.emitGoalResponse(threadId, response, Boolean(response.goal));
+    return { threadId, goal: response.goal };
+  }
+
+  async clearGoal(options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
+    const threadId = await this.prepareGoalThread(options);
+    await this.request("thread/goal/clear", { threadId });
+    this.emitGoalUpdate({ threadId }, false);
+    return { threadId, goal: null };
+  }
+
   interruptActiveTurn(): void {
     if (!this.threadId || !this.activeTurnId) return;
     const threadId = this.threadId;
@@ -324,7 +385,20 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
 
-  private async ensureThread(options: CodexAppServerTurnOptions): Promise<string> {
+  private async prepareGoalThread(options: CodexAppServerThreadOptions): Promise<string> {
+    await this.ensureInitialized(options.env);
+    const previousThreadId = this.threadId;
+    this.resetForUserTurn();
+    this.currentCwd = options.cwd;
+    const threadId = await this.ensureThread(options);
+    if (threadId !== previousThreadId) {
+      this.resetForThreadBoundary();
+    }
+    this.threadId = threadId;
+    return threadId;
+  }
+
+  private async ensureThread(options: CodexAppServerThreadOptions): Promise<string> {
     if (options.threadId) {
       const resumed = await this.request<ThreadResumeResponse>("thread/resume", {
         threadId: options.threadId,
@@ -347,6 +421,10 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       ...(options.systemPrompt ? { developerInstructions: options.systemPrompt } : {}),
     });
     return started.thread.id;
+  }
+
+  private emitGoalResponse(threadId: string, response: ThreadGoalResponse, active: boolean): void {
+    this.emitGoalUpdate(response.goal ? { goal: response.goal, threadId } : { threadId }, active);
   }
 
   private resetForUserTurn(): void {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -240,7 +240,9 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private pendingCollabReplays = new Set<Promise<void>>();
   private lastUsage: TokenUsage | undefined;
   private lastProtocolError: string | undefined;
-  private lastGoalUpdateKey: string | undefined;
+  private activeGoalRequestCount = 0;
+  private pendingGoalNotificationEchoKeys = new Set<string>();
+  private goalNotificationKeysDuringRequest = new Set<string>();
   private currentCwd: string | undefined;
 
   constructor(options: CodexAppServerSessionOptions = {}) {
@@ -291,27 +293,33 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   async setGoal(params: CodexGoalSetParams, options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
-    const threadId = await this.prepareGoalThread(options);
-    const response = await this.request<ThreadGoalResponse>("thread/goal/set", {
-      threadId,
-      ...params,
+    return this.runGoalRequest(async () => {
+      const threadId = await this.prepareGoalThread(options);
+      const response = await this.request<ThreadGoalResponse>("thread/goal/set", {
+        threadId,
+        ...params,
+      });
+      this.emitGoalResponse(threadId, response, true);
+      return { threadId, goal: response.goal };
     });
-    this.emitGoalResponse(threadId, response, true);
-    return { threadId, goal: response.goal };
   }
 
   async getGoal(options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
-    const threadId = await this.prepareGoalThread(options);
-    const response = await this.request<ThreadGoalResponse>("thread/goal/get", { threadId });
-    this.emitGoalResponse(threadId, response, Boolean(response.goal));
-    return { threadId, goal: response.goal };
+    return this.runGoalRequest(async () => {
+      const threadId = await this.prepareGoalThread(options);
+      const response = await this.request<ThreadGoalResponse>("thread/goal/get", { threadId });
+      this.emitGoalResponse(threadId, response, Boolean(response.goal));
+      return { threadId, goal: response.goal };
+    });
   }
 
   async clearGoal(options: CodexAppServerThreadOptions): Promise<CodexGoalResult> {
-    const threadId = await this.prepareGoalThread(options);
-    await this.request("thread/goal/clear", { threadId });
-    this.emitGoalUpdate({ threadId }, false);
-    return { threadId, goal: null };
+    return this.runGoalRequest(async () => {
+      const threadId = await this.prepareGoalThread(options);
+      await this.request("thread/goal/clear", { threadId });
+      this.emitGoalUpdate({ threadId }, false, "response");
+      return { threadId, goal: null };
+    });
   }
 
   interruptActiveTurn(): void {
@@ -427,7 +435,23 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private emitGoalResponse(threadId: string, response: ThreadGoalResponse, active: boolean): void {
-    this.emitGoalUpdate(response.goal ? { goal: response.goal, threadId } : { threadId }, active);
+    this.emitGoalUpdate(response.goal ? { goal: response.goal, threadId } : { threadId }, active, "response");
+  }
+
+  private async runGoalRequest<T>(operation: () => Promise<T>): Promise<T> {
+    if (this.activeGoalRequestCount === 0) {
+      this.pendingGoalNotificationEchoKeys.clear();
+      this.goalNotificationKeysDuringRequest.clear();
+    }
+    this.activeGoalRequestCount += 1;
+    try {
+      return await operation();
+    } finally {
+      this.activeGoalRequestCount = Math.max(0, this.activeGoalRequestCount - 1);
+      if (this.activeGoalRequestCount === 0) {
+        this.goalNotificationKeysDuringRequest.clear();
+      }
+    }
   }
 
   private resetForUserTurn(): void {
@@ -440,7 +464,8 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
     this.completedCollabItemIds.clear();
-    this.lastGoalUpdateKey = undefined;
+    this.pendingGoalNotificationEchoKeys.clear();
+    this.goalNotificationKeysDuringRequest.clear();
   }
 
   /**
@@ -634,10 +659,10 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         this.emitPlanUpdate(data);
         break;
       case "thread/goal/updated":
-        this.emitGoalUpdate(data, true);
+        this.emitGoalUpdate(data, true, "notification");
         break;
       case "thread/goal/cleared":
-        this.emitGoalUpdate(data, false);
+        this.emitGoalUpdate(data, false, "notification");
         break;
       case "warning":
         this.emitProtocolDiagnostic(method, data, "Codex warning", "warning");
@@ -1138,7 +1163,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     });
   }
 
-  private emitGoalUpdate(data: JsonObject | null, active: boolean): void {
+  private emitGoalUpdate(data: JsonObject | null, active: boolean, source: "response" | "notification"): void {
     const goal = asRecord(data?.goal);
     const threadId = asString(goal?.threadId)
       ?? asString(data?.threadId)
@@ -1171,8 +1196,18 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       event.createdAt,
       event.updatedAt,
     ], (_key, value) => value === undefined ? { __hiveType: "undefined" } : value);
-    if (key === this.lastGoalUpdateKey) return;
-    this.lastGoalUpdateKey = key;
+    if (source === "notification") {
+      if (this.pendingGoalNotificationEchoKeys.delete(key)) return;
+      if (this.activeGoalRequestCount > 0) {
+        this.goalNotificationKeysDuringRequest.add(key);
+      }
+    } else {
+      if (this.goalNotificationKeysDuringRequest.delete(key)) {
+        this.pendingGoalNotificationEchoKeys.add(key);
+        return;
+      }
+      this.pendingGoalNotificationEchoKeys.add(key);
+    }
     this.emit("agent_event", event);
   }
 

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -238,6 +238,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   private pendingCollabReplays = new Set<Promise<void>>();
   private lastUsage: TokenUsage | undefined;
   private lastProtocolError: string | undefined;
+  private lastGoalUpdateKey: string | undefined;
   private currentCwd: string | undefined;
 
   constructor(options: CodexAppServerSessionOptions = {}) {
@@ -437,6 +438,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
     this.completedCollabItemIds.clear();
+    this.lastGoalUpdateKey = undefined;
   }
 
   /**
@@ -1141,7 +1143,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     // A goal is scoped to a thread; without one we cannot key it stably for
     // upsert/clear, and a shared "unknown" id would collide across threads.
     if (!threadId) return;
-    this.emit("agent_event", {
+    const event: Extract<NormalizedAgentEvent, { type: "goal_updated" }> = {
       type: "goal_updated",
       id: `codex-goal-${threadId}`,
       active,
@@ -1153,7 +1155,21 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       timeUsedSeconds: asNumber(goal?.timeUsedSeconds),
       createdAt: asNumber(goal?.createdAt),
       updatedAt: asNumber(goal?.updatedAt),
-    });
+    };
+    const key = JSON.stringify([
+      event.threadId,
+      event.active,
+      event.objective,
+      event.status,
+      event.tokenBudget,
+      event.tokensUsed,
+      event.timeUsedSeconds,
+      event.createdAt,
+      event.updatedAt,
+    ], (_key, value) => value === undefined ? { __hiveType: "undefined" } : value);
+    if (key === this.lastGoalUpdateKey) return;
+    this.lastGoalUpdateKey = key;
+    this.emit("agent_event", event);
   }
 
   private emitFileChangeEvents(itemId: string, changes: FileUpdateChange[], status?: string): void {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -134,20 +134,7 @@ type ThreadItem =
       contentItems?: unknown[] | null;
       success?: boolean | null;
     }
-  | {
-      type: "collabAgentToolCall";
-      id: string;
-      tool?: string;
-      status?: string;
-      senderThreadId?: string;
-      receiverThreadId?: string;
-      newThreadId?: string;
-      receiverThreadIds?: string[];
-      prompt?: string | null;
-      model?: string | null;
-      reasoningEffort?: string | null;
-      agentsStates?: Record<string, unknown>;
-    }
+  | CollabToolCallItem
   | { type: "webSearch"; id: string; query?: string; action?: unknown }
   | { type: "imageView"; id: string; path?: string }
   | {
@@ -159,6 +146,21 @@ type ThreadItem =
       savedPath?: string | null;
     }
   | { type: string; id?: string; [key: string]: unknown };
+
+type CollabToolCallItem = {
+  type: "collabAgentToolCall" | "collabToolCall";
+  id: string;
+  tool?: string;
+  status?: string;
+  senderThreadId?: string;
+  receiverThreadId?: string;
+  newThreadId?: string;
+  receiverThreadIds?: string[];
+  prompt?: string | null;
+  model?: string | null;
+  reasoningEffort?: string | null;
+  agentsStates?: Record<string, unknown>;
+};
 
 type FileUpdateChange = {
   path?: string;
@@ -839,8 +841,9 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         }
         break;
       }
-      case "collabAgentToolCall": {
-        const collabItem = item as Extract<ThreadItem, { type: "collabAgentToolCall" }>;
+      case "collabAgentToolCall":
+      case "collabToolCall": {
+        const collabItem = item as CollabToolCallItem;
         if (parentToolUseId && this.isCollabAgentSelfReference(collabItem, context.threadId)) {
           break;
         }
@@ -923,7 +926,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private isCollabAgentSelfReference(
-    item: Extract<ThreadItem, { type: "collabAgentToolCall" }>,
+    item: CollabToolCallItem,
     threadId: string | undefined,
   ): boolean {
     return Boolean(threadId && collabAgentReceiverThreadIds(item).includes(threadId));
@@ -939,13 +942,13 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     return threadId ? this.collabParentByThreadId.get(threadId) : undefined;
   }
 
-  private rememberCollabAgentReceivers(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
+  private rememberCollabAgentReceivers(item: CollabToolCallItem): void {
     for (const threadId of collabAgentReceiverThreadIds(item)) {
       this.collabParentByThreadId.set(threadId, item.id);
     }
   }
 
-  private rememberFallbackCollabAgentReceivers(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
+  private rememberFallbackCollabAgentReceivers(item: CollabToolCallItem): void {
     for (const threadId of collabAgentReceiverThreadIds(item)) {
       if (!this.collabParentByThreadId.has(threadId)) {
         this.collabParentByThreadId.set(threadId, item.id);
@@ -953,7 +956,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     }
   }
 
-  private queueCollabAgentReplay(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): void {
+  private queueCollabAgentReplay(item: CollabToolCallItem): void {
     const threadIds = collabAgentReceiverThreadIds(item);
     if (threadIds.length === 0) return;
     // Catch-up items nest under the spawning Agent card when known; the
@@ -1382,7 +1385,7 @@ function formatUnknown(value: unknown): string {
   }
 }
 
-function collabAgentToolInput(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): JsonObject {
+function collabAgentToolInput(item: CollabToolCallItem): JsonObject {
   return {
     subagent_type: collabAgentLabel(item),
     description: collabAgentDescription(item),
@@ -1398,7 +1401,7 @@ function collabAgentToolInput(item: Extract<ThreadItem, { type: "collabAgentTool
   };
 }
 
-function collabAgentReceiverThreadIds(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): string[] {
+function collabAgentReceiverThreadIds(item: CollabToolCallItem): string[] {
   return [
     ...(item.receiverThreadIds ?? []),
     item.receiverThreadId,
@@ -1406,17 +1409,17 @@ function collabAgentReceiverThreadIds(item: Extract<ThreadItem, { type: "collabA
   ].filter((threadId): threadId is string => Boolean(threadId));
 }
 
-function collabAgentDescription(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): string {
+function collabAgentDescription(item: CollabToolCallItem): string {
   const prompt = item.prompt?.trim().split("\n").find((line) => line.trim());
   if (prompt) return prompt.trim();
   return item.tool === "spawnAgent" ? "Agent" : "";
 }
 
-function collabAgentLabel(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): string {
+function collabAgentLabel(item: CollabToolCallItem): string {
   return item.tool === "spawnAgent" ? "Agent" : formatCollabAgentTool(item.tool);
 }
 
-function collabAgentToolResult(item: Extract<ThreadItem, { type: "collabAgentToolCall" }>): string {
+function collabAgentToolResult(item: CollabToolCallItem): string {
   return JSON.stringify([{
     type: "text",
     text: formatUnknown({

--- a/backend/src/agents/runners/codex-app-server-runner.test.ts
+++ b/backend/src/agents/runners/codex-app-server-runner.test.ts
@@ -5,6 +5,9 @@ import { CodexAppServerRunner } from "./codex-app-server-runner.js";
 class FakeAppServer extends EventEmitter {
   capturedTurnId: string | undefined;
   startTurn = vi.fn(async () => {});
+  setGoal = vi.fn(async () => ({ threadId: "thread-1", goal: null }));
+  getGoal = vi.fn(async () => ({ threadId: "thread-1", goal: null }));
+  clearGoal = vi.fn(async () => ({ threadId: "thread-1", goal: null }));
   interruptActiveTurn = vi.fn();
   close = vi.fn(() => {
     this.capturedTurnId = undefined;
@@ -96,5 +99,22 @@ describe("CodexAppServerRunner", () => {
     appServer.emit("turn_started", { threadId: "thread-1", turnId: "turn-1" });
 
     expect(events).toEqual([{ threadId: "thread-1", turnId: "turn-1" }]);
+  });
+
+  it("forwards goal commands to the app-server client", async () => {
+    const appServer = new FakeAppServer();
+    const runner = new CodexAppServerRunner(appServer);
+    const options = { cwd: "/tmp/project", model: "gpt-5.5" };
+
+    await runner.setGoal({ objective: "Ship backend support", status: "active" }, options);
+    await runner.getGoal(options);
+    await runner.clearGoal(options);
+
+    expect(appServer.setGoal).toHaveBeenCalledWith(
+      { objective: "Ship backend support", status: "active" },
+      options,
+    );
+    expect(appServer.getGoal).toHaveBeenCalledWith(options);
+    expect(appServer.clearGoal).toHaveBeenCalledWith(options);
   });
 });

--- a/backend/src/agents/runners/codex-app-server-runner.ts
+++ b/backend/src/agents/runners/codex-app-server-runner.ts
@@ -1,17 +1,24 @@
 import { EventEmitter } from "node:events";
-import { CodexAppServerSession } from "../providers/codex-app-server.js";
+import {
+  CodexAppServerSession,
+  type CodexGoalResult,
+  type CodexGoalSetParams,
+} from "../providers/codex-app-server.js";
 import type { ThinkingLevel } from "../providers/types.js";
 import type { AgentRunner, AgentRunnerEvent, StopReason } from "./types.js";
 
-interface CodexAppServerRunnerTurn {
+interface CodexAppServerRunnerThread {
   cwd: string;
-  content: string;
-  imagePaths?: string[];
   model?: string;
-  thinkingLevel?: ThinkingLevel;
   systemPrompt?: string;
   threadId?: string;
   env?: Record<string, string>;
+}
+
+interface CodexAppServerRunnerTurn extends CodexAppServerRunnerThread {
+  content: string;
+  imagePaths?: string[];
+  thinkingLevel?: ThinkingLevel;
 }
 
 interface CodexAppServerClient {
@@ -24,6 +31,9 @@ interface CodexAppServerClient {
   on(eventName: "turn_started", listener: (...args: AgentRunnerEvent["turn_started"]) => void): this;
   on(eventName: "error", listener: (...args: AgentRunnerEvent["error"]) => void): this;
   startTurn(turn: CodexAppServerRunnerTurn): Promise<void>;
+  setGoal(params: CodexGoalSetParams, options: CodexAppServerRunnerThread): Promise<CodexGoalResult>;
+  getGoal(options: CodexAppServerRunnerThread): Promise<CodexGoalResult>;
+  clearGoal(options: CodexAppServerRunnerThread): Promise<CodexGoalResult>;
   interruptActiveTurn(): void;
   close(): void;
 }
@@ -57,6 +67,21 @@ export class CodexAppServerRunner extends EventEmitter<AgentRunnerEvent> impleme
     void this.appServer.startTurn(turn).catch((err: unknown) => {
       this.emit("error", err instanceof Error ? err : new Error(String(err)));
     });
+  }
+
+  async setGoal(params: CodexGoalSetParams, options: CodexAppServerRunnerThread): Promise<CodexGoalResult> {
+    this.clearInterruptTimer();
+    return this.appServer.setGoal(params, options);
+  }
+
+  async getGoal(options: CodexAppServerRunnerThread): Promise<CodexGoalResult> {
+    this.clearInterruptTimer();
+    return this.appServer.getGoal(options);
+  }
+
+  async clearGoal(options: CodexAppServerRunnerThread): Promise<CodexGoalResult> {
+    this.clearInterruptTimer();
+    return this.appServer.clearGoal(options);
   }
 
   start(): void {

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -807,8 +807,8 @@ describe("AutomationScheduler", () => {
         "system-prompt.txt",
       );
       const persisted = await readFile(promptPath, "utf-8");
-      expect(persisted).toBe("You are strict.");
-      expect(persisted).not.toContain("## Summary");
+      expect(persisted).toContain("You are strict.");
+      expect(persisted).toContain("## Summary");
 
       scheduler.stop();
     });

--- a/backend/src/services/automation-scheduler.ts
+++ b/backend/src/services/automation-scheduler.ts
@@ -216,6 +216,8 @@ export class AutomationScheduler {
       });
     }
 
+    const resolvedSystemPrompt = systemPrompt ? systemPrompt + SUMMARY_INSTRUCTION : undefined;
+
     // Create session
     const autoDir = join(this.dataDir, "automations", autoId);
     const session = new ConversationSession({
@@ -223,7 +225,7 @@ export class AutomationScheduler {
       dataDir: autoDir,
       workspaceId: autoId,
       sessionId: run.sessionId,
-      systemPrompt: systemPrompt ? systemPrompt + SUMMARY_INSTRUCTION : undefined,
+      systemPrompt: resolvedSystemPrompt,
       skipPermissions: true,
       sessionKind: "automation",
     });
@@ -231,10 +233,10 @@ export class AutomationScheduler {
     this.activeRuns.set(autoId, { run, session });
 
     // Persist resolved system prompt for run log viewer
-    if (systemPrompt) {
+    if (resolvedSystemPrompt) {
       const sessDir = join(autoDir, "sessions", run.sessionId);
       await mkdir(sessDir, { recursive: true });
-      await writeFile(join(sessDir, "system-prompt.txt"), systemPrompt, "utf-8")
+      await writeFile(join(sessDir, "system-prompt.txt"), resolvedSystemPrompt, "utf-8")
         .catch((err) => console.error("[scheduler] Persist system prompt failed:", err));
     }
 

--- a/ios/HiveMobile/Views/Settings/SettingsView.swift
+++ b/ios/HiveMobile/Views/Settings/SettingsView.swift
@@ -130,6 +130,8 @@ struct SettingsView: View {
                             }
                         }
                         .buttonStyle(.plain)
+                        .accessibilityLabel("Accent color: \(option.label)")
+                        .accessibilityValue(option.rawValue == accentId ? "Selected" : "")
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- prevent overlong Codex /goal objectives from creating or resuming app-server threads
- add regression coverage for the 4,000-character app-server objective limit

## Tests
- npx vitest run src/agents/conversation-session.test.ts