### PR TITLE
Add terminal tabs: full-pane interactive shell sessions in workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Hive can run as a local web app, a Tauri desktop app connected to a local or rem
 - Stream assistant text, thinking, tool calls, file changes, diagnostics, tasks, images, plan updates, branch info, diff stats, and script status over the multiplexed hub WebSocket.
 - Attach images to chat messages; backend resizes and stores attachments per session.
 - Browse workspace files, preview raw files, inspect inline diffs, paste selected diff comments into prompts, and use `#file`, `/command`, and `@agent` autocomplete.
+- Open a conversation tab as a full-pane interactive terminal (login shell in the worktree) from the workspace empty state. A tab commits to terminal before its first message and cannot revert; multiple terminal tabs per workspace are allowed. Terminal tabs are a desktop surface and are hidden on iOS.
 
 **Brain**
 - Maintain one normal git clone as the Brain knowledge base.
@@ -261,7 +262,7 @@ This is the public backend surface exposed by route modules under `backend/src/a
 | Health | `GET /health` |
 | Projects | `GET/POST /api/projects`, `GET/DELETE /api/projects/:id`, `POST /api/projects/:id/fetch`, `GET /api/projects/:id/favicon`, `GET/PUT /api/projects/:id/env` |
 | Workspaces | `GET/POST /api/projects/:id/workspaces`, `GET/DELETE /api/workspaces/:wsId`, `GET /api/workspaces/:wsId/files`, `GET /api/workspaces/:wsId/file`, `GET /api/workspaces/:wsId/file/raw`, `GET /api/workspaces/:wsId/file-completions`, `GET /api/workspaces/:wsId/diff`, `GET /api/workspaces/:wsId/diff/stat`, `POST /api/workspaces/:wsId/merge`, `POST /api/workspaces/:wsId/archive`, `GET /api/workspaces/:wsId/pr-status`, `POST /api/workspaces/pr-status/bulk` |
-| Sessions | `GET/POST/DELETE /api/workspaces/:wsId/session`, `GET /api/workspaces/:wsId/session/messages`, `GET/POST /api/workspaces/:wsId/sessions`, `DELETE /api/workspaces/:wsId/sessions/:sessionId`, `GET /api/workspaces/:wsId/sessions/:sessionId/messages`, `GET /api/workspaces/:wsId/sessions/:sessionId/attachments/:filename` |
+| Sessions | `GET/POST/DELETE /api/workspaces/:wsId/session`, `GET /api/workspaces/:wsId/session/messages`, `GET/POST /api/workspaces/:wsId/sessions`, `POST /api/workspaces/:wsId/sessions/:sessionId/convert-to-terminal`, `DELETE /api/workspaces/:wsId/sessions/:sessionId`, `GET /api/workspaces/:wsId/sessions/:sessionId/messages`, `GET /api/workspaces/:wsId/sessions/:sessionId/attachments/:filename` |
 | Brain | `GET/POST/DELETE /api/brain`, `GET /api/brain/files`, `GET/PUT /api/brain/file`, `GET /api/brain/file/raw`, `GET /api/brain/status`, `GET /api/brain/diff`, `POST /api/brain/save` |
 | Models and provider usage | `GET /api/models`, `GET /api/provider-usage` |
 | Completions | `GET /api/workspaces/:wsId/completions?provider=claude\|codex` |
@@ -270,7 +271,7 @@ This is the public backend surface exposed by route modules under `backend/src/a
 | Prompts | `GET/POST /api/prompt-templates`, `PUT/DELETE /api/prompt-templates/:id`, `GET/PUT/DELETE /api/prompts/base`, `GET/PUT/DELETE /api/prompts/brain` |
 | Settings | `GET/PUT /api/settings/notifications`, `POST /api/settings/notifications/test`, `POST /api/settings/notifications/test-apns`, `POST /api/devices/apns`, `GET /api/settings/cli`, `GET/PUT/DELETE /api/settings/instructions`, `POST /api/settings/instructions/sync`, `GET/POST /api/settings/skills`, `GET/PUT/DELETE /api/settings/skills/:id`, `POST /api/settings/skills/:id/sync`, `POST /api/settings/skills/sync-missing`, `GET/POST /api/settings/subagents`, `GET /api/settings/subagents/:id`, `PUT/DELETE /api/settings/subagents/:id/providers/:provider`, `POST /api/settings/subagents/:id/providers/:provider/counterpart` |
 | Account | `GET /api/account/status`, `POST /api/account/connect`, `POST /api/account/connect/poll`, `POST /api/account/disconnect` |
-| Scripts and preferences | `GET /api/workspaces/:wsId/scripts`, `POST /api/workspaces/:wsId/scripts/:type/start`, `POST /api/workspaces/:wsId/scripts/:type/stop`, `POST /api/workspaces/:wsId/terminal/start`, `POST /api/workspaces/:wsId/terminal/stop`, `GET/PUT /api/ui-preferences` |
+| Scripts and preferences | `GET /api/workspaces/:wsId/scripts`, `POST /api/workspaces/:wsId/scripts/:type/start`, `POST /api/workspaces/:wsId/scripts/:type/stop`, `POST /api/workspaces/:wsId/terminal/start`, `POST /api/workspaces/:wsId/terminal/stop`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop`, `GET/PUT /api/ui-preferences` |
 
 `wsId=brain` is valid for session and hub routes through the shared session dispatcher.
 
@@ -288,6 +289,11 @@ Script stream:
 
 - Endpoint: `ws://<host>/ws/script/:wsId?type=<scriptType>`
 - Binary frames are PTY bytes; JSON control messages include `ready`, `exit`, and `error`.
