### PR TITLE
GitHub-style PR status colors + sidebar indicator alignment

### DIFF
--- a/frontend/src/components/PrStatusSection.tsx
+++ b/frontend/src/components/PrStatusSection.tsx
@@ -49,13 +49,13 @@ export function PrStatusSection({ wsId }: PrStatusSectionProps) {
     );
   }
 
-  const { Icon, iconClass, textClass, label } = computePrDisplay(pr);
+  const { Icon, colorClass, label } = computePrDisplay(pr);
 
   return (
     <div className="border-t border-border/50 px-3 py-2.5">
       <div className="flex items-center gap-2 text-xs">
-        <Icon className={cn("size-3.5 shrink-0", iconClass)} />
-        <span className={cn("min-w-0 truncate", textClass)}>
+        <Icon className={cn("size-3.5 shrink-0", colorClass)} />
+        <span className={cn("min-w-0 truncate", colorClass)}>
           PR #{pr.number} &middot; {label}
         </span>
         <a

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -74,7 +74,10 @@ export function SidebarGroupHeader({
         </div>
       )}
       {hasCount && (
-        <div className="absolute inset-y-0 right-0 flex items-center">
+        // Offset by 3px so the count number's center lands on the workspace PR-dot
+        // column below it (the dot sits at px-2 + half its w-2.5 cell = 13px from the
+        // row's right edge, vs. this 20px-wide box's natural 10px center).
+        <div className="absolute inset-y-0 right-[3px] flex items-center">
           <div className="relative flex h-5 w-5 items-center justify-center">
             {isLoading ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />

--- a/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
+++ b/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
@@ -99,7 +99,9 @@ export function SidebarWorkspaceItem({
             <span
               className={cn(
                 "flex shrink-0 items-center gap-2 transition-opacity",
-                canArchive && "group-hover/ws:opacity-0",
+                // While archiving, the spinner takes over the trailing slot — hide
+                // the metadata entirely so it doesn't show through underneath.
+                isArchiving ? "opacity-0" : canArchive && "group-hover/ws:opacity-0",
               )}
             >
               {diffTotals && (
@@ -110,12 +112,19 @@ export function SidebarWorkspaceItem({
                 />
               )}
               <span className="grid w-2.5 place-items-center">
-                {prDisplay && (
+                {prDisplay ? (
                   <span
                     role="img"
                     aria-label={`#${pr!.number} ${prDisplay.label}`}
                     title={`#${pr!.number} ${prDisplay.label}`}
-                    className={cn("size-1.5 rounded-full bg-current", prDisplay.iconClass)}
+                    className={cn("size-1.5 rounded-full bg-current", prDisplay.colorClass)}
+                  />
+                ) : (
+                  // No PR yet: a hollow gray dot keeps the column aligned and reads
+                  // as an empty status slot.
+                  <span
+                    aria-hidden
+                    className="size-1.5 rounded-full border border-muted-foreground/40"
                   />
                 )}
               </span>
@@ -127,15 +136,20 @@ export function SidebarWorkspaceItem({
         </TooltipContent>
       </Tooltip>
 
+      {/* Center the archive overlay (loader + trash) on the PR-dot column, which sits
+          13px from the row's right edge (px-2 = 8px + half the dot's w-2.5 cell = 5px).
+          A w-3.5 (14px) box at right-1.5 (6px) centers there (6 + 7 = 13px); the box must
+          be wider than the ~13px icons, since Chromium start-aligns oversized grid items
+          rather than centering them. */}
       {isArchiving ? (
-        <div className="absolute right-2 top-1/2 -translate-y-1/2 p-0.5">
+        <div className="absolute right-1.5 top-1/2 grid w-3.5 -translate-y-1/2 place-items-center">
           <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
         </div>
       ) : (
         canArchive && (
           <button
             type="button"
-            className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-muted-foreground opacity-0 transition-[opacity,color] duration-150 hover:text-destructive group-hover/ws:opacity-100"
+            className="absolute right-1.5 top-1/2 grid w-3.5 -translate-y-1/2 place-items-center rounded text-muted-foreground opacity-0 transition-[opacity,color] duration-150 hover:text-destructive group-hover/ws:opacity-100"
             onClick={(event) => {
               event.preventDefault();
               event.stopPropagation();

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -72,6 +72,11 @@
   --color-warning-muted: var(--warning-muted);
   --color-warning-border: var(--warning-border);
   --color-warning-contrast: var(--warning-contrast);
+  --color-pr-open: var(--pr-open);
+  --color-pr-draft: var(--pr-draft);
+  --color-pr-merged: var(--pr-merged);
+  --color-pr-closed: var(--pr-closed);
+  --color-pr-attention: var(--pr-attention);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -128,6 +133,14 @@
   --warning-muted: color-mix(in oklch, var(--warning) 10%, transparent);
   --warning-border: color-mix(in oklch, var(--warning) 30%, transparent);
   --warning-contrast: #000000;
+
+  /* PR status — GitHub Primer state palette (light) */
+  --pr-open: #1a7f37;
+  --pr-draft: #6e7781;
+  --pr-merged: #8250df;
+  --pr-closed: #cf222e;
+  --pr-attention: #9a6700;
+
   --border: oklch(0.86 0.006 255);
   --input: oklch(0.94 0.004 255);
   --ring: var(--hive-accent, #635BFF);
@@ -201,6 +214,14 @@
   --warning-muted: color-mix(in oklch, var(--warning) 10%, transparent);
   --warning-border: color-mix(in oklch, var(--warning) 25%, transparent);
   --warning-contrast: #000000;
+
+  /* PR status — GitHub Primer state palette (dark) */
+  --pr-open: #3fb950;
+  --pr-draft: #848d97;
+  --pr-merged: #a371f7;
+  --pr-closed: #f85149;
+  --pr-attention: #d29922;
+
   --border: oklch(1 0 0 / 8%);
   --input: oklch(1 0 0 / 10%);
   --ring: var(--hive-accent, #635BFF);

--- a/frontend/src/lib/pr-display.ts
+++ b/frontend/src/lib/pr-display.ts
@@ -13,8 +13,8 @@ import type { PullRequestInfo } from "@/types";
 
 export interface PrDisplayInfo {
   Icon: LucideIcon;
-  iconClass: string;
-  textClass: string;
+  /** Tailwind text color class from the dedicated PR-status palette (see index.css). */
+  colorClass: string;
   label: string;
 }
 
@@ -28,119 +28,54 @@ export function computePrDisplay(pr: PullRequestInfo): PrDisplayInfo {
 
   // 1. Merged
   if (pr.state === "merged")
-    return {
-      Icon: GitMerge,
-      iconClass: "text-primary",
-      textClass: "text-primary",
-      label: "Merged",
-    };
+    return { Icon: GitMerge, colorClass: "text-pr-merged", label: "Merged" };
 
   // 2. Closed
   if (pr.state === "closed")
-    return {
-      Icon: GitPullRequestClosed,
-      iconClass: "text-muted-foreground",
-      textClass: "text-muted-foreground",
-      label: "Closed",
-    };
+    return { Icon: GitPullRequestClosed, colorClass: "text-pr-closed", label: "Closed" };
 
   // 3. Draft
   if (pr.state === "draft")
-    return {
-      Icon: GitPullRequest,
-      iconClass: "text-muted-foreground",
-      textClass: "text-muted-foreground",
-      label: "Draft",
-    };
+    return { Icon: GitPullRequest, colorClass: "text-pr-draft", label: "Draft" };
 
   // 4. Conflicts
   if (pr.mergeable === false || pr.mergeableState === "conflict")
-    return {
-      Icon: AlertTriangle,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: "Has conflicts",
-    };
+    return { Icon: AlertTriangle, colorClass: "text-pr-closed", label: "Has conflicts" };
 
   // 5. Checks failing
   if (pr.checksStatus === "failure")
-    return {
-      Icon: XCircle,
-      iconClass: "text-destructive",
-      textClass: "text-destructive",
-      label: checksLabel("Checks failing"),
-    };
+    return { Icon: XCircle, colorClass: "text-pr-closed", label: checksLabel("Checks failing") };
 
   // 6. Checks cancelled
   if (pr.checksStatus === "cancelled")
-    return {
-      Icon: Ban,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: "Checks cancelled",
-    };
+    return { Icon: Ban, colorClass: "text-pr-draft", label: "Checks cancelled" };
 
   // 7. Checks pending
   if (pr.checksStatus === "pending")
-    return {
-      Icon: Clock,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: checksLabel("Checks running"),
-    };
+    return { Icon: Clock, colorClass: "text-pr-attention", label: checksLabel("Checks running") };
 
   // 8. Changes requested
   if (pr.reviewStatus === "changes_requested")
-    return {
-      Icon: AlertTriangle,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: "Changes requested",
-    };
+    return { Icon: AlertTriangle, colorClass: "text-pr-closed", label: "Changes requested" };
 
   // 9. Blocked (branch protection)
   if (pr.mergeableState === "blocked")
-    return {
-      Icon: Ban,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: "Blocked",
-    };
+    return { Icon: Ban, colorClass: "text-pr-attention", label: "Blocked" };
 
   // 10. Unstable (non-required checks failing)
   if (pr.mergeableState === "unstable")
-    return {
-      Icon: AlertTriangle,
-      iconClass: "text-warning-foreground",
-      textClass: "text-warning-foreground",
-      label: "Unstable",
-    };
+    return { Icon: AlertTriangle, colorClass: "text-pr-attention", label: "Unstable" };
 
   // 11. Review needed
   if (pr.reviewStatus === "review_required")
-    return {
-      Icon: Eye,
-      iconClass: "text-info-foreground",
-      textClass: "text-info-foreground",
-      label: "Review needed",
-    };
+    return { Icon: Eye, colorClass: "text-pr-attention", label: "Review needed" };
 
   // 12. Ready to merge
   if (pr.mergeable === true || pr.mergeableState === "clean")
-    return {
-      Icon: GitMerge,
-      iconClass: "text-success-foreground",
-      textClass: "text-success-foreground",
-      label: "Ready to merge",
-    };
+    return { Icon: GitMerge, colorClass: "text-pr-open", label: "Ready to merge" };
 
   // 13. Fallback: Open
-  return {
-    Icon: GitPullRequest,
-    iconClass: "text-info-foreground",
-    textClass: "text-info-foreground",
-    label: "Open",
-  };
+  return { Icon: GitPullRequest, colorClass: "text-pr-open", label: "Open" };
 }
 
 const shortLabels: Record<string, string> = {


### PR DESCRIPTION
## Summary

Introduces a dedicated PR-status color palette in the theme (mirroring GitHub Primer's state colors) and routes every PR-status indicator through it, then fixes a set of sidebar alignment/polish details from the recent UI redesign.

## Changes

**Theme — GitHub PR status colors**
- `index.css`: add a `--pr-*` token family (`open` / `draft` / `merged` / `closed` / `attention`) for both light and dark mode, matching GitHub Primer's state palette, plus their `@theme inline` mappings so `text-pr-*` utilities work.
- `pr-display.ts`: `iconClass` and `textClass` were identical across all 13 branches, so they're collapsed into a single `colorClass`, with each state mapped to the new `text-pr-*` tokens. Both consumers (`SidebarWorkspaceItem`, `PrStatusSection`) updated, so the GitHub colors apply everywhere a PR status is shown.

**Sidebar polish**
- **Empty PR dot**: when no PR is open, render a hollow gray dot instead of an empty slot.
- **Archiving state**: hide the PR/diff metadata while archiving so it no longer shows through underneath the spinner.
- **Indicator alignment** (verified pixel-exact via `getBoundingClientRect`):
  - The project workspace-count now sits on the same column as the workspace PR dots below it (was 3px off).
  - The hover archive (trash) icon and the archiving loader now center on the PR-dot column (13px from the row's right edge). A box wider than the icon is used because Chromium start-aligns oversized grid items rather than centering them.

## Testing
- `npm run lint` ✅
- `npm run typecheck` ✅