+
+Terminal stream:
+
+- Endpoint: `ws://<host>/ws/terminal/:wsId?sessionId=<sessionId>`
+- Same PTY protocol as the script stream, keyed by the terminal-tab session id.
 
 Browser stream:
 

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -468,6 +468,20 @@ describe("createNewSession", () => {
 });
 
 describe("terminal sessions", () => {
+  it("excludes terminal sessions from the conversation cap", async () => {
+    // Fill the cap with chat sessions.
+    await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    for (let i = 1; i < MAX_SESSIONS_PER_WORKSPACE; i++) {
+      await createNewSession(wsId, dataDir, CONV_CMD);
+    }
+    // A terminal can still be opened despite the chat cap being full…
+    await expect(
+      createNewSession(wsId, dataDir, CONV_CMD, "terminal"),
+    ).resolves.toBeDefined();
+    // …and it did not consume a chat slot — another chat still rejects.
+    await expect(createNewSession(wsId, dataDir, CONV_CMD)).rejects.toThrow(/Maximum/);
+  });
+
   it("persists kind:terminal in metadata.json and lists it", async () => {
     const session = await createNewSession(wsId, dataDir, CONV_CMD, "terminal");
     expect(session.metadata.kind).toBe("terminal");

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { chmod, mkdir, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { createProject } from "../projects/project-manager.js";
@@ -14,6 +14,7 @@ import {
   getSessionMetadata,
   listWorkspaceSessions,
   createNewSession,
+  convertSessionToTerminal,
   activateSession,
   hardDeleteSession,
   getSpecificSessionMessages,
@@ -22,6 +23,12 @@ import {
   setNotifier,
 } from "./agent-manager.js";
 import { MAX_SESSIONS_PER_WORKSPACE } from "./session-limits.js";
+import { _clearAll as clearAllScripts } from "../services/script-runner.js";
+import {
+  _setTerminalForTests,
+  getTerminalProcess,
+  _clearAllTerminals,
+} from "../services/terminal-runner.js";
 import { loadProject, saveProject } from "../state/state.js";
 import type { ChatMessage, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
@@ -69,6 +76,8 @@ beforeEach(async () => {
 afterEach(async () => {
   setNotifier(new Notifier([]));
   _clearActiveSessions();
+  clearAllScripts();
+  _clearAllTerminals();
   await new Promise((r) => setTimeout(r, 50));
   await rm(tempDir, { recursive: true, force: true });
 });
@@ -207,6 +216,31 @@ describe("getOrCreateSession", () => {
 
     expect(first.session.sessionId).toBe(second.session.sessionId);
     expect([first.created, second.created].filter(Boolean)).toHaveLength(1);
+  });
+
+  it("never resumes a persisted terminal session as the active chat session", async () => {
+    // A terminal session was persisted as the workspace's active session.
+    // Resuming it as the active chat would render a shell over the chat UI and
+    // silently no-op sendMessage, so a fresh chat session must be created.
+    await writeSessionFixture("terminal-session", wsId, {
+      metadata: { kind: "terminal", updatedAt: "2026-02-12T00:00:00.000Z" },
+    });
+
+    const state = await loadProject(projectId, dataDir);
+    const ws = state!.workspaces.find((w) => w.id === wsId)!;
+    ws.status = "busy";
+    ws.activeSessionId = "terminal-session";
+    await saveProject(state!, dataDir);
+
+    const { session, created } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+
+    expect(created).toBe(true);
+    expect(session.sessionId).not.toBe("terminal-session");
+    expect(session.metadata.kind).toBe("chat");
+
+    const updatedState = await loadProject(projectId, dataDir);
+    const updatedWs = updatedState!.workspaces.find((w) => w.id === wsId)!;
+    expect(updatedWs.activeSessionId).toBe(session.sessionId);
   });
 });
 
@@ -430,6 +464,83 @@ describe("createNewSession", () => {
     expect(getSession(wsId)?.sessionId).toBe(second.sessionId);
     expect(getSessionById(wsId, first.sessionId)?.status).toBe("streaming");
     expect(getSessionById(wsId, second.sessionId)?.status).toBe("streaming");
+  });
+});
+
+describe("terminal sessions", () => {
+  it("persists kind:terminal in metadata.json and lists it", async () => {
+    const session = await createNewSession(wsId, dataDir, CONV_CMD, "terminal");
+    expect(session.metadata.kind).toBe("terminal");
+
+    const metaPath = join(dataDir, projectId, "sessions", session.sessionId, "metadata.json");
+    const persisted = JSON.parse(await readFile(metaPath, "utf-8")) as SessionMetadata;
+    expect(persisted.kind).toBe("terminal");
+
+    const sessions = await listWorkspaceSessions(wsId, dataDir);
+    const listed = sessions.find((s) => s.sessionId === session.sessionId);
+    expect(listed?.kind).toBe("terminal");
+  });
+
+  it("defaults to chat kind when none is requested", async () => {
+    const session = await createNewSession(wsId, dataDir, CONV_CMD);
+    expect(session.metadata.kind).toBe("chat");
+  });
+
+  it("treats sendMessage on a terminal session as a no-op (no runner)", async () => {
+    const session = await createNewSession(wsId, dataDir, CONV_CMD, "terminal");
+
+    // Use a real (non-test) command path so a runner would be spawned for a
+    // chat session, proving the terminal guard short-circuits before that.
+    session.sendMessage("hello");
+
+    expect(session.status).toBe("idle");
+    const messages = await session.getMessages();
+    expect(messages).toEqual([]);
+  });
+
+  it("hardDeleteSession kills the terminal PTY keyed by the session id", async () => {
+    const session = await createNewSession(wsId, dataDir, CONV_CMD, "terminal");
+
+    // Seed a fake running terminal PTY keyed by the session id, as
+    // terminal-tabs/start would.
+    _setTerminalForTests(wsId, session.sessionId);
+    expect(getTerminalProcess(wsId, session.sessionId)?.state).toBe("running");
+
+    // stopTerminal() arms a 5s SIGKILL fallback timer on the (fake) PTY. Fake
+    // timers keep that callback from ever firing process.kill during the test.
+    vi.useFakeTimers();
+    try {
+      await hardDeleteSession(wsId, session.sessionId, dataDir);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+
+    expect(getTerminalProcess(wsId, session.sessionId)).toBeUndefined();
+  });
+
+  it("converts an empty chat session into a terminal session in place", async () => {
+    const { session } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    expect(session.metadata.kind).toBe("chat");
+
+    const meta = await convertSessionToTerminal(wsId, session.sessionId, dataDir);
+    expect(meta.kind).toBe("terminal");
+    // Same in-memory instance is mutated (not a fork).
+    expect(session.metadata.kind).toBe("terminal");
+
+    const metaPath = join(dataDir, projectId, "sessions", session.sessionId, "metadata.json");
+    const persisted = JSON.parse(await readFile(metaPath, "utf-8")) as SessionMetadata;
+    expect(persisted.kind).toBe("terminal");
+  });
+
+  it("refuses to convert a session that already has messages", async () => {
+    await writeSessionFixture("chatty-session", wsId, {
+      metadata: { messageCount: 3, updatedAt: "2026-02-12T00:00:00.000Z" },
+    });
+
+    await expect(
+      convertSessionToTerminal(wsId, "chatty-session", dataDir),
+    ).rejects.toThrow(/messages/);
   });
 });
 

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -11,7 +11,8 @@ import { assertSessionCapacity } from "./session-limits.js";
 import { extractSummary, extractPreview } from "../utils/summary-extractor.js";
 import { withKeyedLock } from "../utils/async-lock.js";
 import { parseJsonlMessages, sortByUpdatedAtDesc } from "./session-utils.js";
-import type { ChatMessage, SessionMetadata } from "../types.js";
+import { stopTerminal } from "../services/terminal-runner.js";
+import type { ChatMessage, SessionKind, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
 import { TelegramChannel } from "../notifications/telegram.js";
 import { ApnsChannel } from "../notifications/apns.js";
@@ -129,7 +130,10 @@ function getActiveSession(wsId: string): ConversationSession | undefined {
 }
 
 function getMostRecentlyUpdatedLoadedSession(wsId: string): ConversationSession | undefined {
-  const sessions = getLoadedSessions(wsId);
+  // Terminal sessions are never the active chat session: they render a shell,
+  // not a conversation, and silently no-op sendMessage. Skip them here so they
+  // are never auto-promoted to active.
+  const sessions = getLoadedSessions(wsId).filter((s) => s.metadata.kind !== "terminal");
   if (sessions.length === 0) return undefined;
   const sorted = sortByUpdatedAtDesc(sessions.map((s) => s.metadata));
   return sorted[0] ? getLoadedSessionById(wsId, sorted[0].sessionId) : undefined;
@@ -194,15 +198,20 @@ export async function getOrCreateSession(
     if (persistedActiveId) {
       try {
         const session = await loadSessionFromDisk(ctx, persistedActiveId, dataDir, options);
-        setActiveSession(wsId, session);
-        await persistWorkspaceSessionState(
-          ctx.projectId,
-          wsId,
-          "busy",
-          dataDir,
-          session.sessionId,
-        );
-        return { session, created: false };
+        // A terminal session must never be resumed as the active chat session:
+        // it renders a shell over the chat UI and silently no-ops sendMessage.
+        // Fall through to create a fresh chat session instead.
+        if (session.metadata.kind !== "terminal") {
+          setActiveSession(wsId, session);
+          await persistWorkspaceSessionState(
+            ctx.projectId,
+            wsId,
+            "busy",
+            dataDir,
+            session.sessionId,
+          );
+          return { session, created: false };
+        }
       } catch {
         // Missing/corrupt persisted active session — fall through to create new.
       }
@@ -460,14 +469,20 @@ async function createSession(
   ctx: Awaited<ReturnType<typeof resolveWorkspaceContext>>,
   dataDir: string,
   options?: SessionOptions,
+  kind: SessionKind = "chat",
 ): Promise<ConversationSession> {
-  const systemPrompt = await buildSessionPrompt(
-    ctx.wsPath,
-    ctx.workspace,
-    ctx.projectState,
-    dataDir,
-    options,
-  );
+  // Terminal sessions host a shell PTY, not an agent, so they never need a
+  // system prompt. Building one only does unnecessary work.
+  const systemPrompt =
+    kind === "terminal"
+      ? undefined
+      : await buildSessionPrompt(
+          ctx.wsPath,
+          ctx.workspace,
+          ctx.projectState,
+          dataDir,
+          options,
+        );
 
   const session = new ConversationSession({
     cwd: ctx.wsPath,
@@ -476,6 +491,7 @@ async function createSession(
     command: options?.command,
     systemPrompt,
     skipPermissions: options?.skipPermissions,
+    sessionKind: kind,
   });
   await attachBrowserEnv(session, ctx.workspace.id, options);
   await session.persistMetadata();
@@ -595,12 +611,13 @@ export async function createNewSession(
   wsId: string,
   dataDir = getDataDir(),
   options?: SessionOptions,
+  kind: SessionKind = "chat",
 ): Promise<ConversationSession> {
   return withWorkspaceLock(wsId, async () => {
     const ctx = await resolveWorkspaceContext(wsId, dataDir);
     const existing = await listWorkspaceSessions(wsId, dataDir);
     assertSessionCapacity(existing.length, "sessions");
-    const session = await createSession(ctx, dataDir, options);
+    const session = await createSession(ctx, dataDir, options, kind);
     setActiveSession(wsId, session);
     await persistWorkspaceSessionState(
       ctx.projectId,
@@ -610,6 +627,21 @@ export async function createNewSession(
       session.sessionId,
     );
     return session;
+  });
+}
+
+/** Convert an empty chat session into a terminal session (irreversible). */
+export async function convertSessionToTerminal(
+  wsId: string,
+  sessionId: string,
+  dataDir = getDataDir(),
+): Promise<SessionMetadata> {
+  return withWorkspaceLock(wsId, async () => {
+    const ctx = await resolveWorkspaceContext(wsId, dataDir);
+    const session = await loadSessionFromDisk(ctx, sessionId, dataDir);
+    session.convertToTerminal();
+    await session.persistMetadata();
+    return session.metadata;
   });
 }
 
@@ -650,6 +682,10 @@ export async function hardDeleteSession(
     const loaded = getLoadedSessionById(wsId, sessionId);
     const wasActive = activeSessionIds.get(wsId) === sessionId;
     browserSessionManager.closeSession(wsId, sessionId);
+
+    // Kill any terminal-tab PTY keyed by this session id. Safe no-op for chat
+    // sessions (no PTY is keyed by their id). Runs regardless of in-memory state.
+    stopTerminal(wsId, sessionId);
 
     if (loaded) {
       removeLoadedSession(wsId, sessionId);

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -11,7 +11,7 @@ import { assertSessionCapacity } from "./session-limits.js";
 import { extractSummary, extractPreview } from "../utils/summary-extractor.js";
 import { withKeyedLock } from "../utils/async-lock.js";
 import { parseJsonlMessages, sortByUpdatedAtDesc } from "./session-utils.js";
-import { stopTerminal } from "../services/terminal-runner.js";
+import { removeTerminal } from "../services/terminal-runner.js";
 import type { ChatMessage, SessionKind, SessionMetadata } from "../types.js";
 import { Notifier } from "../notifications/notifier.js";
 import { TelegramChannel } from "../notifications/telegram.js";
@@ -615,8 +615,15 @@ export async function createNewSession(
 ): Promise<ConversationSession> {
   return withWorkspaceLock(wsId, async () => {
     const ctx = await resolveWorkspaceContext(wsId, dataDir);
-    const existing = await listWorkspaceSessions(wsId, dataDir);
-    assertSessionCapacity(existing.length, "sessions");
+    // Terminal tabs are a separate surface and don't count toward the
+    // conversation cap; only chat sessions are capped, and opening a terminal is
+    // never blocked by it.
+    if (kind !== "terminal") {
+      const chatCount = (await listWorkspaceSessions(wsId, dataDir)).filter(
+        (s) => s.kind !== "terminal",
+      ).length;
+      assertSessionCapacity(chatCount, "sessions");
+    }
     const session = await createSession(ctx, dataDir, options, kind);
     setActiveSession(wsId, session);
     await persistWorkspaceSessionState(
@@ -683,9 +690,10 @@ export async function hardDeleteSession(
     const wasActive = activeSessionIds.get(wsId) === sessionId;
     browserSessionManager.closeSession(wsId, sessionId);
 
-    // Kill any terminal-tab PTY keyed by this session id. Safe no-op for chat
-    // sessions (no PTY is keyed by their id). Runs regardless of in-memory state.
-    stopTerminal(wsId, sessionId);
+    // Remove any terminal-tab PTY keyed by this session id: kill it if running
+    // and always drop the registry entry (and its replay buffer) so a deleted
+    // terminal's output can't linger or be replayed. No-op for chat sessions.
+    removeTerminal(wsId, sessionId);
 
     if (loaded) {
       removeLoadedSession(wsId, sessionId);

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -203,7 +203,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private readonly skipPermissions: boolean;
   private readonly disableInteractiveTools: boolean;
   private readonly readOnly: boolean;
-  private readonly sessionKind: SessionKind;
+  // Not readonly: load() restores the persisted kind before any use.
+  private sessionKind: SessionKind;
   private readonly runnerFactory: AgentRunnerFactory;
   private browserEnv: Record<string, string> | undefined;
   private readonly sessionDir: string;
@@ -252,6 +253,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
       messageCount: 0,
+      kind: this.sessionKind,
     };
 
     // Node crashes the whole process on emit("error") with zero listeners.
@@ -338,6 +340,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       session._metadata = meta;
       session.cliSessionId = meta.providerSessionId ?? meta.claudeSessionId;
       session.messageCount = meta.messageCount;
+      // Restore the persisted kind (absent = "chat" for old sessions) and keep
+      // _metadata.kind consistent so subsequent saves never drop it.
+      session.sessionKind = meta.kind ?? "chat";
+      session._metadata.kind = session.sessionKind;
       // Backfill lockedProvider for sessions created before multi-model support.
       // All pre-existing sessions were Claude-only, so default to "claude".
       if (!meta.lockedProvider && meta.messageCount > 0) {
@@ -374,6 +380,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
    *  When `cliContent` is provided, it is sent to the CLI instead of `content`
    *  while the displayed/persisted message remains `content`. */
   sendMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[], cliContent?: string, fileMentions?: FileMention[]): void {
+    // Terminal sessions host a shell PTY, not an agent. Never spawn a runner.
+    // Defensive: the UI does not call this for terminal tabs.
+    if (this.sessionKind === "terminal") {
+      return;
+    }
     if (this._status === "streaming") {
       throw new Error("Already streaming — wait for current message to complete or stop it");
     }
@@ -1525,6 +1536,20 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
   setTitle(title: string): void {
     this._metadata.title = title;
+    this._metadata.updatedAt = new Date().toISOString();
+    this.enqueueMetadataPersist();
+  }
+
+  /** Convert an empty chat session into a terminal session. Irreversible and
+   *  only allowed before the first message — terminal sessions host a shell PTY,
+   *  not an agent, so there must be no conversation history to strand. */
+  convertToTerminal(): void {
+    if (this.sessionKind === "terminal") return;
+    if (this.messageCount > 0) {
+      throw new Error("Cannot convert a session with messages into a terminal");
+    }
+    this.sessionKind = "terminal";
+    this._metadata.kind = "terminal";
     this._metadata.updatedAt = new Date().toISOString();
     this.enqueueMetadataPersist();
   }

--- a/backend/src/agents/session-dispatch.ts
+++ b/backend/src/agents/session-dispatch.ts
@@ -3,7 +3,7 @@ import * as brainManager from "./brain-manager.js";
 import { BRAIN_WORKSPACE_ID } from "./brain-manager.js";
 import { getDataDir } from "../state/state.js";
 import type { ConversationSession } from "./conversation-session.js";
-import type { ChatMessage, SessionMetadata } from "../types.js";
+import type { ChatMessage, SessionKind, SessionMetadata } from "../types.js";
 import type { SessionOptions } from "./agent-manager.js";
 
 /**
@@ -82,10 +82,12 @@ export async function createNewSession(
   wsId: string,
   dataDir = getDataDir(),
   options?: SessionOptions,
+  kind: SessionKind = "chat",
 ): Promise<ConversationSession> {
+  // The Brain is always a "brain" session, so it ignores the requested kind.
   return isBrain(wsId)
     ? brainManager.createNewBrainSession(dataDir, options)
-    : workspaceManager.createNewSession(wsId, dataDir, options);
+    : workspaceManager.createNewSession(wsId, dataDir, options, kind);
 }
 
 export async function activateSession(
@@ -97,6 +99,18 @@ export async function activateSession(
   return isBrain(wsId)
     ? brainManager.activateBrainSession(sessionId, dataDir, options)
     : workspaceManager.activateSession(wsId, sessionId, dataDir, options);
+}
+
+export async function convertSessionToTerminal(
+  wsId: string,
+  sessionId: string,
+  dataDir = getDataDir(),
+): Promise<SessionMetadata> {
+  // Terminal sessions are workspace-only; the Brain never hosts a shell.
+  if (isBrain(wsId)) {
+    throw new Error("Terminal sessions are not supported in the Brain");
+  }
+  return workspaceManager.convertSessionToTerminal(wsId, sessionId, dataDir);
 }
 
 export async function hardDeleteSession(

--- a/backend/src/api/agents.ts
+++ b/backend/src/api/agents.ts
@@ -9,6 +9,7 @@ import {
   getSessionMessages,
   listWorkspaceSessions,
   createNewSession,
+  convertSessionToTerminal,
   hardDeleteSession,
   getSpecificSessionMessages,
   resolveSessionAttachmentPath,
@@ -104,14 +105,36 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
   );
 
   // POST /api/workspaces/:wsId/sessions — create a new session (parks current)
-  app.post<{ Params: { wsId: string } }>(
+  app.post<{ Params: { wsId: string }; Body?: { kind?: string } }>(
     "/api/workspaces/:wsId/sessions",
     async (req, reply) => {
       try {
-        const session = await createNewSession(req.params.wsId, dataDir, sessionOptions);
+        // Only "terminal" is accepted from the body; anything else is a chat.
+        const kind = req.body?.kind === "terminal" ? "terminal" : "chat";
+        const session = await createNewSession(req.params.wsId, dataDir, sessionOptions, kind);
         return reply.status(201).send(session.metadata);
       } catch (err: unknown) {
         const msg = errorMessage(err, "Failed to create session");
+        const code = errorStatus(err);
+        return reply.status(code).send({ error: msg });
+      }
+    },
+  );
+
+  // POST /api/workspaces/:wsId/sessions/:sessionId/convert-to-terminal —
+  // turn an empty chat session into a terminal session in place (irreversible).
+  app.post<{ Params: { wsId: string; sessionId: string } }>(
+    "/api/workspaces/:wsId/sessions/:sessionId/convert-to-terminal",
+    async (req, reply) => {
+      try {
+        const meta = await convertSessionToTerminal(
+          req.params.wsId,
+          req.params.sessionId,
+          dataDir,
+        );
+        return reply.send(meta);
+      } catch (err: unknown) {
+        const msg = errorMessage(err, "Failed to convert session to terminal");
         const code = errorStatus(err);
         return reply.status(code).send({ error: msg });
       }

--- a/backend/src/api/scripts.test.ts
+++ b/backend/src/api/scripts.test.ts
@@ -8,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   startScript: vi.fn(),
   stopScript: vi.fn(),
   getScriptStatus: vi.fn(),
+  startTerminal: vi.fn(),
+  stopTerminal: vi.fn(),
+  listWorkspaceSessions: vi.fn(),
   broadcastToWorkspace: vi.fn(),
 }));
 
@@ -15,6 +18,15 @@ vi.mock("../services/script-runner.js", () => ({
   startScript: mocks.startScript,
   stopScript: mocks.stopScript,
   getScriptStatus: mocks.getScriptStatus,
+}));
+
+vi.mock("../services/terminal-runner.js", () => ({
+  startTerminal: mocks.startTerminal,
+  stopTerminal: mocks.stopTerminal,
+}));
+
+vi.mock("../agents/session-dispatch.js", () => ({
+  listWorkspaceSessions: mocks.listWorkspaceSessions,
 }));
 
 vi.mock("../ws/stream.js", () => ({
@@ -62,10 +74,19 @@ beforeEach(async () => {
   mocks.startScript.mockReset();
   mocks.stopScript.mockReset();
   mocks.getScriptStatus.mockReset();
+  mocks.startTerminal.mockReset();
+  mocks.stopTerminal.mockReset();
+  mocks.listWorkspaceSessions.mockReset();
   mocks.broadcastToWorkspace.mockReset();
   mocks.getScriptStatus.mockReturnValue({});
   mocks.startScript.mockReturnValue({ exitListeners: new Map() });
   mocks.stopScript.mockReturnValue(true);
+  mocks.startTerminal.mockReturnValue({ exitListeners: new Map() });
+  mocks.stopTerminal.mockReturnValue(true);
+  // Default: the terminal-tab session exists and is a terminal kind.
+  mocks.listWorkspaceSessions.mockResolvedValue([
+    { sessionId: "sess-abc", workspaceId: WS_ID, kind: "terminal" },
+  ]);
 
   app = Fastify();
   await app.register((instance: FastifyInstance) => scriptRoutes(instance, dataDir));
@@ -462,6 +483,100 @@ describe("script routes", () => {
       url: `/api/workspaces/${WS_ID}/scripts/run/stop`,
     });
 
+    expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start spawns a terminal PTY without touching the script runner", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/start`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ started: true });
+    // Uses the terminal runner, not the script runner.
+    expect(mocks.startTerminal).toHaveBeenCalledWith(WS_ID, "sess-abc", wsPath);
+    expect(mocks.startScript).not.toHaveBeenCalled();
+    // No script_status broadcast: an open terminal must not light up the
+    // workspace "script running" indicator.
+    expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start returns 404 for unknown workspace", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/workspaces/missing/terminal-tabs/sess-abc/start",
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Workspace not found" });
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start returns 404 when the session does not exist", async () => {
+    mocks.listWorkspaceSessions.mockResolvedValue([]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/start`,
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(res.json()).toEqual({ error: "Session not found" });
+    expect(mocks.startTerminal).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start returns 400 when the session is not a terminal", async () => {
+    mocks.listWorkspaceSessions.mockResolvedValue([
+      { sessionId: "sess-abc", workspaceId: WS_ID, kind: "chat" },
+    ]);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/start`,
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Session is not a terminal" });
+    expect(mocks.startTerminal).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start returns 409 when already running", async () => {
+    mocks.startTerminal.mockImplementation(() => {
+      throw new Error('Terminal "sess-abc" is already running');
+    });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/start`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain('Terminal "sess-abc" is already running');
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop kills the terminal PTY without broadcasting", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/stop`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ stopped: true });
+    expect(mocks.stopTerminal).toHaveBeenCalledWith(WS_ID, "sess-abc");
+    expect(mocks.stopScript).not.toHaveBeenCalled();
+    expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop returns 409 when not running", async () => {
+    mocks.stopTerminal.mockReturnValue(false);
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/workspaces/${WS_ID}/terminal-tabs/sess-abc/stop`,
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(res.json()).toEqual({ error: "No running terminal to stop" });
     expect(mocks.broadcastToWorkspace).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/api/scripts.ts
+++ b/backend/src/api/scripts.ts
@@ -7,6 +7,8 @@ import {
   stopScript,
   getScriptStatus,
 } from "../services/script-runner.js";
+import { startTerminal, stopTerminal } from "../services/terminal-runner.js";
+import { listWorkspaceSessions } from "../agents/session-dispatch.js";
 import { broadcastToWorkspace } from "../ws/stream.js";
 import { workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
@@ -146,6 +148,51 @@ export async function scriptRoutes(app: FastifyInstance, dataDir?: string) {
         scriptType: "terminal",
         state: "idle",
       });
+
+      return reply.send({ stopped: true });
+    },
+  );
+
+  // POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start — terminal-tab shell.
+  // Each tab gets its own PTY in the terminal registry (NOT the script runner),
+  // so an open terminal never lights up the workspace "script running" indicator
+  // and no `script_status` is broadcast. The pane is driven entirely by its own
+  // `/ws/terminal` socket.
+  app.post<{ Params: { wsId: string; sessionId: string } }>(
+    "/api/workspaces/:wsId/terminal-tabs/:sessionId/start",
+    async (req, reply) => {
+      const { wsId, sessionId } = req.params;
+      const resolved = await resolveWsPath(wsId);
+      if (!resolved) return reply.status(404).send({ error: "Workspace not found" });
+
+      // Only terminal-kind sessions get a PTY here.
+      const sessions = await listWorkspaceSessions(wsId, dir);
+      const session = sessions.find((s) => s.sessionId === sessionId);
+      if (!session) {
+        return reply.status(404).send({ error: "Session not found" });
+      }
+      if (session.kind !== "terminal") {
+        return reply.status(400).send({ error: "Session is not a terminal" });
+      }
+
+      try {
+        startTerminal(wsId, sessionId, resolved.wsPath);
+        return reply.send({ started: true });
+      } catch (err: unknown) {
+        return reply.status(409).send({ error: errorMessage(err, "Failed to start terminal") });
+      }
+    },
+  );
+
+  // POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop
+  app.post<{ Params: { wsId: string; sessionId: string } }>(
+    "/api/workspaces/:wsId/terminal-tabs/:sessionId/stop",
+    async (req, reply) => {
+      const { wsId, sessionId } = req.params;
+      const stopped = stopTerminal(wsId, sessionId);
+      if (!stopped) {
+        return reply.status(409).send({ error: "No running terminal to stop" });
+      }
 
       return reply.send({ stopped: true });
     },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,7 @@ import { stopProviderUsagePolling } from "./services/provider-usage.js";
 import { accountRoutes } from "./api/account.js";
 import { scriptRoutes } from "./api/scripts.js";
 import { scriptWsRoutes } from "./ws/script.js";
+import { terminalWsRoutes } from "./ws/terminal.js";
 import { browserWsRoutes } from "./ws/browser.js";
 import { automationRoutes } from "./api/automations.js";
 import { promptTemplateRoutes } from "./api/prompt-templates.js";
@@ -42,6 +43,7 @@ import type { StreamRoutesOptions } from "./ws/stream.js";
 import { preflight } from "./utils/preflight.js";
 import { detectAvailableProviders } from "./agents/providers/registry.js";
 import { stopAllScripts } from "./services/script-runner.js";
+import { stopAllTerminals } from "./services/terminal-runner.js";
 import { initWorkspaceIndex } from "./state/workspace-index.js";
 
 const HOST = process.env.HOST ?? "127.0.0.1";
@@ -325,6 +327,9 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     scriptWsRoutes(instance, { authToken }),
   );
   await app.register((instance: FastifyInstance) =>
+    terminalWsRoutes(instance, { authToken }),
+  );
+  await app.register((instance: FastifyInstance) =>
     browserWsRoutes(instance, { authToken }),
   );
   await app.register((instance: FastifyInstance) =>
@@ -429,6 +434,7 @@ async function main() {
     console.log(`[server] ${signal} received, shutting down...`);
 
     stopAllScripts();
+    stopAllTerminals();
 
     // Drain persist queues with timeout
     await Promise.race([

--- a/backend/src/services/pty-process.ts
+++ b/backend/src/services/pty-process.ts
@@ -1,0 +1,110 @@
+import * as pty from "node-pty";
+import type { IPty } from "node-pty";
+import { buildWorkspaceEnv } from "../utils/env.js";
+
+const MAX_BUFFER_BYTES = 256 * 1024;
+
+/**
+ * A spawned PTY plus the bookkeeping shared by both the script runner and the
+ * terminal runner: a verbatim ring buffer for replay, live data listeners, and
+ * exit listeners. This is the reusable lifecycle core; registries (keying,
+ * status broadcasts) live in the callers.
+ */
+export interface PtyProcess {
+  pty: IPty;
+  state: "running" | "done" | "error";
+  exitCode?: number;
+  /** Verbatim ring buffer of PTY output (ANSI escapes and \r\n preserved). */
+  outputBuffer: string;
+  /** Live data listeners (WS connections). Keyed by arbitrary id. */
+  listeners: Map<string, (data: string) => void>;
+  /** Exit listeners. Keyed by arbitrary id. */
+  exitListeners: Map<string, (code: number) => void>;
+}
+
+/**
+ * Spawn a PTY and wire its output buffer plus data/exit listener dispatch.
+ *
+ * - No command launches a login shell (`-l`) so the user's full profile/PATH is
+ *   sourced — matching what they get in an interactive terminal.
+ * - A command runs once via `-c`.
+ *
+ * The caller owns registration and any status broadcasting.
+ */
+export function spawnPtyProcess(command: string | undefined, cwd: string): PtyProcess {
+  const shell = process.env.SHELL || "/bin/sh";
+  const args = command ? ["-c", command] : ["-l"];
+  const ptyProcess = pty.spawn(shell, args, {
+    cwd,
+    env: buildWorkspaceEnv({ TERM: "xterm-256color" }),
+    cols: 80,
+    rows: 24,
+    name: "xterm-256color",
+  });
+
+  const proc: PtyProcess = {
+    pty: ptyProcess,
+    state: "running",
+    outputBuffer: "",
+    listeners: new Map(),
+    exitListeners: new Map(),
+  };
+
+  ptyProcess.onData((data) => {
+    // Append raw PTY chunk to the ring buffer. We intentionally keep the stream
+    // verbatim (ANSI escapes, partial lines, \r\n) so the replay on reconnect
+    // matches what xterm would have rendered live.
+    proc.outputBuffer += data;
+    if (proc.outputBuffer.length > MAX_BUFFER_BYTES) {
+      const overflow = proc.outputBuffer.length - MAX_BUFFER_BYTES;
+      // Trim at the next newline past the overflow point to avoid slicing an
+      // ANSI escape sequence in half.
+      const nextNewline = proc.outputBuffer.indexOf("\n", overflow);
+      proc.outputBuffer =
+        nextNewline === -1
+          ? proc.outputBuffer.slice(overflow)
+          : proc.outputBuffer.slice(nextNewline + 1);
+    }
+    // Notify live listeners
+    for (const listener of proc.listeners.values()) {
+      listener(data);
+    }
+  });
+
+  ptyProcess.onExit(({ exitCode }) => {
+    proc.exitCode = exitCode;
+    proc.state = exitCode === 0 ? "done" : "error";
+    for (const listener of proc.exitListeners.values()) {
+      listener(exitCode);
+    }
+  });
+
+  return proc;
+}
+
+/**
+ * Kill a running PTY: clear listeners (so no stale broadcasts fire after an
+ * explicit stop), send the kill signal, and arm a 5s SIGKILL fallback that is
+ * cancelled if the process exits first.
+ */
+export function killPtyProcess(proc: PtyProcess): void {
+  // Clear listeners to prevent stale "error" broadcasts/output after explicit stop
+  proc.exitListeners.clear();
+  proc.listeners.clear();
+
+  proc.pty.kill();
+
+  // Fallback SIGKILL after 5s
+  const timeout = setTimeout(() => {
+    try {
+      process.kill(proc.pty.pid, "SIGKILL");
+    } catch {
+      // Process may already be dead
+    }
+  }, 5000);
+
+  const origExit = proc.pty.onExit(() => {
+    clearTimeout(timeout);
+    origExit.dispose();
+  });
+}

--- a/backend/src/services/script-runner.test.ts
+++ b/backend/src/services/script-runner.test.ts
@@ -112,14 +112,14 @@ describe("script-runner", () => {
     expect(getScriptStatus("ws-1").setup?.state).toBe("running");
   });
 
-  it("starts an interactive shell when command is undefined", () => {
+  it("starts an interactive login shell when command is undefined", () => {
     process.env.SHELL = "/bin/bash";
 
     const proc = startScript("ws-1", "terminal", undefined, "/tmp/workspace");
 
     expect(mocks.spawn).toHaveBeenCalledWith(
       "/bin/bash",
-      [],
+      ["-l"],
       expect.objectContaining({
         cwd: "/tmp/workspace",
       }),

--- a/backend/src/services/script-runner.ts
+++ b/backend/src/services/script-runner.ts
@@ -1,23 +1,13 @@
-import * as pty from "node-pty";
 import type { IPty } from "node-pty";
-import { buildWorkspaceEnv } from "../utils/env.js";
+import { type PtyProcess, spawnPtyProcess, killPtyProcess } from "./pty-process.js";
 
 export type ScriptType = string;
 export type ScriptState = "idle" | "running" | "done" | "error";
 
-const MAX_BUFFER_BYTES = 256 * 1024;
-
-export interface ScriptProcess {
-  pty: IPty;
+/** A script PTY: the shared lifecycle core plus the script type tag. */
+export type ScriptProcess = PtyProcess & {
   type: ScriptType;
-  state: ScriptState;
-  exitCode?: number;
-  outputBuffer: string;
-  /** Live data listeners (WS connections). Keyed by arbitrary id. */
-  listeners: Map<string, (data: string) => void>;
-  /** Exit listeners. */
-  exitListeners: Map<string, (code: number) => void>;
-}
+};
 
 const activeScripts = new Map<string, ScriptProcess>();
 
@@ -42,53 +32,10 @@ export function startScript(
     activeScripts.delete(k);
   }
 
-  const shell = process.env.SHELL || "/bin/sh";
-  const args = command ? ["-c", command] : [];
-  const ptyProcess = pty.spawn(shell, args, {
-    cwd,
-    env: buildWorkspaceEnv({ TERM: "xterm-256color" }),
-    cols: 80,
-    rows: 24,
-    name: "xterm-256color",
-  });
-
-  const proc: ScriptProcess = {
-    pty: ptyProcess,
-    type,
-    state: "running",
-    outputBuffer: "",
-    listeners: new Map(),
-    exitListeners: new Map(),
-  };
-
-  ptyProcess.onData((data) => {
-    // Append raw PTY chunk to the ring buffer. We intentionally keep the stream
-    // verbatim (ANSI escapes, partial lines, \r\n) so the replay on reconnect
-    // matches what xterm would have rendered live.
-    proc.outputBuffer += data;
-    if (proc.outputBuffer.length > MAX_BUFFER_BYTES) {
-      const overflow = proc.outputBuffer.length - MAX_BUFFER_BYTES;
-      // Trim at the next newline past the overflow point to avoid slicing an
-      // ANSI escape sequence in half.
-      const nextNewline = proc.outputBuffer.indexOf("\n", overflow);
-      proc.outputBuffer =
-        nextNewline === -1
-          ? proc.outputBuffer.slice(overflow)
-          : proc.outputBuffer.slice(nextNewline + 1);
-    }
-    // Notify live listeners
-    for (const listener of proc.listeners.values()) {
-      listener(data);
-    }
-  });
-
-  ptyProcess.onExit(({ exitCode }) => {
-    proc.exitCode = exitCode;
-    proc.state = exitCode === 0 ? "done" : "error";
-    for (const listener of proc.exitListeners.values()) {
-      listener(exitCode);
-    }
-  });
+  // Attach `type` onto the same object the spawn closures mutate. Spreading
+  // into a new object would break those live references (state/exitCode would
+  // never update), so we augment in place.
+  const proc: ScriptProcess = Object.assign(spawnPtyProcess(command, cwd), { type });
 
   activeScripts.set(k, proc);
   return proc;
@@ -99,28 +46,10 @@ export function stopScript(wsId: string, type: ScriptType): boolean {
   const proc = activeScripts.get(k);
   if (!proc || proc.state !== "running") return false;
 
-  // Clear exit listeners to prevent stale "error" broadcasts after explicit stop
-  proc.exitListeners.clear();
-  proc.listeners.clear();
-
   // Remove from map so getScriptStatus() returns "idle" on subsequent queries
   activeScripts.delete(k);
 
-  proc.pty.kill();
-
-  // Fallback SIGKILL after 5s
-  const timeout = setTimeout(() => {
-    try {
-      process.kill(proc.pty.pid, "SIGKILL");
-    } catch {
-      // Process may already be dead
-    }
-  }, 5000);
-
-  const origExit = proc.pty.onExit(() => {
-    clearTimeout(timeout);
-    origExit.dispose();
-  });
+  killPtyProcess(proc);
 
   return true;
 }
@@ -184,7 +113,7 @@ export function _clearAll(): void {
 export function _setScriptStatusForTests(
   wsId: string,
   type: ScriptType,
-  state: ScriptState,
+  state: Exclude<ScriptState, "idle">,
   exitCode?: number,
 ): void {
   const proc: ScriptProcess = {

--- a/backend/src/services/terminal-runner.test.ts
+++ b/backend/src/services/terminal-runner.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+type DataHandler = (data: string) => void;
+type ExitHandler = (event: { exitCode: number }) => void;
+
+interface MockPtyProcess {
+  pid: number;
+  kill: ReturnType<typeof vi.fn>;
+  write: ReturnType<typeof vi.fn>;
+  resize: ReturnType<typeof vi.fn>;
+  onData: (handler: DataHandler) => { dispose: () => void };
+  onExit: (handler: ExitHandler) => { dispose: () => void };
+  emitData: (data: string) => void;
+  emitExit: (exitCode: number) => void;
+}
+
+const mocks = vi.hoisted(() => {
+  let nextPid = 10_000;
+  const processes: MockPtyProcess[] = [];
+
+  function createProcess(): MockPtyProcess {
+    const dataHandlers = new Set<DataHandler>();
+    const exitHandlers = new Set<ExitHandler>();
+
+    return {
+      pid: nextPid++,
+      kill: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      onData: (handler: DataHandler) => {
+        dataHandlers.add(handler);
+        return { dispose: () => dataHandlers.delete(handler) };
+      },
+      onExit: (handler: ExitHandler) => {
+        exitHandlers.add(handler);
+        return { dispose: () => exitHandlers.delete(handler) };
+      },
+      emitData: (data: string) => {
+        for (const handler of dataHandlers) handler(data);
+      },
+      emitExit: (exitCode: number) => {
+        for (const handler of exitHandlers) handler({ exitCode });
+      },
+    };
+  }
+
+  const spawn = vi.fn(() => {
+    const proc = createProcess();
+    processes.push(proc);
+    return proc;
+  });
+
+  return {
+    spawn,
+    processes,
+    reset() {
+      spawn.mockClear();
+      processes.length = 0;
+      nextPid = 10_000;
+    },
+  };
+});
+
+vi.mock("node-pty", () => ({
+  spawn: mocks.spawn,
+}));
+
+import {
+  startTerminal,
+  stopTerminal,
+  getTerminalProcess,
+  stopAllTerminalsForWorkspace,
+  stopAllTerminals,
+  _clearAllTerminals,
+} from "./terminal-runner.js";
+
+beforeEach(() => {
+  mocks.reset();
+  _clearAllTerminals();
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  _clearAllTerminals();
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+});
+
+describe("terminal-runner", () => {
+  it("starts an interactive login shell and tracks the running process", () => {
+    process.env.SHELL = "/bin/bash";
+
+    const proc = startTerminal("ws-1", "sess-1", "/tmp/workspace");
+
+    expect(mocks.spawn).toHaveBeenCalledWith(
+      "/bin/bash",
+      ["-l"],
+      expect.objectContaining({ cwd: "/tmp/workspace" }),
+    );
+    expect(proc.state).toBe("running");
+    expect(getTerminalProcess("ws-1", "sess-1")).toBe(proc);
+  });
+
+  it("throws when starting a terminal that is already running for the same key", () => {
+    startTerminal("ws-1", "sess-1", "/tmp/workspace");
+    expect(() => startTerminal("ws-1", "sess-1", "/tmp/workspace")).toThrow(
+      'Terminal "sess-1" is already running for workspace ws-1',
+    );
+  });
+
+  it("allows restarting after the previous terminal has exited", () => {
+    const first = startTerminal("ws-1", "sess-1", "/tmp/workspace");
+    mocks.processes[0]?.emitExit(0);
+
+    const second = startTerminal("ws-1", "sess-1", "/tmp/workspace");
+    expect(second).not.toBe(first);
+    expect(second.state).toBe("running");
+  });
+
+  it("returns false when stopping a terminal that is not running", () => {
+    expect(stopTerminal("ws-1", "sess-1")).toBe(false);
+  });
+
+  it("kills the PTY and removes the entry on stop", () => {
+    startTerminal("ws-1", "sess-1", "/tmp/workspace");
+    const pty = mocks.processes[0];
+
+    const stopped = stopTerminal("ws-1", "sess-1");
+
+    expect(stopped).toBe(true);
+    expect(pty?.kill).toHaveBeenCalledTimes(1);
+    expect(getTerminalProcess("ws-1", "sess-1")).toBeUndefined();
+  });
+
+  it("stops all terminals for a workspace without touching other workspaces", () => {
+    startTerminal("ws-1", "sess-a", "/tmp/workspace");
+    startTerminal("ws-1", "sess-b", "/tmp/workspace");
+    startTerminal("ws-2", "sess-c", "/tmp/workspace");
+
+    stopAllTerminalsForWorkspace("ws-1");
+
+    expect(mocks.processes[0]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[1]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[2]?.kill).not.toHaveBeenCalled();
+    expect(getTerminalProcess("ws-1", "sess-a")).toBeUndefined();
+    expect(getTerminalProcess("ws-1", "sess-b")).toBeUndefined();
+    expect(getTerminalProcess("ws-2", "sess-c")?.state).toBe("running");
+  });
+
+  it("stops all terminals across all workspaces", () => {
+    startTerminal("ws-1", "sess-a", "/tmp/workspace");
+    startTerminal("ws-2", "sess-b", "/tmp/workspace");
+
+    stopAllTerminals();
+
+    expect(mocks.processes[0]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[1]?.kill).toHaveBeenCalledTimes(1);
+    expect(getTerminalProcess("ws-1", "sess-a")).toBeUndefined();
+    expect(getTerminalProcess("ws-2", "sess-b")).toBeUndefined();
+  });
+});

--- a/backend/src/services/terminal-runner.test.ts
+++ b/backend/src/services/terminal-runner.test.ts
@@ -68,6 +68,7 @@ vi.mock("node-pty", () => ({
 import {
   startTerminal,
   stopTerminal,
+  removeTerminal,
   getTerminalProcess,
   stopAllTerminalsForWorkspace,
   stopAllTerminals,
@@ -99,6 +100,21 @@ describe("terminal-runner", () => {
     );
     expect(proc.state).toBe("running");
     expect(getTerminalProcess("ws-1", "sess-1")).toBe(proc);
+  });
+
+  it("removeTerminal drops a finished terminal that stopTerminal leaves behind", () => {
+    const proc = startTerminal("ws-1", "sess-1", "/tmp/workspace");
+    // The shell exits on its own → the entry stays registered for reconnect replay.
+    mocks.processes[0].emitExit(0);
+    expect(proc.state).toBe("done");
+
+    // stopTerminal only stops *running* terminals, so the finished entry lingers.
+    expect(stopTerminal("ws-1", "sess-1")).toBe(false);
+    expect(getTerminalProcess("ws-1", "sess-1")).toBe(proc);
+
+    // removeTerminal clears it regardless of state (used on session delete).
+    removeTerminal("ws-1", "sess-1");
+    expect(getTerminalProcess("ws-1", "sess-1")).toBeUndefined();
   });
 
   it("throws when starting a terminal that is already running for the same key", () => {

--- a/backend/src/services/terminal-runner.test.ts
+++ b/backend/src/services/terminal-runner.test.ts
@@ -152,11 +152,12 @@ describe("terminal-runner", () => {
     startTerminal("ws-1", "sess-a", "/tmp/workspace");
     startTerminal("ws-1", "sess-b", "/tmp/workspace");
     startTerminal("ws-2", "sess-c", "/tmp/workspace");
+    mocks.processes[1].emitExit(0);
 
     stopAllTerminalsForWorkspace("ws-1");
 
     expect(mocks.processes[0]?.kill).toHaveBeenCalledTimes(1);
-    expect(mocks.processes[1]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[1]?.kill).not.toHaveBeenCalled();
     expect(mocks.processes[2]?.kill).not.toHaveBeenCalled();
     expect(getTerminalProcess("ws-1", "sess-a")).toBeUndefined();
     expect(getTerminalProcess("ws-1", "sess-b")).toBeUndefined();
@@ -166,11 +167,12 @@ describe("terminal-runner", () => {
   it("stops all terminals across all workspaces", () => {
     startTerminal("ws-1", "sess-a", "/tmp/workspace");
     startTerminal("ws-2", "sess-b", "/tmp/workspace");
+    mocks.processes[1].emitExit(0);
 
     stopAllTerminals();
 
     expect(mocks.processes[0]?.kill).toHaveBeenCalledTimes(1);
-    expect(mocks.processes[1]?.kill).toHaveBeenCalledTimes(1);
+    expect(mocks.processes[1]?.kill).not.toHaveBeenCalled();
     expect(getTerminalProcess("ws-1", "sess-a")).toBeUndefined();
     expect(getTerminalProcess("ws-2", "sess-b")).toBeUndefined();
   });

--- a/backend/src/services/terminal-runner.ts
+++ b/backend/src/services/terminal-runner.ts
@@ -1,0 +1,98 @@
+import type { IPty } from "node-pty";
+import { type PtyProcess, spawnPtyProcess, killPtyProcess } from "./pty-process.js";
+
+/**
+ * Registry of interactive terminal-tab PTYs, keyed by `wsId:sessionId`.
+ *
+ * Deliberately separate from the script runner: terminal tabs must NOT pollute
+ * the workspace "script running" indicator. Terminal panes get their state from
+ * their own `/ws/terminal` socket (ready/exit/error frames), so this registry
+ * never broadcasts `script_status` and is never surfaced by `getScriptStatus`.
+ */
+const activeTerminals = new Map<string, PtyProcess>();
+
+function key(wsId: string, sessionId: string): string {
+  return `${wsId}:${sessionId}`;
+}
+
+/** Spawn an interactive login shell for a terminal-tab session. */
+export function startTerminal(wsId: string, sessionId: string, cwd: string): PtyProcess {
+  const k = key(wsId, sessionId);
+  const existing = activeTerminals.get(k);
+  if (existing && existing.state === "running") {
+    throw new Error(`Terminal "${sessionId}" is already running for workspace ${wsId}`);
+  }
+
+  // Clean up finished process entry if any
+  if (existing) {
+    activeTerminals.delete(k);
+  }
+
+  const proc = spawnPtyProcess(undefined, cwd);
+  activeTerminals.set(k, proc);
+  return proc;
+}
+
+export function stopTerminal(wsId: string, sessionId: string): boolean {
+  const k = key(wsId, sessionId);
+  const proc = activeTerminals.get(k);
+  if (!proc || proc.state !== "running") return false;
+
+  activeTerminals.delete(k);
+  killPtyProcess(proc);
+  return true;
+}
+
+export function getTerminalProcess(wsId: string, sessionId: string): PtyProcess | undefined {
+  return activeTerminals.get(key(wsId, sessionId));
+}
+
+export function stopAllTerminalsForWorkspace(wsId: string): void {
+  const prefix = `${wsId}:`;
+  const sessionIds = [...activeTerminals.keys()]
+    .filter((k) => k.startsWith(prefix))
+    .map((k) => k.slice(prefix.length));
+  for (const sessionId of sessionIds) {
+    stopTerminal(wsId, sessionId);
+  }
+}
+
+/** Stop all running terminals across all workspaces (for graceful shutdown). */
+export function stopAllTerminals(): void {
+  for (const k of [...activeTerminals.keys()]) {
+    const [wsId, ...rest] = k.split(":");
+    const sessionId = rest.join(":");
+    if (wsId && sessionId) stopTerminal(wsId, sessionId);
+  }
+}
+
+/** For test cleanup. */
+export function _clearAllTerminals(): void {
+  for (const proc of activeTerminals.values()) {
+    try {
+      proc.pty.kill();
+    } catch {
+      // ignore
+    }
+  }
+  activeTerminals.clear();
+}
+
+/** Test helper to seed a running terminal without spawning a PTY process. */
+export function _setTerminalForTests(wsId: string, sessionId: string): void {
+  const proc: PtyProcess = {
+    pty: {
+      pid: 0,
+      write: () => {},
+      resize: () => {},
+      kill: () => {},
+      onData: () => ({ dispose: () => {} }),
+      onExit: () => ({ dispose: () => {} }),
+    } as unknown as IPty,
+    state: "running",
+    outputBuffer: "",
+    listeners: new Map(),
+    exitListeners: new Map(),
+  };
+  activeTerminals.set(key(wsId, sessionId), proc);
+}

--- a/backend/src/services/terminal-runner.ts
+++ b/backend/src/services/terminal-runner.ts
@@ -43,6 +43,20 @@ export function stopTerminal(wsId: string, sessionId: string): boolean {
   return true;
 }
 
+/**
+ * Remove a terminal from the registry entirely: kill it if still running, and
+ * always drop the entry (and its replay buffer). Unlike {@link stopTerminal},
+ * this also clears a PTY that already exited — used when the owning session is
+ * deleted so its output can't linger in memory or be replayed afterwards.
+ */
+export function removeTerminal(wsId: string, sessionId: string): void {
+  const k = key(wsId, sessionId);
+  const proc = activeTerminals.get(k);
+  if (!proc) return;
+  activeTerminals.delete(k);
+  if (proc.state === "running") killPtyProcess(proc);
+}
+
 export function getTerminalProcess(wsId: string, sessionId: string): PtyProcess | undefined {
   return activeTerminals.get(key(wsId, sessionId));
 }

--- a/backend/src/services/terminal-runner.ts
+++ b/backend/src/services/terminal-runner.ts
@@ -67,7 +67,7 @@ export function stopAllTerminalsForWorkspace(wsId: string): void {
     .filter((k) => k.startsWith(prefix))
     .map((k) => k.slice(prefix.length));
   for (const sessionId of sessionIds) {
-    stopTerminal(wsId, sessionId);
+    removeTerminal(wsId, sessionId);
   }
 }
 
@@ -76,7 +76,7 @@ export function stopAllTerminals(): void {
   for (const k of [...activeTerminals.keys()]) {
     const [wsId, ...rest] = k.split(":");
     const sessionId = rest.join(":");
-    if (wsId && sessionId) stopTerminal(wsId, sessionId);
+    if (wsId && sessionId) removeTerminal(wsId, sessionId);
   }
 }
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -4,7 +4,7 @@ export type { AgentActivity, AgentActivityCommandAction, AgentActivityFile } fro
 export type WorkspaceStatus = "idle" | "busy";
 
 /** Kind of a persisted agent conversation session. */
-export type SessionKind = "chat" | "automation" | "brain";
+export type SessionKind = "chat" | "automation" | "brain" | "terminal";
 
 export interface Workspace {
   id: string;
@@ -203,6 +203,8 @@ export interface SessionMetadata {
   lockedProvider?: string;
   /** Options from the last user message accepted for execution. */
   lastRunOptions?: MessageOptions;
+  /** Session kind. Absent means "chat" for back-compat with older sessions. */
+  kind?: SessionKind;
 }
 
 export interface ToolCall {

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -18,6 +18,7 @@ import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
 import { copyProjectEnvToWorkspace } from "../state/project-env.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.js";
 import { stopAllForWorkspace } from "../services/script-runner.js";
+import { stopAllTerminalsForWorkspace } from "../services/terminal-runner.js";
 import type { Workspace, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffScope, DiffResponse, DiffStatResponse } from "../types.js";
 
 function findWorkspace(state: ProjectState, wsId: string): Workspace | undefined {
@@ -107,6 +108,7 @@ export async function deleteWorkspace(
   dataDir = getDataDir()
 ): Promise<void> {
   stopAllForWorkspace(wsId);
+  stopAllTerminalsForWorkspace(wsId);
 
   const result = await getWorkspace(wsId, dataDir);
   if (!result) throw new NotFoundError(`Workspace ${wsId} not found`);
@@ -146,6 +148,7 @@ export async function archiveWorkspace(
   dataDir = getDataDir()
 ): Promise<void> {
   stopAllForWorkspace(wsId);
+  stopAllTerminalsForWorkspace(wsId);
 
   const result = await getWorkspace(wsId, dataDir);
   if (!result) throw new NotFoundError(`Workspace ${wsId} not found`);

--- a/backend/src/ws/pty-socket.ts
+++ b/backend/src/ws/pty-socket.ts
@@ -1,0 +1,83 @@
+import type { WebSocket } from "ws";
+import { nanoid } from "nanoid";
+import type { PtyProcess } from "../services/pty-process.js";
+
+const PING_INTERVAL_MS = 30_000;
+
+/**
+ * Bridge a WebSocket to a {@link PtyProcess}.
+ *
+ * Replays the buffered output verbatim, then either sends an immediate `exit`
+ * for a finished process or wires live output, bidirectional input (binary →
+ * `pty.write`, JSON `{type:"resize"}` → `pty.resize`), a keep-alive ping, and
+ * listener cleanup on close. Shared by `/ws/script` and `/ws/terminal` so the
+ * protocol stays identical without duplicating the handler body.
+ */
+export function attachPtyToSocket(socket: WebSocket, proc: PtyProcess): void {
+  // Replay buffered output verbatim (preserves \r\n, ANSI escapes, cursor
+  // positioning). Splitting/rejoining the stream corrupts xterm rendering.
+  if (proc.outputBuffer.length > 0) {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(Buffer.from(proc.outputBuffer), { binary: true });
+    }
+  }
+
+  // If the process already finished, send exit immediately.
+  if (proc.state !== "running") {
+    socket.send(JSON.stringify({ type: "exit", code: proc.exitCode ?? -1 }));
+    return;
+  }
+
+  // Wire live output
+  const listenerId = nanoid(8);
+
+  proc.listeners.set(listenerId, (data) => {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(Buffer.from(data), { binary: true });
+    }
+  });
+
+  proc.exitListeners.set(listenerId, (code) => {
+    if (socket.readyState === socket.OPEN) {
+      socket.send(JSON.stringify({ type: "exit", code }));
+    }
+  });
+
+  socket.send(JSON.stringify({ type: "ready" }));
+
+  const pingTimer = setInterval(() => {
+    if (socket.readyState === socket.OPEN) socket.ping();
+  }, PING_INTERVAL_MS);
+
+  // WS → PTY (bidirectional for interactive prompts)
+  socket.on("message", (raw, isBinary) => {
+    if (proc.state !== "running") return;
+
+    if (isBinary) {
+      proc.pty.write((raw as Buffer).toString("utf8"));
+    } else {
+      try {
+        const msg = JSON.parse((raw as Buffer).toString("utf8"));
+        if (
+          msg.type === "resize" &&
+          typeof msg.cols === "number" &&
+          typeof msg.rows === "number"
+        ) {
+          proc.pty.resize(
+            Math.max(1, Math.min(500, msg.cols)),
+            Math.max(1, Math.min(500, msg.rows)),
+          );
+        }
+      } catch {
+        // Ignore malformed JSON
+      }
+    }
+  });
+
+  // On WS close: detach listener but do NOT kill the process
+  socket.on("close", () => {
+    clearInterval(pingTimer);
+    proc.listeners.delete(listenerId);
+    proc.exitListeners.delete(listenerId);
+  });
+}

--- a/backend/src/ws/pty-socket.ts
+++ b/backend/src/ws/pty-socket.ts
@@ -22,9 +22,11 @@ export function attachPtyToSocket(socket: WebSocket, proc: PtyProcess): void {
     }
   }
 
-  // If the process already finished, send exit immediately.
+  // If the process already finished, send exit and close — there is nothing
+  // left to stream, so an idle open socket would just leak a connection.
   if (proc.state !== "running") {
     socket.send(JSON.stringify({ type: "exit", code: proc.exitCode ?? -1 }));
+    socket.close();
     return;
   }
 
@@ -40,6 +42,9 @@ export function attachPtyToSocket(socket: WebSocket, proc: PtyProcess): void {
   proc.exitListeners.set(listenerId, (code) => {
     if (socket.readyState === socket.OPEN) {
       socket.send(JSON.stringify({ type: "exit", code }));
+      // The PTY is gone; close the socket so it doesn't linger open with a live
+      // ping timer. The `close` handler below detaches listeners.
+      socket.close();
     }
   });
 

--- a/backend/src/ws/terminal.test.ts
+++ b/backend/src/ws/terminal.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import websocket from "@fastify/websocket";
+import WebSocket from "ws";
+import type { PtyProcess } from "../services/pty-process.js";
+
+const mocks = vi.hoisted(() => ({
+  isAuthorized: vi.fn(),
+  getWorkspace: vi.fn(),
+  getTerminalProcess: vi.fn(),
+}));
+
+vi.mock("../utils/auth.js", () => ({
+  isAuthorized: mocks.isAuthorized,
+}));
+
+vi.mock("../workspaces/workspace-manager.js", () => ({
+  getWorkspace: mocks.getWorkspace,
+}));
+
+vi.mock("../services/terminal-runner.js", () => ({
+  getTerminalProcess: mocks.getTerminalProcess,
+}));
+
+import { terminalWsRoutes } from "./terminal.js";
+
+let app: FastifyInstance;
+
+beforeEach(async () => {
+  mocks.isAuthorized.mockReset();
+  mocks.getWorkspace.mockReset();
+  mocks.getTerminalProcess.mockReset();
+  mocks.isAuthorized.mockReturnValue(true);
+  mocks.getWorkspace.mockResolvedValue({
+    projectState: { id: "proj-1" },
+    workspace: { id: "ws-1" },
+  });
+  mocks.getTerminalProcess.mockReturnValue(undefined);
+
+  app = Fastify();
+  await app.register(websocket, { options: { maxPayload: 10 * 1024 * 1024 } });
+  await app.register((instance: FastifyInstance) =>
+    terminalWsRoutes(instance, { authToken: "secret" }),
+  );
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+function createMockProcess(overrides?: Partial<PtyProcess>): PtyProcess {
+  const base: PtyProcess = {
+    pty: {
+      pid: 1234,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(() => ({ dispose: vi.fn() })),
+      onExit: vi.fn(() => ({ dispose: vi.fn() })),
+    } as unknown as PtyProcess["pty"],
+    state: "running",
+    outputBuffer: "",
+    listeners: new Map(),
+    exitListeners: new Map(),
+  };
+
+  return {
+    ...base,
+    ...overrides,
+  };
+}
+
+async function connectTerminalWs(
+  path: string,
+): Promise<{
+  ws: WebSocket;
+  jsonMessages: Array<Record<string, unknown>>;
+  binaryMessages: string[];
+  closed: Promise<{ code: number; reason: Buffer }>;
+}> {
+  const jsonMessages: Array<Record<string, unknown>> = [];
+  const binaryMessages: string[] = [];
+  const ws = await app.injectWS(path, {}, {
+    onInit: (clientWs) => {
+      clientWs.on("message", (data: Buffer, isBinary: boolean) => {
+        if (isBinary) {
+          binaryMessages.push((data as Buffer).toString("utf-8"));
+          return;
+        }
+        jsonMessages.push(JSON.parse(data.toString()) as Record<string, unknown>);
+      });
+    },
+  });
+
+  const closed = new Promise<{ code: number; reason: Buffer }>((resolve) => {
+    ws.once("close", (code, reason) => resolve({ code, reason }));
+  });
+  return { ws, jsonMessages, binaryMessages, closed };
+}
+
+function waitForCondition(predicate: () => boolean, timeoutMs = 3000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      clearInterval(interval);
+      reject(new Error("Timed out waiting for condition"));
+    }, timeoutMs);
+
+    const interval = setInterval(() => {
+      if (!predicate()) return;
+      clearTimeout(timer);
+      clearInterval(interval);
+      resolve();
+    }, 10);
+  });
+}
+
+describe("terminal WS routes", () => {
+  it("rejects unauthorized websocket connections", async () => {
+    mocks.isAuthorized.mockReturnValue(false);
+    const { ws, jsonMessages, closed } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({ type: "error", message: "Unauthorized" });
+    expect(result.code).toBe(1008);
+    expect(result.reason.toString()).toBe("Unauthorized");
+    ws.terminate();
+  });
+
+  it("rejects missing sessionId", async () => {
+    const { ws, jsonMessages, closed } = await connectTerminalWs("/ws/terminal/ws-1");
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({
+      type: "error",
+      message: "Missing 'sessionId' query param",
+    });
+    expect(result.code).toBe(1008);
+    expect(result.reason.toString()).toBe("Invalid sessionId");
+    ws.terminate();
+  });
+
+  it("returns error when workspace does not exist", async () => {
+    mocks.getWorkspace.mockResolvedValue(null);
+    const { ws, jsonMessages, closed } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({ type: "error", message: "Workspace not found" });
+    expect(result.code).toBe(1008);
+    expect(result.reason.toString()).toBe("Workspace not found");
+    ws.terminate();
+  });
+
+  it("returns error when no terminal process exists", async () => {
+    mocks.getTerminalProcess.mockReturnValue(undefined);
+    const { ws, jsonMessages, closed } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    const result = await closed;
+
+    expect(jsonMessages[0]).toEqual({
+      type: "error",
+      message: "No terminal process found",
+    });
+    expect(result.code).toBe(1008);
+    expect(result.reason.toString()).toBe("No terminal process");
+    ws.terminate();
+  });
+
+  it("resolves the PTY by session id", async () => {
+    const proc = createMockProcess({ state: "running" });
+    mocks.getTerminalProcess.mockReturnValue(proc);
+
+    const { ws, jsonMessages } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    await waitForCondition(() => jsonMessages.some((m) => m.type === "ready"));
+
+    expect(mocks.getTerminalProcess).toHaveBeenCalledWith("ws-1", "sess-1");
+    ws.terminate();
+  });
+
+  it("replays buffered output and sends immediate exit for finished processes", async () => {
+    const proc = createMockProcess({
+      state: "done",
+      exitCode: 0,
+      outputBuffer: "line-1\r\nline-2\r\n",
+    });
+    mocks.getTerminalProcess.mockReturnValue(proc);
+
+    const { ws, jsonMessages, binaryMessages } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    await waitForCondition(() => binaryMessages.length > 0 && jsonMessages.length > 0);
+
+    expect(binaryMessages[0]).toBe("line-1\r\nline-2\r\n");
+    expect(jsonMessages).toContainEqual({ type: "exit", code: 0 });
+    expect(jsonMessages).not.toContainEqual({ type: "ready" });
+    expect(proc.listeners.size).toBe(0);
+    expect(proc.exitListeners.size).toBe(0);
+    ws.terminate();
+  });
+
+  it("streams live output, forwards terminal input, and reports exit", async () => {
+    const proc = createMockProcess({
+      state: "running",
+      outputBuffer: "boot",
+    });
+    mocks.getTerminalProcess.mockReturnValue(proc);
+
+    const { ws, jsonMessages, binaryMessages } = await connectTerminalWs(
+      "/ws/terminal/ws-1?sessionId=sess-1",
+    );
+    await new Promise((r) => setTimeout(r, 25));
+    expect(jsonMessages).toContainEqual({ type: "ready" });
+
+    expect(binaryMessages[0]).toBe("boot");
+    expect(proc.listeners.size).toBe(1);
+    expect(proc.exitListeners.size).toBe(1);
+
+    ws.send(Buffer.from("ls\n"), { binary: true });
+    ws.send(JSON.stringify({ type: "resize", cols: 100, rows: 40 }));
+
+    const liveListener = [...proc.listeners.values()][0];
+    expect(liveListener).toBeDefined();
+    liveListener?.("live\n");
+
+    const exitListener = [...proc.exitListeners.values()][0];
+    expect(exitListener).toBeDefined();
+    exitListener?.(3);
+
+    await new Promise((r) => setTimeout(r, 25));
+    expect(binaryMessages.some((m) => m.includes("live"))).toBe(true);
+    expect(jsonMessages.some((m) => m.type === "exit" && m.code === 3)).toBe(true);
+
+    ws.terminate();
+  });
+});

--- a/backend/src/ws/terminal.ts
+++ b/backend/src/ws/terminal.ts
@@ -18,7 +18,7 @@ export async function terminalWsRoutes(
   app: FastifyInstance,
   opts: TerminalWsRoutesOptions = {},
 ) {
-  const { authToken } = opts;
+  const { authToken, dataDir } = opts;
 
   app.get<{
     Params: { wsId: string };
@@ -46,7 +46,7 @@ export async function terminalWsRoutes(
         return;
       }
 
-      const result = await getWorkspace(wsId);
+      const result = await getWorkspace(wsId, dataDir);
       if (!result) {
         socket.send(
           JSON.stringify({ type: "error", message: "Workspace not found" }),

--- a/backend/src/ws/terminal.ts
+++ b/backend/src/ws/terminal.ts
@@ -1,25 +1,30 @@
 import type { FastifyInstance } from "fastify";
 import { getWorkspace } from "../workspaces/workspace-manager.js";
-import { getScriptProcess } from "../services/script-runner.js";
+import { getTerminalProcess } from "../services/terminal-runner.js";
 import { isAuthorized } from "../utils/auth.js";
 import { attachPtyToSocket } from "./pty-socket.js";
 
-export interface ScriptWsRoutesOptions {
+export interface TerminalWsRoutesOptions {
   dataDir?: string;
   authToken?: string;
 }
 
-export async function scriptWsRoutes(
+/**
+ * WebSocket endpoint for terminal-tab sessions. Resolves the PTY from the
+ * terminal registry keyed by the session id and bridges it with the same
+ * {@link attachPtyToSocket} helper as `/ws/script`.
+ */
+export async function terminalWsRoutes(
   app: FastifyInstance,
-  opts: ScriptWsRoutesOptions = {},
+  opts: TerminalWsRoutesOptions = {},
 ) {
   const { authToken } = opts;
 
   app.get<{
     Params: { wsId: string };
-    Querystring: { token?: string; type?: string };
+    Querystring: { token?: string; sessionId?: string };
   }>(
-    "/ws/script/:wsId",
+    "/ws/terminal/:wsId",
     { websocket: true },
     async (socket, req) => {
       const queryToken =
@@ -31,12 +36,13 @@ export async function scriptWsRoutes(
       }
 
       const { wsId } = req.params;
-      const scriptType = typeof req.query.type === "string" ? req.query.type : undefined;
-      if (!scriptType) {
+      const sessionId =
+        typeof req.query.sessionId === "string" ? req.query.sessionId : undefined;
+      if (!sessionId) {
         socket.send(
-          JSON.stringify({ type: "error", message: "Missing 'type' query param" }),
+          JSON.stringify({ type: "error", message: "Missing 'sessionId' query param" }),
         );
-        socket.close(1008, "Invalid type");
+        socket.close(1008, "Invalid sessionId");
         return;
       }
 
@@ -49,12 +55,12 @@ export async function scriptWsRoutes(
         return;
       }
 
-      const proc = getScriptProcess(wsId, scriptType);
+      const proc = getTerminalProcess(wsId, sessionId);
       if (!proc) {
         socket.send(
-          JSON.stringify({ type: "error", message: `No ${scriptType} script process found` }),
+          JSON.stringify({ type: "error", message: "No terminal process found" }),
         );
-        socket.close(1008, "No script process");
+        socket.close(1008, "No terminal process");
         return;
       }
 

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -31,6 +31,8 @@ interface ChatConversationProps {
   pendingToolInputs?: PendingToolInput[];
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
+  /** When set, the workspace welcome offers a button to open a terminal tab. */
+  onStartTerminal?: () => void;
   workspaceName?: string;
   projectName?: string;
   branch?: string;
@@ -61,6 +63,7 @@ export default function ChatConversation({
   pendingToolInputs = [],
   onQuestionAnswer,
   onFileMentionClick,
+  onStartTerminal,
   workspaceName,
   projectName,
   branch,
@@ -205,6 +208,7 @@ export default function ChatConversation({
                 branch={branch}
                 defaultBranch={defaultBranch}
                 fileCount={fileCount ?? 0}
+                onStartTerminal={onStartTerminal}
               />
             </ConversationEmptyState>
           ) : emptyState ? (

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MessageSquareIcon, PlusIcon, XIcon, FileIcon, GitCompareArrowsIcon, TerminalSquareIcon } from "lucide-react";
+import { MessageSquareIcon, PlusIcon, XIcon, FileIcon, GitCompareArrowsIcon } from "lucide-react";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
 import { ProviderIcon, isKnownProvider } from "@/components/chat/ProviderIcon";
 import {
@@ -95,6 +95,28 @@ function getFallbackVisualState({
 }
 
 /**
+ * Filled terminal mark for terminal-kind tabs. A solid window in `currentColor`
+ * (so it reads as the tab's text color — near-black in light, near-white in
+ * dark) with the `>_` prompt knocked out in the card background behind it. This
+ * gives terminal tabs a bolder, distinct silhouette next to the colored provider
+ * marks, instead of a thin outline.
+ */
+function TerminalTabIcon({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="none" data-icon="terminal" aria-hidden>
+      <rect x="2" y="3.5" width="20" height="17" rx="3.5" fill="currentColor" />
+      <path
+        d="m6.5 9.5 3 2.5-3 2.5M12.5 15h4"
+        style={{ stroke: "var(--card)" }}
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/**
  * The tab's leading glyph. The provider mark is the conversation's resting
  * identity (shown once a session locks its provider on the first message), so
  * the whole strip reads which model each conversation runs at a glance.
@@ -124,7 +146,7 @@ function TabLeadingIcon({
     return <span className="size-2 shrink-0 rounded-full bg-primary" />;
   }
   if (sessionKind === "terminal") {
-    return <TerminalSquareIcon className="size-3.5 shrink-0" />;
+    return <TerminalTabIcon className="size-3.5 shrink-0" />;
   }
   if (isKnownProvider(provider)) {
     return <ProviderIcon provider={provider} colored className="size-3.5 shrink-0" />;

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { MessageSquareIcon, PlusIcon, XIcon, FileIcon, GitCompareArrowsIcon } from "lucide-react";
+import { MessageSquareIcon, PlusIcon, XIcon, FileIcon, GitCompareArrowsIcon, TerminalSquareIcon } from "lucide-react";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
 import { ProviderIcon, isKnownProvider } from "@/components/chat/ProviderIcon";
 import {
@@ -13,7 +13,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
-import type { SessionMetadata } from "@/types";
+import type { SessionKind, SessionMetadata } from "@/types";
 import type { FileViewMode } from "@/hooks/useTabs";
 
 // Keep in sync with the backend Brain guard (MAX_BRAIN_SESSIONS in
@@ -106,10 +106,12 @@ function TabLeadingIcon({
   isStreaming,
   isUnread,
   provider,
+  sessionKind,
 }: {
   isStreaming: boolean;
   isUnread: boolean;
   provider?: string;
+  sessionKind?: SessionKind;
 }) {
   if (isStreaming) {
     return (
@@ -120,6 +122,9 @@ function TabLeadingIcon({
   }
   if (isUnread) {
     return <span className="size-2 shrink-0 rounded-full bg-primary" />;
+  }
+  if (sessionKind === "terminal") {
+    return <TerminalSquareIcon className="size-3.5 shrink-0" />;
   }
   if (isKnownProvider(provider)) {
     return <ProviderIcon provider={provider} colored className="size-3.5 shrink-0" />;
@@ -297,7 +302,15 @@ export function ConversationTabs({
                 streamingSessions,
                 unreadSessions,
               });
-              const title = getTabTitle(session);
+              // Terminal sessions with no title fall back to "Terminal N",
+              // where N is the 1-based position among terminal-kind sessions
+              // (the list is already sorted by createdAt asc).
+              const title =
+                session.kind === "terminal" && !session.title
+                  ? `Terminal ${
+                      sessions.filter((s) => s.kind === "terminal").indexOf(session) + 1
+                    }`
+                  : getTabTitle(session);
 
               return (
                 <button
@@ -316,6 +329,7 @@ export function ConversationTabs({
                     isStreaming={isSessionStreaming}
                     isUnread={isSessionUnread}
                     provider={session.lockedProvider ?? (isActive ? activeProvider : undefined)}
+                    sessionKind={session.kind}
                   />
                   <span className="truncate">{title}</span>
                   {sessions.length > 1 && !isSessionStreaming && (

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -244,7 +244,10 @@ export function ConversationTabs({
     updateEdges();
   }, [activeSessionId, sessions, updateEdges]);
 
-  const atLimit = sessions.length >= MAX_SESSIONS_PER_WORKSPACE;
+  // Terminal tabs are a separate surface and don't count toward the conversation
+  // cap (the backend caps chat sessions only), so they must not disable the +.
+  const atLimit =
+    sessions.filter((s) => s.kind !== "terminal").length >= MAX_SESSIONS_PER_WORKSPACE;
 
   return (
     <>

--- a/frontend/src/components/ScriptPanel.tsx
+++ b/frontend/src/components/ScriptPanel.tsx
@@ -1,29 +1,12 @@
-import { useEffect, useRef, useState, useCallback, useMemo } from "react";
-import { Terminal as XTerm } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
+import { useEffect, useState, useCallback } from "react";
+import type { Terminal as XTerm } from "@xterm/xterm";
 import { PlayIcon, SquareIcon, RotateCcwIcon, CheckCircle2Icon, TerminalSquareIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ActivityWave } from "@/components/ui/activity-wave";
+import { XtermSurface } from "@/components/XtermSurface";
 import { cn } from "@/lib/utils";
-import { useThemeType } from "@/hooks/useThemeType";
 import type { ScriptStatusInfo, HiveConfig } from "@/types";
-import "@xterm/xterm/css/xterm.css";
-
-function readThemeColor(name: string, fallback: string): string {
-  if (typeof window === "undefined") return fallback;
-  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
-}
-
-function buildXtermTheme(theme: "dark" | "light") {
-  const foreground = readThemeColor("--foreground", theme === "dark" ? "#e4e4e7" : "#18181b");
-  return {
-    background: readThemeColor("--sidebar", theme === "dark" ? "#0c0c14" : "#f8f8fb"),
-    foreground,
-    cursor: foreground,
-    selectionBackground: readThemeColor("--muted", theme === "dark" ? "#262636" : "#f0f1f4"),
-  };
-}
 
 interface ScriptPanelProps {
   config: HiveConfig | null;
@@ -99,17 +82,7 @@ export default function ScriptPanel({
   const isTerminalTab = tabInfo?.isTerminal ?? false;
   const currentStatus: ScriptStatusInfo = status[effectiveTab] ?? { state: "idle" };
 
-  const containerRef = useRef<HTMLDivElement>(null);
-  const termRef = useRef<XTerm | null>(null);
-  const fitAddonRef = useRef<FitAddon | null>(null);
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const connectedTabRef = useRef<string | null>(null);
-  const theme = useThemeType();
-  const xtermTheme = useMemo(() => buildXtermTheme(theme), [theme]);
-  const themeRef = useRef(xtermTheme);
-  themeRef.current = xtermTheme;
-
-  // Incremented on re-run to force the terminal init effect to re-fire
+  // Incremented on re-run to force the terminal surface to reconnect.
   const [runGeneration, setRunGeneration] = useState(0);
 
   const shouldShowTerminal = currentStatus.state !== "idle";
@@ -120,83 +93,15 @@ export default function ScriptPanel({
       ? "Open an interactive shell"
       : "Start this script";
 
-  const initTerminal = useCallback(() => {
-    const el = containerRef.current;
-    if (!el || termRef.current) return;
-
-    const term = new XTerm({
-      cursorBlink: false,
-      fontSize: 12,
-      fontFamily: '"Geist Mono", Menlo, Monaco, "Courier New", monospace',
-      lineHeight: 1.3,
-      theme: themeRef.current,
-      scrollback: 5000,
-      disableStdin: false,
-    });
-
-    const fitAddon = new FitAddon();
-    term.loadAddon(fitAddon);
-    term.open(el);
-    fitAddon.fit();
-
-    termRef.current = term;
-    fitAddonRef.current = fitAddon;
-
-    // Attach ResizeObserver so fit() fires on every panel resize
-    resizeObserverRef.current?.disconnect();
-    const observer = new ResizeObserver(() => fitAddon.fit());
-    observer.observe(el);
-    resizeObserverRef.current = observer;
-
-    connectedTabRef.current = effectiveTab;
-    onConnectOutput(effectiveTab, term);
-  }, [effectiveTab, onConnectOutput]);
-
-  const destroyTerminal = useCallback(() => {
-    resizeObserverRef.current?.disconnect();
-    resizeObserverRef.current = null;
-    if (termRef.current) {
-      onDisconnectOutput();
-      termRef.current.dispose();
-      termRef.current = null;
-      fitAddonRef.current = null;
-      connectedTabRef.current = null;
-    }
-  }, [onDisconnectOutput]);
-
-  // Init terminal when needed (runGeneration forces re-fire on restart)
-  useEffect(() => {
-    if (shouldShowTerminal) {
-      const timer = setTimeout(() => initTerminal(), 50);
-      return () => clearTimeout(timer);
-    }
-    destroyTerminal();
-    return undefined;
-  }, [shouldShowTerminal, runGeneration, initTerminal, destroyTerminal]);
-
-  // Reconnect when tab changes
-  useEffect(() => {
-    if (shouldShowTerminal && termRef.current && connectedTabRef.current !== effectiveTab) {
-      destroyTerminal();
-      const timer = setTimeout(() => initTerminal(), 50);
-      return () => clearTimeout(timer);
-    }
-    return undefined;
-  }, [effectiveTab, shouldShowTerminal, destroyTerminal, initTerminal]);
-
-  // Cleanup on unmount
-  useEffect(() => {
-    return () => {
-      destroyTerminal();
-    };
-  }, [destroyTerminal]);
-
-  // Live theme updates without recreating the terminal
-  useEffect(() => {
-    if (termRef.current) {
-      termRef.current.options.theme = xtermTheme;
-    }
-  }, [xtermTheme]);
+  // Bridge the surface terminal to the script's PTY output. Returning the
+  // disconnect callback lets XtermSurface tear the WS down on reconnect/unmount.
+  const connect = useCallback(
+    (term: XTerm) => {
+      onConnectOutput(effectiveTab, term);
+      return onDisconnectOutput;
+    },
+    [effectiveTab, onConnectOutput, onDisconnectOutput],
+  );
 
   const handleAction = async () => {
     if (currentStatus.state === "running") {
@@ -206,7 +111,6 @@ export default function ScriptPanel({
         onStop(effectiveTab);
       }
     } else {
-      destroyTerminal();
       if (isTerminalTab) {
         onStartTerminal();
       } else {
@@ -307,10 +211,10 @@ export default function ScriptPanel({
       <div className="relative min-h-0 flex-1 overflow-hidden">
         {shouldShowTerminal ? (
           <>
-            <div
-              ref={containerRef}
+            <XtermSurface
+              connect={connect}
+              connectKey={`${effectiveTab}:${runGeneration}`}
               className="h-full w-full overflow-hidden px-3"
-              style={{ backgroundColor: xtermTheme.background }}
             />
             {/* Port badge */}
             {!isSetupTab && !isTerminalTab && config?.port && currentStatus.state === "running" && (

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -72,10 +72,11 @@ export function TerminalPane({ wsId, sessionId }: TerminalPaneProps) {
       <XtermSurface
         connect={connect}
         connectKey={`${sessionId}:${connectGeneration}`}
-        className="h-full w-full overflow-hidden px-3"
+        backgroundVar="--card"
+        className="h-full w-full overflow-hidden px-6 py-3"
       />
       {showOverlay && (
-        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-sidebar">
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-card">
           <TerminalSquareIcon className="size-8 text-muted-foreground/30" />
           {state.kind === "exited" && (
             <p className="text-xs text-muted-foreground/60">
@@ -86,7 +87,9 @@ export function TerminalPane({ wsId, sessionId }: TerminalPaneProps) {
             <TerminalSquareIcon className="size-3" />
             {state.kind === "exited" ? "Restart" : "Start terminal"}
           </Button>
-          <p className="text-xs text-muted-foreground/60">Open an interactive shell</p>
+          {state.kind === "idle" && (
+            <p className="text-xs text-muted-foreground/60">Open an interactive shell</p>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/components/TerminalPane.tsx
+++ b/frontend/src/components/TerminalPane.tsx
@@ -1,0 +1,94 @@
+import { useCallback, useState } from "react";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { TerminalSquareIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { XtermSurface } from "@/components/XtermSurface";
+import { api } from "@/hooks/useApi";
+import { buildWsUrl } from "@/lib/ws-url";
+import { connectPtyTerminal } from "@/lib/pty-terminal";
+
+interface TerminalPaneProps {
+  wsId: string;
+  sessionId: string;
+}
+
+type PaneState =
+  | { kind: "connecting" }
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "exited"; code: number };
+
+/**
+ * Full-pane interactive shell for a terminal-kind session. On mount it attaches
+ * to the workspace's PTY socket (keyed by `sessionId`): when a PTY is alive the
+ * server replays its scrollback and the pane shows it live; otherwise the server
+ * reports no process and the pane offers a start button. The PTY outlives the
+ * pane — switching away only closes the socket, never the shell.
+ *
+ * State starts as `connecting` (no overlay) so revisiting a live terminal shows
+ * its output without a "Start" flash; it resolves to `running`/`idle`/`exited`
+ * from the first control frame, or falls back to `idle` if the socket dies.
+ */
+export function TerminalPane({ wsId, sessionId }: TerminalPaneProps) {
+  const [state, setState] = useState<PaneState>({ kind: "connecting" });
+  // Bumped to force XtermSurface to drop its terminal and reconnect after a
+  // (re)start, so the new PTY's output replays from a clean surface.
+  const [connectGeneration, setConnectGeneration] = useState(0);
+
+  const connect = useCallback(
+    (term: XTerm) => {
+      const url = buildWsUrl(`/ws/terminal/${wsId}`, { sessionId });
+      return connectPtyTerminal(term, url, {
+        onControl: (msg) => {
+          if (msg.type === "ready") setState({ kind: "running" });
+          else if (msg.type === "error") setState({ kind: "idle" });
+        },
+        onExit: (code) => setState({ kind: "exited", code }),
+        // Socket died unsolicited — no PTY on connect, or a mid-session drop
+        // (network/backend restart). Resolve anything that isn't a clean exit to
+        // idle so the start button reappears; re-POSTing reconnects to a PTY that
+        // is still alive (409 is swallowed). A clean exit keeps its code.
+        onClose: () =>
+          setState((prev) => (prev.kind === "exited" ? prev : { kind: "idle" })),
+      });
+    },
+    [wsId, sessionId],
+  );
+
+  const start = useCallback(async () => {
+    setState({ kind: "connecting" });
+    try {
+      await api.post(`/api/workspaces/${wsId}/terminal-tabs/${sessionId}/start`);
+    } catch {
+      // Already running (409) is fine — reconnect picks up the live PTY.
+    }
+    setConnectGeneration((g) => g + 1);
+  }, [wsId, sessionId]);
+
+  const showOverlay = state.kind === "idle" || state.kind === "exited";
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+      <XtermSurface
+        connect={connect}
+        connectKey={`${sessionId}:${connectGeneration}`}
+        className="h-full w-full overflow-hidden px-3"
+      />
+      {showOverlay && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-3 bg-sidebar">
+          <TerminalSquareIcon className="size-8 text-muted-foreground/30" />
+          {state.kind === "exited" && (
+            <p className="text-xs text-muted-foreground/60">
+              Terminal exited (code {state.code})
+            </p>
+          )}
+          <Button variant="outline" size="sm" onClick={start}>
+            <TerminalSquareIcon className="size-3" />
+            {state.kind === "exited" ? "Restart" : "Start terminal"}
+          </Button>
+          <p className="text-xs text-muted-foreground/60">Open an interactive shell</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/WorkspaceWelcome.tsx
+++ b/frontend/src/components/WorkspaceWelcome.tsx
@@ -1,5 +1,4 @@
 import { GitBranch, Folder, TerminalSquareIcon } from "lucide-react";
-import { Button } from "@/components/ui/button";
 
 interface WorkspaceWelcomeProps {
   projectName: string;
@@ -52,16 +51,23 @@ export function WorkspaceWelcome({
             files
           </span>
         </div>
+        {onStartTerminal && (
+          <div className="flex items-center gap-3">
+            <TerminalSquareIcon className="size-4 shrink-0" />
+            <span>
+              You can{" "}
+              <button
+                type="button"
+                onClick={onStartTerminal}
+                className="cursor-pointer font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground"
+              >
+                start a terminal
+              </button>{" "}
+              in this workspace
+            </span>
+          </div>
+        )}
       </div>
-
-      {onStartTerminal && (
-        <div>
-          <Button variant="outline" size="sm" onClick={onStartTerminal}>
-            <TerminalSquareIcon className="size-3" />
-            Start terminal
-          </Button>
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/WorkspaceWelcome.tsx
+++ b/frontend/src/components/WorkspaceWelcome.tsx
@@ -1,4 +1,5 @@
-import { GitBranch, Folder } from "lucide-react";
+import { GitBranch, Folder, TerminalSquareIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
 
 interface WorkspaceWelcomeProps {
   projectName: string;
@@ -6,6 +7,8 @@ interface WorkspaceWelcomeProps {
   branch: string;
   defaultBranch: string;
   fileCount: number;
+  /** When provided, render a button to open a terminal tab in this workspace. */
+  onStartTerminal?: () => void;
 }
 
 export function WorkspaceWelcome({
@@ -14,6 +17,7 @@ export function WorkspaceWelcome({
   branch,
   defaultBranch,
   fileCount,
+  onStartTerminal,
 }: WorkspaceWelcomeProps) {
   return (
     <div className="flex w-full max-w-lg flex-col gap-6">
@@ -49,6 +53,15 @@ export function WorkspaceWelcome({
           </span>
         </div>
       </div>
+
+      {onStartTerminal && (
+        <div>
+          <Button variant="outline" size="sm" onClick={onStartTerminal}>
+            <TerminalSquareIcon className="size-3" />
+            Start terminal
+          </Button>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/XtermSurface.tsx
+++ b/frontend/src/components/XtermSurface.tsx
@@ -9,10 +9,10 @@ function readThemeColor(name: string, fallback: string): string {
   return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
 }
 
-export function buildXtermTheme(theme: "dark" | "light") {
+export function buildXtermTheme(theme: "dark" | "light", backgroundVar = "--sidebar") {
   const foreground = readThemeColor("--foreground", theme === "dark" ? "#e4e4e7" : "#18181b");
   return {
-    background: readThemeColor("--sidebar", theme === "dark" ? "#0c0c14" : "#f8f8fb"),
+    background: readThemeColor(backgroundVar, theme === "dark" ? "#0c0c14" : "#f8f8fb"),
     foreground,
     cursor: foreground,
     selectionBackground: readThemeColor("--muted", theme === "dark" ? "#262636" : "#f0f1f4"),
@@ -33,6 +33,12 @@ export interface XtermSurfaceProps {
    */
   connectKey?: string;
   className?: string;
+  /**
+   * CSS custom property driving the terminal background. Defaults to the panel
+   * background (`--sidebar`), which suits the scripts panel; the in-chat
+   * terminal passes `--card` so it blends with the conversation card it lives in.
+   */
+  backgroundVar?: string;
 }
 
 /**
@@ -44,10 +50,10 @@ export interface XtermSurfaceProps {
  * Shared by ScriptPanel (setup/run/terminal output) and TerminalPane
  * (full-pane interactive shell).
  */
-export function XtermSurface({ connect, connectKey, className }: XtermSurfaceProps) {
+export function XtermSurface({ connect, connectKey, className, backgroundVar }: XtermSurfaceProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const theme = useThemeType();
-  const xtermTheme = useMemo(() => buildXtermTheme(theme), [theme]);
+  const xtermTheme = useMemo(() => buildXtermTheme(theme, backgroundVar), [theme, backgroundVar]);
   const themeRef = useRef(xtermTheme);
   themeRef.current = xtermTheme;
 

--- a/frontend/src/components/XtermSurface.tsx
+++ b/frontend/src/components/XtermSurface.tsx
@@ -1,0 +1,119 @@
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { Terminal as XTerm } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { useThemeType } from "@/hooks/useThemeType";
+import "@xterm/xterm/css/xterm.css";
+
+function readThemeColor(name: string, fallback: string): string {
+  if (typeof window === "undefined") return fallback;
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim() || fallback;
+}
+
+export function buildXtermTheme(theme: "dark" | "light") {
+  const foreground = readThemeColor("--foreground", theme === "dark" ? "#e4e4e7" : "#18181b");
+  return {
+    background: readThemeColor("--sidebar", theme === "dark" ? "#0c0c14" : "#f8f8fb"),
+    foreground,
+    cursor: foreground,
+    selectionBackground: readThemeColor("--muted", theme === "dark" ? "#262636" : "#f0f1f4"),
+  };
+}
+
+export interface XtermSurfaceProps {
+  /**
+   * Wire a freshly-created terminal to its data source. Return a disconnect
+   * function (called on teardown/unmount/key change), or nothing if there is
+   * nothing to tear down. Treat as stable — it is captured per (re)connect.
+   */
+  connect: (term: XTerm) => (() => void) | void;
+  /**
+   * Changing this string tears down the current terminal and reconnects a fresh
+   * one. Use it to force a reconnect (e.g. tab switch, restart) without
+   * remounting the component.
+   */
+  connectKey?: string;
+  className?: string;
+}
+
+/**
+ * Reusable xterm surface owning the terminal instance lifecycle: creation, fit,
+ * theme (with live updates), a ResizeObserver-driven refit, and teardown. It
+ * invokes {@link XtermSurfaceProps.connect} once the terminal is mounted and
+ * runs the returned disconnect function on cleanup.
+ *
+ * Shared by ScriptPanel (setup/run/terminal output) and TerminalPane
+ * (full-pane interactive shell).
+ */
+export function XtermSurface({ connect, connectKey, className }: XtermSurfaceProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const theme = useThemeType();
+  const xtermTheme = useMemo(() => buildXtermTheme(theme), [theme]);
+  const themeRef = useRef(xtermTheme);
+  themeRef.current = xtermTheme;
+
+  const termRef = useRef<XTerm | null>(null);
+
+  // Keep the latest connect callback without forcing a reconnect when only its
+  // identity changes; reconnects are driven solely by `connectKey`.
+  const connectRef = useRef(connect);
+  connectRef.current = connect;
+
+  const refit = useCallback((fitAddon: FitAddon) => {
+    try {
+      fitAddon.fit();
+    } catch {
+      // fit() can throw if the container has no layout yet; ignore.
+    }
+  }, []);
+
+  // Create + connect the terminal; rebuild on connectKey change.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const term = new XTerm({
+      cursorBlink: false,
+      fontSize: 12,
+      fontFamily: '"Geist Mono", Menlo, Monaco, "Courier New", monospace',
+      lineHeight: 1.3,
+      theme: themeRef.current,
+      scrollback: 5000,
+      disableStdin: false,
+    });
+
+    const fitAddon = new FitAddon();
+    term.loadAddon(fitAddon);
+    term.open(el);
+    refit(fitAddon);
+
+    termRef.current = term;
+
+    const observer = new ResizeObserver(() => refit(fitAddon));
+    observer.observe(el);
+
+    const disconnect = connectRef.current(term);
+
+    return () => {
+      observer.disconnect();
+      disconnect?.();
+      term.dispose();
+      termRef.current = null;
+    };
+  }, [connectKey, refit]);
+
+  // Live theme updates without recreating the terminal.
+  useEffect(() => {
+    const term = termRef.current;
+    if (term?.options) {
+      term.options.theme = xtermTheme;
+    }
+  }, [xtermTheme]);
+
+  return (
+    <div
+      ref={containerRef}
+      className={className}
+      style={{ backgroundColor: xtermTheme.background }}
+    />
+  );
+}

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -91,6 +91,11 @@ export interface ConversationPaneProps {
   // ── Slots ──
   chatInput: ReactNode;
   planActionBar?: ReactNode;
+  /** Full-pane terminal surface, rendered in place of the chat body when the
+   * active session is a terminal-kind session. */
+  terminalView?: ReactNode;
+  /** Opens a terminal tab from the workspace empty state. */
+  onStartTerminal?: () => void;
 }
 
 type QuestionPanelBatchSubmit = React.ComponentProps<typeof QuestionPanel>["onBatchSubmit"];
@@ -143,8 +148,12 @@ export function ConversationPane({
   onDismissQuestion,
   chatInput,
   planActionBar,
+  terminalView,
+  onStartTerminal,
 }: ConversationPaneProps) {
   const showQuestion = pendingToolInputs.some((p) => p.toolName === "AskUserQuestion");
+  const activeIsTerminal =
+    sessions.find((s) => s.sessionId === activeSessionId)?.kind === "terminal";
 
   return (
     <>
@@ -166,53 +175,60 @@ export function ConversationPane({
         activeProvider={activeProvider}
       />
       <div className={!isFileTabActive ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
-        <ChatConversation
-          messages={messages}
-          isStreaming={isStreaming}
-          streamingStartedAt={streamingStartedAt}
-          currentStreamingText={currentStreamingText}
-          currentThinking={currentThinking}
-          activeToolCalls={activeToolCalls}
-          activeAgentActivities={activeAgentActivities}
-          pendingToolInputs={pendingToolInputs}
-          onQuestionAnswer={onQuestionAnswer}
-          onFileMentionClick={onFileMentionClick}
-          workspaceName={workspaceName}
-          projectName={projectName}
-          branch={branch}
-          defaultBranch={defaultBranch}
-          fileCount={fileCount}
-          emptyState={emptyState}
-          switchCounter={switchCounter}
-          agentPlanMode={agentPlanMode}
-          error={error}
-          queuedMessage={queuedMessage}
-          onClearQueue={onClearQueue}
-          scrollToBottomTrigger={scrollToBottomTrigger}
-        />
-        {(goal || tasks.length > 0 || backgroundAgents.length > 0) && !showQuestion && (
-          <TaskTracker
-            goal={goal}
-            tasks={tasks}
-            currentTask={currentTask}
-            counts={taskCounts}
-            trackerStatus={taskTrackerStatus}
-            isStreaming={isStreaming}
-            backgroundAgents={backgroundAgents}
-            backgroundRunningCount={backgroundRunningCount}
-          />
-        )}
-        {showQuestion ? (
-          <QuestionPanel
-            pendingToolInputs={pendingToolInputs}
-            onBatchSubmit={onBatchAnswerQuestions}
-            onDismiss={onDismissQuestion}
-          />
+        {activeIsTerminal ? (
+          terminalView
         ) : (
-          <div className="relative">
-            {planActionBar}
-            {chatInput}
-          </div>
+          <>
+            <ChatConversation
+              messages={messages}
+              isStreaming={isStreaming}
+              streamingStartedAt={streamingStartedAt}
+              currentStreamingText={currentStreamingText}
+              currentThinking={currentThinking}
+              activeToolCalls={activeToolCalls}
+              activeAgentActivities={activeAgentActivities}
+              pendingToolInputs={pendingToolInputs}
+              onQuestionAnswer={onQuestionAnswer}
+              onFileMentionClick={onFileMentionClick}
+              onStartTerminal={onStartTerminal}
+              workspaceName={workspaceName}
+              projectName={projectName}
+              branch={branch}
+              defaultBranch={defaultBranch}
+              fileCount={fileCount}
+              emptyState={emptyState}
+              switchCounter={switchCounter}
+              agentPlanMode={agentPlanMode}
+              error={error}
+              queuedMessage={queuedMessage}
+              onClearQueue={onClearQueue}
+              scrollToBottomTrigger={scrollToBottomTrigger}
+            />
+            {(goal || tasks.length > 0 || backgroundAgents.length > 0) && !showQuestion && (
+              <TaskTracker
+                goal={goal}
+                tasks={tasks}
+                currentTask={currentTask}
+                counts={taskCounts}
+                trackerStatus={taskTrackerStatus}
+                isStreaming={isStreaming}
+                backgroundAgents={backgroundAgents}
+                backgroundRunningCount={backgroundRunningCount}
+              />
+            )}
+            {showQuestion ? (
+              <QuestionPanel
+                pendingToolInputs={pendingToolInputs}
+                onBatchSubmit={onBatchAnswerQuestions}
+                onDismiss={onDismissQuestion}
+              />
+            ) : (
+              <div className="relative">
+                {planActionBar}
+                {chatInput}
+              </div>
+            )}
+          </>
         )}
       </div>
     </>

--- a/frontend/src/hooks/useConversationColumn.ts
+++ b/frontend/src/hooks/useConversationColumn.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "@/hooks/useApi";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
 import { useTabs, type UseTabsReturn } from "@/hooks/useTabs";
@@ -92,6 +93,12 @@ export interface ConversationColumn
   handleCreateSession: () => Promise<void>;
   handleActivateSession: (sessionId: string) => void;
   handleDeleteSession: (sessionId: string) => Promise<void>;
+  /**
+   * Open a terminal tab. Converts the active session in place when it is an
+   * empty chat; otherwise creates a fresh terminal session. Then starts the PTY
+   * and activates the tab.
+   */
+  handleStartTerminal: () => Promise<void>;
 }
 
 export function useConversationColumn(
@@ -112,7 +119,7 @@ export function useConversationColumn(
     switchSession,
   } = conversation;
 
-  const { sessions, loading: sessionsLoading, createSession, deleteSession, refresh: refreshSessions } = useSessions(wsId);
+  const { sessions, loading: sessionsLoading, createSession, convertToTerminal, deleteSession, refresh: refreshSessions } = useSessions(wsId);
 
   // Mirror iOS: fall back to session metadata when WS hasn't delivered
   // lockedProvider yet.
@@ -221,6 +228,37 @@ export function useConversationColumn(
     [deleteSession, sessionId, sessions, handleActivateSession, clearChat, onLastSessionDeleted],
   );
 
+  const handleStartTerminal = useCallback(async () => {
+    if (!wsId) return;
+    let targetId: string;
+    // Convert the active session in place when it's an empty chat; otherwise
+    // spin up a fresh terminal session so existing chats stay untouched.
+    if (
+      activeSession &&
+      activeSession.kind !== "terminal" &&
+      activeSession.messageCount === 0 &&
+      sessionId
+    ) {
+      const converted = await convertToTerminal(sessionId);
+      if (!converted) return;
+      targetId = sessionId;
+    } else {
+      const meta = await createSession("terminal");
+      if (!meta) return;
+      targetId = meta.sessionId;
+    }
+    // The session is already a terminal (convert is irreversible), so land on
+    // the tab no matter what: a failed start must not reject unhandled, and the
+    // pane's idle state offers a Start button to retry.
+    try {
+      await api.post(`/api/workspaces/${wsId}/terminal-tabs/${targetId}/start`);
+    } catch {
+      // Swallowed — TerminalPane shows the idle/Start state for a retry.
+    }
+    refreshSessions();
+    handleActivateSession(targetId);
+  }, [wsId, activeSession, sessionId, convertToTerminal, createSession, refreshSessions, handleActivateSession]);
+
   return {
     ...conversation,
     // Tabs
@@ -259,5 +297,6 @@ export function useConversationColumn(
     handleCreateSession,
     handleActivateSession,
     handleDeleteSession,
+    handleStartTerminal,
   };
 }

--- a/frontend/src/hooks/useScripts.ts
+++ b/frontend/src/hooks/useScripts.ts
@@ -1,7 +1,8 @@
 import { useCallback, useEffect, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
-import { getServerUrl } from "@/hooks/useServerUrl";
+import { buildWsUrl } from "@/lib/ws-url";
+import { connectPtyTerminal } from "@/lib/pty-terminal";
 import type { Terminal as XTerm } from "@xterm/xterm";
 import type {
   ScriptStatusInfo,
@@ -10,24 +11,12 @@ import type {
 
 const EMPTY_STATUS: Record<string, ScriptStatusInfo> = {};
 
-function buildWsUrl(workspaceId: string, type: string): string {
-  const serverUrl = getServerUrl();
-  let wsHost: string;
-  if (serverUrl) {
-    wsHost = serverUrl.replace(/^http/, "ws");
-  } else {
-    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-    wsHost = import.meta.env.VITE_WS_URL || `${protocol}//${window.location.host}`;
-  }
-  const authToken = (import.meta.env.VITE_HIVE_AUTH_TOKEN as string | undefined)?.trim();
-  const params = new URLSearchParams({ type });
-  if (authToken) params.set("token", authToken);
-  return `${wsHost}/ws/script/${workspaceId}?${params.toString()}`;
-}
-
 export function useScripts(wsId: string | undefined) {
   const queryClient = useQueryClient();
-  const wsRef = useRef<WebSocket | null>(null);
+  // Disconnect fn for the active PTY bridge (closes the socket + disposes
+  // listeners). Tracked so a stop mutation can close it before the exit message
+  // races the optimistic idle status.
+  const disconnectRef = useRef<(() => void) | null>(null);
   const connectedTypeRef = useRef<string | null>(null);
 
   const query = useQuery({
@@ -39,8 +28,8 @@ export function useScripts(wsId: string | undefined) {
   // Cleanup WS on unmount
   useEffect(() => {
     return () => {
-      wsRef.current?.close();
-      wsRef.current = null;
+      disconnectRef.current?.();
+      disconnectRef.current = null;
       connectedTypeRef.current = null;
     };
   }, [wsId]);
@@ -58,8 +47,8 @@ export function useScripts(wsId: string | undefined) {
 
   const closeConnectionIfType = (type: string) => {
     if (connectedTypeRef.current !== type) return;
-    wsRef.current?.close();
-    wsRef.current = null;
+    disconnectRef.current?.();
+    disconnectRef.current = null;
     connectedTypeRef.current = null;
   };
 
@@ -107,75 +96,31 @@ export function useScripts(wsId: string | undefined) {
     if (!wsId) return;
 
     // Disconnect previous connection if different type
-    if (wsRef.current) {
-      wsRef.current.close();
-      wsRef.current = null;
-    }
+    disconnectRef.current?.();
+    disconnectRef.current = null;
 
     connectedTypeRef.current = type;
-    const url = buildWsUrl(wsId, type);
-    const ws = new WebSocket(url);
-    ws.binaryType = "arraybuffer";
-    wsRef.current = ws;
-
-    const encoder = new TextEncoder();
-
-    ws.onmessage = (event) => {
-      if (event.data instanceof ArrayBuffer) {
-        term.write(new Uint8Array(event.data));
-      } else {
-        try {
-          const msg = JSON.parse(event.data as string);
-          if (msg.type === "exit") {
-            const exitCode = msg.code ?? -1;
-            queryClient.setQueryData<WorkspaceScriptsResponse>(["scripts", wsId], (prev) =>
-              prev
-                ? {
-                    ...prev,
-                    status: {
-                      ...prev.status,
-                      [type]: { state: exitCode === 0 ? "done" : "error", exitCode },
-                    },
-                  }
-                : prev,
-            );
-          }
-        } catch {
-          // ignore
-        }
-      }
-    };
-
-    ws.onopen = () => {
-      ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
-    };
-
-    // Bidirectional: allow interactive input
-    const inputDisposable = term.onData((data) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(encoder.encode(data));
-      }
+    const url = buildWsUrl(`/ws/script/${wsId}`, { type });
+    disconnectRef.current = connectPtyTerminal(term, url, {
+      onExit: (exitCode) => {
+        queryClient.setQueryData<WorkspaceScriptsResponse>(["scripts", wsId], (prev) =>
+          prev
+            ? {
+                ...prev,
+                status: {
+                  ...prev.status,
+                  [type]: { state: exitCode === 0 ? "done" : "error", exitCode },
+                },
+              }
+            : prev,
+        );
+      },
     });
-
-    const resizeDisposable = term.onResize(({ cols, rows }) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify({ type: "resize", cols, rows }));
-      }
-    });
-
-    ws.onclose = () => {
-      inputDisposable.dispose();
-      resizeDisposable.dispose();
-      if (wsRef.current === ws) {
-        wsRef.current = null;
-        connectedTypeRef.current = null;
-      }
-    };
   }, [wsId, queryClient]);
 
   const disconnectOutput = useCallback(() => {
-    wsRef.current?.close();
-    wsRef.current = null;
+    disconnectRef.current?.();
+    disconnectRef.current = null;
     connectedTypeRef.current = null;
   }, []);
 

--- a/frontend/src/hooks/useSessions.ts
+++ b/frontend/src/hooks/useSessions.ts
@@ -31,9 +31,18 @@ export function useSessions(workspaceId: string | undefined) {
     queryClient.invalidateQueries({ queryKey: ["sessions", workspaceId] });
 
   const createSession = useMutation({
-    mutationFn: () =>
+    mutationFn: (kind?: "terminal") =>
       api.post<SessionMetadata>(
         `/api/workspaces/${workspaceId}/sessions`,
+        kind ? { kind } : undefined,
+      ),
+    onSuccess: invalidate,
+  });
+
+  const convertToTerminal = useMutation({
+    mutationFn: (sessionId: string) =>
+      api.post<SessionMetadata>(
+        `/api/workspaces/${workspaceId}/sessions/${sessionId}/convert-to-terminal`,
       ),
     onSuccess: invalidate,
   });
@@ -47,10 +56,18 @@ export function useSessions(workspaceId: string | undefined) {
   return {
     sessions: sorted,
     loading: query.isLoading,
-    createSession: async (): Promise<SessionMetadata | null> => {
+    createSession: async (kind?: "terminal"): Promise<SessionMetadata | null> => {
       if (!workspaceId) return null;
       try {
-        return await createSession.mutateAsync();
+        return await createSession.mutateAsync(kind);
+      } catch {
+        return null;
+      }
+    },
+    convertToTerminal: async (sessionId: string): Promise<SessionMetadata | null> => {
+      if (!workspaceId) return null;
+      try {
+        return await convertToTerminal.mutateAsync(sessionId);
       } catch {
         return null;
       }

--- a/frontend/src/lib/pty-terminal.ts
+++ b/frontend/src/lib/pty-terminal.ts
@@ -1,0 +1,91 @@
+import type { Terminal as XTerm } from "@xterm/xterm";
+
+/** JSON control messages a PTY WebSocket can send to the client. */
+export interface PtyControlMessage {
+  type: string;
+  code?: number;
+  message?: string;
+}
+
+export interface ConnectPtyTerminalOptions {
+  /** Invoked when the PTY emits an `exit` control message. */
+  onExit?: (code: number) => void;
+  /**
+   * Invoked for every non-binary (JSON control) message from the server, e.g.
+   * `{type:"ready"}`, `{type:"error",message}`. `exit` is still routed through
+   * `onExit` in addition to this callback.
+   */
+  onControl?: (msg: PtyControlMessage) => void;
+  /**
+   * Invoked when the socket closes on its own (server end or network failure),
+   * NOT when the returned disconnect function is called. Lets a caller resolve a
+   * still-pending "connecting" state if the socket dies before any control frame.
+   */
+  onClose?: () => void;
+}
+
+/**
+ * Bridge a PTY WebSocket to an xterm instance: binary chunks are written to the
+ * terminal, terminal input/resize are forwarded to the socket, and JSON control
+ * frames are surfaced via callbacks. Returns a disconnect function that closes
+ * the socket and disposes the terminal listeners.
+ *
+ * Shared by the bottom-right ScriptPanel terminal (`/ws/script`) and the
+ * full-pane TerminalPane (`/ws/terminal`).
+ */
+export function connectPtyTerminal(
+  term: XTerm,
+  url: string,
+  options: ConnectPtyTerminalOptions = {},
+): () => void {
+  const { onExit, onControl, onClose } = options;
+  const ws = new WebSocket(url);
+  ws.binaryType = "arraybuffer";
+
+  const encoder = new TextEncoder();
+
+  ws.onmessage = (event) => {
+    if (event.data instanceof ArrayBuffer) {
+      term.write(new Uint8Array(event.data));
+      return;
+    }
+    try {
+      const msg = JSON.parse(event.data as string) as PtyControlMessage;
+      onControl?.(msg);
+      if (msg.type === "exit") {
+        onExit?.(msg.code ?? -1);
+      }
+    } catch {
+      // Ignore malformed control frames.
+    }
+  };
+
+  ws.onopen = () => {
+    ws.send(JSON.stringify({ type: "resize", cols: term.cols, rows: term.rows }));
+  };
+
+  const inputDisposable = term.onData((data) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(encoder.encode(data));
+    }
+  });
+
+  const resizeDisposable = term.onResize(({ cols, rows }) => {
+    if (ws.readyState === WebSocket.OPEN) {
+      ws.send(JSON.stringify({ type: "resize", cols, rows }));
+    }
+  });
+
+  ws.onclose = () => {
+    inputDisposable.dispose();
+    resizeDisposable.dispose();
+    onClose?.();
+  };
+
+  return () => {
+    inputDisposable.dispose();
+    resizeDisposable.dispose();
+    ws.onclose = null;
+    ws.close();
+  };
+}

--- a/frontend/src/lib/ws-url.ts
+++ b/frontend/src/lib/ws-url.ts
@@ -1,0 +1,26 @@
+import { getServerUrl } from "@/hooks/useServerUrl";
+
+/**
+ * Build a WebSocket URL against the configured backend, factoring the
+ * server-URL resolution and auth-token wiring shared by every PTY-style
+ * endpoint (e.g. `/ws/script`, `/ws/terminal`).
+ *
+ * `path` is the WS path beginning with a slash (e.g. `/ws/terminal/ws-1`).
+ * `params` are appended as query string; the auth token (when configured) is
+ * added automatically as `token`.
+ */
+export function buildWsUrl(path: string, params?: Record<string, string>): string {
+  const serverUrl = getServerUrl();
+  let wsHost: string;
+  if (serverUrl) {
+    wsHost = serverUrl.replace(/^http/, "ws");
+  } else {
+    const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+    wsHost = import.meta.env.VITE_WS_URL || `${protocol}//${window.location.host}`;
+  }
+  const authToken = (import.meta.env.VITE_HIVE_AUTH_TOKEN as string | undefined)?.trim();
+  const search = new URLSearchParams(params ?? {});
+  if (authToken) search.set("token", authToken);
+  const query = search.toString();
+  return query ? `${wsHost}${path}?${query}` : `${wsHost}${path}`;
+}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -9,6 +9,7 @@ import { useWorkspaceLiveDataContext, useClearUnread } from "@/contexts/Workspac
 import { FileTree, renderFileTreeNodes } from "@/components/ai-elements/file-tree";
 import ChatInput, { type ChatInputHandle } from "@/components/ChatInput";
 import { ConversationPane } from "@/components/chat/ConversationPane";
+import { TerminalPane } from "@/components/TerminalPane";
 import { FileTabView } from "@/components/FileTabView";
 import { BranchLabel } from "@/components/BranchLabel";
 import { ModifiedFileList } from "@/components/diff/ModifiedFileList";
@@ -208,6 +209,7 @@ export default function WorkspaceView() {
     handleCreateSession,
     handleActivateSession,
     handleDeleteSession,
+    handleStartTerminal,
   } = useConversationColumn(wsId, { onActivateSession, onLastSessionDeleted });
 
   const [renderMode, setRenderMode] = useState<"raw" | "rendered">("raw");
@@ -497,6 +499,12 @@ export default function WorkspaceView() {
             backgroundRunningCount={bgRunningCount}
             onBatchAnswerQuestions={batchAnswerQuestions}
             onDismissQuestion={() => rejectToolInput("[question_dismissed]")}
+            onStartTerminal={handleStartTerminal}
+            terminalView={
+              wsId && sessionId ? (
+                <TerminalPane key={sessionId} wsId={wsId} sessionId={sessionId} />
+              ) : undefined
+            }
             planActionBar={
               hasPendingPlan && pendingPlanData ? (
                 <PlanActionBar

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -198,6 +198,10 @@ export interface FileMention {
 
 // ── Session / Chat types ────────────────────────────────────────────
 
+/** Discriminates the surface a session drives. Absent = "chat". Keep in sync
+ *  with the backend `SessionKind`. */
+export type SessionKind = "chat" | "automation" | "brain" | "terminal";
+
 export interface SessionMetadata {
   sessionId: string;
   /** Provider-native conversation/thread id used for resume across turns. */
@@ -206,6 +210,8 @@ export interface SessionMetadata {
   claudeSessionId?: string;
   workspaceId: string;
   title?: string;
+  /** Session surface; absent means a regular chat session. */
+  kind?: SessionKind;
   createdAt: string;
   updatedAt: string;
   messageCount: number;

--- a/frontend/tests/components/ConversationPane.test.tsx
+++ b/frontend/tests/components/ConversationPane.test.tsx
@@ -87,6 +87,52 @@ describe("ConversationPane", () => {
     expect(screen.getByTestId("chat-input")).toBeInTheDocument();
   });
 
+  it("renders the terminalView in place of the chat when the active session is a terminal", () => {
+    render(
+      <ConversationPane
+        {...baseProps({
+          activeSessionId: "term-1",
+          sessions: [
+            {
+              sessionId: "term-1",
+              workspaceId: "ws-1",
+              kind: "terminal",
+              createdAt: "2026-02-12T00:00:00.000Z",
+              updatedAt: "2026-02-12T00:00:00.000Z",
+              messageCount: 0,
+            },
+          ],
+          terminalView: <div data-testid="terminal-view">terminal</div>,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
+    expect(screen.queryByTestId("chat-conversation")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+  });
+
+  it("renders the chat (not the terminalView) when the active session is a regular chat", () => {
+    render(
+      <ConversationPane
+        {...baseProps({
+          activeSessionId: "chat-1",
+          sessions: [
+            {
+              sessionId: "chat-1",
+              workspaceId: "ws-1",
+              createdAt: "2026-02-12T00:00:00.000Z",
+              updatedAt: "2026-02-12T00:00:00.000Z",
+              messageCount: 0,
+            },
+          ],
+          terminalView: <div data-testid="terminal-view">terminal</div>,
+        })}
+      />,
+    );
+    expect(screen.getByTestId("chat-conversation")).toBeInTheDocument();
+    expect(screen.queryByTestId("terminal-view")).not.toBeInTheDocument();
+  });
+
   it("shows the task tracker only when tasks/agents exist and no question is pending", () => {
     const { rerender } = render(<ConversationPane {...baseProps()} />);
     expect(screen.queryByTestId("task-tracker")).not.toBeInTheDocument();

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -493,4 +493,52 @@ describe("ConversationTabs — file tab", () => {
     expect(screen.getByText("Second conversation")).toBeInTheDocument();
     expect(document.querySelector("svg.lucide-more-horizontal")).toBeNull();
   });
+
+  it("renders a terminal icon for terminal-kind sessions", () => {
+    const terminal: SessionMetadata = {
+      sessionId: "term-1",
+      workspaceId: "ws-1",
+      kind: "terminal",
+      createdAt: "2026-02-12T00:00:02.000Z",
+      updatedAt: "2026-02-12T00:00:02.000Z",
+      messageCount: 0,
+    };
+    renderTabs({
+      sessions: [makeSession("sess-1", "2026-02-12T00:00:01.000Z", "Chat"), terminal],
+      activeSessionId: "sess-1",
+    });
+
+    const chatTab = screen.getByText("Chat").closest("button")!;
+    expect(chatTab.querySelector("svg.lucide-square-terminal")).toBeNull();
+
+    const termTab = screen.getByText("Terminal 1").closest("button")!;
+    expect(termTab.querySelector("svg.lucide-square-terminal")).toBeInTheDocument();
+  });
+
+  it("titles untitled terminal sessions as 'Terminal N' by their order among terminals", () => {
+    const makeTerminal = (id: string, createdAt: string, title?: string): SessionMetadata => ({
+      sessionId: id,
+      workspaceId: "ws-1",
+      kind: "terminal",
+      title,
+      createdAt,
+      updatedAt: createdAt,
+      messageCount: 0,
+    });
+
+    renderTabs({
+      sessions: [
+        makeSession("chat-1", "2026-02-12T00:00:00.000Z", "Chat"),
+        makeTerminal("term-1", "2026-02-12T00:00:01.000Z"),
+        makeTerminal("term-2", "2026-02-12T00:00:02.000Z", "Build logs"),
+        makeTerminal("term-3", "2026-02-12T00:00:03.000Z"),
+      ],
+      activeSessionId: "chat-1",
+    });
+
+    // 1-based index counts every terminal session, even titled ones.
+    expect(screen.getByText("Terminal 1")).toBeInTheDocument();
+    expect(screen.getByText("Build logs")).toBeInTheDocument();
+    expect(screen.getByText("Terminal 3")).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -69,6 +69,30 @@ describe("ConversationTabs", () => {
     expect(onCreateSession).toHaveBeenCalledTimes(1);
   });
 
+  it("does not count terminal tabs toward the session cap", () => {
+    // 5 chats + 2 terminals is under the chat cap (6), so + stays enabled.
+    const sessions: SessionMetadata[] = [
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeSession(`chat-${i}`, `2026-02-12T00:00:0${i}.000Z`, `Chat ${i}`),
+      ),
+      { ...makeSession("term-1", "2026-02-12T00:01:00.000Z"), kind: "terminal" },
+      { ...makeSession("term-2", "2026-02-12T00:02:00.000Z"), kind: "terminal" },
+    ];
+    renderTabs({ sessions, activeSessionId: "chat-0" });
+    expect(screen.getByTitle("New conversation")).not.toBeDisabled();
+  });
+
+  it("disables the + button at the chat-session cap regardless of terminals", () => {
+    const sessions: SessionMetadata[] = [
+      ...Array.from({ length: 6 }, (_, i) =>
+        makeSession(`chat-${i}`, `2026-02-12T00:00:0${i}.000Z`, `Chat ${i}`),
+      ),
+      { ...makeSession("term-1", "2026-02-12T00:01:00.000Z"), kind: "terminal" },
+    ];
+    renderTabs({ sessions, activeSessionId: "chat-0" });
+    expect(screen.getByTitle(/Session limit reached/i)).toBeDisabled();
+  });
+
   it("activates a non-active tab on click", async () => {
     const user = userEvent.setup();
     const { onActivateSession } = renderTabs();

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -533,10 +533,10 @@ describe("ConversationTabs — file tab", () => {
     });
 
     const chatTab = screen.getByText("Chat").closest("button")!;
-    expect(chatTab.querySelector("svg.lucide-square-terminal")).toBeNull();
+    expect(chatTab.querySelector('svg[data-icon="terminal"]')).toBeNull();
 
     const termTab = screen.getByText("Terminal 1").closest("button")!;
-    expect(termTab.querySelector("svg.lucide-square-terminal")).toBeInTheDocument();
+    expect(termTab.querySelector('svg[data-icon="terminal"]')).toBeInTheDocument();
   });
 
   it("titles untitled terminal sessions as 'Terminal N' by their order among terminals", () => {

--- a/frontend/tests/components/TerminalPane.test.tsx
+++ b/frontend/tests/components/TerminalPane.test.tsx
@@ -1,0 +1,188 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalPane } from "@/components/TerminalPane";
+
+const mocks = vi.hoisted(() => ({
+  apiPost: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: { post: mocks.apiPost },
+}));
+
+vi.mock("@/hooks/useServerUrl", () => ({
+  getServerUrl: () => "",
+}));
+
+const state = vi.hoisted(() => ({
+  terminals: [] as Array<{ write: ReturnType<typeof vi.fn> }>,
+}));
+
+vi.mock("@xterm/xterm", () => ({
+  Terminal: class TerminalMock {
+    cols = 80;
+    rows = 24;
+    options: { theme?: unknown } = {};
+    write = vi.fn();
+    loadAddon = vi.fn();
+    open = vi.fn();
+    dispose = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    constructor() {
+      state.terminals.push(this);
+    }
+  },
+}));
+
+vi.mock("@xterm/addon-fit", () => ({
+  FitAddon: class FitAddonMock {
+    fit = vi.fn();
+  },
+}));
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  binaryType = "";
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+
+  fireMessage(data: string | ArrayBuffer) {
+    this.onmessage?.({ data });
+  }
+}
+
+function lastSocket(): MockWebSocket {
+  const ws = MockWebSocket.instances.at(-1);
+  if (!ws) throw new Error("expected a websocket instance");
+  return ws;
+}
+
+describe("TerminalPane", () => {
+  beforeEach(() => {
+    state.terminals.length = 0;
+    MockWebSocket.instances.length = 0;
+    mocks.apiPost.mockReset();
+    mocks.apiPost.mockResolvedValue({ started: true });
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("connects to the terminal socket with the session id on mount", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    expect(lastSocket().url).toBe("ws://localhost:3000/ws/terminal/ws-1?sessionId=sess-1");
+  });
+
+  it("shows no start overlay before the socket resolves (no flash on revisit)", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    // Connecting state: while the socket is in flight, neither overlay button shows.
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /restart/i })).not.toBeInTheDocument();
+  });
+
+  it("offers a start button when the server reports no running PTY", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "error", message: "No terminal process found" }));
+    });
+    expect(screen.getByRole("button", { name: /start terminal/i })).toBeInTheDocument();
+  });
+
+  it("falls back to idle when the socket closes before resolving", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().onclose?.();
+    });
+    expect(screen.getByRole("button", { name: /start terminal/i })).toBeInTheDocument();
+  });
+
+  it("recovers to an idle overlay when the socket drops mid-session", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "ready" }));
+    });
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+
+    // A mid-session drop must not leave the pane stuck on stale output: it
+    // resolves to idle so the user can reconnect to the (likely still-alive) PTY.
+    act(() => {
+      lastSocket().onclose?.();
+    });
+    expect(screen.getByRole("button", { name: /start terminal/i })).toBeInTheDocument();
+  });
+
+  it("posts start then reconnects when the start button is clicked", async () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "error", message: "No terminal process found" }));
+    });
+
+    const before = MockWebSocket.instances.length;
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /start terminal/i }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/terminal-tabs/sess-1/start");
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThan(before);
+    });
+    // No idle overlay once running.
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the overlay once the PTY reports ready (running)", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "ready" }));
+    });
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+  });
+
+  it("treats binary PTY output as running and writes it to the terminal", () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(new Uint8Array([104, 105]).buffer);
+      // A ready frame flips state to running; binary alone keeps the terminal alive.
+      lastSocket().fireMessage(JSON.stringify({ type: "ready" }));
+    });
+    expect(state.terminals[0].write).toHaveBeenCalledWith(new Uint8Array([104, 105]));
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+  });
+
+  it("shows the exit code and a restart button when the PTY exits", async () => {
+    render(<TerminalPane wsId="ws-1" sessionId="sess-1" />);
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "ready" }));
+    });
+    act(() => {
+      lastSocket().fireMessage(JSON.stringify({ type: "exit", code: 137 }));
+    });
+
+    expect(screen.getByText(/Terminal exited \(code 137\)/i)).toBeInTheDocument();
+
+    const before = MockWebSocket.instances.length;
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: /restart/i }));
+      await Promise.resolve();
+    });
+
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws-1/terminal-tabs/sess-1/start");
+    await waitFor(() => {
+      expect(MockWebSocket.instances.length).toBeGreaterThan(before);
+    });
+  });
+});

--- a/frontend/tests/components/WorkspaceWelcome.test.tsx
+++ b/frontend/tests/components/WorkspaceWelcome.test.tsx
@@ -34,7 +34,7 @@ describe("WorkspaceWelcome", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start a terminal/i })).not.toBeInTheDocument();
   });
 
   it("renders the start-terminal button and invokes the callback when provided", () => {
@@ -50,7 +50,7 @@ describe("WorkspaceWelcome", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: /start terminal/i });
+    const button = screen.getByRole("button", { name: /start a terminal/i });
     fireEvent.click(button);
     expect(onStartTerminal).toHaveBeenCalledTimes(1);
   });

--- a/frontend/tests/components/WorkspaceWelcome.test.tsx
+++ b/frontend/tests/components/WorkspaceWelcome.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 import { WorkspaceWelcome } from "@/components/WorkspaceWelcome";
 
 describe("WorkspaceWelcome", () => {
@@ -20,5 +21,37 @@ describe("WorkspaceWelcome", () => {
     expect(screen.getByText("workspace/san-antonio")).toBeInTheDocument();
     expect(screen.getByText("origin/main")).toBeInTheDocument();
     expect(screen.getByText("12,345")).toBeInTheDocument();
+  });
+
+  it("omits the start-terminal button when onStartTerminal is absent", () => {
+    render(
+      <WorkspaceWelcome
+        projectName="hive"
+        workspaceName="san-antonio"
+        branch="workspace/san-antonio"
+        defaultBranch="main"
+        fileCount={12}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: /start terminal/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the start-terminal button and invokes the callback when provided", () => {
+    const onStartTerminal = vi.fn();
+    render(
+      <WorkspaceWelcome
+        projectName="hive"
+        workspaceName="san-antonio"
+        branch="workspace/san-antonio"
+        defaultBranch="main"
+        fileCount={12}
+        onStartTerminal={onStartTerminal}
+      />,
+    );
+
+    const button = screen.getByRole("button", { name: /start terminal/i });
+    fireEvent.click(button);
+    expect(onStartTerminal).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/hooks/useConversationColumn.test.tsx
+++ b/frontend/tests/hooks/useConversationColumn.test.tsx
@@ -9,12 +9,14 @@ const mocks = vi.hoisted(() => ({
   useSessions: vi.fn(),
   useTasks: vi.fn(),
   useBackgroundAgents: vi.fn(),
+  apiPost: vi.fn(),
 }));
 
 vi.mock("@/hooks/useConversation", () => ({ useConversation: mocks.useConversation }));
 vi.mock("@/hooks/useSessions", () => ({ useSessions: mocks.useSessions }));
 vi.mock("@/hooks/useTasks", () => ({ useTasks: mocks.useTasks }));
 vi.mock("@/hooks/useBackgroundAgents", () => ({ useBackgroundAgents: mocks.useBackgroundAgents }));
+vi.mock("@/hooks/useApi", () => ({ api: { post: mocks.apiPost } }));
 
 // Shared mutable conversation state so we can re-render with different values.
 let conversation: Record<string, unknown>;
@@ -50,11 +52,12 @@ function makeConversation(overrides: Record<string, unknown> = {}) {
 }
 
 const sessionList = [
-  { sessionId: "s1", title: "One", createdAt: "2024-01-01T00:00:00Z" },
-  { sessionId: "s2", title: "Two", createdAt: "2024-01-02T00:00:00Z" },
+  { sessionId: "s1", title: "One", createdAt: "2024-01-01T00:00:00Z", messageCount: 0 },
+  { sessionId: "s2", title: "Two", createdAt: "2024-01-02T00:00:00Z", messageCount: 0 },
 ];
 
 let createSession: ReturnType<typeof vi.fn>;
+let convertToTerminal: ReturnType<typeof vi.fn>;
 let deleteSession: ReturnType<typeof vi.fn>;
 let refresh: ReturnType<typeof vi.fn>;
 
@@ -64,9 +67,11 @@ beforeEach(() => {
   conversation = makeConversation();
   mocks.useConversation.mockImplementation(() => conversation);
   createSession = vi.fn().mockResolvedValue({ sessionId: "s3", title: "New", createdAt: "2024-01-03T00:00:00Z" });
+  convertToTerminal = vi.fn().mockResolvedValue({ sessionId: "s1", kind: "terminal", createdAt: "2024-01-01T00:00:00Z" });
   deleteSession = vi.fn().mockResolvedValue(true);
   refresh = vi.fn();
-  mocks.useSessions.mockReturnValue({ sessions: sessionList, createSession, deleteSession, refresh });
+  mocks.apiPost.mockResolvedValue(undefined);
+  mocks.useSessions.mockReturnValue({ sessions: sessionList, createSession, convertToTerminal, deleteSession, refresh });
   mocks.useTasks.mockReturnValue({ tasks: [], currentTask: undefined, counts: {} });
   mocks.useBackgroundAgents.mockReturnValue({ agents: [], runningCount: 0 });
 });
@@ -137,6 +142,72 @@ describe("useConversationColumn — session handlers", () => {
     expect(conversation.clearChat).not.toHaveBeenCalled();
     expect(onLastSessionDeleted).not.toHaveBeenCalled();
     expect(conversation.switchSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("useConversationColumn — handleStartTerminal", () => {
+  it("converts the active session in place when it is an empty chat", async () => {
+    // Active session s1 is an empty chat (kind absent, messageCount 0).
+    const { result } = renderHook(() => useConversationColumn("ws1"));
+    await act(async () => {
+      await result.current.handleStartTerminal();
+    });
+
+    expect(convertToTerminal).toHaveBeenCalledWith("s1");
+    expect(createSession).not.toHaveBeenCalled();
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws1/terminal-tabs/s1/start");
+    expect(refresh).toHaveBeenCalledTimes(1);
+    // Activating the already-active session is a no-op switch, but the tab is
+    // still re-activated.
+    expect(result.current.activateTab).toBeTypeOf("function");
+  });
+
+  it("creates a fresh terminal session when the active chat already has messages", async () => {
+    mocks.useSessions.mockReturnValue({
+      sessions: [
+        { sessionId: "s1", title: "One", createdAt: "2024-01-01T00:00:00Z", messageCount: 3 },
+      ],
+      createSession,
+      convertToTerminal,
+      deleteSession,
+      refresh,
+    });
+    createSession.mockResolvedValue({ sessionId: "term-1", kind: "terminal", createdAt: "2024-01-04T00:00:00Z" });
+
+    const { result } = renderHook(() => useConversationColumn("ws1"));
+    await act(async () => {
+      await result.current.handleStartTerminal();
+    });
+
+    expect(createSession).toHaveBeenCalledWith("terminal");
+    expect(convertToTerminal).not.toHaveBeenCalled();
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws1/terminal-tabs/term-1/start");
+    expect(conversation.switchSession).toHaveBeenCalledWith("term-1");
+  });
+
+  it("aborts (no start) when the conversion fails", async () => {
+    convertToTerminal.mockResolvedValue(null);
+    const { result } = renderHook(() => useConversationColumn("ws1"));
+    await act(async () => {
+      await result.current.handleStartTerminal();
+    });
+
+    expect(convertToTerminal).toHaveBeenCalledWith("s1");
+    expect(mocks.apiPost).not.toHaveBeenCalled();
+  });
+
+  it("still lands on the tab when the start request fails", async () => {
+    // Convert succeeds but the PTY start rejects. The session is already a
+    // terminal (convert is irreversible), so this must not reject unhandled and
+    // must still refresh + activate so the pane's Start button can retry.
+    mocks.apiPost.mockRejectedValueOnce(new Error("network"));
+    const { result } = renderHook(() => useConversationColumn("ws1"));
+    await act(async () => {
+      await result.current.handleStartTerminal();
+    });
+
+    expect(mocks.apiPost).toHaveBeenCalledWith("/api/workspaces/ws1/terminal-tabs/s1/start");
+    expect(refresh).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/frontend/tests/hooks/useSessions.test.ts
+++ b/frontend/tests/hooks/useSessions.test.ts
@@ -98,7 +98,7 @@ describe("useSessions", () => {
     });
 
     expect(created).toEqual(makeSession("sess-2"));
-    expect(api.post).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions");
+    expect(api.post).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions", undefined);
 
     await waitFor(() => {
       expect(result.current.sessions).toEqual([makeSession("sess-1"), makeSession("sess-2")]);
@@ -189,6 +189,57 @@ describe("useSessions", () => {
       expect(result.current.sessions).toEqual([makeSession("sess-1"), makeSession("sess-3")]);
     });
     expect(api.get).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a terminal session by sending the kind in the body", async () => {
+    vi.mocked(api.get)
+      .mockResolvedValueOnce([makeSession("sess-1")])
+      .mockResolvedValueOnce([makeSession("sess-1"), makeSession("term-1")]);
+    vi.mocked(api.post).mockResolvedValueOnce({ ...makeSession("term-1"), kind: "terminal" });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSessions("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1));
+
+    let created: SessionMetadata | null = null;
+    await act(async () => {
+      created = await result.current.createSession("terminal");
+    });
+
+    expect(created).toEqual({ ...makeSession("term-1"), kind: "terminal" });
+    expect(api.post).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions", { kind: "terminal" });
+  });
+
+  it("converts an empty chat session into a terminal in place", async () => {
+    vi.mocked(api.get).mockResolvedValue([makeSession("sess-1")]);
+    vi.mocked(api.post).mockResolvedValueOnce({ ...makeSession("sess-1"), kind: "terminal" });
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSessions("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1));
+
+    let converted: SessionMetadata | null = null;
+    await act(async () => {
+      converted = await result.current.convertToTerminal("sess-1");
+    });
+
+    expect(converted).toEqual({ ...makeSession("sess-1"), kind: "terminal" });
+    expect(api.post).toHaveBeenCalledWith(
+      "/api/workspaces/ws-1/sessions/sess-1/convert-to-terminal",
+    );
+  });
+
+  it("returns null when convert-to-terminal fails", async () => {
+    vi.mocked(api.get).mockResolvedValue([makeSession("sess-1")]);
+    vi.mocked(api.post).mockRejectedValueOnce(new Error("has messages"));
+    const { wrapper } = createWrapper();
+
+    const { result } = renderHook(() => useSessions("ws-1"), { wrapper });
+    await waitFor(() => expect(result.current.sessions).toHaveLength(1));
+
+    await act(async () => {
+      expect(await result.current.convertToTerminal("sess-1")).toBeNull();
+    });
   });
 
   it("sorts sessions after manual refresh", async () => {

--- a/frontend/tests/lib/pty-terminal.test.ts
+++ b/frontend/tests/lib/pty-terminal.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Terminal as XTerm } from "@xterm/xterm";
+import { connectPtyTerminal } from "@/lib/pty-terminal";
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSED = 3;
+  static instances: MockWebSocket[] = [];
+
+  binaryType = "";
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string | ArrayBuffer }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.readyState = MockWebSocket.CLOSED;
+  });
+
+  constructor(readonly url: string) {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+function createTerminal() {
+  let dataHandler: ((data: string) => void) | null = null;
+  let resizeHandler: ((size: { cols: number; rows: number }) => void) | null = null;
+  const inputDispose = vi.fn();
+  const resizeDispose = vi.fn();
+  const term = {
+    cols: 100,
+    rows: 30,
+    write: vi.fn(),
+    onData: (handler: (data: string) => void) => {
+      dataHandler = handler;
+      return { dispose: inputDispose };
+    },
+    onResize: (handler: (size: { cols: number; rows: number }) => void) => {
+      resizeHandler = handler;
+      return { dispose: resizeDispose };
+    },
+  };
+  return {
+    term: term as unknown as XTerm,
+    emitData: (d: string) => dataHandler?.(d),
+    emitResize: (cols: number, rows: number) => resizeHandler?.({ cols, rows }),
+    inputDispose,
+    resizeDispose,
+  };
+}
+
+function lastSocket(): MockWebSocket {
+  const ws = MockWebSocket.instances.at(-1);
+  if (!ws) throw new Error("expected websocket");
+  return ws;
+}
+
+describe("connectPtyTerminal", () => {
+  beforeEach(() => {
+    MockWebSocket.instances.length = 0;
+    vi.stubGlobal("WebSocket", MockWebSocket as unknown as typeof WebSocket);
+  });
+
+  it("writes binary chunks to the terminal", () => {
+    const { term } = createTerminal();
+    connectPtyTerminal(term, "ws://x/ws/terminal/ws-1");
+    lastSocket().onmessage?.({ data: new Uint8Array([1, 2, 3]).buffer });
+    expect((term.write as ReturnType<typeof vi.fn>)).toHaveBeenCalledWith(new Uint8Array([1, 2, 3]));
+  });
+
+  it("sends an initial resize on open and forwards input + resize", () => {
+    const t = createTerminal();
+    connectPtyTerminal(t.term, "ws://x/ws/terminal/ws-1");
+    const ws = lastSocket();
+
+    ws.onopen?.();
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "resize", cols: 100, rows: 30 }));
+
+    t.emitData("ls\n");
+    const binary = ws.send.mock.calls.find((c) => ArrayBuffer.isView(c[0]))?.[0];
+    expect(new TextDecoder().decode(binary as Uint8Array)).toBe("ls\n");
+
+    t.emitResize(120, 40);
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "resize", cols: 120, rows: 40 }));
+  });
+
+  it("routes exit control frames through onExit and onControl", () => {
+    const onExit = vi.fn();
+    const onControl = vi.fn();
+    const { term } = createTerminal();
+    connectPtyTerminal(term, "ws://x/ws/terminal/ws-1", { onExit, onControl });
+    lastSocket().onmessage?.({ data: JSON.stringify({ type: "exit", code: 7 }) });
+    expect(onControl).toHaveBeenCalledWith({ type: "exit", code: 7 });
+    expect(onExit).toHaveBeenCalledWith(7);
+  });
+
+  it("surfaces non-exit control frames through onControl only", () => {
+    const onExit = vi.fn();
+    const onControl = vi.fn();
+    const { term } = createTerminal();
+    connectPtyTerminal(term, "ws://x/ws/terminal/ws-1", { onExit, onControl });
+    lastSocket().onmessage?.({ data: JSON.stringify({ type: "error", message: "No terminal process found" }) });
+    expect(onControl).toHaveBeenCalledWith({ type: "error", message: "No terminal process found" });
+    expect(onExit).not.toHaveBeenCalled();
+  });
+
+  it("defaults a code-less exit to -1", () => {
+    const onExit = vi.fn();
+    const { term } = createTerminal();
+    connectPtyTerminal(term, "ws://x/ws/terminal/ws-1", { onExit });
+    lastSocket().onmessage?.({ data: JSON.stringify({ type: "exit" }) });
+    expect(onExit).toHaveBeenCalledWith(-1);
+  });
+
+  it("disposes listeners and closes the socket on disconnect", () => {
+    const t = createTerminal();
+    const disconnect = connectPtyTerminal(t.term, "ws://x/ws/terminal/ws-1");
+    disconnect();
+    expect(t.inputDispose).toHaveBeenCalledTimes(1);
+    expect(t.resizeDispose).toHaveBeenCalledTimes(1);
+    expect(lastSocket().close).toHaveBeenCalledTimes(1);
+  });
+
+  it("disposes listeners when the socket closes from the server", () => {
+    const t = createTerminal();
+    connectPtyTerminal(t.term, "ws://x/ws/terminal/ws-1");
+    lastSocket().onclose?.();
+    expect(t.inputDispose).toHaveBeenCalledTimes(1);
+    expect(t.resizeDispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/lib/ws-url.test.ts
+++ b/frontend/tests/lib/ws-url.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getServerUrl: vi.fn(),
+}));
+
+vi.mock("@/hooks/useServerUrl", () => ({ getServerUrl: mocks.getServerUrl }));
+
+import { buildWsUrl } from "@/lib/ws-url";
+
+describe("buildWsUrl", () => {
+  beforeEach(() => {
+    mocks.getServerUrl.mockReset();
+    mocks.getServerUrl.mockReturnValue("");
+    delete import.meta.env.VITE_HIVE_AUTH_TOKEN;
+    delete import.meta.env.VITE_WS_URL;
+  });
+
+  it("derives the ws host from the configured http server URL", () => {
+    mocks.getServerUrl.mockReturnValue("http://127.0.0.1:9000");
+    expect(buildWsUrl("/ws/terminal/ws-1", { sessionId: "s1" })).toBe(
+      "ws://127.0.0.1:9000/ws/terminal/ws-1?sessionId=s1",
+    );
+  });
+
+  it("upgrades https server URLs to wss", () => {
+    mocks.getServerUrl.mockReturnValue("https://remote.example.dev");
+    expect(buildWsUrl("/ws/script/ws-1", { type: "setup" })).toBe(
+      "wss://remote.example.dev/ws/script/ws-1?type=setup",
+    );
+  });
+
+  it("appends the auth token when configured", () => {
+    mocks.getServerUrl.mockReturnValue("http://127.0.0.1:9000");
+    import.meta.env.VITE_HIVE_AUTH_TOKEN = "  secret token  ";
+    expect(buildWsUrl("/ws/terminal/ws-1", { sessionId: "s1" })).toBe(
+      "ws://127.0.0.1:9000/ws/terminal/ws-1?sessionId=s1&token=secret+token",
+    );
+  });
+
+  it("falls back to VITE_WS_URL when no server URL is set", () => {
+    import.meta.env.VITE_WS_URL = "wss://example-ws.acme.dev";
+    expect(buildWsUrl("/ws/script/ws-1", { type: "run" })).toBe(
+      "wss://example-ws.acme.dev/ws/script/ws-1?type=run",
+    );
+  });
+
+  it("omits the query string when there are no params and no token", () => {
+    mocks.getServerUrl.mockReturnValue("http://127.0.0.1:9000");
+    expect(buildWsUrl("/ws/terminal/ws-1")).toBe("ws://127.0.0.1:9000/ws/terminal/ws-1");
+  });
+});

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -177,6 +177,9 @@ struct SessionMetadata: Codable, Hashable, Identifiable {
     let updatedAt: String
     let messageCount: Int
     let lockedProvider: String?
+    /// Session surface; absent means a regular chat session. Mobile hides
+    /// "terminal" sessions, which only exist on the desktop client.
+    let kind: String?
     let lastRunOptions: MessageOptions?
 
     var id: String { sessionId }
@@ -191,6 +194,7 @@ struct SessionMetadata: Codable, Hashable, Identifiable {
         updatedAt: String,
         messageCount: Int,
         lockedProvider: String?,
+        kind: String? = nil,
         lastRunOptions: MessageOptions? = nil
     ) {
         self.sessionId = sessionId
@@ -202,6 +206,7 @@ struct SessionMetadata: Codable, Hashable, Identifiable {
         self.updatedAt = updatedAt
         self.messageCount = messageCount
         self.lockedProvider = lockedProvider
+        self.kind = kind
         self.lastRunOptions = lastRunOptions
     }
 }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -181,7 +181,9 @@ struct ConversationsSection<Header: View>: View {
 
     private func loadSessions() async {
         do {
+            // Terminal sessions are a desktop-only surface; hide them on mobile.
             sessions = try await api.fetchSessions(workspaceId: workspace.id)
+                .filter { $0.kind != "terminal" }
             errorMessage = nil
         } catch is CancellationError {
             // View disappeared.

--- a/ios/Tests/ChatDraftStoreTests/SessionMetadataDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/SessionMetadataDecodingTests.swift
@@ -16,6 +16,7 @@ struct SessionMetadataDecodingTests {
           "updatedAt": "2026-01-02T00:00:00.000Z",
           "messageCount": 7,
           "lockedProvider": "codex",
+          "kind": "chat",
           "lastRunOptions": {
             "planMode": false,
             "model": "codex:gpt-5.5",
@@ -36,6 +37,7 @@ struct SessionMetadataDecodingTests {
         #expect(metadata.updatedAt == "2026-01-02T00:00:00.000Z")
         #expect(metadata.messageCount == 7)
         #expect(metadata.lockedProvider == "codex")
+        #expect(metadata.kind == "chat")
         #expect(metadata.lastRunOptions?.model == "codex:gpt-5.5")
         #expect(metadata.lastRunOptions?.thinkingLevel == .low)
         #expect(metadata.lastRunOptions?.planMode == false)
@@ -62,6 +64,7 @@ struct SessionMetadataDecodingTests {
         #expect(metadata.claudeSessionId == nil)
         #expect(metadata.title == nil)
         #expect(metadata.lockedProvider == nil)
+        #expect(metadata.kind == nil)
         #expect(metadata.lastRunOptions == nil)
     }
 }


### PR DESCRIPTION
## What

Adds a **terminal tab**: a conversation tab whose `kind:"terminal"` renders a full-pane interactive login shell instead of an agent chat.

- Opened from the workspace **empty state** ("Start terminal"): the empty chat is converted in place (irreversible), or a fresh terminal session is created if the active one already has messages.
- **Multiple** terminal tabs per workspace; each gets its own login shell in the worktree.
- **Workspace-only.** Terminal sessions are hidden on iOS (desktop surface).
- Tab shows a terminal icon and an auto title "Terminal N".

## Why a shell tab, not a `claude --resume` / `codex resume`

The original idea (reopen the *same* agent session in a terminal) is a trap: the live runners use piped stdio with stdin closed (no PTY to attach to), so you'd spawn a *new* `claude --resume` → two writers to one transcript and divergence from Hive's `messages.jsonl`; and the Codex CLI path was removed in #247 (it's a JSON-RPC app-server now). A plain shell tab sidesteps all reconciliation.

## How

**Backend** — reuses `node-pty`:
- `pty-process.ts`: shared PTY lifecycle core (spawn login shell, ring-buffer replay, listeners, kill).
- `terminal-runner.ts`: terminal PTY registry keyed by `sessionId`, **deliberately separate from the script runner** so terminals never broadcast `script_status` / pollute the workspace "script running" indicator.
- `/ws/terminal/:wsId?sessionId=` binary socket sharing `attachPtyToSocket` with `/ws/script`.
- REST: `POST /sessions {kind:"terminal"}`, `POST /sessions/:id/convert-to-terminal`, `POST /terminal-tabs/:sessionId/start|stop` (validates the session exists and is a terminal).
- `getOrCreateSession` never resumes a terminal as the active chat session.
- `hardDeleteSession` and workspace delete/archive/shutdown tear down terminal PTYs.

**Frontend** — shared engine (DRY):
- `XtermSurface` + `connectPtyTerminal` + `buildWsUrl` are shared by the bottom-right script terminal (T1) and the new full-pane `TerminalPane` — no copy-pasted xterm/WS logic.
- `ConversationPane` swaps to `TerminalPane` when the active session is a terminal.

## Hardening (from a code-review pass)

- Separate terminal PTY registry → terminals no longer make a workspace look "running a script", and deleting one no longer leaves the indicator stuck.
- `terminal-tabs/start` validates the session is a terminal (404/400).
- `getOrCreateSession` never hands back a terminal as the active chat session (would silently no-op `sendMessage`, esp. on iOS).
- `TerminalPane` keyed by `sessionId` (clean remount per tab); `onClose` recovers a dropped session to an idle/Start state; `handleStartTerminal`'s start is guarded so a failed start after the irreversible convert still lands on the tab.

## Testing

- Backend: lint + typecheck clean, **1526** tests green.
- Frontend: lint + typecheck clean + production build, **1425** tests green.
- iOS: model + filter + decode tests added; `swift test` must be run with the toolchain (unavailable in this environment).

### Manual verification
- [ ] Empty state → "Start terminal" → shell opens; tab gets the terminal icon + "Terminal N".
- [ ] Type commands; `exit` → "exited (code N)" + Restart.
- [ ] Switch tabs and back → reconnect + scrollback, no flash.
- [ ] Close tab (x) → PTY killed.
- [ ] Multiple terminals in parallel.
- [ ] Opening a terminal does NOT make the workspace show as "running a script".
- [ ] `cd ios && swift test`.