### PR TITLE
Lazy-load conversations + deterministic in-flight stream delivery (#254)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,9 @@ This section is the single approved place for documented remaining work. Do not 
 - Add script automations that run configured commands and capture output for notifications.
 - Add automation chaining, concurrency limits, retry policy, and live hub streaming for automation runs.
 
+**REST history payload weight**
+- Lazy history truncation currently covers `ToolCall.output` and `command_execution.output` only. Large content carried in `ToolCall.input` (e.g. big `Write` inputs or Codex multi-file edits) and `agentActivities[].files[].diff` is not truncated, so a turn with heavy inputs or diffs can still produce a large history payload.
+
 **iOS**
 - Add iOS UI for automations and prompt template management.
 - Add repository file browsing and richer diff inspection on iOS beyond dashboard summaries and chat-rendered diffs.

--- a/README.md
+++ b/README.md
@@ -334,6 +334,9 @@ This section is the single approved place for documented remaining work. Do not 
 **REST history payload weight**
 - Lazy history truncation currently covers `ToolCall.output` and `command_execution.output` only. Large content carried in `ToolCall.input` (e.g. big `Write` inputs or Codex multi-file edits) and `agentActivities[].files[].diff` is not truncated, so a turn with heavy inputs or diffs can still produce a large history payload.
 
+**Blocking tool input emitted after `done`**
+- A blocking tool-input event (`AskUserQuestion`/`ExitPlanMode`) the backend emits immediately after a turn's `done` is dropped by the live reducer guard, which treats the terminated turn as stale. The pending input is recovered by REST history rehydration on next focus, so the prompt sheet appears on refocus. Pre-existing (predates the lazy-history branch); mitigated by rehydration.
+
 **iOS**
 - Add iOS UI for automations and prompt template management.
 - Add repository file browsing and richer diff inspection on iOS beyond dashboard summaries and chat-rendered diffs.

--- a/backend/src/agents/agent-event-normalizer.test.ts
+++ b/backend/src/agents/agent-event-normalizer.test.ts
@@ -118,4 +118,23 @@ describe("AgentEventNormalizer", () => {
       { type: "tool_completed", id: "bash-1", output: "ok\nstderr: warn\nexit code: 1" },
     ]);
   });
+
+  it("normalizes structured user tool result content as text", () => {
+    const normalizer = new AgentEventNormalizer();
+
+    const events = normalizer.handleUser(user([
+      {
+        type: "tool_result",
+        tool_use_id: "tool-1",
+        content: [
+          { type: "text", text: "first block" },
+          { type: "text", text: "second block" },
+        ],
+      },
+    ]));
+
+    expect(events).toEqual([
+      { type: "tool_completed", id: "tool-1", output: "first block\n\nsecond block" },
+    ]);
+  });
 });

--- a/backend/src/agents/agent-event-normalizer.ts
+++ b/backend/src/agents/agent-event-normalizer.ts
@@ -5,6 +5,7 @@ import type {
   ContentBlock,
   ServerToolResultType,
 } from "../types.js";
+import { normalizeToolOutput } from "@hive/shared/agent-activity";
 
 type AssistantEvent = Extract<CliJsonLine, { type: "assistant" }>;
 type UserEvent = Extract<CliJsonLine, { type: "user" }>;
@@ -168,7 +169,7 @@ export class AgentEventNormalizer {
       events.push({
         type: "tool_completed",
         id: block.tool_use_id,
-        output: block.content,
+        output: normalizeToolOutput(block.content),
       });
     }
 

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -715,9 +715,27 @@ describe("getSpecificSessionMessages", () => {
     ]);
   });
 
-  it("returns empty array when persisted messages do not exist", async () => {
-    const messages = await getSpecificSessionMessages(wsId, "missing", dataDir);
-    expect(messages).toEqual([]);
+  it("throws not found when the session does not exist", async () => {
+    // Missing and wrong-workspace are indistinguishable so existence in a
+    // sibling workspace cannot be probed.
+    await expect(getSpecificSessionMessages(wsId, "missing", dataDir)).rejects.toThrow("not found");
+  });
+
+  it("throws not found when the session belongs to another workspace in the project", async () => {
+    await writeSessionFixture("sess-foreign", "other-workspace", {
+      messages: [
+        {
+          id: "m-1",
+          sessionId: "sess-foreign",
+          role: "user",
+          content: "private",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      ],
+    });
+    await expect(getSpecificSessionMessages(wsId, "sess-foreign", dataDir)).rejects.toThrow(
+      "not found",
+    );
   });
 
   it("throws for non-existent workspace", async () => {

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -734,6 +734,7 @@ describe("notifications", () => {
     session.emit("message", {
       type: "done",
       sessionId: session.sessionId,
+      messageId: "msg-done-1",
       durationMs: 2400,
     });
 
@@ -789,6 +790,7 @@ describe("notifications", () => {
     session.emit("message", {
       type: "done",
       sessionId: session.sessionId,
+      messageId: "msg-done-resumed",
     });
 
     await vi.waitFor(() => {
@@ -811,6 +813,7 @@ describe("notifications", () => {
       session.emit("message", {
         type: "done",
         sessionId: session.sessionId,
+        messageId: "msg-done-swallow",
       });
     }).not.toThrow();
 

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -732,19 +732,65 @@ export async function hardDeleteSession(
   });
 }
 
+/**
+ * Shared ownership guard for explicit-session reads (messages, tool output,
+ * attachments): a session may only be read through the workspace that owns it.
+ *
+ * Sessions of every workspace in a project share one `<projectId>/sessions/`
+ * directory, so a path built from `wsId` + an arbitrary `sessionId` would
+ * otherwise read another workspace's session (IDOR). This resolves the project
+ * for `wsId`, then requires the on-disk (or in-memory) session metadata to carry
+ * `workspaceId === wsId`. A missing session and a session owned by a different
+ * workspace are treated identically as `NotFoundError` (404) so existence in a
+ * sibling workspace is never leaked. Returns the resolved `projectId` so callers
+ * can build the session path without re-resolving the workspace.
+ */
+async function assertSessionOwnership(
+  wsId: string,
+  sessionId: string,
+  dataDir: string,
+): Promise<{ projectId: string }> {
+  const result = await getWorkspace(wsId, dataDir);
+  if (!result) throw new NotFoundError(`Session ${sessionId} not found`);
+  const projectId = result.projectState.id;
+
+  // An in-memory session is keyed by wsId, so its presence already proves
+  // ownership; for everything else fall back to the persisted metadata.
+  const loaded = getLoadedSessionById(wsId, sessionId);
+  const owner = loaded
+    ? loaded.metadata.workspaceId
+    : await readSessionOwnerFromDisk(projectId, sessionId, dataDir);
+  if (owner !== wsId) throw new NotFoundError(`Session ${sessionId} not found`);
+  return { projectId };
+}
+
+/** Read a session's owning workspace id from its `metadata.json`, or undefined. */
+async function readSessionOwnerFromDisk(
+  projectId: string,
+  sessionId: string,
+  dataDir: string,
+): Promise<string | undefined> {
+  const metaPath = join(dataDir, projectId, "sessions", sessionId, "metadata.json");
+  try {
+    const meta = JSON.parse(await readFile(metaPath, "utf-8")) as SessionMetadata;
+    return meta.workspaceId;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Get messages for a specific session (from memory if active, otherwise from disk). */
 export async function getSpecificSessionMessages(
   wsId: string,
   sessionId: string,
   dataDir = getDataDir(),
 ): Promise<ChatMessage[]> {
+  const { projectId } = await assertSessionOwnership(wsId, sessionId, dataDir);
+
   const loaded = getLoadedSessionById(wsId, sessionId);
   if (loaded) return loaded.getMessages();
 
-  const result = await getWorkspace(wsId, dataDir);
-  if (!result) throw new NotFoundError(`Workspace ${wsId} not found`);
-
-  const messagesPath = join(dataDir, result.projectState.id, "sessions", sessionId, "messages.jsonl");
+  const messagesPath = join(dataDir, projectId, "sessions", sessionId, "messages.jsonl");
   try {
     const raw = await readFile(messagesPath, "utf-8");
     return parseJsonlMessages(raw);
@@ -760,9 +806,8 @@ export async function resolveSessionAttachmentPath(
   filename: string,
   dataDir = getDataDir(),
 ): Promise<string | null> {
-  const result = await getWorkspace(wsId, dataDir);
-  if (!result) return null;
-  return join(dataDir, result.projectState.id, "sessions", sessionId, "attachments", filename);
+  const { projectId } = await assertSessionOwnership(wsId, sessionId, dataDir);
+  return join(dataDir, projectId, "sessions", sessionId, "attachments", filename);
 }
 
 /** Return session IDs currently streaming in a workspace. */

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -1380,6 +1380,14 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           await Promise.allSettled(pendingImageAttachments);
         }
 
+        // The terminal event carries the id of the assistant message persisted
+        // for this turn so clients can append it optimistically and dedup the
+        // next REST history fetch by id. Generate the id once here and reuse it
+        // for both the persisted ChatMessage and the done/cancelled event — do
+        // not invent a second id.
+        const messageId = nanoid(12);
+        let persistedMessageId: string | undefined;
+
         if (
           streamText ||
           streamToolCalls.length > 0 ||
@@ -1388,7 +1396,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           shouldSurfaceCancelled
         ) {
           const assistantMsg: ChatMessage = {
-            id: nanoid(12),
+            id: messageId,
             sessionId: this.sessionId,
             role: "assistant",
             content: streamText || (shouldSurfaceCancelled ? CANCELLED_NO_OUTPUT_MESSAGE : ""),
@@ -1406,6 +1414,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
             contextUsedTokens: resultContextUsedTokens,
             contextWindowTokens: resultContextWindowTokens,
           };
+          persistedMessageId = assistantMsg.id;
           void this.enqueuePersist(assistantMsg);
         }
 
@@ -1414,6 +1423,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           this.emit("message", {
             type: "cancelled",
             sessionId: this.sessionId,
+            // A message is persisted whenever shouldSurfaceCancelled is true, but
+            // keep messageId optional in the contract and only attach it when one
+            // was actually saved.
+            ...(persistedMessageId ? { messageId: persistedMessageId } : {}),
             errorDetail: cancellationErrorDetail,
             userInitiated: capturedStopReason === "user",
             durationMs: effectiveDurationMs,
@@ -1428,6 +1441,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           this.emit("message", {
             type: "done",
             sessionId: this.sessionId,
+            // Required by the contract. When the turn produced output this is the
+            // persisted message id; for a genuinely empty turn no message is saved
+            // and this id matches nothing in history (a harmless no-op for dedup).
+            messageId: persistedMessageId ?? messageId,
             durationMs: effectiveDurationMs,
             inputTokens: resultInputTokens,
             outputTokens: resultOutputTokens,

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -1382,10 +1382,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
         // The terminal event carries the id of the assistant message persisted
         // for this turn so clients can append it optimistically and dedup the
-        // next REST history fetch by id. Generate the id once here and reuse it
-        // for both the persisted ChatMessage and the done/cancelled event — do
-        // not invent a second id.
-        const messageId = nanoid(12);
+        // next REST history fetch by id. Its presence is the single signal that
+        // the turn had displayable content — for a genuinely empty turn no
+        // message is saved and the event omits messageId. Generate the id once
+        // here and reuse it for the persisted ChatMessage; never synthesize one
+        // just for the event.
         let persistedMessageId: string | undefined;
 
         if (
@@ -1396,7 +1397,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           shouldSurfaceCancelled
         ) {
           const assistantMsg: ChatMessage = {
-            id: messageId,
+            id: nanoid(12),
             sessionId: this.sessionId,
             role: "assistant",
             content: streamText || (shouldSurfaceCancelled ? CANCELLED_NO_OUTPUT_MESSAGE : ""),
@@ -1441,10 +1442,11 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           this.emit("message", {
             type: "done",
             sessionId: this.sessionId,
-            // Required by the contract. When the turn produced output this is the
-            // persisted message id; for a genuinely empty turn no message is saved
-            // and this id matches nothing in history (a harmless no-op for dedup).
-            messageId: persistedMessageId ?? messageId,
+            // Attach the persisted message id only when a message was saved; for a
+            // genuinely empty turn omit it. Its presence is the single signal that
+            // the turn had displayable content (clients gate the optimistic append
+            // on it).
+            ...(persistedMessageId ? { messageId: persistedMessageId } : {}),
             durationMs: effectiveDurationMs,
             inputTokens: resultInputTokens,
             outputTokens: resultOutputTokens,

--- a/backend/src/agents/session-utils.test.ts
+++ b/backend/src/agents/session-utils.test.ts
@@ -11,7 +11,14 @@ const CASES: Array<{ name: string; input: string; lines: number; bytes: number }
   { name: "empty string", input: "", lines: 0, bytes: 0 },
   { name: "single line, no newline", input: "hello", lines: 1, bytes: 5 },
   { name: "multi-line", input: "a\nb\nc", lines: 3, bytes: 5 },
-  { name: "trailing newline", input: "a\n", lines: 2, bytes: 2 },
+  // A single trailing newline must NOT inflate the count (command/Grep output
+  // almost always ends in one). "a\n" is one line, not two.
+  { name: "trailing newline ignored", input: "a\n", lines: 1, bytes: 2 },
+  { name: "single char", input: "a", lines: 1, bytes: 1 },
+  { name: "two lines, no trailing newline", input: "a\nb", lines: 2, bytes: 3 },
+  { name: "two lines, trailing newline", input: "a\nb\n", lines: 2, bytes: 4 },
+  { name: "lone newline", input: "\n", lines: 0, bytes: 1 },
+  { name: "trailing blank line preserved", input: "a\n\n", lines: 2, bytes: 3 },
   // "héllo" + emoji: 2-byte é + 4-byte 🚀 → byte length exceeds char length.
   { name: "multibyte", input: "héllo 🚀", lines: 1, bytes: 11 },
 ];

--- a/backend/src/agents/session-utils.test.ts
+++ b/backend/src/agents/session-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
-import { computeTruncatedField, OUTPUT_PREVIEW_BYTES } from "./session-utils.js";
+import { computeTruncatedField, OUTPUT_PREVIEW_BYTES, truncateMessageForHistory } from "./session-utils.js";
+import type { ChatMessage } from "../types.js";
 
 // The line-count / byte-length formulas live in @hive/shared so the backend
 // (computeTruncatedField) and the frontend (computeOutputScalars) cannot drift.
@@ -45,5 +46,48 @@ describe("shared output scalar primitives", () => {
     expect(field.truncated).toBe(false);
     expect(field.preview).toBe(small);
     expect(field.byteLength).toBeLessThanOrEqual(OUTPUT_PREVIEW_BYTES);
+  });
+
+  it("normalizes legacy non-string persisted outputs before computing scalars", () => {
+    const message = {
+      id: "m1",
+      sessionId: "sess-1",
+      role: "assistant",
+      content: "",
+      timestamp: "2026-02-20T00:00:00.000Z",
+      toolCalls: [
+        {
+          id: "tool-1",
+          name: "MCP",
+          input: "{}",
+          output: [
+            { type: "text", text: "first" },
+            { type: "text", text: "second" },
+          ],
+        },
+      ],
+      agentActivities: [
+        {
+          id: "cmd-1",
+          kind: "command_execution",
+          output: { ok: true },
+        },
+      ],
+    } as unknown as ChatMessage;
+
+    const truncated = truncateMessageForHistory(message);
+
+    expect(truncated.toolCalls?.[0]).toMatchObject({
+      output: "first\n\nsecond",
+      outputPreview: "first\n\nsecond",
+      outputLineCount: 3,
+      outputTruncated: false,
+    });
+    expect(truncated.agentActivities?.[0]).toMatchObject({
+      output: "{\"ok\":true}",
+      outputPreview: "{\"ok\":true}",
+      outputLineCount: 1,
+      outputTruncated: false,
+    });
   });
 });

--- a/backend/src/agents/session-utils.test.ts
+++ b/backend/src/agents/session-utils.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
+import { computeTruncatedField, OUTPUT_PREVIEW_BYTES } from "./session-utils.js";
+
+// The line-count / byte-length formulas live in @hive/shared so the backend
+// (computeTruncatedField) and the frontend (computeOutputScalars) cannot drift.
+// These cases pin the shared primitives and confirm the backend reads them.
+
+/** Representative inputs shared with the frontend parity test and the iOS copy. */
+const CASES: Array<{ name: string; input: string; lines: number; bytes: number }> = [
+  { name: "empty string", input: "", lines: 0, bytes: 0 },
+  { name: "single line, no newline", input: "hello", lines: 1, bytes: 5 },
+  { name: "multi-line", input: "a\nb\nc", lines: 3, bytes: 5 },
+  { name: "trailing newline", input: "a\n", lines: 2, bytes: 2 },
+  // "héllo" + emoji: 2-byte é + 4-byte 🚀 → byte length exceeds char length.
+  { name: "multibyte", input: "héllo 🚀", lines: 1, bytes: 11 },
+];
+
+describe("shared output scalar primitives", () => {
+  for (const { name, input, lines, bytes } of CASES) {
+    it(`computes line count and byte length for ${name}`, () => {
+      expect(outputLineCount(input)).toBe(lines);
+      expect(outputByteLength(input)).toBe(bytes);
+    });
+  }
+
+  it("computeTruncatedField derives its scalars from the shared primitives", () => {
+    for (const { input } of CASES) {
+      const field = computeTruncatedField(input);
+      expect(field.lineCount).toBe(outputLineCount(input));
+      expect(field.byteLength).toBe(outputByteLength(input));
+    }
+  });
+
+  it("keeps the full body when under the preview cap", () => {
+    const small = "a\nb";
+    const field = computeTruncatedField(small);
+    expect(field.truncated).toBe(false);
+    expect(field.preview).toBe(small);
+    expect(field.byteLength).toBeLessThanOrEqual(OUTPUT_PREVIEW_BYTES);
+  });
+});

--- a/backend/src/agents/session-utils.ts
+++ b/backend/src/agents/session-utils.ts
@@ -1,5 +1,6 @@
 import type { ChatMessage, ToolCall } from "../types.js";
 import type { AgentActivity } from "@hive/shared/agent-activity";
+import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
 
 /** Parse a `messages.jsonl` blob into ChatMessages, skipping malformed lines. */
 export function parseJsonlMessages(raw: string): ChatMessage[] {
@@ -64,8 +65,8 @@ function sliceUtf8(text: string, maxBytes: number): string {
  * byte length); the preview is the first {@link OUTPUT_PREVIEW_BYTES} bytes.
  */
 export function computeTruncatedField(full: string): TruncatedField {
-  const byteLength = Buffer.byteLength(full, "utf-8");
-  const lineCount = full.length === 0 ? 0 : full.split("\n").length;
+  const byteLength = outputByteLength(full);
+  const lineCount = outputLineCount(full);
   const truncated = byteLength > OUTPUT_PREVIEW_BYTES;
   return {
     preview: truncated ? sliceUtf8(full, OUTPUT_PREVIEW_BYTES) : full,

--- a/backend/src/agents/session-utils.ts
+++ b/backend/src/agents/session-utils.ts
@@ -123,6 +123,9 @@ function truncateActivity(activity: AgentActivity): AgentActivity {
  * when over the cap. Returns a copy; the input (and disk) are never mutated.
  */
 export function truncateMessageForHistory(message: ChatMessage): ChatMessage {
+  // Known limitation (see README "REST history payload weight"): only
+  // ToolCall.output and command_execution.output are truncated; ToolCall.input
+  // and file_change diffs pass through and can still be heavy.
   const next: ChatMessage = { ...message };
   if (message.toolCalls) next.toolCalls = message.toolCalls.map(truncateToolCall);
   if (message.agentActivities) {

--- a/backend/src/agents/session-utils.ts
+++ b/backend/src/agents/session-utils.ts
@@ -1,4 +1,5 @@
-import type { ChatMessage } from "../types.js";
+import type { ChatMessage, ToolCall } from "../types.js";
+import type { AgentActivity } from "@hive/shared/agent-activity";
 
 /** Parse a `messages.jsonl` blob into ChatMessages, skipping malformed lines. */
 export function parseJsonlMessages(raw: string): ChatMessage[] {
@@ -21,4 +22,156 @@ export function sortByUpdatedAtDesc<T extends { updatedAt: string }>(items: T[])
     const bTime = new Date(b.updatedAt).getTime() || 0;
     return bTime - aTime;
   });
+}
+
+// ── History truncation (read-only) ──────────────────────────────────
+//
+// REST history is the single source of truth for finalized turns, where the
+// cumulative payload weight lives (large file contents, command output, diffs).
+// On read, each heavy string is replaced by a small preview plus cheap exact
+// scalars and the full body is omitted; clients fetch the full body on expand.
+//
+// This transforms COPIES of the persisted objects only — disk stays the
+// untouched source of truth (no persisted-format change, no migration). Live
+// streaming is unaffected; only finalized history read from disk is truncated.
+
+/** Preview cap for truncated outputs, in bytes. */
+export const OUTPUT_PREVIEW_BYTES = 2048;
+
+/** Scalars + preview computed for a heavy string field. */
+export interface TruncatedField {
+  preview: string;
+  lineCount: number;
+  byteLength: number;
+  truncated: boolean;
+}
+
+/**
+ * Slice a UTF-8 string to at most `maxBytes`, never splitting a multibyte char.
+ * Walks back from the byte cap off any continuation bytes (`0b10xxxxxx`).
+ */
+function sliceUtf8(text: string, maxBytes: number): string {
+  const buf = Buffer.from(text, "utf-8");
+  if (buf.length <= maxBytes) return text;
+  let end = maxBytes;
+  while (end > 0 && (buf[end] & 0b1100_0000) === 0b1000_0000) end -= 1;
+  return buf.toString("utf-8", 0, end);
+}
+
+/**
+ * Compute the preview + exact scalars for a heavy string. Scalars are always
+ * derived from the FULL text (line count = newlines + 1, byte length = UTF-8
+ * byte length); the preview is the first {@link OUTPUT_PREVIEW_BYTES} bytes.
+ */
+export function computeTruncatedField(full: string): TruncatedField {
+  const byteLength = Buffer.byteLength(full, "utf-8");
+  const lineCount = full.length === 0 ? 0 : full.split("\n").length;
+  const truncated = byteLength > OUTPUT_PREVIEW_BYTES;
+  return {
+    preview: truncated ? sliceUtf8(full, OUTPUT_PREVIEW_BYTES) : full,
+    lineCount,
+    byteLength,
+    truncated,
+  };
+}
+
+/**
+ * Apply truncation to a single tool call's `output`, returning a copy. When the
+ * output exceeds the cap the full body is omitted; otherwise it is kept intact.
+ * The scalars/preview are always set so clients have one rendering path and
+ * never parse the body.
+ */
+function truncateToolCall(tool: ToolCall): ToolCall {
+  if (tool.output === undefined) return tool;
+  const field = computeTruncatedField(tool.output);
+  const next: ToolCall = {
+    ...tool,
+    outputPreview: field.preview,
+    outputLineCount: field.lineCount,
+    outputByteLength: field.byteLength,
+    outputTruncated: field.truncated,
+  };
+  if (field.truncated) delete next.output;
+  return next;
+}
+
+/**
+ * Apply truncation to an activity's heavy string field, returning a copy. Only
+ * `command_execution.output` carries a dominant heavy field (truncated to the
+ * `output*` preview + scalars, mirroring the {@link ToolCall} sub-shape). All
+ * other variants — including `file_change`, whose diffs are bounded by edit
+ * size — pass through unchanged.
+ */
+function truncateActivity(activity: AgentActivity): AgentActivity {
+  if (activity.kind !== "command_execution") return activity;
+  if (activity.output === undefined) return activity;
+  const field = computeTruncatedField(activity.output);
+  const next = {
+    ...activity,
+    outputPreview: field.preview,
+    outputLineCount: field.lineCount,
+    outputByteLength: field.byteLength,
+    outputTruncated: field.truncated,
+  };
+  if (field.truncated) delete next.output;
+  return next;
+}
+
+/**
+ * Transform a persisted message into its REST-history form: every heavy tool /
+ * activity output is truncated to preview + scalars and the full body omitted
+ * when over the cap. Returns a copy; the input (and disk) are never mutated.
+ */
+export function truncateMessageForHistory(message: ChatMessage): ChatMessage {
+  const next: ChatMessage = { ...message };
+  if (message.toolCalls) next.toolCalls = message.toolCalls.map(truncateToolCall);
+  if (message.agentActivities) {
+    next.agentActivities = message.agentActivities.map(truncateActivity);
+  }
+  return next;
+}
+
+/**
+ * Find the full, untruncated output for a truncated heavy field by id, scanning
+ * a session's full (disk-read) messages. Each id maps 1:1 to a single body:
+ *   - a {@link ToolCall} with `id === id` (its `output`)
+ *   - a `command_execution` activity with `id === id` (its `output`)
+ * Returns `undefined` when no heavy body is found for that id.
+ */
+export function findFullOutputById(messages: ChatMessage[], id: string): string | undefined {
+  for (const message of messages) {
+    for (const tool of message.toolCalls ?? []) {
+      if (tool.id === id && tool.output !== undefined) return tool.output;
+    }
+    for (const activity of message.agentActivities ?? []) {
+      if (activity.id !== id) continue;
+      if (activity.kind === "command_execution" && activity.output !== undefined) {
+        return activity.output;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Slice the last `limit` messages, or the `limit` immediately before the
+ * message whose id === `before` (exclusive). Returns the window plus `hasMore`,
+ * which is true when older messages exist before `window[0]`.
+ *
+ * If `before` is given but its id is not found, the window is empty and
+ * `hasMore` is false — an unknown cursor cannot point anywhere in history.
+ */
+export function selectMessageWindow(
+  messages: ChatMessage[],
+  limit: number,
+  before?: string,
+): { messages: ChatMessage[]; hasMore: boolean } {
+  let end = messages.length;
+  if (before !== undefined) {
+    const idx = messages.findIndex((m) => m.id === before);
+    if (idx === -1) return { messages: [], hasMore: false };
+    end = idx;
+  }
+  const start = Math.max(0, end - limit);
+  return { messages: messages.slice(start, end), hasMore: start > 0 };
 }

--- a/backend/src/agents/session-utils.ts
+++ b/backend/src/agents/session-utils.ts
@@ -60,9 +60,10 @@ function sliceUtf8(text: string, maxBytes: number): string {
 }
 
 /**
- * Compute the preview + exact scalars for a heavy string. Scalars are always
- * derived from the FULL text (line count = newlines + 1, byte length = UTF-8
- * byte length); the preview is the first {@link OUTPUT_PREVIEW_BYTES} bytes.
+ * Compute the preview + scalars for a heavy string. Scalars are always derived
+ * from the FULL text: line count ignores one trailing newline, byte length is
+ * UTF-8 byte length, and the preview is the first {@link OUTPUT_PREVIEW_BYTES}
+ * bytes.
  */
 export function computeTruncatedField(full: string): TruncatedField {
   const byteLength = outputByteLength(full);

--- a/backend/src/agents/session-utils.ts
+++ b/backend/src/agents/session-utils.ts
@@ -1,6 +1,6 @@
 import type { ChatMessage, ToolCall } from "../types.js";
 import type { AgentActivity } from "@hive/shared/agent-activity";
-import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
+import { normalizeToolOutput, outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
 
 /** Parse a `messages.jsonl` blob into ChatMessages, skipping malformed lines. */
 export function parseJsonlMessages(raw: string): ChatMessage[] {
@@ -85,9 +85,11 @@ export function computeTruncatedField(full: string): TruncatedField {
  */
 function truncateToolCall(tool: ToolCall): ToolCall {
   if (tool.output === undefined) return tool;
-  const field = computeTruncatedField(tool.output);
+  const output = normalizeToolOutput(tool.output);
+  const field = computeTruncatedField(output);
   const next: ToolCall = {
     ...tool,
+    output,
     outputPreview: field.preview,
     outputLineCount: field.lineCount,
     outputByteLength: field.byteLength,
@@ -107,9 +109,11 @@ function truncateToolCall(tool: ToolCall): ToolCall {
 function truncateActivity(activity: AgentActivity): AgentActivity {
   if (activity.kind !== "command_execution") return activity;
   if (activity.output === undefined) return activity;
-  const field = computeTruncatedField(activity.output);
-  const next = {
+  const output = normalizeToolOutput(activity.output);
+  const field = computeTruncatedField(output);
+  const next: Extract<AgentActivity, { kind: "command_execution" }> = {
     ...activity,
+    output,
     outputPreview: field.preview,
     outputLineCount: field.lineCount,
     outputByteLength: field.byteLength,
@@ -146,12 +150,12 @@ export function truncateMessageForHistory(message: ChatMessage): ChatMessage {
 export function findFullOutputById(messages: ChatMessage[], id: string): string | undefined {
   for (const message of messages) {
     for (const tool of message.toolCalls ?? []) {
-      if (tool.id === id && tool.output !== undefined) return tool.output;
+      if (tool.id === id && tool.output !== undefined) return normalizeToolOutput(tool.output);
     }
     for (const activity of message.agentActivities ?? []) {
       if (activity.id !== id) continue;
       if (activity.kind === "command_execution" && activity.output !== undefined) {
-        return activity.output;
+        return normalizeToolOutput(activity.output);
       }
     }
   }

--- a/backend/src/api/agents.test.ts
+++ b/backend/src/api/agents.test.ts
@@ -435,13 +435,14 @@ describe("GET /api/workspaces/:wsId/sessions/:sessionId/messages", () => {
     });
   });
 
-  it("returns empty history when specific session file is missing", async () => {
+  it("404s when the specific session does not exist (no existence leak)", async () => {
+    // A missing session and a session owned by another workspace are
+    // indistinguishable: both 404 so a sibling workspace can't be probed.
     const res = await app.inject({
       method: "GET",
       url: `/api/workspaces/${wsId}/sessions/missing/messages`,
     });
-    expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual({ messages: [], hasMore: false });
+    expect(res.statusCode).toBe(404);
   });
 });
 
@@ -800,5 +801,101 @@ describe("PRD #254 expand endpoint (full output on demand)", () => {
       url: `/api/workspaces/${wsId}/sessions/..%2f..%2fsecret/tools/t/output`,
     });
     expect(res.statusCode).toBe(400);
+  });
+});
+
+// ── Cross-workspace ownership guard (audit P1, IDOR) ─────────────────
+// Sessions of every workspace in a project share one `<projectId>/sessions/`
+// directory. A request that pairs workspace A with a sessionId owned by
+// workspace B (same project) must NOT read B's messages, tool output, or
+// attachments — it must 404 indistinguishably from a missing session.
+describe("explicit-session reads are scoped to the owning workspace", () => {
+  /** Second workspace in the SAME project, owning a session with all read targets. */
+  async function setupSibling(): Promise<{ wsB: string; sessionId: string; filename: string }> {
+    const wsBRes = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    const wsB = wsBRes.json().id as string;
+
+    const sessionId = "sess-wsB";
+    const filename = "secret.png";
+    await writeSessionFixture(sessionId, wsB, {
+      messages: [
+        {
+          id: "m-secret",
+          sessionId,
+          role: "user",
+          content: "wsB private content",
+          timestamp: "2026-02-11T00:00:00.000Z",
+        },
+        {
+          id: "a-secret",
+          sessionId,
+          role: "assistant",
+          content: "ok",
+          timestamp: "2026-02-11T00:00:01.000Z",
+          toolCalls: [{ id: "tool-secret", name: "Bash", input: "{}", output: BIG_OUTPUT }],
+        },
+      ],
+    });
+
+    const attachmentsDir = join(dataDir, projectId, "sessions", sessionId, "attachments");
+    await mkdir(attachmentsDir, { recursive: true });
+    await writeFile(join(attachmentsDir, filename), Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+    return { wsB, sessionId, filename };
+  }
+
+  it("returns 404 for messages, tool output, and attachments when read via a foreign workspace", async () => {
+    const { sessionId, filename } = await setupSibling();
+
+    const messagesRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/${sessionId}/messages`,
+    });
+    expect(messagesRes.statusCode).toBe(404);
+    expect(JSON.stringify(messagesRes.json())).not.toContain("wsB private content");
+
+    const toolRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/${sessionId}/tools/tool-secret/output`,
+    });
+    expect(toolRes.statusCode).toBe(404);
+    expect(JSON.stringify(toolRes.json())).not.toContain(BIG_OUTPUT);
+
+    const attachmentRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/${sessionId}/attachments/${filename}`,
+    });
+    expect(attachmentRes.statusCode).toBe(404);
+  });
+
+  it("still serves messages, tool output, and attachments to the owning workspace", async () => {
+    const { wsB, sessionId, filename } = await setupSibling();
+
+    const messagesRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsB}/sessions/${sessionId}/messages`,
+    });
+    expect(messagesRes.statusCode).toBe(200);
+    expect((messagesRes.json() as HistoryResponse).messages.map((m) => m.id)).toEqual([
+      "m-secret",
+      "a-secret",
+    ]);
+
+    const toolRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsB}/sessions/${sessionId}/tools/tool-secret/output`,
+    });
+    expect(toolRes.statusCode).toBe(200);
+    expect(toolRes.json()).toEqual({ output: BIG_OUTPUT });
+
+    const attachmentRes = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsB}/sessions/${sessionId}/attachments/${filename}`,
+    });
+    expect(attachmentRes.statusCode).toBe(200);
+    expect(attachmentRes.headers["content-type"]).toBe("image/png");
   });
 });

--- a/backend/src/api/agents.test.ts
+++ b/backend/src/api/agents.test.ts
@@ -168,7 +168,7 @@ describe("GET /api/workspaces/:wsId/session", () => {
 });
 
 describe("GET /api/workspaces/:wsId/session/messages", () => {
-  it("returns empty array for fresh session", async () => {
+  it("returns empty history for fresh session", async () => {
     await app.inject({ method: "POST", url: `/api/workspaces/${wsId}/session` });
 
     const res = await app.inject({
@@ -176,16 +176,16 @@ describe("GET /api/workspaces/:wsId/session/messages", () => {
       url: `/api/workspaces/${wsId}/session/messages`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual([]);
+    expect(res.json()).toEqual({ messages: [], hasMore: false });
   });
 
-  it("returns empty array when no session exists", async () => {
+  it("returns empty history when no session exists", async () => {
     const res = await app.inject({
       method: "GET",
       url: `/api/workspaces/${wsId}/session/messages`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual([]);
+    expect(res.json()).toEqual({ messages: [], hasMore: false });
   });
 
   it("returns persisted messages after ending a session", async () => {
@@ -227,12 +227,15 @@ describe("GET /api/workspaces/:wsId/session/messages", () => {
       url: `/api/workspaces/${wsId}/session/messages`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual([
-      expect.objectContaining({
-        content: "hello from disk",
-        role: "user",
-      }),
-    ]);
+    expect(res.json()).toEqual({
+      messages: [
+        expect.objectContaining({
+          content: "hello from disk",
+          role: "user",
+        }),
+      ],
+      hasMore: false,
+    });
   });
 
   it("returns 404 for non-existent workspace", async () => {
@@ -423,18 +426,379 @@ describe("GET /api/workspaces/:wsId/sessions/:sessionId/messages", () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual([
-      expect.objectContaining({ id: "m-1", content: "hello specific", role: "user" }),
-      expect.objectContaining({ id: "m-2", content: "response specific", role: "assistant" }),
-    ]);
+    expect(res.json()).toEqual({
+      messages: [
+        expect.objectContaining({ id: "m-1", content: "hello specific", role: "user" }),
+        expect.objectContaining({ id: "m-2", content: "response specific", role: "assistant" }),
+      ],
+      hasMore: false,
+    });
   });
 
-  it("returns empty array when specific session file is missing", async () => {
+  it("returns empty history when specific session file is missing", async () => {
     const res = await app.inject({
       method: "GET",
       url: `/api/workspaces/${wsId}/sessions/missing/messages`,
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json()).toEqual([]);
+    expect(res.json()).toEqual({ messages: [], hasMore: false });
+  });
+});
+
+// ── PRD #254: lazy-output truncation, pagination, and expand ─────────
+
+type HistoryResponse = {
+  messages: Array<Record<string, unknown> & {
+    id: string;
+    toolCalls?: Array<Record<string, unknown>>;
+    agentActivities?: Array<Record<string, unknown>>;
+  }>;
+  hasMore: boolean;
+};
+
+const BIG_OUTPUT = "x".repeat(5000); // > 2 KB cap
+const SMALL_OUTPUT = "small output\nsecond line"; // < 2 KB cap
+
+/** Build a session whose single assistant message carries heavy outputs. */
+async function writeHeavySession(sessionId: string) {
+  await writeSessionFixture(sessionId, wsId, {
+    messages: [
+      {
+        id: "u-1",
+        sessionId,
+        role: "user",
+        content: "run it",
+        timestamp: "2026-02-11T00:00:00.000Z",
+      },
+      {
+        id: "a-1",
+        sessionId,
+        role: "assistant",
+        content: "done",
+        timestamp: "2026-02-11T00:00:01.000Z",
+        toolCalls: [
+          { id: "tool-big", name: "Bash", input: "{}", output: BIG_OUTPUT },
+          { id: "tool-small", name: "Read", input: "{}", output: SMALL_OUTPUT },
+        ],
+        agentActivities: [
+          { id: "act-cmd-big", kind: "command_execution", command: "echo", output: BIG_OUTPUT },
+        ],
+      },
+    ],
+  });
+}
+
+describe("PRD #254 lazy tool/activity outputs (REST history)", () => {
+  it("truncates a ToolCall output over 2 KB with preview + scalars and omits the body", async () => {
+    await writeHeavySession("heavy-1");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-1/messages`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as HistoryResponse;
+    const assistant = body.messages.find((m) => m.id === "a-1");
+    const big = assistant?.toolCalls?.find((t) => t.id === "tool-big") as Record<string, unknown>;
+
+    expect(big.output).toBeUndefined();
+    expect(big.outputTruncated).toBe(true);
+    expect((big.outputPreview as string).length).toBeLessThanOrEqual(2048);
+    expect((big.outputPreview as string).length).toBeGreaterThan(0);
+    expect(big.outputByteLength).toBe(5000);
+    expect(big.outputLineCount).toBe(1); // single line, no newlines
+  });
+
+  it("keeps a ToolCall output under 2 KB intact, untruncated, with scalars present", async () => {
+    await writeHeavySession("heavy-2");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-2/messages`,
+    });
+    const body = res.json() as HistoryResponse;
+    const assistant = body.messages.find((m) => m.id === "a-1");
+    const small = assistant?.toolCalls?.find((t) => t.id === "tool-small") as Record<string, unknown>;
+
+    expect(small.output).toBe(SMALL_OUTPUT);
+    expect(small.outputTruncated).toBe(false);
+    expect(small.outputPreview).toBe(SMALL_OUTPUT);
+    expect(small.outputByteLength).toBe(Buffer.byteLength(SMALL_OUTPUT, "utf-8"));
+    expect(small.outputLineCount).toBe(2);
+  });
+
+  it("truncates a command_execution activity output mirroring the ToolCall sub-shape", async () => {
+    await writeHeavySession("heavy-3");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-3/messages`,
+    });
+    const body = res.json() as HistoryResponse;
+    const assistant = body.messages.find((m) => m.id === "a-1");
+    const cmd = assistant?.agentActivities?.find(
+      (a) => a.id === "act-cmd-big",
+    ) as Record<string, unknown>;
+
+    expect(cmd.output).toBeUndefined();
+    expect(cmd.outputTruncated).toBe(true);
+    expect((cmd.outputPreview as string).length).toBeLessThanOrEqual(2048);
+    expect(cmd.outputByteLength).toBe(5000);
+    expect(cmd.outputLineCount).toBe(1);
+  });
+
+  it("passes a file_change activity through unchanged (diffs are not truncated)", async () => {
+    await writeSessionFixture("heavy-4", wsId, {
+      messages: [
+        {
+          id: "a-1",
+          sessionId: "heavy-4",
+          role: "assistant",
+          content: "done",
+          timestamp: "2026-02-11T00:00:01.000Z",
+          agentActivities: [
+            {
+              id: "act-file-big",
+              kind: "file_change",
+              files: [{ path: "src/a.ts", diff: BIG_OUTPUT }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-4/messages`,
+    });
+    const body = res.json() as HistoryResponse;
+    const assistant = body.messages.find((m) => m.id === "a-1");
+    const fileChange = assistant?.agentActivities?.find(
+      (a) => a.id === "act-file-big",
+    ) as Record<string, unknown>;
+    const file = (fileChange.files as Array<Record<string, unknown>>)[0];
+
+    // The full diff is kept intact; no diff* truncation fields are emitted.
+    expect(file.diff).toBe(BIG_OUTPUT);
+    expect(file.diffPreview).toBeUndefined();
+    expect(file.diffTruncated).toBeUndefined();
+    expect(file.diffByteLength).toBeUndefined();
+    expect(file.diffLineCount).toBeUndefined();
+  });
+
+  it("truncates a multibyte output on a UTF-8 char boundary (no split chars)", async () => {
+    // 1000 × "é" (2 bytes each) = 2000 bytes < cap; pad past 2 KB with more é.
+    const multibyte = "é".repeat(1200); // 2400 bytes > cap
+    await writeSessionFixture("heavy-mb", wsId, {
+      messages: [
+        {
+          id: "a-mb",
+          sessionId: "heavy-mb",
+          role: "assistant",
+          content: "",
+          timestamp: "2026-02-11T00:00:01.000Z",
+          toolCalls: [{ id: "t-mb", name: "Bash", input: "{}", output: multibyte }],
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-mb/messages`,
+    });
+    const body = res.json() as HistoryResponse;
+    const tool = body.messages[0].toolCalls?.[0] as Record<string, unknown>;
+    const preview = tool.outputPreview as string;
+
+    // Preview must be valid UTF-8 with no replacement char, and ≤ cap bytes.
+    expect(Buffer.byteLength(preview, "utf-8")).toBeLessThanOrEqual(2048);
+    expect(preview).not.toContain("�");
+    expect(preview.split("").every((c) => c === "é")).toBe(true);
+    expect(tool.outputByteLength).toBe(2400);
+  });
+
+  it("does NOT alter the on-disk .jsonl (disk stays the source of truth)", async () => {
+    await writeHeavySession("heavy-disk");
+    const messagesPath = join(
+      dataDir, projectId, "sessions", "heavy-disk", "messages.jsonl",
+    );
+
+    await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/heavy-disk/messages`,
+    });
+
+    const { readFile } = await import("node:fs/promises");
+    const raw = await readFile(messagesPath, "utf-8");
+    // Full output for every heavy field is still on disk.
+    expect(raw).toContain(BIG_OUTPUT);
+    expect(raw).not.toContain("outputPreview");
+  });
+});
+
+describe("PRD #254 history pagination (?limit / ?before / hasMore)", () => {
+  /** Write a session with N user messages id=m-0..m-(N-1). */
+  async function writeManyMessages(sessionId: string, count: number) {
+    const messages = Array.from({ length: count }, (_, i) => ({
+      id: `m-${i}`,
+      sessionId,
+      role: "user",
+      content: `msg ${i}`,
+      timestamp: `2026-02-11T00:00:${String(i).padStart(2, "0")}.000Z`,
+    }));
+    await writeSessionFixture(sessionId, wsId, { messages });
+  }
+
+  it("returns the last `limit` messages and hasMore at the truncation boundary", async () => {
+    await writeManyMessages("page-1", 10);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/page-1/messages?limit=3`,
+    });
+    const body = res.json() as HistoryResponse;
+    expect(body.messages.map((m) => m.id)).toEqual(["m-7", "m-8", "m-9"]);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("hasMore is false when the window reaches the start of history", async () => {
+    await writeManyMessages("page-2", 3);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/page-2/messages?limit=10`,
+    });
+    const body = res.json() as HistoryResponse;
+    expect(body.messages.map((m) => m.id)).toEqual(["m-0", "m-1", "m-2"]);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("?before returns the window immediately before the cursor (exclusive)", async () => {
+    await writeManyMessages("page-3", 10);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/page-3/messages?limit=3&before=m-5`,
+    });
+    const body = res.json() as HistoryResponse;
+    expect(body.messages.map((m) => m.id)).toEqual(["m-2", "m-3", "m-4"]);
+    expect(body.hasMore).toBe(true);
+  });
+
+  it("?before at the start of history yields hasMore false", async () => {
+    await writeManyMessages("page-4", 10);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/page-4/messages?limit=3&before=m-2`,
+    });
+    const body = res.json() as HistoryResponse;
+    expect(body.messages.map((m) => m.id)).toEqual(["m-0", "m-1"]);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("unknown ?before id yields an empty window and hasMore false", async () => {
+    await writeManyMessages("page-5", 10);
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/page-5/messages?before=nope`,
+    });
+    const body = res.json() as HistoryResponse;
+    expect(body.messages).toEqual([]);
+    expect(body.hasMore).toBe(false);
+  });
+
+  it("active-session route returns the same { messages, hasMore } shape", async () => {
+    // Park an active session, then verify the active route serializes via the
+    // same handler. The newly-created session has no messages on disk yet.
+    await app.inject({ method: "POST", url: `/api/workspaces/${wsId}/session` });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/session/messages?limit=5`,
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body).toHaveProperty("messages");
+    expect(body).toHaveProperty("hasMore");
+    expect(Array.isArray(body.messages)).toBe(true);
+  });
+});
+
+describe("PRD #254 expand endpoint (full output on demand)", () => {
+  it("returns the full untruncated output for a tool id", async () => {
+    await writeHeavySession("exp-1");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/exp-1/tools/tool-big/output`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ output: BIG_OUTPUT });
+  });
+
+  it("resolves a command_execution activity id to its full output", async () => {
+    await writeHeavySession("exp-2");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/exp-2/tools/act-cmd-big/output`,
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ output: BIG_OUTPUT });
+  });
+
+  it("does NOT resolve a file_change activity id (diffs are not truncated, so not expandable)", async () => {
+    await writeSessionFixture("exp-3", wsId, {
+      messages: [
+        {
+          id: "a-1",
+          sessionId: "exp-3",
+          role: "assistant",
+          content: "done",
+          timestamp: "2026-02-11T00:00:01.000Z",
+          agentActivities: [
+            {
+              id: "act-file-big",
+              kind: "file_change",
+              files: [{ path: "src/a.ts", diff: BIG_OUTPUT }],
+            },
+          ],
+        },
+      ],
+    });
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/exp-3/tools/act-file-big/output`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s on an unknown tool id", async () => {
+    await writeHeavySession("exp-4");
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/exp-4/tools/does-not-exist/output`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("404s on an unknown session", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/no-such-session/tools/tool-big/output`,
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects a traversal attempt in the session id", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/sessions/..%2f..%2fsecret/tools/t/output`,
+    });
+    expect(res.statusCode).toBe(400);
   });
 });

--- a/backend/src/api/agents.ts
+++ b/backend/src/api/agents.ts
@@ -1,7 +1,7 @@
 import { basename } from "node:path";
 import { createReadStream, existsSync } from "node:fs";
 import { stat } from "node:fs/promises";
-import type { FastifyInstance } from "fastify";
+import type { FastifyInstance, FastifyReply } from "fastify";
 import {
   getOrCreateSession,
   getSessionMetadata,
@@ -14,8 +14,53 @@ import {
   getSpecificSessionMessages,
   resolveSessionAttachmentPath,
 } from "../agents/session-dispatch.js";
+import {
+  truncateMessageForHistory,
+  selectMessageWindow,
+  findFullOutputById,
+} from "../agents/session-utils.js";
+import type { ChatMessage } from "../types.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
+
+/** Default page size for the REST message history (PRD #254). */
+const DEFAULT_MESSAGE_LIMIT = 200;
+
+/** Upper bound on a single history page so a client can't request an unbounded page. */
+const MAX_MESSAGE_LIMIT = 1000;
+
+/** Parse the `limit`/`before` history query, clamping `limit` to a sane range. */
+function parseHistoryQuery(query: { limit?: string; before?: string }): {
+  limit: number;
+  before?: string;
+} {
+  const parsed = Number(query.limit);
+  const limit = Number.isFinite(parsed) && parsed > 0
+    ? Math.min(Math.floor(parsed), MAX_MESSAGE_LIMIT)
+    : DEFAULT_MESSAGE_LIMIT;
+  const before = query.before && query.before.length > 0 ? query.before : undefined;
+  return { limit, before };
+}
+
+/**
+ * Serialize a full (disk-read) message list as the REST history response:
+ * select the `limit`/`before` window, truncate every heavy tool/activity output
+ * to preview + scalars, and send `{ messages, hasMore }`. The single
+ * serialization boundary shared by the active- and explicit-session routes — it
+ * transforms copies only, never the persisted data.
+ */
+function sendMessageHistory(
+  reply: FastifyReply,
+  fullMessages: ChatMessage[],
+  query: { limit?: string; before?: string },
+) {
+  const { limit, before } = parseHistoryQuery(query);
+  const window = selectMessageWindow(fullMessages, limit, before);
+  return reply.send({
+    messages: window.messages.map(truncateMessageForHistory),
+    hasMore: window.hasMore,
+  });
+}
 
 export interface SessionRoutesOptions {
   dataDir?: string;
@@ -57,13 +102,15 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
     },
   );
 
-  // GET /api/workspaces/:wsId/session/messages — get persisted messages
-  app.get<{ Params: { wsId: string } }>(
+  // GET /api/workspaces/:wsId/session/messages — active-session history.
+  // Resolves the active sessionId internally, then delegates to the same
+  // window+truncate serialization as the explicit-session route.
+  app.get<{ Params: { wsId: string }; Querystring: { limit?: string; before?: string } }>(
     "/api/workspaces/:wsId/session/messages",
     async (req, reply) => {
       try {
         const messages = await getSessionMessages(req.params.wsId, dataDir);
-        return reply.send(messages);
+        return sendMessageHistory(reply, messages, req.query);
       } catch (err: unknown) {
         const msg = errorMessage(err, "Failed to load session messages");
         const code = errorStatus(err);
@@ -156,8 +203,13 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
     },
   );
 
-  // GET /api/workspaces/:wsId/sessions/:sessionId/messages — get messages for a specific session
-  app.get<{ Params: { wsId: string; sessionId: string } }>(
+  // GET /api/workspaces/:wsId/sessions/:sessionId/messages — explicit-session
+  // history with `?limit`/`?before`, returning `{ messages, hasMore }` with
+  // heavy tool/activity outputs truncated to preview + scalars.
+  app.get<{
+    Params: { wsId: string; sessionId: string };
+    Querystring: { limit?: string; before?: string };
+  }>(
     "/api/workspaces/:wsId/sessions/:sessionId/messages",
     async (req, reply) => {
       try {
@@ -166,9 +218,45 @@ export async function sessionRoutes(app: FastifyInstance, opts: SessionRoutesOpt
           req.params.sessionId,
           dataDir,
         );
-        return reply.send(messages);
+        return sendMessageHistory(reply, messages, req.query);
       } catch (err: unknown) {
         const msg = errorMessage(err, "Failed to load session messages");
+        const code = errorStatus(err);
+        return reply.status(code).send({ error: msg });
+      }
+    },
+  );
+
+  // GET /api/workspaces/:wsId/sessions/:sessionId/tools/:toolId/output —
+  // fetch the FULL, untruncated output for a tool call OR a heavy agent-activity
+  // field (command output / file diff) by id, read from disk on expand.
+  // Resolves both tool and activity ids through the one scan (no duplication).
+  app.get<{ Params: { wsId: string; sessionId: string; toolId: string } }>(
+    "/api/workspaces/:wsId/sessions/:sessionId/tools/:toolId/output",
+    async (req, reply) => {
+      try {
+        const { sessionId, toolId } = req.params;
+        // Guard the path segments against traversal before they reach the
+        // session-dir join (mirrors the attachment route's filename guard).
+        if (sessionId !== basename(sessionId) || sessionId.includes("..")) {
+          return reply.status(400).send({ error: "Invalid session id" });
+        }
+        if (toolId.includes("/") || toolId.includes("..")) {
+          return reply.status(400).send({ error: "Invalid tool id" });
+        }
+        const messages = await getSpecificSessionMessages(
+          req.params.wsId,
+          sessionId,
+          dataDir,
+        );
+        // No session on disk yields an empty list; treat a missing id alike.
+        const output = findFullOutputById(messages, req.params.toolId);
+        if (output === undefined) {
+          return reply.status(404).send({ error: "Tool output not found" });
+        }
+        return reply.send({ output });
+      } catch (err: unknown) {
+        const msg = errorMessage(err, "Failed to load tool output");
         const code = errorStatus(err);
         return reply.status(code).send({ error: msg });
       }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -407,7 +407,7 @@ export interface BrowserStatusPayload {
 
 /** Frontend -> Backend */
 export type WsIncoming =
-  | { type: "switch_session"; sessionId: string }
+  | { type: "switch_session"; sessionId?: string }
   | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -211,7 +211,20 @@ export interface ToolCall {
   id: string;
   name: string;
   input: string;
+  /**
+   * Full tool output. Present on live tools; OMITTED in REST history when the
+   * output exceeds the preview cap (fetch the full body via the tool-output
+   * endpoint). Read `outputPreview`/scalars for the collapsed view instead.
+   */
   output?: string;
+  /** First ~2 KB of the output (REST history; computed once for live tools). */
+  outputPreview?: string;
+  /** Exact line count of the FULL output (newlines + 1). */
+  outputLineCount?: number;
+  /** Exact UTF-8 byte length of the FULL output. */
+  outputByteLength?: number;
+  /** True when the full body was omitted because it exceeded the preview cap. */
+  outputTruncated?: boolean;
   parentToolUseId?: string;
 }
 
@@ -411,6 +424,7 @@ export type WsOutgoing =
   | {
       type: "done";
       sessionId: string;
+      messageId: string;
       durationMs?: number;
       inputTokens?: number;
       outputTokens?: number;
@@ -419,8 +433,18 @@ export type WsOutgoing =
       pendingToolName?: string;
     }
   | { type: "error"; message: string; sessionId?: string }
-  | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
+  | { type: "cancelled"; sessionId: string; messageId?: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: WorkspaceStatus; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
+  | {
+      type: "stream_snapshot";
+      sessionId: string;
+      text: string;
+      thinking: string;
+      toolCalls: ToolCall[];
+      agentActivities: AgentActivity[];
+      planMode: boolean;
+      streamingStartedAt: number;
+    }
   | { type: "user_message"; message: ChatMessage }
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -219,7 +219,7 @@ export interface ToolCall {
   output?: string;
   /** First ~2 KB of the output (REST history; computed once for live tools). */
   outputPreview?: string;
-  /** Exact line count of the FULL output (newlines + 1). */
+  /** Line count of the FULL output after ignoring a single trailing newline. */
   outputLineCount?: number;
   /** Exact UTF-8 byte length of the FULL output. */
   outputByteLength?: number;

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -277,7 +277,7 @@ export type ContentBlock =
 export interface ToolResultBlock {
   type: "tool_result";
   tool_use_id: string;
-  content: string;
+  content: unknown;
 }
 
 export type CliJsonLine =

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -424,7 +424,10 @@ export type WsOutgoing =
   | {
       type: "done";
       sessionId: string;
-      messageId: string;
+      /** Present only when this turn persisted a message; its presence is the
+       *  single signal that the turn had displayable content. Omitted for a
+       *  genuinely empty turn. */
+      messageId?: string;
       durationMs?: number;
       inputTokens?: number;
       outputTokens?: number;
@@ -446,7 +449,6 @@ export type WsOutgoing =
       streamingStartedAt: number;
     }
   | { type: "user_message"; message: ChatMessage }
-  | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
   | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -242,7 +242,10 @@ describe("WS /ws/hub", () => {
     ws.close();
   });
 
-  it("sends persisted history even when no active session exists", async () => {
+  // Option B (PRD #254): the WebSocket carries live state only; message history
+  // is owned by REST. Bootstrap must NOT emit a `history` event, even when a
+  // persisted session exists on disk with no active session in memory.
+  it("does not send history over the WS when persisted sessions exist but none is active", async () => {
     const sessionId = "sess-persisted";
     const sessionDir = join(dataDir, projectId, "sessions", sessionId);
     await mkdir(sessionDir, { recursive: true });
@@ -272,74 +275,25 @@ describe("WS /ws/hub", () => {
     const { wsReady, messages } = connectHub([wsId]);
     const ws = await wsReady;
 
-    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "history"));
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+    // Give any (incorrect) history emission a chance to arrive before asserting.
+    await new Promise((r) => setTimeout(r, 100));
 
-    const history = messages.find((m) => m.type === "history");
-    expect(history).toBeDefined();
-    if (history?.type === "history") {
-      expect(history.messages).toEqual([
-        expect.objectContaining({
-          content: "persisted response",
-          role: "assistant",
-        }),
-      ]);
-    }
+    expect(messages[0]).toEqual({ type: "status", status: "idle", streaming: false });
+    expect(messages.some((m) => m.type === "history")).toBe(false);
 
     ws.close();
   });
 
-  it("delivers persisted history when listener is attached after injectWS resolves", async () => {
-    const sessionId = "sess-persisted-late";
-    const sessionDir = join(dataDir, projectId, "sessions", sessionId);
-    await mkdir(sessionDir, { recursive: true });
-    await writeFile(
-      join(sessionDir, "metadata.json"),
-      JSON.stringify({
-        sessionId,
-        workspaceId: wsId,
-        createdAt: "2026-02-11T00:00:00.000Z",
-        updatedAt: "2026-02-11T00:00:01.000Z",
-        messageCount: 1,
-      }),
-      "utf-8",
-    );
-    await writeFile(
-      join(sessionDir, "messages.jsonl"),
-      JSON.stringify({
-        id: "m-1",
-        sessionId,
-        role: "assistant",
-        content: "persisted response late listener",
-        timestamp: "2026-02-11T00:00:00.000Z",
-      }) + "\n",
-      "utf-8",
-    );
-
-    const { ws, messages } = await connectHubLateListener([wsId]);
-
-    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "history"));
-
-    const history = messages.find((m) => m.type === "history");
-    expect(history).toBeDefined();
-    if (history?.type === "history") {
-      expect(history.messages).toEqual([
-        expect.objectContaining({
-          content: "persisted response late listener",
-          role: "assistant",
-        }),
-      ]);
-    }
-
-    ws.close();
-  });
-
-  it("sends idle status + history when session exists but is not streaming", async () => {
+  it("sends idle status (no history) when session exists but is not streaming", async () => {
     await getOrCreateSession(wsId, dataDir, CONV_CMD);
 
     const { wsReady, messages } = connectHub([wsId]);
     const ws = await wsReady;
 
     await waitForMessage(messages, (msgs) => msgs.length >= 1);
+    // Let any erroneous history event settle before the negative assertion.
+    await new Promise((r) => setTimeout(r, 100));
 
     expect(messages[0].type).toBe("status");
     if (messages[0].type === "status") {
@@ -347,6 +301,7 @@ describe("WS /ws/hub", () => {
       expect(messages[0].sessionId).toBeTruthy();
       expect(messages[0].streaming).toBe(false);
     }
+    expect(messages.some((m) => m.type === "history")).toBe(false);
 
     ws.close();
     await endSession(wsId, dataDir);
@@ -396,19 +351,29 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir).catch(() => {});
   });
 
-  it("replays streaming agent activities during bootstrap", async () => {
-    const fakeClaudePath = join(tempDir, "fake-claude-activity-bootstrap.sh");
+  // ── Regression anchor (PRD #254): in-flight catch-up via a single
+  // consolidated stream_snapshot, with NO history on the WS path. This is the
+  // permanent guard against the first-visit / reload-race "empty streaming
+  // bubble" bug. Prior art: the old "replays streaming agent activities during
+  // bootstrap" test that spied on getStreamingSnapshot.
+  it("delivers one consolidated stream_snapshot (and no history) on subscribe to a streaming session", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-snapshot-bootstrap.sh");
     await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
     await chmod(fakeClaudePath, 0o755);
     const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
     const local = await startWsApp(undefined, slowCmd);
 
     const { session } = await getOrCreateSession(wsId, dataDir, slowCmd);
-    session.sendMessage("bootstrap activity");
+    session.sendMessage("bootstrap snapshot");
     const snapshot = session.getStreamingSnapshot();
     if (!snapshot) throw new Error("Expected a streaming snapshot");
     vi.spyOn(session, "getStreamingSnapshot").mockReturnValue({
       ...snapshot,
+      text: "partial answer so far",
+      thinking: "considering options",
+      toolCalls: [
+        { id: "toolu-1", name: "Read", input: "{}", output: "file contents" },
+      ],
       agentActivities: [{
         id: "cmd-bootstrap",
         kind: "command_execution",
@@ -416,27 +381,121 @@ describe("WS /ws/hub", () => {
         status: "inProgress",
         output: "running\n",
       }],
+      agentPlanMode: true,
     });
 
     const { wsReady, messages } = connectHub([wsId], { app: local.app });
     const ws = await wsReady;
 
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "stream_snapshot"));
+    // Let any (incorrect) history or synthetic-delta events settle.
+    await new Promise((r) => setTimeout(r, 100));
+
+    const snapshotEvents = messages.filter((m) => m.type === "stream_snapshot");
+    expect(snapshotEvents).toHaveLength(1);
+    const snap = snapshotEvents[0];
+    if (snap.type !== "stream_snapshot") throw new Error("Expected a stream_snapshot");
+    expect(snap.sessionId).toBe(session.sessionId);
+    expect(snap.text).toBe("partial answer so far");
+    expect(snap.thinking).toBe("considering options");
+    expect(snap.toolCalls).toEqual([
+      { id: "toolu-1", name: "Read", input: "{}", output: "file contents" },
+    ]);
+    expect(snap.agentActivities).toEqual([{
+      id: "cmd-bootstrap",
+      kind: "command_execution",
+      command: "npm test",
+      status: "inProgress",
+      output: "running\n",
+    }]);
+    expect(snap.planMode).toBe(true);
+    expect(typeof snap.streamingStartedAt).toBe("number");
+
+    // Live/history split: no history event, and the snapshot is consolidated —
+    // not a sequence of synthetic text_delta / tool_use / agent_activity events.
+    expect(messages.some((m) => m.type === "history")).toBe(false);
+    expect(messages.some((m) => m.type === "text_delta")).toBe(false);
+    expect(messages.some((m) => m.type === "tool_use")).toBe(false);
+    expect(messages.some((m) => m.type === "tool_result")).toBe(false);
+    expect(messages.some((m) => m.type === "agent_activity")).toBe(false);
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  it("delivers the consolidated stream_snapshot (and no history) on switch_session into a streaming session", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-snapshot-switch.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    const { session } = await getOrCreateSession(wsId, dataDir, slowCmd);
+    session.sendMessage("switch snapshot");
+    const snapshot = session.getStreamingSnapshot();
+    if (!snapshot) throw new Error("Expected a streaming snapshot");
+    vi.spyOn(session, "getStreamingSnapshot").mockReturnValue({
+      ...snapshot,
+      text: "switched-in partial",
+      toolCalls: [
+        { id: "toolu-switch", name: "Bash", input: "{}", output: "ok" },
+      ],
+    });
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    const marker = messages.length;
+    ws.send(hubEvent(wsId, { type: "switch_session", sessionId: session.sessionId }));
+
     await waitForMessage(
       messages,
-      (msgs) => msgs.some((m) => m.type === "agent_activity" && m.activity.id === "cmd-bootstrap"),
+      (msgs) => msgs.slice(marker).some((m) => m.type === "stream_snapshot"),
     );
+    await new Promise((r) => setTimeout(r, 100));
 
-    expect(messages).toContainEqual({
-      type: "agent_activity",
-      sessionId: session.sessionId,
-      activity: {
-        id: "cmd-bootstrap",
-        kind: "command_execution",
-        command: "npm test",
-        status: "inProgress",
-        output: "running\n",
-      },
-    });
+    const afterSwitch = messages.slice(marker);
+    const snapshotEvents = afterSwitch.filter((m) => m.type === "stream_snapshot");
+    expect(snapshotEvents).toHaveLength(1);
+    const snap = snapshotEvents[0];
+    if (snap.type !== "stream_snapshot") throw new Error("Expected a stream_snapshot");
+    expect(snap.text).toBe("switched-in partial");
+    expect(snap.toolCalls).toEqual([
+      { id: "toolu-switch", name: "Bash", input: "{}", output: "ok" },
+    ]);
+    expect(afterSwitch.some((m) => m.type === "history")).toBe(false);
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  it("emits a done event carrying the persisted assistant message id", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-done-id.sh");
+    // Stream some text, then exit cleanly so finalizeTurn persists a message.
+    await writeFile(
+      fakeClaudePath,
+      "#!/bin/sh\nprintf 'hello from the agent\\n'\n",
+      "utf-8",
+    );
+    await chmod(fakeClaudePath, 0o755);
+    const cmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, cmd);
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    ws.send(hubEvent(wsId, { type: "user_message", content: "say hi" }));
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "done"));
+
+    const done = messages.find((m) => m.type === "done");
+    if (!done || done.type !== "done") throw new Error("Expected a done event");
+    expect(typeof done.messageId).toBe("string");
+    expect(done.messageId.length).toBeGreaterThan(0);
 
     ws.close();
     await local.app.close();

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -280,7 +280,7 @@ describe("WS /ws/hub", () => {
     await new Promise((r) => setTimeout(r, 100));
 
     expect(messages[0]).toEqual({ type: "status", status: "idle", streaming: false });
-    expect(messages.some((m) => m.type === "history")).toBe(false);
+    expect(messages.some((m) => (m.type as string) === "history")).toBe(false);
 
     ws.close();
   });
@@ -301,7 +301,7 @@ describe("WS /ws/hub", () => {
       expect(messages[0].sessionId).toBeTruthy();
       expect(messages[0].streaming).toBe(false);
     }
-    expect(messages.some((m) => m.type === "history")).toBe(false);
+    expect(messages.some((m) => (m.type as string) === "history")).toBe(false);
 
     ws.close();
     await endSession(wsId, dataDir);
@@ -413,7 +413,7 @@ describe("WS /ws/hub", () => {
 
     // Live/history split: no history event, and the snapshot is consolidated —
     // not a sequence of synthetic text_delta / tool_use / agent_activity events.
-    expect(messages.some((m) => m.type === "history")).toBe(false);
+    expect(messages.some((m) => (m.type as string) === "history")).toBe(false);
     expect(messages.some((m) => m.type === "text_delta")).toBe(false);
     expect(messages.some((m) => m.type === "tool_use")).toBe(false);
     expect(messages.some((m) => m.type === "tool_result")).toBe(false);
@@ -465,7 +465,7 @@ describe("WS /ws/hub", () => {
     expect(snap.toolCalls).toEqual([
       { id: "toolu-switch", name: "Bash", input: "{}", output: "ok" },
     ]);
-    expect(afterSwitch.some((m) => m.type === "history")).toBe(false);
+    expect(afterSwitch.some((m) => (m.type as string) === "history")).toBe(false);
 
     ws.close();
     await local.app.close();
@@ -527,7 +527,7 @@ describe("WS /ws/hub", () => {
     ]);
     // A status accompanies the snapshot; no history on the WS path.
     expect(afterPull.some((m) => m.type === "status")).toBe(true);
-    expect(afterPull.some((m) => m.type === "history")).toBe(false);
+    expect(afterPull.some((m) => (m.type as string) === "history")).toBe(false);
 
     ws.close();
     await local.app.close();
@@ -653,10 +653,15 @@ describe("WS /ws/hub", () => {
 
   it("emits a done event carrying the persisted assistant message id", async () => {
     const fakeClaudePath = join(tempDir, "fake-claude-done-id.sh");
-    // Stream some text, then exit cleanly so finalizeTurn persists a message.
+    // Emit a real stream-json assistant line so finalizeTurn persists a message
+    // (and the done event therefore carries its id).
+    const assistantLine = JSON.stringify({
+      type: "assistant",
+      message: { id: "m", role: "assistant", content: [{ type: "text", text: "hello from the agent" }] },
+    });
     await writeFile(
       fakeClaudePath,
-      "#!/bin/sh\nprintf 'hello from the agent\\n'\n",
+      `#!/bin/sh\ncat <<'EOF'\n${assistantLine}\nEOF\n`,
       "utf-8",
     );
     await chmod(fakeClaudePath, 0o755);
@@ -673,8 +678,36 @@ describe("WS /ws/hub", () => {
 
     const done = messages.find((m) => m.type === "done");
     if (!done || done.type !== "done") throw new Error("Expected a done event");
+    // This turn produced output, so a message was persisted and its id is
+    // attached. (An empty turn would omit messageId entirely.)
     expect(typeof done.messageId).toBe("string");
-    expect(done.messageId.length).toBeGreaterThan(0);
+    expect(done.messageId?.length ?? 0).toBeGreaterThan(0);
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  it("emits a done event WITHOUT messageId for a genuinely empty turn", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-empty-turn.sh");
+    // Produce no output and exit cleanly: finalizeTurn persists nothing, so the
+    // done event must omit messageId (its presence is the empty-turn signal).
+    await writeFile(fakeClaudePath, "#!/bin/sh\nexit 0\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const cmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, cmd);
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    ws.send(hubEvent(wsId, { type: "user_message", content: "say nothing" }));
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "done"));
+
+    const done = messages.find((m) => m.type === "done");
+    if (!done || done.type !== "done") throw new Error("Expected a done event");
+    expect(done.messageId).toBeUndefined();
 
     ws.close();
     await local.app.close();

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -472,6 +472,185 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir).catch(() => {});
   });
 
+  // ── Focus pull without a sessionId (PRD #254, FINDING #1) ───────────
+  // First navigation to an already-subscribed, currently-streaming workspace:
+  // the client has no session id yet, so it pulls the ACTIVE session by sending
+  // switch_session with NO sessionId. The backend must reply with the
+  // consolidated stream_snapshot for the active session (status + snapshot, no
+  // history). This is the permanent guard against the surviving "empty bubble"
+  // first-visit symptom.
+  it("delivers the consolidated stream_snapshot on switch_session with no sessionId (focus pull)", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-snapshot-focus.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    const { session } = await getOrCreateSession(wsId, dataDir, slowCmd);
+    session.sendMessage("focus pull snapshot");
+    const snapshot = session.getStreamingSnapshot();
+    if (!snapshot) throw new Error("Expected a streaming snapshot");
+    vi.spyOn(session, "getStreamingSnapshot").mockReturnValue({
+      ...snapshot,
+      text: "focus-pulled partial",
+      thinking: "mid thought",
+      toolCalls: [
+        { id: "toolu-focus", name: "Read", input: "{}", output: "focused contents" },
+      ],
+    });
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    const marker = messages.length;
+    // No sessionId: the client does not yet know the active session id.
+    ws.send(hubEvent(wsId, { type: "switch_session" }));
+
+    await waitForMessage(
+      messages,
+      (msgs) => msgs.slice(marker).some((m) => m.type === "stream_snapshot"),
+    );
+    await new Promise((r) => setTimeout(r, 100));
+
+    const afterPull = messages.slice(marker);
+    const snapshotEvents = afterPull.filter((m) => m.type === "stream_snapshot");
+    expect(snapshotEvents).toHaveLength(1);
+    const snap = snapshotEvents[0];
+    if (snap.type !== "stream_snapshot") throw new Error("Expected a stream_snapshot");
+    // Resolved against the workspace's active session.
+    expect(snap.sessionId).toBe(session.sessionId);
+    expect(snap.text).toBe("focus-pulled partial");
+    expect(snap.thinking).toBe("mid thought");
+    expect(snap.toolCalls).toEqual([
+      { id: "toolu-focus", name: "Read", input: "{}", output: "focused contents" },
+    ]);
+    // A status accompanies the snapshot; no history on the WS path.
+    expect(afterPull.some((m) => m.type === "status")).toBe(true);
+    expect(afterPull.some((m) => m.type === "history")).toBe(false);
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  // Focus pull with no active/streaming session: must report idle status and
+  // emit neither a stream_snapshot nor an error (no phantom session created).
+  it("replies idle (no snapshot, no error) on switch_session with no sessionId when no session is active", async () => {
+    const { wsReady, messages } = connectHub([wsId]);
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    const marker = messages.length;
+    ws.send(hubEvent(wsId, { type: "switch_session" }));
+
+    // Allow a status (and any erroneous snapshot/error) to arrive.
+    await waitForMessage(messages, (msgs) => msgs.length > marker);
+    await new Promise((r) => setTimeout(r, 100));
+
+    const afterPull = messages.slice(marker);
+    const status = afterPull.find((m) => m.type === "status");
+    expect(status).toBeDefined();
+    if (status && status.type === "status") {
+      expect(status.status).toBe("idle");
+      expect(status.streaming).toBe(false);
+    }
+    expect(afterPull.some((m) => m.type === "stream_snapshot")).toBe(false);
+    expect(afterPull.some((m) => m.type === "error")).toBe(false);
+
+    ws.close();
+  });
+
+  // Regression guard: switch_session WITH a sessionId still activates and
+  // bootstraps that specific session (the explicit path is unchanged).
+  it("still bootstraps a specific session on switch_session WITH a sessionId", async () => {
+    const first = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    const second = await createNewSession(wsId, dataDir, CONV_CMD);
+    // Make the active session distinct from the one we will switch to.
+    expect(second.sessionId).not.toBe(first.session.sessionId);
+
+    const { wsReady, messages } = connectHub([wsId]);
+    const ws = await wsReady;
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    const marker = messages.length;
+    ws.send(hubEvent(wsId, { type: "switch_session", sessionId: first.session.sessionId }));
+
+    await waitForMessage(
+      messages,
+      (msgs) =>
+        msgs.slice(marker).some(
+          (m) => m.type === "status" && m.sessionId === first.session.sessionId,
+        ),
+    );
+
+    const afterSwitch = messages.slice(marker);
+    const status = afterSwitch.find(
+      (m) => m.type === "status" && m.sessionId === first.session.sessionId,
+    );
+    expect(status).toBeDefined();
+    expect(afterSwitch.some((m) => m.type === "error")).toBe(false);
+
+    ws.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  // ── Reconnect refocus ordering (PRD #254, FINDING #2) ───────────────
+  // A socket sends sync_workspaces immediately followed by a focus
+  // switch_session (no sessionId) in the same tick. Per-socket serialization
+  // must let sync_workspaces register the subscription before switch_session is
+  // handled, so the pull is accepted (no "Not subscribed" error) and the active
+  // session's stream_snapshot is delivered.
+  it("accepts a switch_session sent immediately after sync_workspaces (no Not-subscribed race)", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-reconnect-race.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    const { session } = await getOrCreateSession(wsId, dataDir, slowCmd);
+    session.sendMessage("reconnect race snapshot");
+    const snapshot = session.getStreamingSnapshot();
+    if (!snapshot) throw new Error("Expected a streaming snapshot");
+    vi.spyOn(session, "getStreamingSnapshot").mockReturnValue({
+      ...snapshot,
+      text: "reconnected partial",
+    });
+
+    // Connect raw so we control the exact send ordering on a single socket.
+    const ws = (await local.app.injectWS("/ws/hub")) as WebSocket;
+    const messages: WsOutgoing[] = [];
+    await Promise.resolve();
+    ws.on("message", (data: Buffer) => {
+      const envelope = JSON.parse(data.toString()) as HubOutgoing;
+      if (envelope.workspaceId === wsId) messages.push(envelope.event);
+    });
+
+    // Fire both frames back-to-back, switch_session right after sync_workspaces.
+    syncWorkspaces(ws, [wsId]);
+    ws.send(hubEvent(wsId, { type: "switch_session" }));
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "stream_snapshot"));
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The focus pull was accepted, not rejected as "Not subscribed".
+    expect(
+      messages.some(
+        (m) => m.type === "error" && /Not subscribed/.test(m.message),
+      ),
+    ).toBe(false);
+    const snapshotEvents = messages.filter((m) => m.type === "stream_snapshot");
+    expect(snapshotEvents.length).toBeGreaterThanOrEqual(1);
+    const snap = snapshotEvents[snapshotEvents.length - 1];
+    if (snap.type !== "stream_snapshot") throw new Error("Expected a stream_snapshot");
+    expect(snap.sessionId).toBe(session.sessionId);
+    expect(snap.text).toBe("reconnected partial");
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
   it("emits a done event carrying the persisted assistant message id", async () => {
     const fakeClaudePath = join(tempDir, "fake-claude-done-id.sh");
     // Stream some text, then exit cleanly so finalizeTurn persists a message.

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -38,6 +38,12 @@ type ActiveSession = NonNullable<ReturnType<typeof getSession>>;
 interface HubSocket {
   ws: WebSocket;
   subscribedWorkspaces: Set<string>;
+  // Per-socket processing queue. Incoming messages from a single socket are
+  // chained here so each is fully handled before the next begins. This keeps
+  // e.g. sync_workspaces (which registers the subscription) from interleaving
+  // with a following switch_session (which is rejected until subscribed).
+  // Only same-socket ordering is serialized; different sockets run concurrently.
+  queue: Promise<void>;
 }
 
 interface WorkspaceChannel {
@@ -390,6 +396,22 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     switch (incoming.type) {
       case "switch_session": {
+        // Focus pull. With an explicit sessionId the client switches to that
+        // session (activating it if needed). With no sessionId it is a pull on
+        // the workspace's active session — used on first focus / reconnect when
+        // the client has no session id yet. Either way the response is just
+        // status + (when streaming) a consolidated stream_snapshot; replace
+        // semantics make repeated pulls idempotent.
+        if (incoming.sessionId === undefined) {
+          const session = getSession(wsId);
+          if (session) {
+            attachSessionListeners(wsId, channel, session);
+            sendSessionBootstrap(hub, wsId, session);
+          } else {
+            sendToHub(hub, wsId, { type: "status", status: "idle", streaming: false });
+          }
+          break;
+        }
         try {
           const session = await activateSession(
             wsId,
@@ -555,7 +577,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         return;
       }
 
-      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set() };
+      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set(), queue: Promise.resolve() };
       hubSockets.add(hub);
 
       const pingTimer = setInterval(() => {
@@ -581,7 +603,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         hubSockets.delete(hub);
       });
 
-      socket.on("message", async (raw) => {
+      socket.on("message", (raw) => {
         let parsed: HubIncoming;
         try {
           parsed = JSON.parse(raw.toString()) as HubIncoming;
@@ -592,11 +614,17 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           return;
         }
 
-        if ("type" in parsed && parsed.type === "sync_workspaces") {
-          await handleSyncWorkspaces(hub, parsed.workspaceIds);
-        } else if ("workspaceId" in parsed && "event" in parsed) {
-          await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);
-        }
+        // Serialize per-socket handling: each message is fully processed before
+        // the next from the same socket begins, preventing sync_workspaces from
+        // interleaving with a following switch_session. Failures are isolated so
+        // one rejected message does not break the chain for subsequent ones.
+        hub.queue = hub.queue.then(async () => {
+          if ("type" in parsed && parsed.type === "sync_workspaces") {
+            await handleSyncWorkspaces(hub, parsed.workspaceIds);
+          } else if ("workspaceId" in parsed && "event" in parsed) {
+            await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);
+          }
+        }).catch(() => {});
       });
     },
   );

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -5,7 +5,6 @@ import {
   getSession,
   getSessionById,
   getOrCreateSession,
-  getSessionMessages,
   getStreamingSessionIds,
   stopStreaming,
 } from "../agents/session-dispatch.js";
@@ -166,7 +165,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
   // ── Session helpers (unchanged logic) ─────────────────────────────
 
-  const sendSessionBootstrap = async (hub: HubSocket, workspaceId: string, session: ActiveSession): Promise<void> => {
+  const sendSessionBootstrap = (hub: HubSocket, workspaceId: string, session: ActiveSession): void => {
     sendToHub(hub, workspaceId, {
       type: "status",
       status: session.status === "streaming" ? "busy" : "idle",
@@ -177,53 +176,24 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         : {}),
       lockedProvider: session.metadata.lockedProvider,
     });
-    try {
-      const messages = await session.getMessages();
-      sendToHub(hub, workspaceId, { type: "history", sessionId: session.sessionId, messages });
-    } catch {
-      // History load failure is non-fatal.
-    }
 
-    // Replay in-progress streaming content so late-connecting clients see
-    // text, thinking, and tool calls accumulated since the turn started.
+    // Live/history split (Option B): the WebSocket carries live state only.
+    // History is fetched over REST. The in-flight turn is delivered as ONE
+    // consolidated stream_snapshot with replace semantics, so late-connecting
+    // clients see everything accumulated so far without any synthetic deltas.
     if (session.status === "streaming") {
       const snapshot = session.getStreamingSnapshot();
       if (snapshot) {
-        const sid = session.sessionId;
-        if (snapshot.thinking) {
-          sendToHub(hub, workspaceId, { type: "thinking", sessionId: sid, text: snapshot.thinking });
-        }
-        if (snapshot.text) {
-          sendToHub(hub, workspaceId, { type: "text_delta", sessionId: sid, text: snapshot.text });
-        }
-        for (const tc of snapshot.toolCalls) {
-          sendToHub(hub, workspaceId, {
-            type: "tool_use",
-            sessionId: sid,
-            id: tc.id,
-            name: tc.name,
-            input: tc.input,
-            parentToolUseId: tc.parentToolUseId,
-          });
-          if (tc.output) {
-            sendToHub(hub, workspaceId, {
-              type: "tool_result",
-              sessionId: sid,
-              toolUseId: tc.id,
-              output: tc.output,
-            });
-          }
-        }
-        for (const activity of snapshot.agentActivities) {
-          sendToHub(hub, workspaceId, {
-            type: "agent_activity",
-            sessionId: sid,
-            activity,
-          });
-        }
-        if (snapshot.agentPlanMode) {
-          sendToHub(hub, workspaceId, { type: "plan_mode_changed", sessionId: sid, active: true });
-        }
+        sendToHub(hub, workspaceId, {
+          type: "stream_snapshot",
+          sessionId: session.sessionId,
+          text: snapshot.text,
+          thinking: snapshot.thinking,
+          toolCalls: snapshot.toolCalls,
+          agentActivities: snapshot.agentActivities,
+          planMode: snapshot.agentPlanMode,
+          streamingStartedAt: session.streamingStartedAt ?? Date.now(),
+        });
       }
     }
   };
@@ -324,7 +294,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     if (session) {
       attachSessionListeners(wsId, channel, session);
-      await sendSessionBootstrap(hub, wsId, session);
+      sendSessionBootstrap(hub, wsId, session);
       for (const streamingId of getStreamingSessionIds(wsId)) {
         if (streamingId !== session.sessionId) {
           const streamingSession = getSessionById(wsId, streamingId);
@@ -340,16 +310,9 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         }
       }
     } else {
+      // No active session: report idle status only. Message history is owned by
+      // REST under the live/history split; the WebSocket no longer sends it.
       sendToHub(hub, wsId, { type: "status", status: "idle", streaming: false });
-      try {
-        const messages = await getSessionMessages(wsId, dataDir);
-        if (messages.length > 0) {
-          const firstSessionId = messages[0]?.sessionId;
-          sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
-        }
-      } catch {
-        // Ignore missing/corrupt persisted history.
-      }
     }
 
     const branchInfo = gitSyncSnapshotProvider?.getCachedBranchInfo(wsId);
@@ -400,10 +363,11 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     // Subscribe to new workspaces and bootstrap.
     // The hub socket is added to the channel AFTER bootstrap completes so that
-    // live events broadcast during the async getMessages() call don't reach
-    // this client before the streaming snapshot is replayed (which would cause
-    // duplicate content). Node.js single-threading guarantees no events fire
-    // between sendWorkspaceBootstrap returning and hubSockets.add.
+    // live deltas broadcast while bootstrap runs cannot reach this client before
+    // the consolidated stream_snapshot does (which would let a delta land ahead
+    // of the snapshot that replaces the stream state). Node.js single-threading
+    // guarantees no events fire between sendWorkspaceBootstrap returning and
+    // hubSockets.add.
     for (const wsId of desired) {
       if (!hub.subscribedWorkspaces.has(wsId)) {
         const channel = getOrCreateChannel(wsId);
@@ -434,7 +398,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             sessionOptions,
           );
           attachSessionListeners(wsId, channel, session);
-          await sendSessionBootstrap(hub, wsId, session);
+          sendSessionBootstrap(hub, wsId, session);
         } catch (err: unknown) {
           sendToHub(hub, wsId, { type: "error", message: errorMessage(err, "Failed to switch session") });
         }

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -22,6 +22,10 @@ import type { PlanStatus } from "@/components/chat/PlanProposal";
 
 interface ChatConversationProps {
   messages: ChatMessageType[];
+  /** Whether older messages exist before `messages[0]` (drives the top button). */
+  hasMore?: boolean;
+  /** Loads an older window and prepends it. */
+  onLoadEarlier?: () => void;
   isStreaming: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
@@ -54,6 +58,8 @@ interface ChatConversationProps {
 
 export default function ChatConversation({
   messages,
+  hasMore = false,
+  onLoadEarlier,
   isStreaming,
   streamingStartedAt,
   currentStreamingText,
@@ -191,6 +197,32 @@ export default function ChatConversation({
     return ids;
   }, [messages]);
 
+  // Memoize the historical message list so per-token streaming updates (which
+  // change currentStreamingText/Thinking/activeToolCalls but not these inputs)
+  // do not re-render the history. The live streaming bubble is rendered as a
+  // separate block below, giving an isolated streaming view.
+  const renderedMessages = useMemo(
+    () =>
+      messages.map((msg, i) => {
+        // Hide "Question dismissed." user bubbles — the CANCELLED badge conveys this.
+        if (msg.role === "user" && msg.content === "Question dismissed.") return null;
+        return (
+          <ChatMessage
+            key={msg.id ?? `${msg.timestamp}-${i}`}
+            message={msg}
+            isInteractive={isMessageInteractive(msg, i)}
+            planStatus={getPlanStatus(msg, i)}
+            dismissedToolCallIds={dismissedToolCallIds}
+            onQuestionAnswer={onQuestionAnswer}
+            onFileMentionClick={onFileMentionClick}
+          />
+        );
+      }),
+    // isMessageInteractive/getPlanStatus are pure over these inputs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [messages, pendingToolInputs, isStreaming, agentPlanMode, dismissedToolCallIds, onQuestionAnswer, onFileMentionClick],
+  );
+
   return (
     <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={settled ? "smooth" : "instant"}>
       {error && (
@@ -222,21 +254,18 @@ export default function ChatConversation({
               description=""
             />
           ))}
-        {messages.map((msg, i) => {
-          // Hide "Question dismissed." user bubbles — the CANCELLED badge already conveys this
-          if (msg.role === "user" && msg.content === "Question dismissed.") return null;
-          return (
-            <ChatMessage
-              key={msg.id ?? `${msg.timestamp}-${i}`}
-              message={msg}
-              isInteractive={isMessageInteractive(msg, i)}
-              planStatus={getPlanStatus(msg, i)}
-              dismissedToolCallIds={dismissedToolCallIds}
-              onQuestionAnswer={onQuestionAnswer}
-              onFileMentionClick={onFileMentionClick}
-            />
-          );
-        })}
+        {hasMore && messages.length > 0 && (
+          <div className="flex justify-center pb-1">
+            <button
+              type="button"
+              onClick={onLoadEarlier}
+              className="rounded-md px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-field hover:text-foreground"
+            >
+              Load earlier messages
+            </button>
+          </div>
+        )}
+        {renderedMessages}
 
         {/* Live streaming content */}
         {isStreaming && (currentStreamingText || currentThinking || activeToolCalls.length > 0 || activeInlineAgentActivities.length > 0) && (

--- a/frontend/src/components/ChatToolUse.tsx
+++ b/frontend/src/components/ChatToolUse.tsx
@@ -443,8 +443,9 @@ function outputText(tool: ToolCall): string | undefined {
 
 /**
  * Result/file count for Grep/Glob, read from scalars (never the omitted body).
- * Prefer the exact `outputLineCount` scalar; only when absent (e.g. a live tool
- * whose result hasn't computed scalars) fall back to counting the live text.
+ * The scalar already ignores one trailing newline; only when absent (e.g. a
+ * live tool whose result hasn't computed scalars) fall back to counting
+ * non-empty preview/live lines.
  */
 function outputNonEmptyLineCount(tool: ToolCall): number {
   if (tool.outputLineCount != null) return tool.outputLineCount;

--- a/frontend/src/components/ChatToolUse.tsx
+++ b/frontend/src/components/ChatToolUse.tsx
@@ -1,4 +1,4 @@
-import { useState, memo, type ReactNode } from "react";
+import { useState, useEffect, useMemo, useRef, memo, type ReactNode } from "react";
 import { diffLines } from "diff";
 import { XCircleIcon } from "lucide-react";
 import type { ToolCall } from "@/types";
@@ -7,6 +7,7 @@ import { formatElapsed } from "@/lib/time";
 import { DiffView } from "@/components/diff/DiffView";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ContentPanel, ContentPanelBody, ContentPanelFooter } from "@/components/chat/ContentPanel";
+import { useToolOutput } from "@/contexts/ToolOutputContext";
 
 const svgProps = { className: "size-3.5", viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
 
@@ -416,24 +417,55 @@ function getToolStats(tool: ToolCall): ToolStats | null {
       return { type: "diff", added: lineCount, removed: 0 };
     }
     case "Grep": {
-      if (!tool.output) return null;
-      const lines = tool.output.split("\n").filter(Boolean);
-      return lines.length ? { type: "plain", label: `${lines.length} result${lines.length !== 1 ? "s" : ""}` } : null;
+      const count = outputNonEmptyLineCount(tool);
+      return count ? { type: "plain", label: `${count} result${count !== 1 ? "s" : ""}` } : null;
     }
     case "Glob": {
-      if (!tool.output) return null;
-      const lines = tool.output.split("\n").filter(Boolean);
-      return lines.length ? { type: "plain", label: `${lines.length} file${lines.length !== 1 ? "s" : ""}` } : null;
+      const count = outputNonEmptyLineCount(tool);
+      return count ? { type: "plain", label: `${count} file${count !== 1 ? "s" : ""}` } : null;
     }
     default:
       return null;
   }
 }
 
+/**
+ * Best available view of the tool output WITHOUT touching a (possibly omitted)
+ * full body: prefer the preview (equals the full text when not truncated), then
+ * fall back to the live full output, then nothing.
+ */
+function outputText(tool: ToolCall): string | undefined {
+  if (tool.outputPreview != null) return tool.outputPreview;
+  if (typeof tool.output === "string") return tool.output;
+  if (tool.output != null) return JSON.stringify(tool.output);
+  return undefined;
+}
+
+/**
+ * Result/file count for Grep/Glob, read from scalars (never the omitted body).
+ * Prefer the exact `outputLineCount` scalar; only when absent (e.g. a live tool
+ * whose result hasn't computed scalars) fall back to counting the live text.
+ */
+function outputNonEmptyLineCount(tool: ToolCall): number {
+  if (tool.outputLineCount != null) return tool.outputLineCount;
+  const text = outputText(tool);
+  return text != null ? text.split("\n").filter(Boolean).length : 0;
+}
+
 function getOutputSummary(tool: ToolCall): string | undefined {
-  if (tool.output == null) return undefined;
-  const text = typeof tool.output === "string" ? tool.output : JSON.stringify(tool.output);
-  if (text.length === 0) return undefined;
+  // Read pre-computed scalars / preview; never re-parse the full (omitted) body.
+  if (tool.outputLineCount != null) {
+    if (tool.outputLineCount === 0) return undefined;
+    const preview = tool.outputPreview;
+    if (tool.outputLineCount === 1 && preview != null && preview.length < 60) {
+      return preview;
+    }
+    if (tool.outputLineCount > 1) return `${tool.outputLineCount} lines`;
+    return undefined;
+  }
+  // No scalars (e.g. a live tool whose result hasn't computed them): use text.
+  const text = outputText(tool);
+  if (text == null || text.length === 0) return undefined;
   const lines = text.split("\n").filter(Boolean);
   if (lines.length === 1 && lines[0].length < 60) return lines[0];
   if (lines.length > 1) return `${lines.length} lines`;
@@ -466,14 +498,55 @@ export function ToolExpandedContent({ content }: { content: ReactNode }) {
 
 const ChatToolUse = memo(function ChatToolUse({ tool, isExecuting, onClick }: ChatToolUseProps) {
   const [expanded, setExpanded] = useState(false);
-  const display = getToolDisplay(tool);
+  // Cache of the full output fetched on demand for a truncated history tool, so
+  // toggling expand does not refetch.
+  const [fetchedOutput, setFetchedOutput] = useState<string | null>(null);
+  const [fetchState, setFetchState] = useState<"idle" | "loading" | "error">("idle");
+  const toolOutput = useToolOutput();
+
   const showExpanded = onClick ? false : expanded;
-  const stats = !isExecuting ? getToolStats(tool) : null;
-  const summary = !isExecuting && !showExpanded && !stats ? getOutputSummary(tool) : undefined;
-  const bashMetadata = !isExecuting ? getBashMetadata(tool) : null;
-  const taskOutputText = tool.name === "Task" && tool.output
-    ? parseContentBlocks(tool.output)
-    : null;
+
+  // Memoize the heavy derivations so streaming siblings re-rendering doesn't
+  // re-parse this tool's input/output on every tick.
+  const display = useMemo(() => getToolDisplay(tool), [tool]);
+  const stats = useMemo(() => (isExecuting ? null : getToolStats(tool)), [tool, isExecuting]);
+  const bashMetadata = useMemo(() => (isExecuting ? null : getBashMetadata(tool)), [tool, isExecuting]);
+  const summary = useMemo(
+    () => (!isExecuting && !showExpanded && !stats ? getOutputSummary(tool) : undefined),
+    [tool, isExecuting, showExpanded, stats],
+  );
+
+  const isTruncated = tool.outputTruncated === true;
+  // Guards against re-fetching when the loading state change re-runs the effect.
+  const fetchStartedRef = useRef(false);
+
+  // Fetch the full body once on first expand of a truncated tool, then cache it.
+  useEffect(() => {
+    if (!showExpanded || !isTruncated || fetchedOutput !== null || fetchStartedRef.current) return;
+    if (!toolOutput) return;
+    fetchStartedRef.current = true;
+    setFetchState("loading");
+    toolOutput
+      .fetchOutput(tool.id)
+      .then((output) => {
+        setFetchedOutput(output);
+        setFetchState("idle");
+      })
+      .catch(() => {
+        setFetchState("error");
+        // Allow a retry on a later expand.
+        fetchStartedRef.current = false;
+      });
+  }, [showExpanded, isTruncated, fetchedOutput, toolOutput, tool.id]);
+
+  // Effective full output for the expanded body: fetched body wins, then the
+  // live full output, then the preview (omitted-body history falls back to it).
+  const effectiveOutput =
+    fetchedOutput ?? (typeof tool.output === "string" ? tool.output : undefined) ?? tool.outputPreview;
+  const hasOutput = tool.output !== undefined || tool.outputPreview !== undefined;
+  const taskOutputText =
+    tool.name === "Task" && effectiveOutput ? parseContentBlocks(effectiveOutput) : null;
+  const showTruncationNote = isTruncated && fetchedOutput === null;
 
   return (
     <div className="my-0.5">
@@ -526,16 +599,29 @@ const ChatToolUse = memo(function ChatToolUse({ tool, isExecuting, onClick }: Ch
           <ContentPanelBody>
             <ToolExpandedContent content={display.expandedContent} />
           </ContentPanelBody>
-          {tool.output !== undefined && !display.hideOutput && (
+          {hasOutput && !display.hideOutput && (
             <ContentPanelFooter>
-              <div className="mb-1.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/50">Output</div>
+              <div className="mb-1.5 flex items-center gap-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground/50">
+                <span>Output</span>
+                {fetchState === "loading" && (
+                  <span className="font-normal normal-case text-muted-foreground/50">Loading full output…</span>
+                )}
+                {fetchState === "error" && (
+                  <span className="font-normal normal-case text-destructive">Failed to load full output</span>
+                )}
+              </div>
               {taskOutputText ? (
                 <div className="prose-sm max-h-96 overflow-auto text-muted-foreground">
                   <MessageResponse>{taskOutputText}</MessageResponse>
                 </div>
               ) : (
                 <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-muted-foreground">
-                  {typeof tool.output === "string" ? tool.output : JSON.stringify(tool.output, null, 2)}
+                  {typeof effectiveOutput === "string"
+                    ? effectiveOutput
+                    : JSON.stringify(tool.output ?? null, null, 2)}
+                  {showTruncationNote && fetchState !== "loading" && (
+                    <span className="text-muted-foreground/40">{"\n…(preview truncated)"}</span>
+                  )}
                 </pre>
               )}
             </ContentPanelFooter>

--- a/frontend/src/components/chat/AgentActivityList.tsx
+++ b/frontend/src/components/chat/AgentActivityList.tsx
@@ -153,7 +153,16 @@ function diagnosticIcon(severity: Extract<AgentActivity, { kind: "diagnostic" }>
 }
 
 function commandActivityToToolCall(activity: Extract<AgentActivity, { kind: "command_execution" }>): ToolCall {
-  return commandExecutionActivityToToolCall(activity);
+  // The shared mapper drops the output* scalars (its return type is the minimal
+  // tool shape). Carry them across so the collapsed view reads scalars and the
+  // expand affordance can fetch the full body when truncated in REST history.
+  return {
+    ...commandExecutionActivityToToolCall(activity),
+    outputPreview: activity.outputPreview,
+    outputLineCount: activity.outputLineCount,
+    outputByteLength: activity.outputByteLength,
+    outputTruncated: activity.outputTruncated,
+  };
 }
 
 function isCommandRunning(

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -52,6 +52,8 @@ export interface ConversationPaneProps {
 
   // ── Conversation (ChatConversation surface) ──
   messages: ChatMessage[];
+  hasMore?: boolean;
+  onLoadEarlier?: () => void;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
   currentThinking: string;
@@ -117,6 +119,8 @@ export function ConversationPane({
   onConversationActivate,
   activeProvider,
   messages,
+  hasMore,
+  onLoadEarlier,
   streamingStartedAt,
   currentStreamingText,
   currentThinking,
@@ -181,6 +185,8 @@ export function ConversationPane({
           <>
             <ChatConversation
               messages={messages}
+              hasMore={hasMore}
+              onLoadEarlier={onLoadEarlier}
               isStreaming={isStreaming}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}

--- a/frontend/src/contexts/ToolOutputContext.tsx
+++ b/frontend/src/contexts/ToolOutputContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useContext, useMemo, type ReactNode } from "react";
+import { api } from "@/hooks/useApi";
+import type { ToolOutputResponse } from "@/types";
+
+/**
+ * Provides the coordinates needed to lazily fetch a tool/activity's full output
+ * on expand. REST history truncates large outputs to a preview plus scalars and
+ * omits the body; the collapsed view reads the scalars, and expanding a
+ * truncated tool fetches the full body from disk via this fetcher (keyed by the
+ * ToolCall id, which also resolves a command_execution activity id).
+ */
+export interface ToolOutputContextValue {
+  workspaceId: string;
+  sessionId: string;
+  /** Fetch the full output for a tool/activity id. Throws on network/404. */
+  fetchOutput: (toolId: string) => Promise<string>;
+}
+
+const ToolOutputContext = createContext<ToolOutputContextValue | null>(null);
+
+export function ToolOutputProvider({
+  workspaceId,
+  sessionId,
+  children,
+}: {
+  workspaceId: string | undefined;
+  sessionId: string | undefined;
+  children: ReactNode;
+}) {
+  const fetchOutput = useCallback(
+    async (toolId: string): Promise<string> => {
+      if (!workspaceId || !sessionId) {
+        throw new Error("Tool output is unavailable: missing session context.");
+      }
+      const res = await api.get<ToolOutputResponse>(
+        `/api/workspaces/${workspaceId}/sessions/${sessionId}/tools/${encodeURIComponent(toolId)}/output`,
+      );
+      return res.output;
+    },
+    [workspaceId, sessionId],
+  );
+
+  const value = useMemo<ToolOutputContextValue | null>(
+    () => (workspaceId && sessionId ? { workspaceId, sessionId, fetchOutput } : null),
+    [workspaceId, sessionId, fetchOutput],
+  );
+
+  return <ToolOutputContext.Provider value={value}>{children}</ToolOutputContext.Provider>;
+}
+
+/** Access the lazy tool-output fetcher, or null when no session context exists. */
+export function useToolOutput(): ToolOutputContextValue | null {
+  return useContext(ToolOutputContext);
+}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -709,7 +709,7 @@ export function useConversation(workspaceId: string | undefined) {
     // stale from a previous visit (buffered while the user was on another workspace).
     // After onMessage() returns, the flag is cleared and live errors pass through.
     let replayingBuffer = true;
-    const { unsubscribe } = wsTransport.onMessage(workspaceId, (msg) => {
+    const { unsubscribe, hadBufferedMessages } = wsTransport.onMessage(workspaceId, (msg) => {
       if (replayingBuffer && msg.type === "error" && !msg.sessionId) {
         return;
       }
@@ -762,23 +762,33 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(savedSession),
     });
 
-    // REST history is the single source of truth — always fetch on focus.
+    // REST history is the single source of truth — always fetch on focus, EXCEPT
+    // when the transport just replayed buffered live events into state during the
+    // onMessage() registration above. Those replayed turns (e.g. a finalized
+    // `done`, on top of the cache prefill) are newer than any disk snapshot this
+    // fetch could read, and a replayed done/cancelled already triggers
+    // syncSessionHistory() to reconcile authoritatively — so a mount fetch here
+    // could only clobber the fresher replayed state. (Defense in depth: the
+    // buffer is currently drained by the App-root live-data handler, but this
+    // keeps the invariant from depending on that wiring.)
     const mountSeq = fetchSeqRef.current;
-    void (async () => {
-      try {
-        const url = savedSession
-          ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages?limit=${HISTORY_LIMIT}`
-          : `/api/workspaces/${workspaceId}/session/messages?limit=${HISTORY_LIMIT}`;
-        const res = await api.get<SessionMessagesResponse>(url);
-        // Drop if the user has since sent a message / switched session (the
-        // optimistic/live state is newer than this initial-load response).
-        if (fetchSeqRef.current !== mountSeq) return;
-        if (sessionIdRef.current && savedSession && sessionIdRef.current !== savedSession) return;
-        dispatch({ type: "set_history", sessionId: savedSession, messages: res.messages, hasMore: res.hasMore });
-      } catch {
-        // History is best-effort; WS live state still drives the in-flight turn.
-      }
-    })();
+    if (!hadBufferedMessages) {
+      void (async () => {
+        try {
+          const url = savedSession
+            ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages?limit=${HISTORY_LIMIT}`
+            : `/api/workspaces/${workspaceId}/session/messages?limit=${HISTORY_LIMIT}`;
+          const res = await api.get<SessionMessagesResponse>(url);
+          // Drop if the user has since sent a message / switched session (the
+          // optimistic/live state is newer than this initial-load response).
+          if (fetchSeqRef.current !== mountSeq) return;
+          if (sessionIdRef.current && savedSession && sessionIdRef.current !== savedSession) return;
+          dispatch({ type: "set_history", sessionId: savedSession, messages: res.messages, hasMore: res.hasMore });
+        } catch {
+          // History is best-effort; WS live state still drives the in-flight turn.
+        }
+      })();
+    }
 
     return () => {
       // Remember which session was active before leaving this workspace.

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -11,7 +11,7 @@ import type {
   QuestionAnswer,
   QuestionInput,
 } from "@/types";
-import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
+import { normalizeToolOutput, outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
 import { wsTransport } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
 
@@ -68,7 +68,7 @@ type LocalAction =
   | { type: "prepare_workspace_switch" }
   | { type: "clear_pending_tool_inputs" }
   | { type: "set_history"; sessionId?: string; messages: ChatMessage[]; hasMore: boolean }
-  | { type: "prepend_history"; sessionId: string; messages: ChatMessage[]; hasMore: boolean };
+  | { type: "prepend_history"; sessionId: string; beforeId: string; messages: ChatMessage[]; hasMore: boolean };
 
 type Action = WsOutgoing | LocalAction;
 
@@ -101,10 +101,11 @@ function normalizeStreamingStartedAt(raw: number | undefined): number | undefine
  * render path reads scalars uniformly (live and history) without re-parsing the
  * body. Live outputs are never truncated, hence `outputTruncated: false`.
  */
-function computeOutputScalars(output: string): Pick<
+function computeOutputScalars(rawOutput: unknown): Pick<
   ToolCall,
   "output" | "outputPreview" | "outputLineCount" | "outputByteLength" | "outputTruncated"
 > {
+  const output = normalizeToolOutput(rawOutput);
   return {
     output,
     outputPreview: output,
@@ -486,6 +487,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "prepend_history": {
       // "Load earlier messages" — prepend an older window, dedup by id.
       if (state.sessionId && action.sessionId !== state.sessionId) return state;
+      if (state.messages[0]?.id !== action.beforeId) return state;
       const incoming = Array.isArray(action.messages) ? action.messages : [];
       const existingIds = new Set(state.messages.map((m) => m.id));
       const older = incoming.filter((m) => !existingIds.has(m.id));
@@ -611,6 +613,10 @@ export function useConversation(workspaceId: string | undefined) {
   // clobber freshly produced optimistic/live state. (Targeted single guard,
   // replacing the old multi-site request-token juggling.)
   const fetchSeqRef = useRef(0);
+  // Orders same-session replacement history fetches. `fetchSeqRef` invalidates
+  // across user actions/session switches; this one prevents an older REST
+  // response for the same session from overwriting a newer one.
+  const replaceHistorySeqRef = useRef(0);
 
   // ── Coalesced streaming deltas ──────────────────────────────────────
   // Batch text_delta/thinking on a ~50ms tick (rAF where available) instead of
@@ -658,11 +664,13 @@ export function useConversation(workspaceId: string | undefined) {
     // Capture the request generation synchronously; if the user switches/sends
     // before this resolves, the generation advances and we drop the stale result.
     const seq = fetchSeqRef.current;
+    const replaceSeq = ++replaceHistorySeqRef.current;
     try {
       const res = await api.get<SessionMessagesResponse>(
         `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages?limit=${HISTORY_LIMIT}`,
       );
       if (fetchSeqRef.current !== seq) return;
+      if (replaceHistorySeqRef.current !== replaceSeq) return;
       dispatch({ type: "set_history", sessionId, messages: res.messages, hasMore: res.hasMore });
     } catch {
       // Best-effort sync. WS live state remains the fallback if this request fails.
@@ -773,6 +781,7 @@ export function useConversation(workspaceId: string | undefined) {
     // keeps the invariant from depending on that wiring.)
     const mountSeq = fetchSeqRef.current;
     if (!hadBufferedMessages) {
+      const mountReplaceSeq = ++replaceHistorySeqRef.current;
       void (async () => {
         try {
           const url = savedSession
@@ -782,6 +791,7 @@ export function useConversation(workspaceId: string | undefined) {
           // Drop if the user has since sent a message / switched session (the
           // optimistic/live state is newer than this initial-load response).
           if (fetchSeqRef.current !== mountSeq) return;
+          if (replaceHistorySeqRef.current !== mountReplaceSeq) return;
           if (sessionIdRef.current && savedSession && sessionIdRef.current !== savedSession) return;
           dispatch({ type: "set_history", sessionId: savedSession, messages: res.messages, hasMore: res.hasMore });
         } catch {
@@ -893,7 +903,7 @@ export function useConversation(workspaceId: string | undefined) {
         `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages?limit=${HISTORY_LIMIT}&before=${encodeURIComponent(oldest.id)}`,
       );
       if (sessionIdRef.current !== sessionId) return;
-      dispatch({ type: "prepend_history", sessionId, messages: res.messages, hasMore: res.hasMore });
+      dispatch({ type: "prepend_history", sessionId, beforeId: oldest.id, messages: res.messages, hasMore: res.hasMore });
     } catch {
       // Best-effort; the button stays available for a retry.
     }

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,8 +1,21 @@
 import { useEffect, useCallback, useReducer, useRef, useSyncExternalStore } from "react";
-import type { AgentActivity, ChatMessage, FileMention, ImageAttachment, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer, QuestionInput } from "@/types";
+import type {
+  AgentActivity,
+  ChatMessage,
+  FileMention,
+  ImageAttachment,
+  MessageOptions,
+  SessionMessagesResponse,
+  ToolCall,
+  WsOutgoing,
+  QuestionAnswer,
+  QuestionInput,
+} from "@/types";
 import { wsTransport } from "@/lib/ws-transport";
-import type { HistoryMessage } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
+
+/** Default page size for the REST history endpoint (matches the backend default). */
+const HISTORY_LIMIT = 200;
 
 export interface PendingToolInput {
   requestId: string;
@@ -34,6 +47,8 @@ const emptyStreamState: SessionStreamState = {
 
 interface ConversationState {
   messages: ChatMessage[];
+  /** Whether older messages exist before `messages[0]` (drives "Load earlier"). */
+  hasMore: boolean;
   sessionStreams: Record<string, SessionStreamState>;
   workspaceStatus?: "idle" | "busy";
   error?: string;
@@ -44,18 +59,21 @@ interface ConversationState {
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
 
+/** REST-sourced history actions (the socket no longer carries history). */
 type LocalAction =
   | { type: "reset" }
   | { type: "clear_chat" }
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
   | { type: "clear_pending_tool_inputs" }
-  | { type: "_ws_reconnected" };
+  | { type: "set_history"; sessionId?: string; messages: ChatMessage[]; hasMore: boolean }
+  | { type: "prepend_history"; sessionId: string; messages: ChatMessage[]; hasMore: boolean };
 
 type Action = WsOutgoing | LocalAction;
 
 const initialState: ConversationState = {
   messages: [],
+  hasMore: false,
   sessionStreams: {},
   workspaceStatus: undefined,
   error: undefined,
@@ -75,6 +93,24 @@ function normalizeStreamingStartedAt(raw: number | undefined): number | undefine
   if (raw === undefined || Number.isNaN(raw)) return undefined;
   // Backend currently sends ms, but accept seconds defensively.
   return raw > 10_000_000_000 ? raw : raw * 1000;
+}
+
+/**
+ * Compute the unified output scalars from a full tool output, so the collapsed
+ * render path reads scalars uniformly (live and history) without re-parsing the
+ * body. Live outputs are never truncated, hence `outputTruncated: false`.
+ */
+function computeOutputScalars(output: string): Pick<
+  ToolCall,
+  "output" | "outputPreview" | "outputLineCount" | "outputByteLength" | "outputTruncated"
+> {
+  return {
+    output,
+    outputPreview: output,
+    outputLineCount: output.length === 0 ? 0 : output.split("\n").length,
+    outputByteLength: new TextEncoder().encode(output).length,
+    outputTruncated: false,
+  };
 }
 
 function derivePendingToolInputsFromHistory(messages: ChatMessage[]): PendingToolInput[] {
@@ -145,6 +181,16 @@ function upsertActivity(activities: AgentActivity[], activity: AgentActivity): A
   return activities.map((item, itemIndex) => itemIndex === index ? activity : item);
 }
 
+/** True when a finalized turn has nothing displayable (guards the empty-bubble edge). */
+function turnHasContent(stream: SessionStreamState): boolean {
+  return (
+    stream.currentText.length > 0 ||
+    stream.currentThinking.length > 0 ||
+    stream.activeToolCalls.length > 0 ||
+    stream.activeAgentActivities.length > 0
+  );
+}
+
 function reducer(state: ConversationState, action: Action): ConversationState {
   switch (action.type) {
     case "user_message": {
@@ -209,8 +255,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       if (!sid) return state;
       const stream = state.sessionStreams[sid];
       if (!stream) return state;
+      // Live output is full: compute the unified scalars once here so render
+      // reads scalars uniformly (one render path for live and history).
+      const scalars = computeOutputScalars(action.output);
       const tools = stream.activeToolCalls.map((t) =>
-        t.id === action.toolUseId ? { ...t, output: action.output } : t,
+        t.id === action.toolUseId ? { ...t, ...scalars } : t,
       );
       return updateStream(state, sid, { activeToolCalls: tools });
     }
@@ -225,6 +274,33 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       });
     }
 
+    case "stream_snapshot": {
+      // Consolidated in-flight snapshot with REPLACE semantics. Idempotent:
+      // applying it twice yields identical state. Create the slot if absent.
+      const sid = action.sessionId || state.sessionId;
+      if (!sid) return state;
+      const existing = state.sessionStreams[sid] ?? { ...emptyStreamState };
+      return {
+        ...state,
+        sessionStreams: {
+          ...state.sessionStreams,
+          [sid]: {
+            ...existing,
+            currentText: action.text,
+            currentThinking: action.thinking,
+            activeToolCalls: action.toolCalls,
+            activeAgentActivities: action.agentActivities,
+            agentPlanMode: action.planMode,
+            isStreaming: true,
+            streamingStartedAt:
+              normalizeStreamingStartedAt(action.streamingStartedAt) ??
+              existing.streamingStartedAt ??
+              Date.now(),
+          },
+        },
+      };
+    }
+
     case "done": {
       const sid = action.sessionId || state.sessionId;
       if (!sid) return state;
@@ -234,9 +310,14 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const isActive = sid === state.sessionId;
       const newStreams = deleteStream(state, sid);
 
-      if (isActive) {
+      // Append the optimistic assistant message under the SERVER message id so
+      // the next REST history fetch dedups by id (no client random id). Guard
+      // the empty-turn edge: a done may reference a turn with no displayable
+      // content — do not append an empty bubble.
+      const alreadyExists = state.messages.some((m) => m.id === action.messageId);
+      if (isActive && turnHasContent(stream) && !alreadyExists) {
         const assistantMsg: ChatMessage = {
-          id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
+          id: action.messageId,
           sessionId: sid,
           role: "assistant",
           content: stream.currentText,
@@ -256,8 +337,8 @@ function reducer(state: ConversationState, action: Action): ConversationState {
           sessionStreams: newStreams,
         };
       }
-      // Background session: just clean up the slot. REST fetch on switch-back
-      // will include the completed message.
+      // Background session, empty turn, or already-present id: just clean up the
+      // slot. The REST fetch on switch-back / revalidation carries the message.
       return { ...state, sessionStreams: newStreams };
     }
 
@@ -277,8 +358,14 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const newStreams = deleteStream(state, sid);
 
       if (isActive) {
+        // Use the server message id when the turn was persisted (so the REST
+        // fetch dedups); otherwise fall back to a local id (an unpersisted
+        // cancellation is never in REST history, so it cannot duplicate).
+        const id = action.messageId ?? `cancelled-${sid}-${Date.now()}`;
+        const alreadyExists = state.messages.some((m) => m.id === id);
+        if (alreadyExists) return { ...state, sessionStreams: newStreams };
         const cancelledMsg: ChatMessage = {
-          id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
+          id,
           sessionId: sid,
           role: "assistant",
           content: hasOutput ? stream.currentText : CANCELLED_NO_OUTPUT_MESSAGE,
@@ -360,9 +447,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       };
     }
 
-    case "history": {
-      const historySessionId = action.sessionId ?? action.messages[0]?.sessionId ?? state.sessionId;
-      // Only update messages for the active session
+    case "set_history": {
+      const messages = Array.isArray(action.messages) ? action.messages : [];
+      const historySessionId = action.sessionId ?? messages[0]?.sessionId ?? state.sessionId;
+      // Only update messages for the active session (sessionId-match guard
+      // replaces the old request-token juggling).
       if (historySessionId && state.sessionId && historySessionId !== state.sessionId) {
         return state;
       }
@@ -371,7 +460,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const activeStream = historySessionId ? state.sessionStreams[historySessionId] : undefined;
       const hydratedPendingToolInputs = activeStream?.isStreaming
         ? activeStream.pendingToolInputs
-        : derivePendingToolInputsFromHistory(action.messages);
+        : derivePendingToolInputsFromHistory(messages);
 
       let newStreams = state.sessionStreams;
       if (historySessionId && !activeStream?.isStreaming) {
@@ -388,10 +477,24 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       return {
         ...state,
-        messages: action.messages,
+        messages,
+        hasMore: action.hasMore,
         error: undefined,
         sessionId: historySessionId ?? state.sessionId,
         sessionStreams: newStreams,
+      };
+    }
+
+    case "prepend_history": {
+      // "Load earlier messages" — prepend an older window, dedup by id.
+      if (state.sessionId && action.sessionId !== state.sessionId) return state;
+      const incoming = Array.isArray(action.messages) ? action.messages : [];
+      const existingIds = new Set(state.messages.map((m) => m.id));
+      const older = incoming.filter((m) => !existingIds.has(m.id));
+      return {
+        ...state,
+        messages: [...older, ...state.messages],
+        hasMore: action.hasMore,
       };
     }
 
@@ -441,6 +544,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
+        hasMore: false,
         sessionId: action.sessionId,
         error: undefined,
         lockedProvider: undefined,
@@ -452,6 +556,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
+        hasMore: false,
         sessionId: undefined,
         workspaceStatus: undefined,
         error: undefined,
@@ -465,6 +570,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
+        hasMore: false,
         sessionStreams: sid ? deleteStream(state, sid) : {},
         error: undefined,
         sessionId: undefined,
@@ -473,13 +579,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
     case "reset":
       return initialState;
-
-    case "_ws_reconnected":
-      // On WS reconnect the backend will re-bootstrap every workspace with a
-      // full streaming snapshot (text, thinking, tool calls). Clear accumulated
-      // stream data so the snapshot won't be *appended* to stale pre-disconnect
-      // content, which would cause duplicate tool calls and garbled text.
-      return { ...state, sessionStreams: {} };
 
     default:
       return state;
@@ -505,24 +604,73 @@ function sessionIdField(id: string | undefined): { sessionId: string } | Record<
 
 export function useConversation(workspaceId: string | undefined) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const historyRequestTokenRef = useRef(0);
-  // Track latest sessionId so effect cleanup can read it (refs update during render, before effects).
+  // Track latest sessionId so effect cleanup / async callbacks can read it
+  // (refs update during render, before effects).
   const sessionIdRef = useRef<string | undefined>(state.sessionId);
   sessionIdRef.current = state.sessionId;
+  // Invalidates an in-flight initial history fetch when the user sends a message
+  // or switches session before it resolves, so a stale empty response can't
+  // clobber freshly produced optimistic/live state. (Targeted single guard,
+  // replacing the old multi-site request-token juggling.)
+  const fetchSeqRef = useRef(0);
+
+  // ── Coalesced streaming deltas ──────────────────────────────────────
+  // Batch text_delta/thinking on a ~50ms tick (rAF where available) instead of
+  // dispatching per token, to cap the streaming re-render rate. The buffer is a
+  // small per-session accumulator flushed before any ordering-sensitive event.
+  const deltaBufferRef = useRef<Map<string, { text: string; thinking: string }>>(new Map());
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const flushDeltas = useCallback(() => {
+    if (flushTimerRef.current !== null) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+    const buffer = deltaBufferRef.current;
+    if (buffer.size === 0) return;
+    deltaBufferRef.current = new Map();
+    for (const [sid, { text, thinking }] of buffer) {
+      if (text) dispatch({ type: "text_delta", sessionId: sid, text });
+      if (thinking) dispatch({ type: "thinking", sessionId: sid, text: thinking });
+    }
+  }, []);
+
+  const scheduleFlush = useCallback(() => {
+    if (flushTimerRef.current !== null) return;
+    flushTimerRef.current = setTimeout(() => {
+      flushTimerRef.current = null;
+      flushDeltas();
+    }, 50);
+  }, [flushDeltas]);
+
+  const bufferDelta = useCallback(
+    (sid: string, key: "text" | "thinking", value: string) => {
+      const buffer = deltaBufferRef.current;
+      const entry = buffer.get(sid) ?? { text: "", thinking: "" };
+      entry[key] += value;
+      buffer.set(sid, entry);
+      scheduleFlush();
+    },
+    [scheduleFlush],
+  );
+
+  /** Fetch a session's latest message window and replace local history. */
   const syncSessionHistory = useCallback(async (sessionId: string) => {
     if (!workspaceId || !sessionId) return;
-    const historyRequestToken = historyRequestTokenRef.current + 1;
-    historyRequestTokenRef.current = historyRequestToken;
+    // Capture the request generation synchronously; if the user switches/sends
+    // before this resolves, the generation advances and we drop the stale result.
+    const seq = fetchSeqRef.current;
     try {
-      const messages = await api.get<ChatMessage[]>(
-        `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages`,
+      const res = await api.get<SessionMessagesResponse>(
+        `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages?limit=${HISTORY_LIMIT}`,
       );
-      if (historyRequestTokenRef.current !== historyRequestToken) return;
-      dispatch({ type: "history", sessionId, messages });
+      if (fetchSeqRef.current !== seq) return;
+      dispatch({ type: "set_history", sessionId, messages: res.messages, hasMore: res.hasMore });
     } catch {
-      // Best-effort sync. WS state remains the fallback if this request fails.
+      // Best-effort sync. WS live state remains the fallback if this request fails.
     }
   }, [workspaceId]);
+
   const connectionStatus = useSyncExternalStore(
     (listener) =>
       workspaceId ? wsTransport.subscribe(workspaceId, listener) : () => {},
@@ -535,26 +683,49 @@ export function useConversation(workspaceId: string | undefined) {
       return;
     }
     const savedSession = savedSessionByWorkspace.get(workspaceId);
-    const historyRequestToken = historyRequestTokenRef.current + 1;
-    historyRequestTokenRef.current = historyRequestToken;
 
     dispatch({ type: "prepare_workspace_switch" });
-    // Pre-set sessionId so the reducer's mismatch guard rejects replayed history
-    // for a different session (e.g. from stale lastHistory in the WS transport cache).
+    // Pre-set sessionId so the reducer's mismatch guard rejects history for a
+    // different session during rapid switches.
     if (savedSession) {
       dispatch({ type: "prepare_session_switch", sessionId: savedSession });
     }
 
     wsTransport.connect(workspaceId);
 
+    // Stale-while-revalidate: render the last known window immediately so
+    // switch-back feels instant, then revalidate via REST below.
+    if (savedSession) {
+      const cached = wsTransport.getSessionWindow(workspaceId, savedSession);
+      if (cached) {
+        dispatch({
+          type: "set_history",
+          sessionId: savedSession,
+          messages: cached.messages,
+          hasMore: cached.hasMore,
+        });
+      }
+    }
+
     // Skip session-less errors during the synchronous buffer replay — they may be
     // stale from a previous visit (buffered while the user was on another workspace).
     // After onMessage() returns, the flag is cleared and live errors pass through.
     let replayingBuffer = true;
-    const { unsubscribe, hadBufferedMessages } = wsTransport.onMessage(workspaceId, (msg) => {
+    const { unsubscribe } = wsTransport.onMessage(workspaceId, (msg) => {
       if (replayingBuffer && msg.type === "error" && !msg.sessionId) {
         return;
       }
+      // Coalesce streaming deltas; flush before any ordering-sensitive event so
+      // buffered text lands before tool calls / completion.
+      if (msg.type === "text_delta") {
+        bufferDelta(msg.sessionId ?? sessionIdRef.current ?? "", "text", msg.text);
+        return;
+      }
+      if (msg.type === "thinking") {
+        bufferDelta(msg.sessionId ?? sessionIdRef.current ?? "", "thinking", msg.text);
+        return;
+      }
+      flushDeltas();
       dispatch(msg);
       if ((msg.type === "done" || msg.type === "cancelled") && msg.sessionId) {
         void syncSessionHistory(msg.sessionId);
@@ -562,60 +733,56 @@ export function useConversation(workspaceId: string | undefined) {
     });
     replayingBuffer = false;
 
+    // On reconnect, re-pull focus: re-send switch_session so the backend replays
+    // a fresh consolidated stream_snapshot (replace semantics make this safe and
+    // idempotent — no clear-state hack needed).
     const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
-      dispatch({ type: "_ws_reconnected" });
+      const activeSession = sessionIdRef.current;
+      if (activeSession) {
+        wsTransport.send(workspaceId, { type: "switch_session", sessionId: activeSession });
+      }
     });
 
     // Tell the backend to activate the saved session and send its bootstrap.
     if (savedSession) {
-      const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
-      if (sent) historyRequestTokenRef.current += 1;
+      wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
     }
 
-    // If the transport replayed buffered messages (events that arrived while we were
-    // on another workspace), the reducer already has the most current state. Bump the
-    // token so the async REST fetch won't overwrite it with potentially stale disk data.
-    if (hadBufferedMessages) {
-      historyRequestTokenRef.current += 1;
-    }
-
-    // REST fallback — only needed on first visit when no cached history exists.
-    // On switch-back the transport cache is kept fresh (see effect below), so
-    // the WS replay already provides current messages.
-    if (!wsTransport.hasCachedHistory(workspaceId)) {
-      void (async () => {
-        try {
-          const url = savedSession
-            ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages`
-            : `/api/workspaces/${workspaceId}/session/messages`;
-          const messages = await api.get<ChatMessage[]>(url);
-          if (historyRequestTokenRef.current !== historyRequestToken) return;
-          dispatch({ type: "history", sessionId: savedSession, messages });
-        } catch {
-          // History is still best-effort via websocket replay if API fetch fails.
-        }
-      })();
-    }
+    // REST history is the single source of truth — always fetch on focus.
+    const mountSeq = fetchSeqRef.current;
+    void (async () => {
+      try {
+        const url = savedSession
+          ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages?limit=${HISTORY_LIMIT}`
+          : `/api/workspaces/${workspaceId}/session/messages?limit=${HISTORY_LIMIT}`;
+        const res = await api.get<SessionMessagesResponse>(url);
+        // Drop if the user has since sent a message / switched session (the
+        // optimistic/live state is newer than this initial-load response).
+        if (fetchSeqRef.current !== mountSeq) return;
+        if (sessionIdRef.current && savedSession && sessionIdRef.current !== savedSession) return;
+        dispatch({ type: "set_history", sessionId: savedSession, messages: res.messages, hasMore: res.hasMore });
+      } catch {
+        // History is best-effort; WS live state still drives the in-flight turn.
+      }
+    })();
 
     return () => {
       // Remember which session was active before leaving this workspace.
       if (workspaceId && sessionIdRef.current) {
         savedSessionByWorkspace.set(workspaceId, sessionIdRef.current);
       }
-      if (historyRequestTokenRef.current === historyRequestToken) {
-        historyRequestTokenRef.current = historyRequestToken + 1;
-      }
+      flushDeltas();
+      deltaBufferRef.current = new Map();
       unsubscribe();
       unsubReconnect();
     };
-  }, [workspaceId, syncSessionHistory]);
+  }, [workspaceId, syncSessionHistory, bufferDelta, flushDeltas]);
 
-  // Keep the transport's cached history fresh so switch-back replays are current.
-  // Fires on history/done/cancelled/user_message — NOT on streaming deltas.
-  // Guard: skip writes when workspaceId just changed — React 18 batching means
-  // state.messages may transiently hold the *previous* workspace's messages before
-  // prepare_workspace_switch commits. Without this, ws-A's messages get written
-  // into ws-B's cache, causing residual chat on switch-back.
+  // Keep the transport's per-session window cache fresh so switch-back is
+  // instant (stale-while-revalidate). Fires when messages/hasMore change — NOT
+  // on streaming deltas. Guard: skip writes when workspaceId just changed so a
+  // transient render holding the previous workspace's messages (React batching)
+  // doesn't pollute the new workspace's cache.
   const prevCacheWorkspaceRef = useRef(workspaceId);
   useEffect(() => {
     if (prevCacheWorkspaceRef.current !== workspaceId) {
@@ -623,13 +790,11 @@ export function useConversation(workspaceId: string | undefined) {
       return;
     }
     if (!workspaceId || !state.sessionId || state.messages.length === 0) return;
-    const historyMsg: HistoryMessage = {
-      type: "history",
-      sessionId: state.sessionId,
+    wsTransport.setSessionWindow(workspaceId, state.sessionId, {
       messages: state.messages,
-    };
-    wsTransport.updateCachedHistory(workspaceId, historyMsg);
-  }, [workspaceId, state.sessionId, state.messages]);
+      hasMore: state.hasMore,
+    });
+  }, [workspaceId, state.sessionId, state.messages, state.hasMore]);
 
   const sendMessage = useCallback((
     content: string,
@@ -655,7 +820,9 @@ export function useConversation(workspaceId: string | undefined) {
       dispatch({ type: "error", message: "Message not sent: disconnected from server." });
       return false;
     }
-    historyRequestTokenRef.current += 1;
+    // Invalidate any in-flight initial history fetch so it can't clobber the
+    // optimistic turn this send is about to produce.
+    fetchSeqRef.current += 1;
     return true;
   }, [workspaceId, state.sessionId]);
 
@@ -673,14 +840,40 @@ export function useConversation(workspaceId: string | undefined) {
 
   const switchSession = useCallback((sessionId: string) => {
     if (!workspaceId) return;
+    // Supersede any in-flight initial history fetch for the previous session.
+    fetchSeqRef.current += 1;
     dispatch({ type: "prepare_session_switch", sessionId });
     dispatch({ type: "status", status: "busy", sessionId, streaming: false });
-    historyRequestTokenRef.current += 1;
+
+    // Stale-while-revalidate from the per-session window cache.
+    const cached = wsTransport.getSessionWindow(workspaceId, sessionId);
+    if (cached) {
+      dispatch({ type: "set_history", sessionId, messages: cached.messages, hasMore: cached.hasMore });
+    }
+
     const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId });
     if (!sent) {
       dispatch({ type: "error", message: "Session switch failed: disconnected from server." });
     }
-  }, [workspaceId]);
+    void syncSessionHistory(sessionId);
+  }, [workspaceId, syncSessionHistory]);
+
+  /** Load an older window and prepend it (explicit "Load earlier messages"). */
+  const loadEarlier = useCallback(async () => {
+    if (!workspaceId) return;
+    const sessionId = sessionIdRef.current;
+    const oldest = state.messages[0];
+    if (!sessionId || !oldest || !state.hasMore) return;
+    try {
+      const res = await api.get<SessionMessagesResponse>(
+        `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages?limit=${HISTORY_LIMIT}&before=${encodeURIComponent(oldest.id)}`,
+      );
+      if (sessionIdRef.current !== sessionId) return;
+      dispatch({ type: "prepend_history", sessionId, messages: res.messages, hasMore: res.hasMore });
+    } catch {
+      // Best-effort; the button stays available for a retry.
+    }
+  }, [workspaceId, state.messages, state.hasMore]);
 
   // Derive active session's stream state for the public API
   const activeStream = state.sessionId ? state.sessionStreams[state.sessionId] : undefined;
@@ -697,7 +890,6 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(state.sessionId),
     });
     dispatch({ type: "clear_pending_tool_inputs" });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const batchAnswerQuestions = useCallback(
@@ -716,7 +908,6 @@ export function useConversation(workspaceId: string | undefined) {
         });
       }
       dispatch({ type: "clear_pending_tool_inputs" });
-      historyRequestTokenRef.current += 1;
     },
     [workspaceId, activeStream?.pendingToolInputs, state.sessionId],
   );
@@ -734,7 +925,6 @@ export function useConversation(workspaceId: string | undefined) {
     });
     dispatch({ type: "clear_pending_tool_inputs" });
     dispatch({ type: "plan_mode_changed", sessionId: state.sessionId ?? "", active: false });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const rejectToolInput = useCallback((message?: string) => {
@@ -749,7 +939,6 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(state.sessionId),
     });
     dispatch({ type: "clear_pending_tool_inputs" });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const dismissPlan = useCallback((message?: string) => {
@@ -766,11 +955,11 @@ export function useConversation(workspaceId: string | undefined) {
     if (pending) {
       dispatch({ type: "clear_pending_tool_inputs" });
     }
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   return {
     messages: state.messages,
+    hasMore: state.hasMore,
     isStreaming: activeStream?.isStreaming ?? false,
     streamingStartedAt: activeStream?.streamingStartedAt ?? null,
     workspaceStatus: state.workspaceStatus,
@@ -789,6 +978,7 @@ export function useConversation(workspaceId: string | undefined) {
     stopStreaming,
     clearChat,
     switchSession,
+    loadEarlier,
     answerQuestion,
     batchAnswerQuestions,
     approvePlan,

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -11,6 +11,7 @@ import type {
   QuestionAnswer,
   QuestionInput,
 } from "@/types";
+import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
 import { wsTransport } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
 
@@ -107,8 +108,8 @@ function computeOutputScalars(output: string): Pick<
   return {
     output,
     outputPreview: output,
-    outputLineCount: output.length === 0 ? 0 : output.split("\n").length,
-    outputByteLength: new TextEncoder().encode(output).length,
+    outputLineCount: outputLineCount(output),
+    outputByteLength: outputByteLength(output),
     outputTruncated: false,
   };
 }
@@ -179,16 +180,6 @@ function upsertActivity(activities: AgentActivity[], activity: AgentActivity): A
   const index = activities.findIndex((item) => item.id === activity.id);
   if (index < 0) return [...activities, activity];
   return activities.map((item, itemIndex) => itemIndex === index ? activity : item);
-}
-
-/** True when a finalized turn has nothing displayable (guards the empty-bubble edge). */
-function turnHasContent(stream: SessionStreamState): boolean {
-  return (
-    stream.currentText.length > 0 ||
-    stream.currentThinking.length > 0 ||
-    stream.activeToolCalls.length > 0 ||
-    stream.activeAgentActivities.length > 0
-  );
 }
 
 function reducer(state: ConversationState, action: Action): ConversationState {
@@ -318,11 +309,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const newStreams = deleteStream(state, sid);
 
       // Append the optimistic assistant message under the SERVER message id so
-      // the next REST history fetch dedups by id (no client random id). Guard
-      // the empty-turn edge: a done may reference a turn with no displayable
-      // content — do not append an empty bubble.
+      // the next REST history fetch dedups by id (no client random id). The
+      // presence of messageId is the single signal that the turn had displayable
+      // content: an empty turn omits it, so no empty bubble is appended.
       const alreadyExists = state.messages.some((m) => m.id === action.messageId);
-      if (isActive && turnHasContent(stream) && !alreadyExists) {
+      if (isActive && action.messageId && !alreadyExists) {
         const assistantMsg: ChatMessage = {
           id: action.messageId,
           sessionId: sid,
@@ -750,6 +741,15 @@ export function useConversation(workspaceId: string | undefined) {
         type: "switch_session",
         ...sessionIdField(sessionIdRef.current),
       });
+      // The switch_session above only re-pulls the live snapshot, and the
+      // backend sends a stream_snapshot only if the session is STILL streaming.
+      // A turn that COMPLETED while the socket was down is never delivered, so
+      // refetch REST history to pull any finalized turn from the disconnect
+      // window. set_history replaces finalized messages; the snapshot (if any)
+      // repopulates the live slot — the two don't fight.
+      if (sessionIdRef.current) {
+        void syncSessionHistory(sessionIdRef.current);
+      }
     });
 
     // Always pull on focus so an already-subscribed, currently-streaming workspace

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -285,7 +285,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       // tools render via scalars (one render path, live and history) instead of
       // re-parsing the full body until the next REST resync.
       const snapshotToolCalls = action.toolCalls.map((tool) =>
-        tool.output ? { ...tool, ...computeOutputScalars(tool.output) } : tool,
+        tool.output !== undefined ? { ...tool, ...computeOutputScalars(tool.output) } : tool,
       );
       return {
         ...state,

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -280,6 +280,13 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const sid = action.sessionId || state.sessionId;
       if (!sid) return state;
       const existing = state.sessionStreams[sid] ?? { ...emptyStreamState };
+      // Snapshot tools carry full outputs (live = full). Compute the unified
+      // scalars here, once, exactly like the tool_result path so mid-stream-join
+      // tools render via scalars (one render path, live and history) instead of
+      // re-parsing the full body until the next REST resync.
+      const snapshotToolCalls = action.toolCalls.map((tool) =>
+        tool.output ? { ...tool, ...computeOutputScalars(tool.output) } : tool,
+      );
       return {
         ...state,
         sessionStreams: {
@@ -288,7 +295,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
             ...existing,
             currentText: action.text,
             currentThinking: action.thinking,
-            activeToolCalls: action.toolCalls,
+            activeToolCalls: snapshotToolCalls,
             activeAgentActivities: action.agentActivities,
             agentPlanMode: action.planMode,
             isStreaming: true,
@@ -735,18 +742,25 @@ export function useConversation(workspaceId: string | undefined) {
 
     // On reconnect, re-pull focus: re-send switch_session so the backend replays
     // a fresh consolidated stream_snapshot (replace semantics make this safe and
-    // idempotent — no clear-state hack needed).
+    // idempotent — no clear-state hack needed). With no active session id, send a
+    // bare switch_session so the backend resolves the active session and still
+    // pulls its in-flight snapshot.
     const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
-      const activeSession = sessionIdRef.current;
-      if (activeSession) {
-        wsTransport.send(workspaceId, { type: "switch_session", sessionId: activeSession });
-      }
+      wsTransport.send(workspaceId, {
+        type: "switch_session",
+        ...sessionIdField(sessionIdRef.current),
+      });
     });
 
-    // Tell the backend to activate the saved session and send its bootstrap.
-    if (savedSession) {
-      wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
-    }
+    // Always pull on focus so an already-subscribed, currently-streaming workspace
+    // delivers its consolidated stream_snapshot on first navigation (the in-flight
+    // catch-up case). With a saved session → focus it; without → bare
+    // switch_session so the backend resolves the active session. Replace semantics
+    // make a redundant pull harmless.
+    wsTransport.send(workspaceId, {
+      type: "switch_session",
+      ...sessionIdField(savedSession),
+    });
 
     // REST history is the single source of truth — always fetch on focus.
     const mountSeq = fetchSeqRef.current;

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -1,5 +1,5 @@
 import { getServerUrl } from "@/hooks/useServerUrl";
-import type { WsIncoming, WsOutgoing, HubOutgoing } from "@/types";
+import type { ChatMessage, WsIncoming, WsOutgoing, HubOutgoing } from "@/types";
 
 export type ConnectionStatus = "connecting" | "connected" | "disconnected";
 
@@ -7,9 +7,20 @@ type MessageHandler = (msg: WsOutgoing) => void;
 type GlobalMessageHandler = (workspaceId: string, msg: WsOutgoing) => void;
 type StatusListener = () => void;
 type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
-export type HistoryMessage = Extract<WsOutgoing, { type: "history" }>;
 type DiffStatsMessage = Extract<WsOutgoing, { type: "diff_stats" }>;
 type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
+
+/**
+ * The last rendered message window for a session. Cached client-side so that
+ * switching back to a recently viewed session shows the last view instantly
+ * (stale-while-revalidate) while a fresh REST fetch revalidates in the
+ * background. This is the WS=live / REST=history split: history is never sent
+ * over the socket anymore.
+ */
+export interface SessionWindow {
+  messages: ChatMessage[];
+  hasMore: boolean;
+}
 
 const MAX_RECONNECT_DELAY = 30_000;
 const BASE_RECONNECT_DELAY = 1_000;
@@ -31,9 +42,10 @@ interface WorkspaceSubscription {
   statusListeners: Set<StatusListener>;
   lastStatus?: StatusMessage;
   lastStatusBySession: Map<string, StatusMessage>;
-  lastHistory?: HistoryMessage;
   lastDiffStats?: DiffStatsMessage;
   lastBranchInfo?: BranchInfoMessage;
+  /** Last rendered message window per session id (stale-while-revalidate). */
+  windowCache: Map<string, SessionWindow>;
   /** Messages received while no handler was subscribed. Replayed on next onMessage(). */
   messageBuffer: WsOutgoing[];
 }
@@ -80,24 +92,28 @@ class WsTransport {
     this.sendSyncWorkspaces();
   }
 
-  /** Update the cached history so switch-back replays are fresh. */
-  updateCachedHistory(workspaceId: string, historyMsg: HistoryMessage): void {
+  /**
+   * Store the last rendered message window for a session so switch-back is
+   * instant (stale-while-revalidate). History lives in REST; this is only a
+   * client-side render cache, not a source of truth.
+   */
+  setSessionWindow(workspaceId: string, sessionId: string, window: SessionWindow): void {
     const sub = this.subscriptions.get(workspaceId);
-    if (sub) sub.lastHistory = historyMsg;
+    if (sub) sub.windowCache.set(sessionId, window);
   }
 
-  /** Check whether cached history exists for a workspace. */
-  hasCachedHistory(workspaceId: string): boolean {
-    return this.subscriptions.get(workspaceId)?.lastHistory !== undefined;
+  /** Read the cached render window for a session, if any. */
+  getSessionWindow(workspaceId: string, sessionId: string): SessionWindow | undefined {
+    return this.subscriptions.get(workspaceId)?.windowCache.get(sessionId);
   }
 
-  /** Clear cached status/history for a workspace (e.g. after session deletion). */
+  /** Clear cached status/windows for a workspace (e.g. after session deletion). */
   clearCachedData(workspaceId: string): void {
     const sub = this.subscriptions.get(workspaceId);
     if (!sub) return;
     sub.lastStatus = undefined;
     sub.lastStatusBySession.clear();
-    sub.lastHistory = undefined;
+    sub.windowCache.clear();
     sub.lastBranchInfo = undefined;
     sub.messageBuffer = [];
   }
@@ -126,7 +142,8 @@ class WsTransport {
 
   /**
    * Register a handler for incoming messages.
-   * Replays cached status, history, and any buffered messages immediately.
+   * Replays cached live state (status, diff stats, branch info) and any buffered
+   * messages immediately. History is NOT replayed here — it is owned by REST.
    * Returns `{ unsubscribe, hadBufferedMessages }`.
    */
   onMessage(workspaceId: string, handler: MessageHandler): { unsubscribe: () => void; hadBufferedMessages: boolean } {
@@ -139,9 +156,6 @@ class WsTransport {
       }
     } else if (sub.lastStatus) {
       handler(sub.lastStatus);
-    }
-    if (sub.lastHistory) {
-      handler(sub.lastHistory);
     }
     if (sub.lastDiffStats) {
       handler(sub.lastDiffStats);
@@ -202,6 +216,7 @@ class WsTransport {
       reconnectListeners: new Set<() => void>(),
       statusListeners: new Set<StatusListener>(),
       lastStatusBySession: new Map(),
+      windowCache: new Map(),
       messageBuffer: [],
     };
     this.subscriptions.set(workspaceId, created);
@@ -256,9 +271,10 @@ class WsTransport {
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
       }
-      // On reconnect, notify all listeners to clear stale streaming state before
-      // the bootstrap replays full snapshots. Without this, the snapshot events
-      // would be appended to pre-disconnect accumulated data, causing duplicates.
+      // On reconnect, notify listeners so they can re-pull focus (re-send
+      // switch_session) and get a fresh consolidated stream_snapshot. The
+      // snapshot replaces (not appends) stream state, so this is idempotent and
+      // recovers the live turn cleanly after a dropped connection.
       if (isReconnect) {
         for (const sub of this.subscriptions.values()) {
           for (const listener of sub.reconnectListeners) listener();
@@ -303,7 +319,8 @@ class WsTransport {
     const sub = this.subscriptions.get(workspaceId);
     if (!sub) return;
 
-    // Update per-workspace caches
+    // Update per-workspace live caches. History is owned by REST and never
+    // travels over the socket, so there is nothing to cache for it here.
     if (msg.type === "status") {
       sub.lastStatus = msg;
       if (msg.sessionId) {
@@ -311,8 +328,6 @@ class WsTransport {
       } else if (msg.status === "idle") {
         sub.lastStatusBySession.clear();
       }
-    } else if (msg.type === "history") {
-      sub.lastHistory = msg;
     } else if (msg.type === "diff_stats") {
       sub.lastDiffStats = msg;
     } else if (msg.type === "branch_info") {

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -271,6 +271,11 @@ class WsTransport {
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
       }
+      // Send the subscription FIRST so the on-the-wire order is sync_workspaces →
+      // switch_session. The backend serializes per-socket messages, so the
+      // subscription lands before any reconnect-triggered switch_session and there
+      // is no "Not subscribed" error flash.
+      this.sendSyncWorkspaces();
       // On reconnect, notify listeners so they can re-pull focus (re-send
       // switch_session) and get a fresh consolidated stream_snapshot. The
       // snapshot replaces (not appends) stream state, so this is idempotent and
@@ -281,7 +286,6 @@ class WsTransport {
         }
       }
       this.setHubStatus("connected");
-      this.sendSyncWorkspaces();
     };
 
     ws.onmessage = (event) => {

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -10,6 +10,30 @@ type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
 type DiffStatsMessage = Extract<WsOutgoing, { type: "diff_stats" }>;
 type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
+function isCachedReplayMessage(msg: WsOutgoing): boolean {
+  return msg.type === "status" || msg.type === "diff_stats" || msg.type === "branch_info";
+}
+
+function isConversationBufferedMessage(msg: WsOutgoing): boolean {
+  switch (msg.type) {
+    case "user_message":
+    case "text_delta":
+    case "thinking":
+    case "tool_use":
+    case "tool_result":
+    case "agent_activity":
+    case "tool_input_required":
+    case "tool_input_resolved":
+    case "stream_snapshot":
+    case "done":
+    case "cancelled":
+    case "plan_mode_changed":
+      return true;
+    default:
+      return false;
+  }
+}
+
 /**
  * The last rendered message window for a session. Cached client-side so that
  * switching back to a recently viewed session shows the last view instantly
@@ -144,7 +168,9 @@ class WsTransport {
    * Register a handler for incoming messages.
    * Replays cached live state (status, diff stats, branch info) and any buffered
    * messages immediately. History is NOT replayed here — it is owned by REST.
-   * Returns `{ unsubscribe, hadBufferedMessages }`.
+   * Returns `{ unsubscribe, hadBufferedMessages }`, where the flag means the
+   * replay included conversation-state events. Cached metadata/status replays do
+   * not count because REST history still needs to hydrate the message window.
    */
   onMessage(workspaceId: string, handler: MessageHandler): { unsubscribe: () => void; hadBufferedMessages: boolean } {
     const sub = this.getOrCreateSubscription(workspaceId);
@@ -164,7 +190,7 @@ class WsTransport {
       handler(sub.lastBranchInfo);
     }
 
-    const hadBufferedMessages = sub.messageBuffer.length > 0;
+    const hadBufferedMessages = sub.messageBuffer.some(isConversationBufferedMessage);
     for (const msg of sub.messageBuffer) {
       handler(msg);
     }
@@ -347,7 +373,7 @@ class WsTransport {
     // Dispatch to handlers or buffer
     if (sub.messageHandlers.size > 0) {
       for (const handler of sub.messageHandlers) handler(msg);
-    } else {
+    } else if (!isCachedReplayMessage(msg)) {
       sub.messageBuffer.push(msg);
     }
   }

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/contexts/WorkspaceLiveDataContext";
 import ChatInput, { type ChatInputHandle } from "@/components/ChatInput";
 import { ConversationPane } from "@/components/chat/ConversationPane";
+import { ToolOutputProvider } from "@/contexts/ToolOutputContext";
 import { CenterCard } from "@/components/CenterCard";
 import { PageHeader } from "@/components/AppLayout";
 import { BrainWelcome } from "@/components/BrainWelcome";
@@ -118,6 +119,8 @@ export default function BrainView() {
   // WorkspaceView via useConversationColumn.
   const {
     messages,
+    hasMore,
+    loadEarlier,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -348,6 +351,7 @@ export default function BrainView() {
           <div className="flex min-w-0 h-full flex-col overflow-hidden">
             <BrainHeader path={repoPath} upstream={brainUpstream} />
             <CenterCard>
+            <ToolOutputProvider workspaceId={BRAIN_WORKSPACE_ID} sessionId={sessionId}>
             <ConversationPane
               sessions={sessions}
               activeSessionId={sessionId}
@@ -364,6 +368,8 @@ export default function BrainView() {
               onFileTabClose={closeFileTab}
               onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
               messages={messages}
+              hasMore={hasMore}
+              onLoadEarlier={loadEarlier}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}
               currentThinking={currentThinking}
@@ -418,6 +424,7 @@ export default function BrainView() {
                 )
               }
             />
+            </ToolOutputProvider>
             {isFileTabActive && openFile && (
               <FileTabView
                 wsId={BRAIN_WORKSPACE_ID}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -9,6 +9,7 @@ import { useWorkspaceLiveDataContext, useClearUnread } from "@/contexts/Workspac
 import { FileTree, renderFileTreeNodes } from "@/components/ai-elements/file-tree";
 import ChatInput, { type ChatInputHandle } from "@/components/ChatInput";
 import { ConversationPane } from "@/components/chat/ConversationPane";
+import { ToolOutputProvider } from "@/contexts/ToolOutputContext";
 import { TerminalPane } from "@/components/TerminalPane";
 import { FileTabView } from "@/components/FileTabView";
 import { BranchLabel } from "@/components/BranchLabel";
@@ -154,6 +155,8 @@ export default function WorkspaceView() {
 
   const {
     messages,
+    hasMore,
+    loadEarlier,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -454,6 +457,7 @@ export default function WorkspaceView() {
             />
           </PageHeader>
           <CenterCard>
+          <ToolOutputProvider workspaceId={wsId} sessionId={sessionId}>
           <ConversationPane
             sessions={sessions}
             activeSessionId={sessionId}
@@ -470,6 +474,8 @@ export default function WorkspaceView() {
             onFileTabClose={closeFileTab}
             onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
             messages={messages}
+            hasMore={hasMore}
+            onLoadEarlier={loadEarlier}
             streamingStartedAt={streamingStartedAt}
             currentStreamingText={currentStreamingText}
             currentThinking={currentThinking}
@@ -541,6 +547,7 @@ export default function WorkspaceView() {
               )
             }
           />
+          </ToolOutputProvider>
           {isFileTabActive && openFile && wsId && (
             <FileTabView
               wsId={wsId}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -417,7 +417,9 @@ export interface ModelCatalogResponse {
 
 /** Frontend -> Backend */
 export type WsIncoming =
-  | { type: "switch_session"; sessionId: string }
+  // sessionId optional: omit it to pull focus on the workspace's active session
+  // (the backend resolves it). Present to focus an explicit session.
+  | { type: "switch_session"; sessionId?: string }
   | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -228,7 +228,7 @@ export interface ToolCall {
   output?: string;
   /** First ~2 KB of the output (REST history). */
   outputPreview?: string;
-  /** Exact line count of the FULL output. */
+  /** Line count of the FULL output after ignoring a single trailing newline. */
   outputLineCount?: number;
   /** Exact UTF-8 byte length of the FULL output. */
   outputByteLength?: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -436,8 +436,10 @@ export type WsOutgoing =
   | {
       type: "done";
       sessionId: string;
-      /** Server-persisted message id for the finalized assistant turn. */
-      messageId: string;
+      /** Server-persisted message id for the finalized assistant turn. Present
+       *  only when the turn persisted a message; its presence is the single
+       *  signal that the turn had displayable content (omitted for empty turns). */
+      messageId?: string;
       durationMs?: number;
       inputTokens?: number;
       outputTokens?: number;
@@ -459,7 +461,6 @@ export type WsOutgoing =
       streamingStartedAt: number;
     }
   | { type: "user_message"; message: ChatMessage }
-  | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }
   | { type: "diff_stats"; stats: DiffStatResponse }
   | { type: "script_status"; scriptType: ScriptType; state: ScriptState; exitCode?: number }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -224,7 +224,16 @@ export interface ToolCall {
   id: string;
   name: string;
   input: string;
+  /** Full output. Present live; OMITTED in REST history when truncated. */
   output?: string;
+  /** First ~2 KB of the output (REST history). */
+  outputPreview?: string;
+  /** Exact line count of the FULL output. */
+  outputLineCount?: number;
+  /** Exact UTF-8 byte length of the FULL output. */
+  outputByteLength?: number;
+  /** True when the full body was omitted because it exceeded the preview cap. */
+  outputTruncated?: boolean;
   parentToolUseId?: string;
 }
 
@@ -252,6 +261,22 @@ export interface ChatMessage {
   contextUsedTokens?: number;
   /** Context window size reported by the provider for this turn. */
   contextWindowTokens?: number;
+}
+
+/**
+ * Response of the session-history REST endpoints
+ * (`GET /api/workspaces/:wsId/sessions/:sessionId/messages` and the active-session
+ * `GET /api/workspaces/:wsId/session/messages`). `hasMore` is true when older
+ * messages exist before `messages[0]`; use `messages[0].id` as the next `before`.
+ */
+export interface SessionMessagesResponse {
+  messages: ChatMessage[];
+  hasMore: boolean;
+}
+
+/** Response of `GET /api/workspaces/:wsId/sessions/:sessionId/tools/:toolId/output`. */
+export interface ToolOutputResponse {
+  output: string;
 }
 
 // ── Question / Plan types (for AskUserQuestion & ExitPlanMode tools) ─
@@ -409,6 +434,8 @@ export type WsOutgoing =
   | {
       type: "done";
       sessionId: string;
+      /** Server-persisted message id for the finalized assistant turn. */
+      messageId: string;
       durationMs?: number;
       inputTokens?: number;
       outputTokens?: number;
@@ -417,8 +444,18 @@ export type WsOutgoing =
       pendingToolName?: string;
     }
   | { type: "error"; message: string; sessionId?: string }
-  | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
+  | { type: "cancelled"; sessionId: string; messageId?: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: "idle" | "busy"; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
+  | {
+      type: "stream_snapshot";
+      sessionId: string;
+      text: string;
+      thinking: string;
+      toolCalls: ToolCall[];
+      agentActivities: AgentActivity[];
+      planMode: boolean;
+      streamingStartedAt: number;
+    }
   | { type: "user_message"; message: ChatMessage }
   | { type: "history"; messages: ChatMessage[]; sessionId?: string }
   | { type: "branch_info"; info: BranchInfo }

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -549,3 +549,33 @@ describe("ChatConversation question-dismissed rendering", () => {
     expect(screen.queryByTestId("msg-u1")).not.toBeInTheDocument();
   });
 });
+
+describe("ChatConversation load-earlier", () => {
+  const someMessages: ChatMessage[] = [
+    { id: "m1", sessionId: "s1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+  ];
+
+  it("shows the 'Load earlier messages' button when hasMore and there are messages", () => {
+    renderConversation({ messages: someMessages, hasMore: true });
+    expect(screen.getByRole("button", { name: /load earlier messages/i })).toBeInTheDocument();
+  });
+
+  it("hides the button when hasMore is false", () => {
+    renderConversation({ messages: someMessages, hasMore: false });
+    expect(screen.queryByRole("button", { name: /load earlier messages/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the button when there are no messages even if hasMore is true", () => {
+    renderConversation({ messages: [], hasMore: true });
+    expect(screen.queryByRole("button", { name: /load earlier messages/i })).not.toBeInTheDocument();
+  });
+
+  it("calls onLoadEarlier when the button is clicked", async () => {
+    const onLoadEarlier = vi.fn();
+    renderConversation({ messages: someMessages, hasMore: true, onLoadEarlier });
+
+    await userEvent.click(screen.getByRole("button", { name: /load earlier messages/i }));
+
+    expect(onLoadEarlier).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/components/ChatToolUse.test.tsx
+++ b/frontend/tests/components/ChatToolUse.test.tsx
@@ -1,8 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ChatToolUse from "@/components/ChatToolUse";
+import { ToolOutputProvider } from "@/contexts/ToolOutputContext";
 import type { ToolCall } from "@/types";
+
+const getMock = vi.fn();
+vi.mock("@/hooks/useApi", () => ({
+  api: { get: (...args: unknown[]) => getMock(...args) },
+}));
 
 function tool(overrides: Partial<ToolCall>): ToolCall {
   return {
@@ -14,7 +20,19 @@ function tool(overrides: Partial<ToolCall>): ToolCall {
   };
 }
 
+function renderWithContext(node: React.ReactElement) {
+  return render(
+    <ToolOutputProvider workspaceId="ws-1" sessionId="sess-1">
+      {node}
+    </ToolOutputProvider>,
+  );
+}
+
 describe("ChatToolUse", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+  });
+
   it("shows fallback content when tool input is invalid JSON", async () => {
     const user = userEvent.setup();
     render(<ChatToolUse tool={tool({ input: "{not-json", output: "result" })} />);
@@ -280,5 +298,112 @@ describe("ChatToolUse", () => {
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(screen.queryByText("Path: src/main.ts")).not.toBeInTheDocument();
     expect(screen.queryByText("Output")).not.toBeInTheDocument();
+  });
+
+  describe("lazy output (truncated history tools)", () => {
+    it("reads scalars for the collapsed Grep summary without parsing the full body", () => {
+      // History-truncated Grep: full output omitted, only scalars/preview present.
+      render(
+        <ChatToolUse
+          tool={tool({
+            name: "Grep",
+            input: JSON.stringify({ pattern: "foo" }),
+            output: undefined,
+            outputPreview: "match-a\nmatch-b",
+            outputLineCount: 42,
+            outputByteLength: 999_999,
+            outputTruncated: true,
+          })}
+        />,
+      );
+
+      // The collapsed stat is derived from scalars, not the (omitted) full body.
+      expect(screen.getByText("42 results")).toBeInTheDocument();
+    });
+
+    it("fetches the full output on expand when truncated and renders it", async () => {
+      const user = userEvent.setup();
+      getMock.mockResolvedValueOnce({ output: "the full multi-kilobyte body" });
+
+      renderWithContext(
+        <ChatToolUse
+          tool={tool({
+            id: "trunc-1",
+            name: "Bash",
+            input: JSON.stringify({ command: "cat big.log" }),
+            output: undefined,
+            outputPreview: "first 2kb preview…",
+            outputLineCount: 5000,
+            outputByteLength: 500_000,
+            outputTruncated: true,
+          })}
+        />,
+      );
+
+      // Preview is shown before expanding nothing is fetched.
+      expect(getMock).not.toHaveBeenCalled();
+
+      await user.click(screen.getByRole("button", { name: /bash/i }));
+
+      await waitFor(() => {
+        expect(getMock).toHaveBeenCalledWith(
+          "/api/workspaces/ws-1/sessions/sess-1/tools/trunc-1/output",
+        );
+      });
+      await waitFor(() => {
+        expect(screen.getByText("the full multi-kilobyte body")).toBeInTheDocument();
+      });
+    });
+
+    it("does not refetch on a second expand toggle", async () => {
+      const user = userEvent.setup();
+      getMock.mockResolvedValue({ output: "fetched once" });
+
+      renderWithContext(
+        <ChatToolUse
+          tool={tool({
+            id: "trunc-2",
+            name: "Bash",
+            input: JSON.stringify({ command: "x" }),
+            output: undefined,
+            outputPreview: "preview",
+            outputLineCount: 100,
+            outputByteLength: 300_000,
+            outputTruncated: true,
+          })}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: /bash/i });
+      await user.click(button); // expand → fetch
+      await waitFor(() => expect(screen.getByText("fetched once")).toBeInTheDocument());
+      await user.click(button); // collapse
+      await user.click(button); // expand again → cached, no refetch
+
+      expect(getMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not fetch when the output is not truncated", async () => {
+      const user = userEvent.setup();
+
+      renderWithContext(
+        <ChatToolUse
+          tool={tool({
+            name: "Bash",
+            input: JSON.stringify({ command: "echo hi" }),
+            output: "hi\n",
+            outputPreview: "hi\n",
+            outputLineCount: 2,
+            outputByteLength: 3,
+            outputTruncated: false,
+          })}
+        />,
+      );
+
+      await user.click(screen.getByRole("button", { name: /bash/i }));
+
+      expect(getMock).not.toHaveBeenCalled();
+      expect(screen.getByText("Output")).toBeInTheDocument();
+    });
   });
 });

--- a/frontend/tests/components/ChatToolUse.test.tsx
+++ b/frontend/tests/components/ChatToolUse.test.tsx
@@ -393,7 +393,7 @@ describe("ChatToolUse", () => {
             input: JSON.stringify({ command: "echo hi" }),
             output: "hi\n",
             outputPreview: "hi\n",
-            outputLineCount: 2,
+            outputLineCount: 1, // "hi\n" → 1 (trailing newline ignored)
             outputByteLength: 3,
             outputTruncated: false,
           })}

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -370,7 +370,7 @@ describe("Sidebar", () => {
 
     // A background turn completes -> unread dot.
     act(() => {
-      __wsMock.emit(BRAIN_WORKSPACE_ID, { type: "done", sessionId: "brain-sess-1" });
+      __wsMock.emit(BRAIN_WORKSPACE_ID, { type: "done", sessionId: "brain-sess-1", messageId: "msg-brain-sess-1" });
     });
     expect(brainLink.querySelector("[aria-label='Unread activity']")).not.toBeNull();
 
@@ -1298,7 +1298,7 @@ describe("Sidebar", () => {
     await screen.findByText("workspace/paris");
 
     act(() => {
-      __wsMock.emit("w2", { type: "done", sessionId: "sess-2" });
+      __wsMock.emit("w2", { type: "done", sessionId: "sess-2", messageId: "msg-sess-2" });
     });
 
     const inactiveLink = screen.getByRole("link", { name: /workspace\/paris/i });
@@ -1313,7 +1313,7 @@ describe("Sidebar", () => {
     await screen.findByText("workspace/tokyo");
 
     act(() => {
-      __wsMock.emit("w1", { type: "done", sessionId: "sess-1" });
+      __wsMock.emit("w1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
     });
 
     const activeLink = screen.getByRole("link", { name: /workspace\/tokyo/i });
@@ -1341,7 +1341,7 @@ describe("Sidebar", () => {
     const inactiveLink = screen.getByRole("link", { name: /workspace\/paris/i });
 
     act(() => {
-      __wsMock.emit("w2", { type: "done", sessionId: "sess-2" });
+      __wsMock.emit("w2", { type: "done", sessionId: "sess-2", messageId: "msg-sess-2" });
     });
     expect(findSidebarUnreadDot(inactiveLink)).toBeInTheDocument();
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2937,6 +2937,70 @@ describe("useConversation", () => {
         sessionId: "sess-active",
       });
     });
+
+    it("refetches REST history on reconnect to recover a turn that completed while disconnected", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-active", streaming: true });
+      });
+      expect(result.current.sessionId).toBe("sess-active");
+      // Drop the mount-time pull so the assertion targets only the
+      // reconnect-triggered REST refetch.
+      __apiMock.getMock.mockClear();
+
+      // The turn that finished during the disconnect is only available via REST;
+      // the live snapshot path can't deliver it because the session is no longer
+      // streaming once we reconnect.
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        {
+          id: "u1",
+          sessionId: "sess-active",
+          role: "user",
+          content: "before disconnect",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+        {
+          id: "a1",
+          sessionId: "sess-active",
+          role: "assistant",
+          content: "completed while socket was down",
+          timestamp: "2026-02-12T00:00:01.000Z",
+        },
+      ]));
+
+      await act(async () => {
+        __wsMock.triggerReconnect("ws-1");
+        await Promise.resolve();
+      });
+
+      expect(__apiMock.getMock).toHaveBeenCalledWith(
+        "/api/workspaces/ws-1/sessions/sess-active/messages?limit=200",
+      );
+      await waitFor(() => {
+        expect(result.current.messages).toEqual([
+          expect.objectContaining({ id: "u1", content: "before disconnect" }),
+          expect.objectContaining({ id: "a1", content: "completed while socket was down" }),
+        ]);
+      });
+    });
+
+    it("does not refetch REST history on reconnect when no session is active", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+      renderHook(() => useConversation("ws-1"));
+      // Drop the mount-time pull so the assertion isolates the reconnect path.
+      __apiMock.getMock.mockClear();
+
+      act(() => {
+        __wsMock.triggerReconnect("ws-1");
+      });
+
+      // No session id → nothing to refetch (the bare switch_session resolves it).
+      expect(__apiMock.getMock).not.toHaveBeenCalled();
+    });
   });
 
   describe("finalization dedup by server message id", () => {
@@ -2973,7 +3037,7 @@ describe("useConversation", () => {
       expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(1);
     });
 
-    it("does not append an empty assistant bubble when the done turn has no content", async () => {
+    it("does not append an empty assistant bubble when done omits messageId", async () => {
       const { __wsMock } = await getWsMock();
       const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -2982,13 +3046,38 @@ describe("useConversation", () => {
           type: "user_message",
           message: { id: "u1", sessionId: "sess-1", role: "user", content: "noop", timestamp: "2026-02-20T00:00:00.000Z" },
         });
-        // No text/tools produced — an empty turn.
-        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "empty-1" });
+        // Empty turn: the backend persists nothing and omits messageId, so its
+        // absence is the single signal that no bubble should be appended.
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
       });
 
       // Only the user message remains; no empty assistant bubble.
       expect(result.current.messages).toHaveLength(1);
       expect(result.current.messages[0]?.role).toBe("user");
+    });
+
+    it("appends one deduped assistant bubble when done carries messageId", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "hello back" });
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "asst-1" });
+      });
+
+      const assistants = result.current.messages.filter((m) => m.role === "assistant");
+      expect(assistants).toHaveLength(1);
+      expect(assistants[0]).toMatchObject({ id: "asst-1", content: "hello back" });
+
+      // A re-delivered done (e.g. after reconnect) must not double the bubble.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "asst-1" });
+      });
+      expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(1);
     });
   });
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1,12 +1,17 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useConversation, _resetSavedSessions } from "@/hooks/useConversation";
-import type { ChatMessage, WsOutgoing } from "@/types";
+import type { ChatMessage, SessionMessagesResponse, WsOutgoing } from "@/types";
+
+/** Convenience: wrap a bare message array in the `{messages, hasMore}` REST shape. */
+function historyResponse(messages: ChatMessage[], hasMore = false): SessionMessagesResponse {
+  return { messages, hasMore };
+}
 
 vi.mock("@/hooks/useApi", () => {
   const getMock = vi.fn(
     () =>
-      new Promise<ChatMessage[]>(() => {
+      new Promise<SessionMessagesResponse>(() => {
         // Keep pending by default to avoid unintentional state updates in tests.
       }),
   );
@@ -21,7 +26,7 @@ vi.mock("@/hooks/useApi", () => {
         getMock.mockReset();
         getMock.mockImplementation(
           () =>
-            new Promise<ChatMessage[]>(() => {
+            new Promise<SessionMessagesResponse>(() => {
               // Keep pending by default to avoid unintentional state updates in tests.
             }),
         );
@@ -32,18 +37,28 @@ vi.mock("@/hooks/useApi", () => {
 
 vi.mock("@/lib/ws-transport", () => {
   type ConnectionStatus = "connecting" | "connected" | "disconnected";
+  interface SessionWindow { messages: ChatMessage[]; hasMore: boolean }
   const statuses = new Map<string, ConnectionStatus>();
   const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
   const statusListeners = new Map<string, Set<() => void>>();
+  const reconnectListeners = new Map<string, Set<() => void>>();
   const replayMessages = new Map<string, WsOutgoing[]>();
   const bufferedFlags = new Map<string, boolean>();
-  const cachedHistories = new Map<string, WsOutgoing>();
+  const windows = new Map<string, Map<string, SessionWindow>>();
 
   const getSet = <T,>(source: Map<string, Set<T>>, workspaceId: string) => {
     const existing = source.get(workspaceId);
     if (existing) return existing;
     const created = new Set<T>();
     source.set(workspaceId, created);
+    return created;
+  };
+
+  const windowMap = (workspaceId: string) => {
+    const existing = windows.get(workspaceId);
+    if (existing) return existing;
+    const created = new Map<string, SessionWindow>();
+    windows.set(workspaceId, created);
     return created;
   };
 
@@ -77,8 +92,9 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: bufferedFlags.get(workspaceId) ?? false,
       };
     }),
-    onReconnect: vi.fn((_workspaceId: string, _callback: () => void) => {
-      return () => {};
+    onReconnect: vi.fn((workspaceId: string, callback: () => void) => {
+      getSet(reconnectListeners, workspaceId).add(callback);
+      return () => { getSet(reconnectListeners, workspaceId).delete(callback); };
     }),
     subscribe: (workspaceId: string, listener: () => void) => {
       getSet(statusListeners, workspaceId).add(listener);
@@ -87,12 +103,14 @@ vi.mock("@/lib/ws-transport", () => {
       };
     },
     getStatus: (workspaceId: string) => statuses.get(workspaceId) ?? "disconnected",
-    updateCachedHistory: vi.fn((workspaceId: string, historyMsg: WsOutgoing) => {
-      cachedHistories.set(workspaceId, historyMsg);
+    setSessionWindow: vi.fn((workspaceId: string, sessionId: string, window: SessionWindow) => {
+      windowMap(workspaceId).set(sessionId, window);
     }),
-    hasCachedHistory: vi.fn((workspaceId: string) => cachedHistories.has(workspaceId)),
+    getSessionWindow: vi.fn((workspaceId: string, sessionId: string) =>
+      windowMap(workspaceId).get(sessionId),
+    ),
     clearCachedData: vi.fn((workspaceId: string) => {
-      cachedHistories.delete(workspaceId);
+      windows.delete(workspaceId);
       replayMessages.delete(workspaceId);
       bufferedFlags.delete(workspaceId);
     }),
@@ -102,21 +120,25 @@ vi.mock("@/lib/ws-transport", () => {
     emit: (workspaceId: string, msg: WsOutgoing) => {
       for (const handler of messageHandlers.get(workspaceId) ?? []) handler(msg);
     },
+    triggerReconnect: (workspaceId: string) => {
+      for (const cb of reconnectListeners.get(workspaceId) ?? []) cb();
+    },
     reset: () => {
       statuses.clear();
       messageHandlers.clear();
       statusListeners.clear();
+      reconnectListeners.clear();
       replayMessages.clear();
       bufferedFlags.clear();
-      cachedHistories.clear();
+      windows.clear();
       wsTransport.connect.mockClear();
       wsTransport.disconnect.mockClear();
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
       wsTransport.onMessage.mockClear();
-      wsTransport.updateCachedHistory.mockClear();
-      wsTransport.hasCachedHistory.mockClear();
+      wsTransport.setSessionWindow.mockClear();
+      wsTransport.getSessionWindow.mockClear();
       wsTransport.clearCachedData.mockClear();
     },
     setReplay: (workspaceId: string, messages: WsOutgoing[]) => {
@@ -128,29 +150,32 @@ vi.mock("@/lib/ws-transport", () => {
     sendMock: wsTransport.send,
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
-    updateCachedHistoryMock: wsTransport.updateCachedHistory,
-    hasCachedHistoryMock: wsTransport.hasCachedHistory,
-    setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => {
-      cachedHistories.set(workspaceId, historyMsg);
+    setSessionWindowMock: wsTransport.setSessionWindow,
+    getSessionWindowMock: wsTransport.getSessionWindow,
+    setSessionWindow: (workspaceId: string, sessionId: string, window: SessionWindow) => {
+      windowMap(workspaceId).set(sessionId, window);
     },
   };
 
   return { wsTransport, __wsMock };
 });
 
+interface SessionWindowShape { messages: ChatMessage[]; hasMore: boolean }
+
 const getWsMock = async () =>
   (await import("@/lib/ws-transport")) as unknown as {
     __wsMock: {
       emit: (workspaceId: string, msg: WsOutgoing) => void;
+      triggerReconnect: (workspaceId: string) => void;
       reset: () => void;
       setReplay: (workspaceId: string, messages: WsOutgoing[]) => void;
       setBuffered: (workspaceId: string, value: boolean) => void;
       sendMock: ReturnType<typeof vi.fn>;
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
-      updateCachedHistoryMock: ReturnType<typeof vi.fn>;
-      hasCachedHistoryMock: ReturnType<typeof vi.fn>;
-      setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => void;
+      setSessionWindowMock: ReturnType<typeof vi.fn>;
+      getSessionWindowMock: ReturnType<typeof vi.fn>;
+      setSessionWindow: (workspaceId: string, sessionId: string, window: SessionWindowShape) => void;
     };
   };
 
@@ -161,6 +186,18 @@ const getApiMock = async () =>
       reset: () => void;
     };
   };
+
+/**
+ * Streaming deltas (text_delta/thinking) are coalesced on a ~50ms tick. Tests
+ * that emit deltas and then assert the streaming view directly must flush that
+ * tick. Emitting any non-delta event also flushes pending deltas synchronously,
+ * so tests that follow deltas with done/tool_use don't need this.
+ */
+async function flushStreamDeltas() {
+  await act(async () => {
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
+}
 
 describe("useConversation", () => {
   beforeEach(async () => {
@@ -323,7 +360,7 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "text_delta", text: "Hi " });
       __wsMock.emit("ws-1", { type: "text_delta", text: "there" });
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
     });
 
     expect(result.current.isStreaming).toBe(false);
@@ -337,8 +374,8 @@ describe("useConversation", () => {
   it("resyncs persisted session history on done to recover missed deltas", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-1",
@@ -353,7 +390,7 @@ describe("useConversation", () => {
         content: "final answer from persistence",
         timestamp: "2026-02-12T00:00:01.000Z",
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -369,14 +406,14 @@ describe("useConversation", () => {
         },
       });
       // No text_delta received (simulates session unfocused while streaming).
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
     });
 
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(2);
       expect(result.current.messages.at(-1)?.content).toBe("final answer from persistence");
     });
-    expect(__apiMock.getMock).toHaveBeenNthCalledWith(2, "/api/workspaces/ws-1/sessions/sess-1/messages");
+    expect(__apiMock.getMock).toHaveBeenNthCalledWith(2, "/api/workspaces/ws-1/sessions/sess-1/messages?limit=200");
   });
 
   it("preserves parentToolUseId from tool_use events in active and persisted tool calls", async () => {
@@ -415,7 +452,7 @@ describe("useConversation", () => {
     ]);
 
     act(() => {
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
     });
 
     const assistant = result.current.messages.at(-1);
@@ -784,7 +821,7 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", {
         type: "done",
-        sessionId: "sess-activity",
+        sessionId: "sess-activity", messageId: "msg-sess-activity",
       });
     });
 
@@ -803,7 +840,7 @@ describe("useConversation", () => {
 
   it("keeps persisted agent activities from history", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "a1",
         sessionId: "sess-history-activity",
@@ -818,7 +855,7 @@ describe("useConversation", () => {
           },
         ],
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -909,24 +946,10 @@ describe("useConversation", () => {
     });
   });
 
-  it("hydrates persisted history after mount even when websocket replays stale history", async () => {
-    const { __wsMock } = await getWsMock();
+  it("hydrates persisted history from REST on mount (single source of truth)", async () => {
     const { __apiMock } = await getApiMock();
 
-    __wsMock.setReplay("ws-1", [{
-      type: "history",
-      messages: [
-        {
-          id: "a1",
-          sessionId: "sess-1",
-          role: "assistant",
-          content: "stale-only-assistant",
-          timestamp: "2026-02-12T00:00:00.000Z",
-        },
-      ],
-    }]);
-
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-1",
@@ -941,7 +964,7 @@ describe("useConversation", () => {
         content: "world",
         timestamp: "2026-02-12T00:00:01.000Z",
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -954,54 +977,38 @@ describe("useConversation", () => {
     expect(result.current.messages[1]?.content).toBe("world");
   });
 
-  it("does not overwrite replayed buffered state when transport reports buffered messages", async () => {
-    const { __wsMock } = await getWsMock();
+  it("loads history from the active-session REST endpoint on first visit", async () => {
     const { __apiMock } = await getApiMock();
 
-    __wsMock.setReplay("ws-1", [{
-      type: "history",
-      sessionId: "sess-buffered",
-      messages: [
-        {
-          id: "m-buffered",
-          sessionId: "sess-buffered",
-          role: "assistant",
-          content: "latest from buffered websocket",
-          timestamp: "2026-02-12T00:00:00.000Z",
-        },
-      ],
-    }]);
-    __wsMock.setBuffered("ws-1", true);
-
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
-        id: "m-stale",
-        sessionId: "sess-buffered",
+        id: "m-disk",
+        sessionId: "sess-fresh",
         role: "assistant",
-        content: "stale from disk",
+        content: "from disk",
         timestamp: "2026-02-12T00:00:00.000Z",
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(1);
     });
-    expect(result.current.messages[0]?.content).toBe("latest from buffered websocket");
+    expect(result.current.messages[0]?.content).toBe("from disk");
 
     await waitFor(() => {
-      expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/session/messages");
+      expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/session/messages?limit=200");
     });
-    expect(result.current.messages[0]?.content).toBe("latest from buffered websocket");
+    expect(result.current.messages[0]?.content).toBe("from disk");
   });
 
   it("does not overwrite backend user message with a late history request", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    let resolveHistory: ((messages: ChatMessage[]) => void) | undefined;
+    let resolveHistory: ((res: SessionMessagesResponse) => void) | undefined;
     __apiMock.getMock.mockReturnValueOnce(
-      new Promise<ChatMessage[]>((resolve) => {
+      new Promise<SessionMessagesResponse>((resolve) => {
         resolveHistory = resolve;
       }),
     );
@@ -1025,7 +1032,7 @@ describe("useConversation", () => {
     expect(result.current.messages[0]?.role).toBe("user");
 
     act(() => {
-      resolveHistory?.([]);
+      resolveHistory?.(historyResponse([]));
     });
 
     await waitFor(() => {
@@ -1036,7 +1043,7 @@ describe("useConversation", () => {
 
   it("hydrates sessionId from initial history payload", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-hydrated",
@@ -1044,7 +1051,7 @@ describe("useConversation", () => {
         content: "hello",
         timestamp: "2026-02-12T00:00:00.000Z",
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1056,7 +1063,7 @@ describe("useConversation", () => {
 
   it("rehydrates AskUserQuestion pending input from history when WS request event was missed", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-q",
@@ -1086,7 +1093,7 @@ describe("useConversation", () => {
           },
         ],
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1104,7 +1111,7 @@ describe("useConversation", () => {
 
   it("falls back to empty object when history tool input is not valid JSON", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-q",
@@ -1126,7 +1133,7 @@ describe("useConversation", () => {
           },
         ],
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1138,7 +1145,7 @@ describe("useConversation", () => {
 
   it("rehydrates ExitPlanMode pending input from history when WS request event was missed", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
       {
         id: "u1",
         sessionId: "sess-plan",
@@ -1160,7 +1167,7 @@ describe("useConversation", () => {
           },
         ],
       },
-    ]);
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1176,8 +1183,9 @@ describe("useConversation", () => {
     );
   });
 
-  it("clears stale pending tool inputs when history has no pending prompts", async () => {
+  it("clears stale pending tool inputs when the REST resync has no pending prompts", async () => {
     const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
     const { result } = renderHook(() => useConversation("ws-1"));
 
     act(() => {
@@ -1193,34 +1201,35 @@ describe("useConversation", () => {
     });
     expect(result.current.pendingToolInputs).toHaveLength(1);
 
-    act(() => {
-      __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-      __wsMock.emit("ws-1", {
-        type: "history",
+    // done triggers a REST resync; the loaded history has no pending prompts.
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+      {
+        id: "u1",
         sessionId: "sess-1",
-        messages: [
-          {
-            id: "u1",
-            sessionId: "sess-1",
-            role: "user",
-            content: "done",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-          {
-            id: "a1",
-            sessionId: "sess-1",
-            role: "assistant",
-            content: "completed",
-            timestamp: "2026-02-12T00:00:01.000Z",
-          },
-        ],
-      });
+        role: "user",
+        content: "done",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "completed",
+        timestamp: "2026-02-12T00:00:01.000Z",
+      },
+    ]));
+
+    await act(async () => {
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "a1" });
+      await Promise.resolve();
     });
 
-    expect(result.current.pendingToolInputs).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.pendingToolInputs).toEqual([]);
+    });
   });
 
-  it("keeps active pending tool inputs when a history event arrives during streaming", async () => {
+  it("keeps live pending tool inputs across a stream_snapshot replay", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1242,29 +1251,22 @@ describe("useConversation", () => {
       }),
     ]);
 
+    // A consolidated catch-up snapshot replaces stream accumulators but must not
+    // drop the in-flight pending question.
     act(() => {
       __wsMock.emit("ws-1", {
-        type: "history",
+        type: "stream_snapshot",
         sessionId: "sess-1",
-        messages: [
-          {
-            id: "a1",
-            sessionId: "sess-1",
-            role: "assistant",
-            content: "",
-            timestamp: "2026-02-12T00:00:01.000Z",
-            toolCalls: [
-              {
-                id: "tool-history",
-                name: "AskUserQuestion",
-                input: JSON.stringify({ questions: [{ question: "stale history" }] }),
-              },
-            ],
-          },
-        ],
+        text: "thinking about it",
+        thinking: "",
+        toolCalls: [],
+        agentActivities: [],
+        planMode: false,
+        streamingStartedAt: 1_700_000_000_000,
       });
     });
 
+    expect(result.current.currentStreamingText).toBe("thinking about it");
     expect(result.current.pendingToolInputs).toEqual([
       expect.objectContaining({
         requestId: "req-live",
@@ -1273,10 +1275,17 @@ describe("useConversation", () => {
     ]);
   });
 
-  it("switches sessions and loads specific session history", async () => {
+  it("switches sessions and loads specific session history from REST", async () => {
     const { __apiMock } = await getApiMock();
-    const { __wsMock } = await getWsMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
+    __apiMock.getMock.mockResolvedValue(historyResponse([
+      {
+        id: "m-1",
+        sessionId: "sess-2",
+        role: "assistant",
+        content: "loaded from target session",
+        timestamp: "2026-02-12T00:00:01.000Z",
+      },
+    ]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1284,51 +1293,21 @@ describe("useConversation", () => {
       await result.current.switchSession("sess-2");
     });
 
-    act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-2",
-        messages: [
-          {
-            id: "m-1",
-            sessionId: "sess-2",
-            role: "assistant",
-            content: "loaded from target session",
-            timestamp: "2026-02-12T00:00:01.000Z",
-          },
-        ],
-      });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({ id: "m-1", content: "loaded from target session" }),
+      ]);
     });
-
-    expect(__apiMock.getMock).toHaveBeenCalledTimes(1);
-    expect(result.current.messages).toEqual([
-      expect.objectContaining({ id: "m-1", content: "loaded from target session" }),
-    ]);
+    expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-2/messages?limit=200");
     expect(result.current.sessionId).toBe("sess-2");
     expect(result.current.isStreaming).toBe(false);
   });
 
   it("keeps target session visible and sets an error when switch_session send fails", async () => {
     const { __wsMock } = await getWsMock();
+    // REST stays pending (default mock) so messages remain empty regardless.
     __wsMock.sendMock.mockReturnValueOnce(false);
     const { result } = renderHook(() => useConversation("ws-1"));
-
-    act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-old",
-        messages: [
-          {
-            id: "m-old",
-            sessionId: "sess-old",
-            role: "assistant",
-            content: "old",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-        ],
-      });
-    });
-    expect(result.current.messages).toHaveLength(1);
 
     await act(async () => {
       await result.current.switchSession("sess-fail");
@@ -1346,8 +1325,8 @@ describe("useConversation", () => {
 
   it("keeps selected session id when switched session has no messages", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
-    __apiMock.getMock.mockResolvedValueOnce([]);
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1359,10 +1338,29 @@ describe("useConversation", () => {
     expect(result.current.sessionId).toBe("sess-empty");
   });
 
-  it("ignores stale session history response when switching rapidly", async () => {
+  it("ignores a stale session history response when switching rapidly", async () => {
     const { __apiMock } = await getApiMock();
-    const { __wsMock } = await getWsMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
+
+    // Each switch fires a REST resync. Make sess-old's resolve late, sess-new's
+    // resolve immediately; the stale sess-old payload must not clobber sess-new.
+    let resolveOld: ((res: SessionMessagesResponse) => void) | undefined;
+    __apiMock.getMock.mockImplementation((url: string) => {
+      if (url.includes("sessions/sess-old/")) {
+        return new Promise<SessionMessagesResponse>((resolve) => { resolveOld = resolve; });
+      }
+      if (url.includes("sessions/sess-new/")) {
+        return Promise.resolve(historyResponse([
+          {
+            id: "m-new",
+            sessionId: "sess-new",
+            role: "assistant",
+            content: "new session payload",
+            timestamp: "2026-02-12T00:00:02.000Z",
+          },
+        ]));
+      }
+      return new Promise<SessionMessagesResponse>(() => {});
+    });
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -1374,38 +1372,29 @@ describe("useConversation", () => {
       await result.current.switchSession("sess-new");
     });
 
-    act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-old",
-        messages: [
-          {
-            id: "m-old",
-            sessionId: "sess-old",
-            role: "assistant",
-            content: "stale payload",
-            timestamp: "2026-02-12T00:00:03.000Z",
-          },
-        ],
-      });
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-new",
-        messages: [
-          {
-            id: "m-new",
-            sessionId: "sess-new",
-            role: "assistant",
-            content: "new session payload",
-            timestamp: "2026-02-12T00:00:02.000Z",
-          },
-        ],
-      });
+    // sess-new's response should have landed.
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({ id: "m-new", content: "new session payload" }),
+      ]);
     });
 
-    await waitFor(() => {
-      expect(result.current.sessionId).toBe("sess-new");
+    // The stale sess-old response arrives after we've moved to sess-new.
+    await act(async () => {
+      resolveOld?.(historyResponse([
+        {
+          id: "m-old",
+          sessionId: "sess-old",
+          role: "assistant",
+          content: "stale payload",
+          timestamp: "2026-02-12T00:00:03.000Z",
+        },
+      ]));
+      await Promise.resolve();
     });
+
+    // The stale payload must NOT clobber sess-new.
+    expect(result.current.sessionId).toBe("sess-new");
     expect(result.current.messages).toEqual([
       expect.objectContaining({ id: "m-new", content: "new session payload" }),
     ]);
@@ -1553,6 +1542,7 @@ describe("useConversation", () => {
       __wsMock.emit("ws-1", { type: "thinking", text: "First " });
       __wsMock.emit("ws-1", { type: "thinking", text: "second" });
     });
+    await flushStreamDeltas();
 
     expect(result.current.currentThinking).toBe("First second");
   });
@@ -1577,7 +1567,7 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "thinking", text: "Deep thought" });
       __wsMock.emit("ws-1", { type: "text_delta", text: "Answer" });
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
     });
 
     const assistant = result.current.messages.at(-1);
@@ -1680,7 +1670,7 @@ describe("useConversation", () => {
 
     act(() => {
       __wsMock.emit("ws-1", { type: "text_delta", text: "Hello" });
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 4500 });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1", durationMs: 4500 });
     });
 
     const assistant = result.current.messages.at(-1);
@@ -1925,7 +1915,7 @@ describe("useConversation", () => {
   it("uses session-specific REST endpoint when restoring saved session", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValue([]);
+    __apiMock.getMock.mockResolvedValue(historyResponse([]));
     const { result, rerender } = renderHook(
       ({ wsId }) => useConversation(wsId),
       { initialProps: { wsId: "ws-1" } },
@@ -1943,14 +1933,14 @@ describe("useConversation", () => {
 
     // Switch away and back
     __apiMock.getMock.mockClear();
-    __apiMock.getMock.mockResolvedValue([]);
+    __apiMock.getMock.mockResolvedValue(historyResponse([]));
     rerender({ wsId: "ws-2" });
     __wsMock.setReplay("ws-1", []);
     rerender({ wsId: "ws-1" });
 
     await waitFor(() => {
       expect(__apiMock.getMock).toHaveBeenCalledWith(
-        "/api/workspaces/ws-1/sessions/sess-B/messages",
+        "/api/workspaces/ws-1/sessions/sess-B/messages?limit=200",
       );
     });
   });
@@ -1976,6 +1966,7 @@ describe("useConversation", () => {
       });
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Hello " });
     });
+    await flushStreamDeltas();
 
     expect(result.current.currentStreamingText).toBe("Hello ");
     expect(result.current.isStreaming).toBe(true);
@@ -1997,6 +1988,7 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "World" });
     });
+    await flushStreamDeltas();
 
     // Pre-switch + post-switch text are both present
     expect(result.current.sessionId).toBe("sess-1");
@@ -2024,6 +2016,7 @@ describe("useConversation", () => {
       });
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "data" });
     });
+    await flushStreamDeltas();
 
     expect(result.current.currentStreamingText).toBe("data");
 
@@ -2063,6 +2056,7 @@ describe("useConversation", () => {
       });
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Before " });
     });
+    await flushStreamDeltas();
 
     expect(result.current.currentStreamingText).toBe("Before ");
 
@@ -2073,7 +2067,7 @@ describe("useConversation", () => {
     __wsMock.setReplay("ws-1", [
       { type: "status", status: "busy", sessionId: "sess-1", streaming: true },
       { type: "text_delta", sessionId: "sess-1", text: "after" },
-      { type: "done", sessionId: "sess-1", durationMs: 1234 },
+      { type: "done", sessionId: "sess-1", messageId: "msg-sess-1", durationMs: 1234 },
     ]);
     rerender({ wsId: "ws-1" });
 
@@ -2102,7 +2096,7 @@ describe("useConversation", () => {
         },
       });
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Done" });
-      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 100 });
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1", durationMs: 100 });
     });
 
     expect(result.current.isStreaming).toBe(false);
@@ -2237,9 +2231,17 @@ describe("useConversation", () => {
     expect(result.current.streamingStartedAt).toBe(1_700_000_002_000);
   });
 
-  it("preserves streamingStartedAt on same-session history while streaming", async () => {
+  it("preserves streamingStartedAt when a same-session REST history lands while streaming", async () => {
     const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_666);
+
+    // The initial mount fetch resolves only after a stream is in progress.
+    let resolveMount: ((res: SessionMessagesResponse) => void) | undefined;
+    __apiMock.getMock.mockReturnValueOnce(
+      new Promise<SessionMessagesResponse>((resolve) => { resolveMount = resolve; }),
+    );
+
     const { result } = renderHook(() => useConversation("ws-1"));
 
     act(() => {
@@ -2254,19 +2256,20 @@ describe("useConversation", () => {
         },
       });
       __wsMock.emit("ws-1", { type: "text_delta", text: "partial" });
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-1",
-        messages: [
-          {
-            id: "u1",
-            sessionId: "sess-1",
-            role: "user",
-            content: "hello",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-        ],
-      });
+    });
+    expect(result.current.streamingStartedAt).toBe(1_700_000_001_666);
+
+    await act(async () => {
+      resolveMount?.(historyResponse([
+        {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "hello",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      ]));
+      await Promise.resolve();
     });
 
     expect(result.current.isStreaming).toBe(true);
@@ -2407,7 +2410,7 @@ describe("useConversation", () => {
   it("clears lockedProvider on session switch", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
     const { result } = renderHook(() => useConversation("ws-1"));
 
     act(() => {
@@ -2432,7 +2435,7 @@ describe("useConversation", () => {
   it("picks up lockedProvider from bootstrap status on session switch", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
     const { result } = renderHook(() => useConversation("ws-1"));
 
     await act(async () => {
@@ -2453,8 +2456,8 @@ describe("useConversation", () => {
     expect(result.current.lockedProvider).toBe("claude");
   });
 
-  describe("transport cache freshness", () => {
-    it("updates transport cache when messages change after done event", async () => {
+  describe("session window cache (stale-while-revalidate)", () => {
+    it("writes the per-session window to the transport when messages change after done", async () => {
       const { __wsMock } = await getWsMock();
 
       const { result } = renderHook(() => useConversation("ws-1"));
@@ -2466,21 +2469,23 @@ describe("useConversation", () => {
           message: { id: "u1", sessionId: "sess-1", role: "user", content: "hello", timestamp: "2026-02-20T00:00:00.000Z" },
         });
         __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "hi back" });
-        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 100 });
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1", durationMs: 100 });
       });
 
-      // After done, messages should have both user + assistant messages.
-      // The cache-update effect should have pushed them to the transport.
       expect(result.current.messages).toHaveLength(2);
-      expect(__wsMock.updateCachedHistoryMock).toHaveBeenCalled();
-      const lastCall = __wsMock.updateCachedHistoryMock.mock.calls.at(-1)!;
+      expect(__wsMock.setSessionWindowMock).toHaveBeenCalled();
+      const lastCall = __wsMock.setSessionWindowMock.mock.calls.at(-1)!;
       expect(lastCall[0]).toBe("ws-1");
-      expect(lastCall[1].type).toBe("history");
-      expect(lastCall[1].sessionId).toBe("sess-1");
-      expect(lastCall[1].messages).toHaveLength(2);
+      expect(lastCall[1]).toBe("sess-1");
+      expect(lastCall[2].messages).toHaveLength(2);
+      expect(lastCall[2]).toHaveProperty("hasMore");
     });
 
-    it("does not update cache with empty messages during workspace switch", async () => {
+    it("does not write the window with empty messages during workspace switch", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValue(historyResponse([
+        { id: "m1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+      ]));
       const { __wsMock } = await getWsMock();
 
       const { result, rerender } = renderHook(
@@ -2488,29 +2493,24 @@ describe("useConversation", () => {
         { initialProps: { wsId: "ws-1" } },
       );
 
-      // Populate messages for ws-1
-      await act(async () => {
-        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-        __wsMock.emit("ws-1", {
-          type: "history",
-          sessionId: "sess-1",
-          messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" }],
-        });
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(1);
       });
+      __wsMock.setSessionWindowMock.mockClear();
 
-      expect(result.current.messages).toHaveLength(1);
-      __wsMock.updateCachedHistoryMock.mockClear();
-
-      // Switch to ws-2 — messages clear, cache should NOT be overwritten with empty
+      // Switch to ws-2 — messages clear, window must NOT be overwritten with empty.
       rerender({ wsId: "ws-2" });
 
-      // Check that no call was made with empty messages for ws-1
-      for (const call of __wsMock.updateCachedHistoryMock.mock.calls) {
-        expect(call[1].messages.length).toBeGreaterThan(0);
+      for (const call of __wsMock.setSessionWindowMock.mock.calls) {
+        expect(call[2].messages.length).toBeGreaterThan(0);
       }
     });
 
-    it("skips cache write on first effect cycle after workspace switch to prevent cross-workspace pollution", async () => {
+    it("skips window write on first effect cycle after workspace switch to prevent cross-workspace pollution", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValue(historyResponse([
+        { id: "m1", sessionId: "sess-1", role: "user", content: "ws-1 msg", timestamp: "2026-02-20T00:00:00.000Z" },
+      ]));
       const { __wsMock } = await getWsMock();
 
       const { result, rerender } = renderHook(
@@ -2518,55 +2518,63 @@ describe("useConversation", () => {
         { initialProps: { wsId: "ws-1" } },
       );
 
-      // Populate ws-1 with messages
-      await act(async () => {
-        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-        __wsMock.emit("ws-1", {
-          type: "history",
-          sessionId: "sess-1",
-          messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "ws-1 msg", timestamp: "2026-02-20T00:00:00.000Z" }],
-        });
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(1);
       });
+      __wsMock.setSessionWindowMock.mockClear();
 
-      expect(result.current.messages).toHaveLength(1);
-      __wsMock.updateCachedHistoryMock.mockClear();
-
-      // Switch to ws-2 — React 18 batching may transiently leave state.messages
-      // holding ws-1's messages while workspaceId is already ws-2. The guard
-      // (prevCacheWorkspaceRef) should prevent writing ws-1's messages into ws-2's cache.
+      // The guard (prevCacheWorkspaceRef) prevents writing ws-1's messages into ws-2's cache.
       rerender({ wsId: "ws-2" });
 
-      const ws2CacheCalls = __wsMock.updateCachedHistoryMock.mock.calls.filter(
+      const ws2CacheCalls = __wsMock.setSessionWindowMock.mock.calls.filter(
         ([wsId]: [string]) => wsId === "ws-2",
       );
       expect(ws2CacheCalls).toHaveLength(0);
     });
 
-    it("skips REST fetch when transport has cached history", async () => {
+    it("renders the cached window immediately and still revalidates via REST on switch-back", async () => {
       const { __wsMock } = await getWsMock();
       const { __apiMock } = await getApiMock();
-      __apiMock.getMock.mockResolvedValue([]);
 
-      // Pre-populate the cache so hasCachedHistory returns true
-      __wsMock.setCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "sess-1",
-        messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" }],
+      // Seed a window for ws-1 / sess-cached and pre-set the saved session.
+      __wsMock.setSessionWindow("ws-1", "sess-cached", {
+        messages: [{ id: "m1", sessionId: "sess-cached", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" }],
+        hasMore: false,
       });
 
-      renderHook(() => useConversation("ws-1"));
+      // A fresher REST window revalidates the cached view.
+      __apiMock.getMock.mockResolvedValue(historyResponse([
+        { id: "m1", sessionId: "sess-cached", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" },
+        { id: "a1", sessionId: "sess-cached", role: "assistant", content: "revalidated", timestamp: "2026-02-20T00:00:01.000Z" },
+      ]));
 
-      // REST should NOT have been called since cache exists
-      expect(__apiMock.getMock).not.toHaveBeenCalled();
+      const { result, rerender } = renderHook(
+        ({ wsId }) => useConversation(wsId),
+        { initialProps: { wsId: "ws-other" as string | undefined } },
+      );
+
+      // Establish that ws-1's saved session is sess-cached, then visit ws-1.
+      act(() => {
+        rerender({ wsId: "ws-1" });
+      });
+      // Without a saved session yet, prime it via status then re-enter.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-cached", streaming: false });
+      });
+
+      // REST still fires (single source of truth) — stale-while-revalidate.
+      await waitFor(() => {
+        expect(__apiMock.getMock).toHaveBeenCalled();
+      });
+      expect(result.current.sessionId).toBe("sess-cached");
     });
 
-    it("fires REST fetch on first visit when no cached history exists", async () => {
+    it("always fires a REST fetch on first visit", async () => {
       const { __apiMock } = await getApiMock();
-      __apiMock.getMock.mockReturnValue(new Promise<ChatMessage[]>(() => {}));
+      __apiMock.getMock.mockReturnValue(new Promise<SessionMessagesResponse>(() => {}));
 
       renderHook(() => useConversation("ws-1"));
 
-      // REST should fire since there's no cached history
       await waitFor(() => {
         expect(__apiMock.getMock).toHaveBeenCalledWith(
           expect.stringContaining("/api/workspaces/ws-1/"),
@@ -2598,7 +2606,7 @@ describe("useConversation", () => {
         __wsMock.emit("ws-1", { type: "text_delta", text: "Hello back" });
         __wsMock.emit("ws-1", {
           type: "done",
-          sessionId: "sess-1",
+          sessionId: "sess-1", messageId: "msg-sess-1",
           durationMs: 2000,
           inputTokens: 45_000,
           outputTokens: 1_200,
@@ -2621,7 +2629,7 @@ describe("useConversation", () => {
         __wsMock.emit("ws-1", { type: "text_delta", text: "Codex reply" });
         __wsMock.emit("ws-1", {
           type: "done",
-          sessionId: "sess-1",
+          sessionId: "sess-1", messageId: "msg-sess-1",
           inputTokens: 41_000,
           outputTokens: 900,
           contextUsedTokens: 42_000,
@@ -2657,13 +2665,283 @@ describe("useConversation", () => {
 
       act(() => {
         __wsMock.emit("ws-1", { type: "text_delta", text: "Reply" });
-        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "msg-sess-1" });
       });
 
       const assistant = result.current.messages.at(-1);
       expect(assistant?.role).toBe("assistant");
       expect(assistant?.inputTokens).toBeUndefined();
       expect(assistant?.outputTokens).toBeUndefined();
+    });
+  });
+
+  describe("stream_snapshot (consolidated catch-up, replace semantics)", () => {
+    const snapshot = (overrides: Partial<Extract<WsOutgoing, { type: "stream_snapshot" }>> = {}) => ({
+      type: "stream_snapshot" as const,
+      sessionId: "sess-1",
+      text: "partial answer",
+      thinking: "let me think",
+      toolCalls: [
+        { id: "t1", name: "Read", input: JSON.stringify({ file_path: "/a.ts" }), output: "contents" },
+      ],
+      agentActivities: [],
+      planMode: false,
+      streamingStartedAt: 1_700_000_000_000,
+      ...overrides,
+    });
+
+    it("replaces the session stream slot from a snapshot and is idempotent", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", snapshot());
+      });
+
+      const first = {
+        text: result.current.currentStreamingText,
+        thinking: result.current.currentThinking,
+        toolCalls: result.current.activeToolCalls,
+        isStreaming: result.current.isStreaming,
+      };
+      expect(first).toEqual({
+        text: "partial answer",
+        thinking: "let me think",
+        toolCalls: [expect.objectContaining({ id: "t1", output: "contents" })],
+        isStreaming: true,
+      });
+
+      // Applying the SAME snapshot again must not duplicate or alter state.
+      act(() => {
+        __wsMock.emit("ws-1", snapshot());
+      });
+
+      expect(result.current.currentStreamingText).toBe("partial answer");
+      expect(result.current.currentThinking).toBe("let me think");
+      expect(result.current.activeToolCalls).toHaveLength(1);
+      expect(result.current.activeToolCalls).toEqual([
+        expect.objectContaining({ id: "t1" }),
+      ]);
+    });
+
+    it("creates the stream slot when a snapshot arrives without a prior status", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        // First-visit case: snapshot arrives with no pre-existing slot.
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: false });
+        __wsMock.emit("ws-1", snapshot({ thinking: "", toolCalls: [], agentActivities: [] }));
+      });
+
+      expect(result.current.sessionId).toBe("sess-1");
+      expect(result.current.currentStreamingText).toBe("partial answer");
+      expect(result.current.isStreaming).toBe(true);
+    });
+
+    it("a later snapshot replaces (not appends) prior live deltas", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "stale " });
+        __wsMock.emit("ws-1", {
+          type: "tool_use", sessionId: "sess-1", id: "told", name: "Bash", input: "{}",
+        });
+      });
+      await flushStreamDeltas();
+      expect(result.current.currentStreamingText).toBe("stale ");
+
+      act(() => {
+        __wsMock.emit("ws-1", snapshot({ text: "fresh full text", toolCalls: [] }));
+      });
+
+      // Replace semantics: the stale delta text and tool are gone, not merged.
+      expect(result.current.currentStreamingText).toBe("fresh full text");
+      expect(result.current.activeToolCalls).toEqual([]);
+    });
+  });
+
+  describe("finalization dedup by server message id", () => {
+    it("appends the optimistic assistant message with the server id, then dedups on REST fetch", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+
+      // The done-resync returns history that INCLUDES the just-finalized turn.
+      __apiMock.getMock.mockResolvedValue(historyResponse([
+        { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        { id: "server-msg-1", sessionId: "sess-1", role: "assistant", content: "Answer", timestamp: "2026-02-20T00:00:01.000Z" },
+      ]));
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", text: "Answer" });
+      });
+
+      await act(async () => {
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "server-msg-1" });
+        await Promise.resolve();
+      });
+
+      // Optimistic append used the server id; the REST resync must NOT duplicate it.
+      await waitFor(() => {
+        const assistants = result.current.messages.filter((m) => m.id === "server-msg-1");
+        expect(assistants).toHaveLength(1);
+      });
+      expect(result.current.messages.filter((m) => m.role === "assistant")).toHaveLength(1);
+    });
+
+    it("does not append an empty assistant bubble when the done turn has no content", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "noop", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        // No text/tools produced — an empty turn.
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "empty-1" });
+      });
+
+      // Only the user message remains; no empty assistant bubble.
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0]?.role).toBe("user");
+    });
+  });
+
+  describe("live tool_result computes unified scalars once", () => {
+    it("stores outputPreview/outputLineCount/outputByteLength/outputTruncated on the tool", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "grep", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "tool_use", id: "g1", name: "Grep", input: "{}" });
+      });
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "tool_result", toolUseId: "g1", output: "line1\nline2\nline3" });
+      });
+
+      const tool = result.current.activeToolCalls[0];
+      expect(tool).toMatchObject({
+        id: "g1",
+        output: "line1\nline2\nline3",
+        outputPreview: "line1\nline2\nline3",
+        outputLineCount: 3,
+        outputByteLength: 17,
+        outputTruncated: false,
+      });
+    });
+
+    it("computes a line count of 0 for empty output", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "x", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "tool_use", id: "g1", name: "Bash", input: "{}" });
+        __wsMock.emit("ws-1", { type: "tool_result", toolUseId: "g1", output: "" });
+      });
+
+      expect(result.current.activeToolCalls[0]).toMatchObject({
+        outputPreview: "",
+        outputLineCount: 0,
+        outputTruncated: false,
+      });
+    });
+  });
+
+  describe("loadEarlier + hasMore", () => {
+    it("prepends an older window and updates hasMore", async () => {
+      const { __apiMock } = await getApiMock();
+      // Initial window: one recent message, more exist before it.
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m2", sessionId: "sess-1", role: "assistant", content: "recent", timestamp: "2026-02-20T00:00:02.000Z" },
+      ], true));
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(1);
+      });
+      expect(result.current.hasMore).toBe(true);
+
+      // loadEarlier fetches the window before messages[0].
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m1", sessionId: "sess-1", role: "user", content: "older", timestamp: "2026-02-20T00:00:01.000Z" },
+      ], false));
+
+      await act(async () => {
+        await result.current.loadEarlier();
+      });
+
+      expect(result.current.messages.map((m) => m.id)).toEqual(["m1", "m2"]);
+      expect(result.current.hasMore).toBe(false);
+      expect(__apiMock.getMock).toHaveBeenLastCalledWith(
+        "/api/workspaces/ws-1/sessions/sess-1/messages?limit=200&before=m2",
+      );
+    });
+
+    it("loadEarlier is a no-op when hasMore is false", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m1", sessionId: "sess-1", role: "user", content: "only", timestamp: "2026-02-20T00:00:00.000Z" },
+      ], false));
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(1);
+      });
+      expect(result.current.hasMore).toBe(false);
+      __apiMock.getMock.mockClear();
+
+      await act(async () => {
+        await result.current.loadEarlier();
+      });
+
+      expect(__apiMock.getMock).not.toHaveBeenCalled();
+      expect(result.current.messages).toHaveLength(1);
+    });
+
+    it("dedups overlapping ids when prepending an older window", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m2", sessionId: "sess-1", role: "user", content: "b", timestamp: "2026-02-20T00:00:02.000Z" },
+        { id: "m3", sessionId: "sess-1", role: "assistant", content: "c", timestamp: "2026-02-20T00:00:03.000Z" },
+      ], true));
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(2);
+      });
+
+      // The older window overlaps on m2 (same id) and adds m1.
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m1", sessionId: "sess-1", role: "user", content: "a", timestamp: "2026-02-20T00:00:01.000Z" },
+        { id: "m2", sessionId: "sess-1", role: "user", content: "b", timestamp: "2026-02-20T00:00:02.000Z" },
+      ], false));
+
+      await act(async () => {
+        await result.current.loadEarlier();
+      });
+
+      expect(result.current.messages.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
     });
   });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -46,6 +46,20 @@ vi.mock("@/lib/ws-transport", () => {
   const bufferedFlags = new Map<string, boolean>();
   const windows = new Map<string, Map<string, SessionWindow>>();
 
+  const isConversationBufferedMessage = (msg: WsOutgoing) =>
+    msg.type === "user_message" ||
+    msg.type === "text_delta" ||
+    msg.type === "thinking" ||
+    msg.type === "tool_use" ||
+    msg.type === "tool_result" ||
+    msg.type === "agent_activity" ||
+    msg.type === "tool_input_required" ||
+    msg.type === "tool_input_resolved" ||
+    msg.type === "stream_snapshot" ||
+    msg.type === "done" ||
+    msg.type === "cancelled" ||
+    msg.type === "plan_mode_changed";
+
   const getSet = <T,>(source: Map<string, Set<T>>, workspaceId: string) => {
     const existing = source.get(workspaceId);
     if (existing) return existing;
@@ -89,7 +103,9 @@ vi.mock("@/lib/ws-transport", () => {
       }
       return {
         unsubscribe: () => { getSet(messageHandlers, workspaceId).delete(handler); },
-        hadBufferedMessages: bufferedFlags.get(workspaceId) ?? false,
+        hadBufferedMessages:
+          bufferedFlags.get(workspaceId) ??
+          (replayMessages.get(workspaceId)?.some(isConversationBufferedMessage) ?? false),
       };
     }),
     onReconnect: vi.fn((workspaceId: string, callback: () => void) => {
@@ -2319,7 +2335,6 @@ describe("useConversation", () => {
     __wsMock.setReplay("ws-1", [
       { type: "error", message: "stale connection error" },
     ]);
-    __wsMock.setBuffered("ws-1", true);
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -2336,7 +2351,6 @@ describe("useConversation", () => {
       { type: "status", status: "busy", sessionId: "sess-1", streaming: true },
       { type: "error", sessionId: "sess-1", message: "session error from buffer" },
     ]);
-    __wsMock.setBuffered("ws-1", true);
 
     const { result } = renderHook(() => useConversation("ws-1"));
 
@@ -2350,7 +2364,6 @@ describe("useConversation", () => {
     __wsMock.setReplay("ws-1", [
       { type: "error", message: "stale error" },
     ]);
-    __wsMock.setBuffered("ws-1", true);
 
     const { result } = renderHook(() => useConversation("ws-1"));
     expect(result.current.error).toBeUndefined();
@@ -2361,6 +2374,28 @@ describe("useConversation", () => {
     });
 
     expect(result.current.error).toBe("live error");
+  });
+
+  it("still fetches REST history when buffer replay only contains cached metadata", async () => {
+    const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
+
+    __wsMock.setReplay("ws-1", [
+      { type: "status", status: "idle", sessionId: "sess-1", streaming: false },
+      { type: "branch_info", info: { name: "lazy-load-conversations", lastSyncedAt: "2026-02-20T00:00:00.000Z" } },
+    ]);
+    __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+      { id: "m1", sessionId: "sess-1", role: "assistant", content: "from disk", timestamp: "2026-02-20T00:00:01.000Z" },
+    ]));
+
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    await waitFor(() => {
+      expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/session/messages?limit=200");
+    });
+    await waitFor(() => {
+      expect(result.current.messages.map((m) => m.id)).toEqual(["m1"]);
+    });
   });
 
   it("ignores session-scoped error for a background session", async () => {
@@ -2810,6 +2845,37 @@ describe("useConversation", () => {
       });
     });
 
+    it("normalizes non-string snapshot tool output before computing scalars", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", snapshot({
+          toolCalls: [
+            {
+              id: "mcp-1",
+              name: "MCP",
+              input: "{}",
+              output: [
+                { type: "text", text: "first" },
+                { type: "text", text: "second" },
+              ] as unknown as string,
+            },
+          ],
+        }));
+      });
+
+      expect(result.current.activeToolCalls[0]).toMatchObject({
+        id: "mcp-1",
+        output: "first\n\nsecond",
+        outputPreview: "first\n\nsecond",
+        outputLineCount: 3,
+        outputByteLength: 13,
+        outputTruncated: false,
+      });
+    });
+
     it("computes zero scalars for a snapshot tool that completed with empty output", async () => {
       const { __wsMock } = await getWsMock();
       const { result } = renderHook(() => useConversation("ws-1"));
@@ -2987,6 +3053,60 @@ describe("useConversation", () => {
       });
     });
 
+    it("drops older same-session REST history responses when a newer replacement resolves first", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([]));
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      await waitFor(() => {
+        expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/session/messages?limit=200");
+      });
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-active", streaming: true });
+      });
+      expect(result.current.sessionId).toBe("sess-active");
+
+      const pending: Array<{ resolve: (res: SessionMessagesResponse) => void }> = [];
+      __apiMock.getMock.mockImplementation(
+        () =>
+          new Promise<SessionMessagesResponse>((resolve) => {
+            pending.push({ resolve });
+          }),
+      );
+
+      act(() => {
+        __wsMock.triggerReconnect("ws-1");
+        __wsMock.triggerReconnect("ws-1");
+      });
+
+      await waitFor(() => {
+        expect(pending).toHaveLength(2);
+      });
+
+      await act(async () => {
+        pending[1]?.resolve(historyResponse([
+          { id: "u1", sessionId: "sess-active", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+          { id: "a-new", sessionId: "sess-active", role: "assistant", content: "newer", timestamp: "2026-02-20T00:00:01.000Z" },
+        ]));
+        await Promise.resolve();
+      });
+
+      await waitFor(() => {
+        expect(result.current.messages.map((m) => m.id)).toEqual(["u1", "a-new"]);
+      });
+
+      await act(async () => {
+        pending[0]?.resolve(historyResponse([
+          { id: "u1", sessionId: "sess-active", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        ]));
+        await Promise.resolve();
+      });
+
+      expect(result.current.messages.map((m) => m.id)).toEqual(["u1", "a-new"]);
+    });
+
     it("does not refetch REST history on reconnect when no session is active", async () => {
       const { __wsMock } = await getWsMock();
       const { __apiMock } = await getApiMock();
@@ -3128,6 +3248,32 @@ describe("useConversation", () => {
         outputTruncated: false,
       });
     });
+
+    it("normalizes non-string live tool_result output before computing scalars", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "mcp", timestamp: "2026-02-20T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "tool_use", id: "mcp-1", name: "MCP", input: "{}" });
+        __wsMock.emit("ws-1", {
+          type: "tool_result",
+          toolUseId: "mcp-1",
+          output: { result: "ok" } as unknown as string,
+        });
+      });
+
+      expect(result.current.activeToolCalls[0]).toMatchObject({
+        output: "{\"result\":\"ok\"}",
+        outputPreview: "{\"result\":\"ok\"}",
+        outputLineCount: 1,
+        outputByteLength: 15,
+        outputTruncated: false,
+      });
+    });
   });
 
   describe("loadEarlier + hasMore", () => {
@@ -3206,6 +3352,59 @@ describe("useConversation", () => {
       });
 
       expect(result.current.messages.map((m) => m.id)).toEqual(["m1", "m2", "m3"]);
+    });
+
+    it("drops a loadEarlier response when the visible window changed while it was in flight", async () => {
+      const { __wsMock } = await getWsMock();
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValueOnce(historyResponse([
+        { id: "m2", sessionId: "sess-1", role: "user", content: "b", timestamp: "2026-02-20T00:00:02.000Z" },
+        { id: "m3", sessionId: "sess-1", role: "assistant", content: "c", timestamp: "2026-02-20T00:00:03.000Z" },
+      ], true));
+
+      const { result } = renderHook(() => useConversation("ws-1"));
+      await waitFor(() => {
+        expect(result.current.messages.map((m) => m.id)).toEqual(["m2", "m3"]);
+      });
+
+      let resolveOlder: ((res: SessionMessagesResponse) => void) | undefined;
+      __apiMock.getMock.mockImplementation((url: string) => {
+        if (url.includes("&before=m2")) {
+          return new Promise<SessionMessagesResponse>((resolve) => {
+            resolveOlder = resolve;
+          });
+        }
+        return Promise.resolve(historyResponse([
+          { id: "m3", sessionId: "sess-1", role: "assistant", content: "c", timestamp: "2026-02-20T00:00:03.000Z" },
+          { id: "m4", sessionId: "sess-1", role: "assistant", content: "fresh", timestamp: "2026-02-20T00:00:04.000Z" },
+        ], true));
+      });
+
+      void act(() => {
+        void result.current.loadEarlier();
+      });
+
+      await waitFor(() => {
+        expect(resolveOlder).toBeDefined();
+      });
+
+      await act(async () => {
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", messageId: "m4" });
+        await Promise.resolve();
+      });
+      await waitFor(() => {
+        expect(result.current.messages.map((m) => m.id)).toEqual(["m3", "m4"]);
+      });
+
+      await act(async () => {
+        resolveOlder?.(historyResponse([
+          { id: "m1", sessionId: "sess-1", role: "user", content: "a", timestamp: "2026-02-20T00:00:01.000Z" },
+        ], false));
+        await Promise.resolve();
+      });
+
+      expect(result.current.messages.map((m) => m.id)).toEqual(["m3", "m4"]);
+      expect(result.current.hasMore).toBe(true);
     });
   });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -135,7 +135,10 @@ vi.mock("@/lib/ws-transport", () => {
       wsTransport.disconnect.mockClear();
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
-      wsTransport.send.mockClear();
+      // Reset (not just clear) so a per-test mockImplementation/mockReturnValueOnce
+      // override can't leak into the next test, then restore the default.
+      wsTransport.send.mockReset();
+      wsTransport.send.mockImplementation((_workspaceId: string, _message: unknown) => true);
       wsTransport.onMessage.mockClear();
       wsTransport.setSessionWindow.mockClear();
       wsTransport.getSessionWindow.mockClear();
@@ -326,8 +329,12 @@ describe("useConversation", () => {
 
   it("does not add user message when transport send fails", async () => {
     const { __wsMock } = await getWsMock();
-    __wsMock.sendMock.mockReturnValueOnce(false);
     const { result } = renderHook(() => useConversation("ws-1"));
+    // The mount-time focus pull also calls send(); fail only the user_message so
+    // the assertion targets the message send regardless of call ordering.
+    __wsMock.sendMock.mockImplementation(
+      (_ws: string, msg: { type: string }) => msg.type !== "user_message",
+    );
 
     act(() => {
       const sent = result.current.sendMessage("hello");
@@ -583,6 +590,8 @@ describe("useConversation", () => {
   it("batchAnswerQuestions sends one response per tool with original questions and clears pending", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
+    // Drop the mount-time focus pull so the two responses are calls 1 and 2.
+    __wsMock.sendMock.mockClear();
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -647,6 +656,8 @@ describe("useConversation", () => {
   it("clears pending tool inputs on tool_input_resolved (dismissed on another client)", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
+    // Ignore the mount-time focus pull; this asserts no response is sent.
+    __wsMock.sendMock.mockClear();
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1" });
@@ -672,6 +683,8 @@ describe("useConversation", () => {
   it("clears pending tool inputs when the session resumes streaming (answered on another client)", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
+    // Ignore the mount-time focus pull; this asserts no response is sent.
+    __wsMock.sendMock.mockClear();
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1" });
@@ -1306,8 +1319,13 @@ describe("useConversation", () => {
   it("keeps target session visible and sets an error when switch_session send fails", async () => {
     const { __wsMock } = await getWsMock();
     // REST stays pending (default mock) so messages remain empty regardless.
-    __wsMock.sendMock.mockReturnValueOnce(false);
     const { result } = renderHook(() => useConversation("ws-1"));
+    // The mount-time focus pull also sends switch_session; fail only the explicit
+    // switch to sess-fail so the assertion targets that call.
+    __wsMock.sendMock.mockImplementation(
+      (_ws: string, msg: { type: string; sessionId?: string }) =>
+        !(msg.type === "switch_session" && msg.sessionId === "sess-fail"),
+    );
 
     await act(async () => {
       await result.current.switchSession("sess-fail");
@@ -1710,6 +1728,8 @@ describe("useConversation", () => {
   it("does nothing when rejectToolInput is called with no pending inputs", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
+    // Ignore the mount-time focus pull; this asserts the action sends nothing.
+    __wsMock.sendMock.mockClear();
 
     act(() => {
       result.current.rejectToolInput("no pending");
@@ -2761,6 +2781,131 @@ describe("useConversation", () => {
       // Replace semantics: the stale delta text and tool are gone, not merged.
       expect(result.current.currentStreamingText).toBe("fresh full text");
       expect(result.current.activeToolCalls).toEqual([]);
+    });
+
+    it("computes unified output scalars for snapshot tools that carry output", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      // A mid-stream-join snapshot whose tool carries a full output must render
+      // via the same computed scalars as the live tool_result path — not the raw
+      // full body — so there is one render path for live and history.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", snapshot({
+          toolCalls: [
+            { id: "g1", name: "Grep", input: "{}", output: "line1\nline2\nline3" },
+          ],
+        }));
+      });
+
+      const tool = result.current.activeToolCalls[0];
+      expect(tool).toMatchObject({
+        id: "g1",
+        output: "line1\nline2\nline3",
+        outputPreview: "line1\nline2\nline3",
+        outputLineCount: 3,
+        outputByteLength: 17,
+        outputTruncated: false,
+      });
+    });
+
+    it("leaves snapshot tools without output untouched (no scalars synthesized)", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", snapshot({
+          toolCalls: [{ id: "pending", name: "Bash", input: "{}" }],
+        }));
+      });
+
+      const tool = result.current.activeToolCalls[0];
+      expect(tool).toMatchObject({ id: "pending", name: "Bash" });
+      expect(tool?.output).toBeUndefined();
+      expect(tool?.outputPreview).toBeUndefined();
+      expect(tool?.outputLineCount).toBeUndefined();
+    });
+  });
+
+  describe("focus pull on mount (in-flight catch-up)", () => {
+    it("sends a bare switch_session (no sessionId) when there is no saved session", async () => {
+      const { __wsMock } = await getWsMock();
+      // No saved session for ws-1 (beforeEach resets saved sessions). The mount
+      // effect must still pull focus so an already-streaming workspace delivers
+      // its consolidated stream_snapshot on first navigation.
+      renderHook(() => useConversation("ws-1"));
+
+      const switchCalls = __wsMock.sendMock.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "switch_session",
+      );
+      expect(switchCalls).toHaveLength(1);
+      expect(switchCalls[0]?.[0]).toBe("ws-1");
+      expect((switchCalls[0]?.[1] as { sessionId?: string }).sessionId).toBeUndefined();
+    });
+
+    it("sends switch_session with the saved session id when one exists", async () => {
+      const { __wsMock } = await getWsMock();
+      const { rerender } = renderHook(
+        ({ wsId }) => useConversation(wsId),
+        { initialProps: { wsId: "ws-1" } },
+      );
+
+      // Establish a session, then leave so cleanup saves ws-1 → sess-saved.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-saved", streaming: false });
+      });
+      rerender({ wsId: "ws-2" });
+      __wsMock.sendMock.mockClear();
+
+      // Returning to ws-1 must focus the saved session explicitly.
+      rerender({ wsId: "ws-1" });
+
+      const switchCalls = __wsMock.sendMock.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "switch_session",
+      );
+      expect(switchCalls).toContainEqual([
+        "ws-1",
+        { type: "switch_session", sessionId: "sess-saved" },
+      ]);
+    });
+
+    it("re-pulls focus on reconnect with a bare switch_session when no session is active", async () => {
+      const { __wsMock } = await getWsMock();
+      renderHook(() => useConversation("ws-1"));
+      // Drop the mount-time pull so we isolate the reconnect-triggered send.
+      __wsMock.sendMock.mockClear();
+
+      act(() => {
+        __wsMock.triggerReconnect("ws-1");
+      });
+
+      const switchCalls = __wsMock.sendMock.mock.calls.filter(
+        ([, msg]) => (msg as { type?: string }).type === "switch_session",
+      );
+      expect(switchCalls).toHaveLength(1);
+      expect((switchCalls[0]?.[1] as { sessionId?: string }).sessionId).toBeUndefined();
+    });
+
+    it("re-pulls focus on reconnect with the active session id when one is set", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-active", streaming: true });
+      });
+      expect(result.current.sessionId).toBe("sess-active");
+      __wsMock.sendMock.mockClear();
+
+      act(() => {
+        __wsMock.triggerReconnect("ws-1");
+      });
+
+      expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+        type: "switch_session",
+        sessionId: "sess-active",
+      });
     });
   });
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2810,6 +2810,36 @@ describe("useConversation", () => {
       });
     });
 
+    it("computes zero scalars for a snapshot tool that completed with empty output", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      // A completed tool whose output is "" must get the SAME zero scalars the
+      // live tool_result path computes (outputPreview "", counts 0, untruncated)
+      // — not be mistaken for a still-running tool and left without scalars.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", snapshot({
+          toolCalls: [{ id: "e1", name: "Bash", input: "{}", output: "" }],
+        }));
+      });
+
+      const tool = result.current.activeToolCalls[0];
+      expect(tool).toMatchObject({
+        id: "e1",
+        output: "",
+        outputPreview: "",
+        outputLineCount: 0,
+        outputByteLength: 0,
+        outputTruncated: false,
+      });
+      // The scalars must be present (computed), not undefined.
+      expect(tool?.outputPreview).not.toBeUndefined();
+      expect(tool?.outputLineCount).not.toBeUndefined();
+      expect(tool?.outputByteLength).not.toBeUndefined();
+      expect(tool?.outputTruncated).not.toBeUndefined();
+    });
+
     it("leaves snapshot tools without output untouched (no scalars synthesized)", async () => {
       const { __wsMock } = await getWsMock();
       const { result } = renderHook(() => useConversation("ws-1"));

--- a/frontend/tests/lib/output-scalars.test.ts
+++ b/frontend/tests/lib/output-scalars.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { outputByteLength, outputLineCount } from "@hive/shared/agent-activity";
+
+// The frontend's computeOutputScalars (useConversation) and the backend's
+// computeTruncatedField (session-utils) both read these shared primitives, so
+// the line-count / byte-length formulas cannot drift between packages. These
+// CASES mirror backend/src/agents/session-utils.test.ts byte-for-byte.
+const CASES: Array<{ name: string; input: string; lines: number; bytes: number }> = [
+  { name: "empty string", input: "", lines: 0, bytes: 0 },
+  { name: "single line, no newline", input: "hello", lines: 1, bytes: 5 },
+  { name: "multi-line", input: "a\nb\nc", lines: 3, bytes: 5 },
+  { name: "trailing newline", input: "a\n", lines: 2, bytes: 2 },
+  { name: "multibyte", input: "héllo 🚀", lines: 1, bytes: 11 },
+];
+
+describe("shared output scalar primitives (frontend)", () => {
+  for (const { name, input, lines, bytes } of CASES) {
+    it(`computes line count and byte length for ${name}`, () => {
+      expect(outputLineCount(input)).toBe(lines);
+      expect(outputByteLength(input)).toBe(bytes);
+    });
+  }
+});

--- a/frontend/tests/lib/output-scalars.test.ts
+++ b/frontend/tests/lib/output-scalars.test.ts
@@ -9,7 +9,14 @@ const CASES: Array<{ name: string; input: string; lines: number; bytes: number }
   { name: "empty string", input: "", lines: 0, bytes: 0 },
   { name: "single line, no newline", input: "hello", lines: 1, bytes: 5 },
   { name: "multi-line", input: "a\nb\nc", lines: 3, bytes: 5 },
-  { name: "trailing newline", input: "a\n", lines: 2, bytes: 2 },
+  // A single trailing newline must NOT inflate the count (command/Grep output
+  // almost always ends in one). "a\n" is one line, not two.
+  { name: "trailing newline ignored", input: "a\n", lines: 1, bytes: 2 },
+  { name: "single char", input: "a", lines: 1, bytes: 1 },
+  { name: "two lines, no trailing newline", input: "a\nb", lines: 2, bytes: 3 },
+  { name: "two lines, trailing newline", input: "a\nb\n", lines: 2, bytes: 4 },
+  { name: "lone newline", input: "\n", lines: 0, bytes: 1 },
+  { name: "trailing blank line preserved", input: "a\n\n", lines: 2, bytes: 3 },
   { name: "multibyte", input: "héllo 🚀", lines: 1, bytes: 11 },
 ];
 

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -169,16 +169,14 @@ describe("wsTransport", () => {
     });
   });
 
-  it("tracks cached history via updateCachedHistory and clears it with clearCachedData", () => {
+  it("tracks the per-session render window and clears it with clearCachedData", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
 
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    expect(wsTransport.getSessionWindow("ws-1", "sess-1")).toBeUndefined();
 
-    wsTransport.updateCachedHistory("ws-1", {
-      type: "history",
-      sessionId: "sess-1",
+    wsTransport.setSessionWindow("ws-1", "sess-1", {
       messages: [
         {
           id: "m1",
@@ -188,27 +186,24 @@ describe("wsTransport", () => {
           timestamp: "2026-02-20T00:00:00.000Z",
         },
       ],
+      hasMore: false,
     });
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+    expect(wsTransport.getSessionWindow("ws-1", "sess-1")?.messages).toHaveLength(1);
 
     wsTransport.clearCachedData("ws-1");
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    expect(wsTransport.getSessionWindow("ws-1", "sess-1")).toBeUndefined();
   });
 
-  it("drops cached history after disconnectAll removes subscriptions", () => {
+  it("drops the session window after disconnectAll removes subscriptions", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
 
-    wsTransport.updateCachedHistory("ws-1", {
-      type: "history",
-      sessionId: "sess-1",
-      messages: [],
-    });
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+    wsTransport.setSessionWindow("ws-1", "sess-1", { messages: [], hasMore: false });
+    expect(wsTransport.getSessionWindow("ws-1", "sess-1")).toBeDefined();
 
     wsTransport.disconnectAll();
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    expect(wsTransport.getSessionWindow("ws-1", "sess-1")).toBeUndefined();
   });
 
   it("dispatches parsed incoming messages to handlers (via hub envelope)", () => {
@@ -230,6 +225,30 @@ describe("wsTransport", () => {
       "[ws] Failed to parse message:",
       expect.any(SyntaxError),
     );
+    unsubscribe();
+  });
+
+  it("delivers stream_snapshot events to message handlers (live catch-up)", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    const received: WsOutgoing[] = [];
+    const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => received.push(msg));
+
+    const snapshot: WsOutgoing = {
+      type: "stream_snapshot",
+      sessionId: "s1",
+      text: "live",
+      thinking: "",
+      toolCalls: [],
+      agentActivities: [],
+      planMode: false,
+      streamingStartedAt: 1_700_000_000_000,
+    };
+    socket.hubMessage("ws-1", snapshot);
+
+    expect(received).toContainEqual(snapshot);
     unsubscribe();
   });
 
@@ -415,7 +434,7 @@ describe("wsTransport", () => {
     expect(wsTransport.getStatus("ws-1")).toBe("disconnected");
   });
 
-  it("replays status, history, and buffered messages to newly attached handlers", () => {
+  it("replays cached status and buffered messages to newly attached handlers (history is not cached)", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
@@ -426,22 +445,10 @@ describe("wsTransport", () => {
     });
 
     socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
-    socket.hubMessage("ws-1", {
-      type: "history",
-      messages: [
-        {
-          id: "u1",
-          sessionId: "s1",
-          role: "user",
-          content: "hello",
-          timestamp: "2026-02-12T00:00:00.000Z",
-        },
-      ],
-    } as WsOutgoing);
     socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "partial" });
-    socket.hubMessage("ws-1", { type: "done", sessionId: "s1" });
+    socket.hubMessage("ws-1", { type: "done", sessionId: "s1", messageId: "a1" });
 
-    expect(firstHandler).toHaveLength(4);
+    expect(firstHandler).toHaveLength(3);
     unsubscribe();
 
     // Messages arriving while no handler is subscribed should be buffered
@@ -456,7 +463,7 @@ describe("wsTransport", () => {
       },
     } as WsOutgoing);
     socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "response" });
-    socket.hubMessage("ws-1", { type: "done", sessionId: "s1" });
+    socket.hubMessage("ws-1", { type: "done", sessionId: "s1", messageId: "a2" });
 
     const replayed: WsOutgoing[] = [];
     const result = wsTransport.onMessage("ws-1", (msg) => {
@@ -465,21 +472,9 @@ describe("wsTransport", () => {
 
     expect(result.hadBufferedMessages).toBe(true);
     expect(replayed).toEqual([
-      // Cached status + history
+      // Cached status only — history lives in REST, never replayed over the socket.
       { type: "status", status: "busy", streaming: true },
-      {
-        type: "history",
-        messages: [
-          {
-            id: "u1",
-            sessionId: "s1",
-            role: "user",
-            content: "hello",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-        ],
-      },
-      // Buffered messages
+      // Buffered live messages
       {
         type: "user_message",
         message: {
@@ -491,7 +486,7 @@ describe("wsTransport", () => {
         },
       },
       { type: "text_delta", sessionId: "s1", text: "response" },
-      { type: "done", sessionId: "s1" },
+      { type: "done", sessionId: "s1", messageId: "a2" },
     ]);
   });
 
@@ -511,18 +506,13 @@ describe("wsTransport", () => {
       streaming: true,
       sessionId: "s-new",
     });
-    socket.hubMessage("ws-1", {
-      type: "history",
-      sessionId: "s-new",
-      messages: [],
-    } as WsOutgoing);
     unsubscribe();
 
     // Buffer events from multiple sessions while no message handlers are attached.
     socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s-old", text: "stale" });
-    socket.hubMessage("ws-1", { type: "done", sessionId: "s-old" });
+    socket.hubMessage("ws-1", { type: "done", sessionId: "s-old", messageId: "old-1" });
     socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s-new", text: "fresh" });
-    socket.hubMessage("ws-1", { type: "done", sessionId: "s-new" });
+    socket.hubMessage("ws-1", { type: "done", sessionId: "s-new", messageId: "new-1" });
 
     const replayed: WsOutgoing[] = [];
     const result = wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
@@ -530,11 +520,10 @@ describe("wsTransport", () => {
     expect(result.hadBufferedMessages).toBe(true);
     expect(replayed).toEqual([
       { type: "status", status: "busy", streaming: true, sessionId: "s-new" },
-      { type: "history", sessionId: "s-new", messages: [] },
       { type: "text_delta", sessionId: "s-old", text: "stale" },
-      { type: "done", sessionId: "s-old" },
+      { type: "done", sessionId: "s-old", messageId: "old-1" },
       { type: "text_delta", sessionId: "s-new", text: "fresh" },
-      { type: "done", sessionId: "s-new" },
+      { type: "done", sessionId: "s-new", messageId: "new-1" },
     ]);
   });
 
@@ -630,7 +619,7 @@ describe("wsTransport", () => {
       });
     });
 
-    it("replays branch_info together with status and history", () => {
+    it("replays branch_info together with status and diff_stats (not history)", () => {
       wsTransport.connect("ws-1");
       const socket = MockWebSocket.instances[0]!;
       socket.open();
@@ -639,7 +628,6 @@ describe("wsTransport", () => {
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
 
       socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
-      socket.hubMessage("ws-1", { type: "history", messages: [] } as WsOutgoing);
       socket.hubMessage("ws-1", {
         type: "diff_stats",
         stats: { committed: [], uncommitted: [] },
@@ -655,9 +643,10 @@ describe("wsTransport", () => {
 
       const types = replayed.map((m) => m.type);
       expect(types).toContain("status");
-      expect(types).toContain("history");
       expect(types).toContain("diff_stats");
       expect(types).toContain("branch_info");
+      // History is owned by REST and never replayed over the socket.
+      expect(types).not.toContain("history");
     });
 
     it("updates cached branch_info when a newer one arrives", () => {
@@ -688,7 +677,7 @@ describe("wsTransport", () => {
   });
 
   describe("clearCachedData", () => {
-    it("clears cached status, history, and message buffer", () => {
+    it("clears cached status, window, and message buffer", () => {
       wsTransport.connect("ws-1");
       const socket = MockWebSocket.instances[0]!;
       socket.open();
@@ -696,13 +685,14 @@ describe("wsTransport", () => {
       const first: WsOutgoing[] = [];
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
       socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
-      socket.hubMessage("ws-1", { type: "history", messages: [] } as WsOutgoing);
       unsubscribe();
 
+      wsTransport.setSessionWindow("ws-1", "s1", { messages: [], hasMore: false });
       socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "buffered" });
 
       wsTransport.clearCachedData("ws-1");
 
+      expect(wsTransport.getSessionWindow("ws-1", "s1")).toBeUndefined();
       const replayed: WsOutgoing[] = [];
       const result = wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
       expect(replayed).toEqual([]);
@@ -766,66 +756,49 @@ describe("wsTransport", () => {
     });
   });
 
-  describe("updateCachedHistory / hasCachedHistory", () => {
-    it("replays updated history to next handler", () => {
-      wsTransport.connect("ws-1");
-      const socket = MockWebSocket.instances[0]!;
-      socket.open();
-
-      const first: WsOutgoing[] = [];
-      const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
-      socket.hubMessage("ws-1", { type: "history", messages: [{ id: "old" }] } as WsOutgoing);
-      unsubscribe();
-
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "s1",
-        messages: [{ id: "old" }, { id: "new" }] as never[],
-      });
-
-      const replayed: WsOutgoing[] = [];
-      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
-      const history = replayed.find((m) => m.type === "history");
-      expect(history).toBeDefined();
-      expect((history as { messages: { id: string }[] }).messages).toEqual([
-        { id: "old" },
-        { id: "new" },
-      ]);
-    });
-
-    it("hasCachedHistory returns false when no history was received", () => {
+  describe("session window cache", () => {
+    it("round-trips a per-session window via set/getSessionWindow", () => {
       wsTransport.connect("ws-1");
       MockWebSocket.instances[0]!.open();
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+
+      const window = {
+        messages: [
+          { id: "m1", sessionId: "s1", role: "user" as const, content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        ],
+        hasMore: true,
+      };
+      wsTransport.setSessionWindow("ws-1", "s1", window);
+
+      const read = wsTransport.getSessionWindow("ws-1", "s1");
+      expect(read).toEqual(window);
     });
 
-    it("hasCachedHistory returns true after updateCachedHistory", () => {
+    it("keeps windows separate per session", () => {
       wsTransport.connect("ws-1");
       MockWebSocket.instances[0]!.open();
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        messages: [],
-      });
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+
+      wsTransport.setSessionWindow("ws-1", "s1", { messages: [], hasMore: false });
+      wsTransport.setSessionWindow("ws-1", "s2", { messages: [], hasMore: true });
+
+      expect(wsTransport.getSessionWindow("ws-1", "s1")?.hasMore).toBe(false);
+      expect(wsTransport.getSessionWindow("ws-1", "s2")?.hasMore).toBe(true);
     });
 
-    it("hasCachedHistory returns false after clearCachedData", () => {
+    it("getSessionWindow returns undefined when none is cached", () => {
       wsTransport.connect("ws-1");
       MockWebSocket.instances[0]!.open();
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        messages: [],
-      });
-      wsTransport.clearCachedData("ws-1");
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+      expect(wsTransport.getSessionWindow("ws-1", "s1")).toBeUndefined();
     });
 
-    it("is a no-op for unknown workspace", () => {
-      wsTransport.updateCachedHistory("unknown", {
-        type: "history",
-        messages: [],
-      });
-      expect(wsTransport.hasCachedHistory("unknown")).toBe(false);
+    it("setSessionWindow is a no-op for an unknown workspace", () => {
+      wsTransport.setSessionWindow("unknown", "s1", { messages: [], hasMore: false });
+      expect(wsTransport.getSessionWindow("unknown", "s1")).toBeUndefined();
+    });
+
+    it("does not expose any legacy history-cache API", () => {
+      // Guard against re-introducing the removed lastHistory cache.
+      expect((wsTransport as unknown as Record<string, unknown>).updateCachedHistory).toBeUndefined();
+      expect((wsTransport as unknown as Record<string, unknown>).hasCachedHistory).toBeUndefined();
     });
   });
 });

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -344,6 +344,39 @@ describe("wsTransport", () => {
     expect(MockWebSocket.instances).toHaveLength(2);
   });
 
+  it("sends sync_workspaces BEFORE firing reconnect listeners", () => {
+    wsTransport.connect("ws-1");
+    const first = MockWebSocket.instances[0]!;
+    first.open();
+
+    // The reconnect listener (which re-sends switch_session) must only fire after
+    // the subscription is on the wire, so the on-the-wire order is
+    // sync_workspaces → switch_session and the backend never sees "Not subscribed".
+    let syncSeenWhenReconnectFired: string[][] | null = null;
+    wsTransport.onReconnect("ws-1", () => {
+      syncSeenWhenReconnectFired = getSyncMessages(MockWebSocket.instances[1]!);
+    });
+
+    first.close();
+    vi.advanceTimersByTime(1000);
+    const second = MockWebSocket.instances[1]!;
+    second.open();
+
+    // At the instant the reconnect listener fired, the post-reconnect sync had
+    // already been sent on the new socket.
+    expect(syncSeenWhenReconnectFired).not.toBeNull();
+    expect(syncSeenWhenReconnectFired!).toEqual([expect.arrayContaining(["ws-1"])]);
+  });
+
+  it("does not fire reconnect listeners on the initial (non-reconnect) open", () => {
+    const reconnect = vi.fn();
+    wsTransport.connect("ws-1");
+    wsTransport.onReconnect("ws-1", reconnect);
+    MockWebSocket.instances[0]!.open();
+
+    expect(reconnect).not.toHaveBeenCalled();
+  });
+
   it("re-sends sync_workspaces on reconnect", () => {
     wsTransport.syncWorkspaces(["ws-1", "ws-2"]);
     const first = MockWebSocket.instances[0]!;

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -672,12 +672,16 @@ describe("wsTransport", () => {
       unsubscribe();
 
       const replayed: WsOutgoing[] = [];
-      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
+      const result = wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
 
       const types = replayed.map((m) => m.type);
       expect(types).toContain("status");
       expect(types).toContain("diff_stats");
       expect(types).toContain("branch_info");
+      expect(types.filter((type) => type === "status")).toHaveLength(1);
+      expect(types.filter((type) => type === "diff_stats")).toHaveLength(1);
+      expect(types.filter((type) => type === "branch_info")).toHaveLength(1);
+      expect(result.hadBufferedMessages).toBe(false);
       // History is owned by REST and never replayed over the socket.
       expect(types).not.toContain("history");
     });

--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -43,10 +43,18 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         let command: String?
         let cwd: String?
         let status: String?
+        /// Full output. Present live; omitted in REST history when truncated
+        /// (PRD #254) — read `outputPreview`/scalars instead.
         let output: String?
         let exitCode: Int?
         let durationMs: Int?
         let commandActions: [AgentActivityCommandAction]?
+        // Lazy-output scalars (PRD #254), mirroring the ToolCall sub-shape.
+        // Only `command_execution` carries a dominant heavy output field.
+        let outputPreview: String?
+        let outputLineCount: Int?
+        let outputByteLength: Int?
+        let outputTruncated: Bool?
 
         init(
             id: String,
@@ -56,7 +64,11 @@ enum AgentActivity: Codable, Equatable, Identifiable {
             output: String?,
             exitCode: Int?,
             durationMs: Int?,
-            commandActions: [AgentActivityCommandAction]? = nil
+            commandActions: [AgentActivityCommandAction]? = nil,
+            outputPreview: String? = nil,
+            outputLineCount: Int? = nil,
+            outputByteLength: Int? = nil,
+            outputTruncated: Bool? = nil
         ) {
             self.id = id
             self.command = command
@@ -66,6 +78,10 @@ enum AgentActivity: Codable, Equatable, Identifiable {
             self.exitCode = exitCode
             self.durationMs = durationMs
             self.commandActions = commandActions
+            self.outputPreview = outputPreview
+            self.outputLineCount = outputLineCount
+            self.outputByteLength = outputByteLength
+            self.outputTruncated = outputTruncated
         }
     }
 
@@ -155,6 +171,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
     private enum CodingKeys: String, CodingKey {
         case id, kind
         case command, cwd, status, output, exitCode, durationMs, commandActions
+        case outputPreview, outputLineCount, outputByteLength, outputTruncated
         case files
         case steps
         case active, threadId, objective, tokenBudget, tokensUsed, timeUsedSeconds, createdAt, updatedAt
@@ -201,6 +218,10 @@ enum AgentActivity: Codable, Equatable, Identifiable {
             try container.encodeIfPresent(activity.exitCode, forKey: .exitCode)
             try container.encodeIfPresent(activity.durationMs, forKey: .durationMs)
             try container.encodeIfPresent(activity.commandActions, forKey: .commandActions)
+            try container.encodeIfPresent(activity.outputPreview, forKey: .outputPreview)
+            try container.encodeIfPresent(activity.outputLineCount, forKey: .outputLineCount)
+            try container.encodeIfPresent(activity.outputByteLength, forKey: .outputByteLength)
+            try container.encodeIfPresent(activity.outputTruncated, forKey: .outputTruncated)
         case .fileChange(let activity):
             try container.encode(activity.id, forKey: .id)
             try container.encodeIfPresent(activity.status, forKey: .status)
@@ -388,7 +409,13 @@ private func toolCall(for activity: AgentActivity.CommandExecution) -> ToolCall 
             "durationMs": activity.durationMs
         ]),
         output: activity.output,
-        parentToolUseId: nil
+        parentToolUseId: nil,
+        // Carry through history truncation scalars so the collapsed view reads
+        // them instead of parsing the (possibly omitted) body (PRD #254).
+        outputPreview: activity.outputPreview,
+        outputLineCount: activity.outputLineCount,
+        outputByteLength: activity.outputByteLength,
+        outputTruncated: activity.outputTruncated
     )
 }
 

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -236,7 +236,7 @@ struct ToolCall: Codable, Identifiable {
     // reads scalars instead of re-parsing the body and there is one shape.
     /// First ~2 KB of output (UTF-8). Present on history; computed live.
     let outputPreview: String?
-    /// Exact line count of the full output (newlines + 1; 0 when empty).
+    /// Line count of the full output after ignoring a single trailing newline.
     let outputLineCount: Int?
     /// Exact UTF-8 byte length of the full output.
     let outputByteLength: Int?
@@ -291,18 +291,33 @@ struct ToolCall: Codable, Identifiable {
 let outputPreviewByteCap = 2048
 
 /// Compute the preview + exact scalars for a heavy output string, matching the
-/// backend `computeTruncatedField` byte-for-byte: line count = newlines + 1 (0
-/// when empty), byte length = UTF-8 byte length, truncated when over the cap,
-/// preview = first `outputPreviewByteCap` UTF-8 bytes (never splitting a
-/// multibyte scalar).
+/// shared TS `outputLineCount` byte-for-byte: a single trailing newline is NOT
+/// counted (0 when empty), byte length = UTF-8 byte length, truncated when over
+/// the cap, preview = first `outputPreviewByteCap` UTF-8 bytes (never splitting
+/// a multibyte scalar).
 func computeOutputScalars(_ full: String) -> (preview: String, lineCount: Int, byteLength: Int, truncated: Bool) {
     let bytes = Array(full.utf8)
     let byteLength = bytes.count
-    // Count newlines by UTF-8 byte (0x0A), then + 1 — exactly matching the
-    // backend's `full.split("\n").length`. Counting raw bytes (not Swift
-    // grapheme `Character`s) keeps "\r\n" counted as one break like JS does.
-    let lineCount = full.isEmpty ? 0 : bytes.reduce(into: 1) { count, byte in
-        if byte == 0x0A { count += 1 }
+    // Line count matching the shared TS primitive exactly:
+    //   if s.length === 0 -> 0
+    //   body = s.endsWith("\n") ? s.slice(0,-1) : s
+    //   return body.length === 0 ? 0 : body.split("\n").length
+    // So we drop a single trailing newline, then count newlines + 1 over the
+    // remaining bytes. Counting raw UTF-8 bytes (not Swift grapheme
+    // `Character`s) keeps "\r\n" counted as one break like JS does.
+    let lineCount: Int
+    if bytes.isEmpty {
+        lineCount = 0
+    } else {
+        // Drop a single trailing "\n" (0x0A) to match `slice(0, -1)`.
+        let bodyEnd = bytes.last == 0x0A ? bytes.count - 1 : bytes.count
+        if bodyEnd == 0 {
+            lineCount = 0
+        } else {
+            lineCount = bytes[0..<bodyEnd].reduce(into: 1) { count, byte in
+                if byte == 0x0A { count += 1 }
+            }
+        }
     }
     let truncated = byteLength > outputPreviewByteCap
     let preview = truncated ? sliceUtf8(full, maxBytes: outputPreviewByteCap) : full
@@ -317,6 +332,21 @@ private func sliceUtf8(_ text: String, maxBytes: Int) -> String {
     var end = maxBytes
     while end > 0 && (bytes[end] & 0b1100_0000) == 0b1000_0000 { end -= 1 }
     return String(decoding: bytes[0..<end], as: UTF8.self)
+}
+
+// MARK: - Tool output cache key (PRD #254)
+
+/// Composite cache key scoping a tool id to its session (workspaceId +
+/// sessionId). Keying by tool id alone is unsafe: Codex tool ids are sequential
+/// per turn (`item_1`, `item_2`, …) and so repeat across sessions/workspaces,
+/// which would let one session's `item_1` body be served for another session's
+/// `item_1`. The `\u{1}` separators cannot appear in workspace/session/tool ids,
+/// so the joined string is unambiguous.
+///
+/// Lives here (a test-target source) so the keying can be unit-tested without
+/// pulling the SwiftUI View layer into the test module.
+func toolOutputCacheKey(workspaceId: String, sessionId: String, toolId: String) -> String {
+    "\(workspaceId)\u{1}\(sessionId)\u{1}\(toolId)"
 }
 
 // MARK: - REST history page (PRD #254)

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -35,7 +35,7 @@ enum WorkspaceStatus: String, Codable {
     case busy
 }
 
-enum MessageRole: String, Codable {
+enum MessageRole: String, Codable, Equatable {
     case user
     case assistant
 }
@@ -222,7 +222,7 @@ struct FileMention: Codable, Equatable {
     let relativePath: String
 }
 
-struct ToolCall: Codable, Identifiable {
+struct ToolCall: Codable, Equatable, Identifiable {
     let id: String
     let name: String
     let input: String
@@ -358,7 +358,7 @@ struct MessagesPage: Codable {
     let hasMore: Bool
 }
 
-struct ChatMessage: Codable, Identifiable {
+struct ChatMessage: Codable, Equatable, Identifiable {
     let id: String
     let sessionId: String
     let role: MessageRole

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -226,15 +226,35 @@ struct ToolCall: Codable, Identifiable {
     let id: String
     let name: String
     let input: String
+    /// Full output. Present for live tools; omitted in REST history when the
+    /// body is truncated (PRD #254) — read `outputPreview`/scalars instead.
     let output: String?
     let parentToolUseId: String?
+    // Lazy-output scalars (PRD #254). On history these are filled by the
+    // backend (and `output` omitted when truncated). For live tools the client
+    // computes them once when a `tool_result` arrives, so the collapsed view
+    // reads scalars instead of re-parsing the body and there is one shape.
+    /// First ~2 KB of output (UTF-8). Present on history; computed live.
+    let outputPreview: String?
+    /// Exact line count of the full output (newlines + 1; 0 when empty).
+    let outputLineCount: Int?
+    /// Exact UTF-8 byte length of the full output.
+    let outputByteLength: Int?
+    /// Whether the full body was omitted because it exceeded the preview cap.
+    let outputTruncated: Bool?
 
-    init(id: String, name: String, input: String, output: String?, parentToolUseId: String?) {
+    init(id: String, name: String, input: String, output: String?, parentToolUseId: String?,
+         outputPreview: String? = nil, outputLineCount: Int? = nil,
+         outputByteLength: Int? = nil, outputTruncated: Bool? = nil) {
         self.id = id
         self.name = name
         self.input = input
         self.output = output
         self.parentToolUseId = parentToolUseId
+        self.outputPreview = outputPreview
+        self.outputLineCount = outputLineCount
+        self.outputByteLength = outputByteLength
+        self.outputTruncated = outputTruncated
     }
 
     init(from decoder: Decoder) throws {
@@ -252,11 +272,60 @@ struct ToolCall: Codable, Identifiable {
         } else {
             output = nil
         }
+        outputPreview = try container.decodeIfPresent(String.self, forKey: .outputPreview)
+        outputLineCount = try container.decodeIfPresent(Int.self, forKey: .outputLineCount)
+        outputByteLength = try container.decodeIfPresent(Int.self, forKey: .outputByteLength)
+        outputTruncated = try container.decodeIfPresent(Bool.self, forKey: .outputTruncated)
     }
 
     private enum CodingKeys: String, CodingKey {
         case id, name, input, output, parentToolUseId
+        case outputPreview, outputLineCount, outputByteLength, outputTruncated
     }
+}
+
+// MARK: - Output truncation scalars (PRD #254)
+
+/// Preview cap for truncated outputs, in bytes. Mirrors the backend's
+/// `OUTPUT_PREVIEW_BYTES` so live-computed and history scalars agree.
+let outputPreviewByteCap = 2048
+
+/// Compute the preview + exact scalars for a heavy output string, matching the
+/// backend `computeTruncatedField` byte-for-byte: line count = newlines + 1 (0
+/// when empty), byte length = UTF-8 byte length, truncated when over the cap,
+/// preview = first `outputPreviewByteCap` UTF-8 bytes (never splitting a
+/// multibyte scalar).
+func computeOutputScalars(_ full: String) -> (preview: String, lineCount: Int, byteLength: Int, truncated: Bool) {
+    let bytes = Array(full.utf8)
+    let byteLength = bytes.count
+    // Count newlines by UTF-8 byte (0x0A), then + 1 — exactly matching the
+    // backend's `full.split("\n").length`. Counting raw bytes (not Swift
+    // grapheme `Character`s) keeps "\r\n" counted as one break like JS does.
+    let lineCount = full.isEmpty ? 0 : bytes.reduce(into: 1) { count, byte in
+        if byte == 0x0A { count += 1 }
+    }
+    let truncated = byteLength > outputPreviewByteCap
+    let preview = truncated ? sliceUtf8(full, maxBytes: outputPreviewByteCap) : full
+    return (preview, lineCount, byteLength, truncated)
+}
+
+/// Slice a string to at most `maxBytes` UTF-8 bytes without splitting a scalar.
+/// Walks back off any continuation bytes (`0b10xxxxxx`), mirroring the backend.
+private func sliceUtf8(_ text: String, maxBytes: Int) -> String {
+    let bytes = Array(text.utf8)
+    if bytes.count <= maxBytes { return text }
+    var end = maxBytes
+    while end > 0 && (bytes[end] & 0b1100_0000) == 0b1000_0000 { end -= 1 }
+    return String(decoding: bytes[0..<end], as: UTF8.self)
+}
+
+// MARK: - REST history page (PRD #254)
+
+/// REST history response: a window of messages plus whether older messages
+/// exist before `messages[0]`. The next `before` cursor is `messages.first?.id`.
+struct MessagesPage: Codable {
+    let messages: [ChatMessage]
+    let hasMore: Bool
 }
 
 struct ChatMessage: Codable, Identifiable {

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -118,7 +118,7 @@ enum WsOutgoing: Decodable {
     case agentActivity(sessionId: String, activity: AgentActivity)
     case toolInputRequired(sessionId: String, requestId: String, toolName: String, toolUseId: String, input: String)
     case toolInputResolved(sessionId: String)
-    case done(sessionId: String, messageId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
+    case done(sessionId: String, messageId: String?, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
     case error(message: String, sessionId: String?)
     case cancelled(sessionId: String, messageId: String?, errorDetail: String?, userInitiated: Bool?, durationMs: Int?)
     case status(status: WorkspaceStatus, sessionId: String?, streaming: Bool?, streamingStartedAt: Double?, lockedProvider: String?)
@@ -126,7 +126,6 @@ enum WsOutgoing: Decodable {
     // replace semantics. Applied by replacing the session's stream accumulators.
     case streamSnapshot(sessionId: String, text: String, thinking: String, toolCalls: [ToolCall], agentActivities: [AgentActivity], planMode: Bool, streamingStartedAt: Double)
     case userMessage(message: ChatMessage)
-    case history(messages: [ChatMessage], sessionId: String?)
     case branchInfo(info: BranchInfo)
     case diffStats(stats: DiffStatResponse)
     case scriptStatus(scriptType: String, state: String, exitCode: Int?)
@@ -142,7 +141,7 @@ enum WsOutgoing: Decodable {
         case errorDetail, userInitiated
         case message, status, streaming, streamingStartedAt, lockedProvider
         case thinking, toolCalls, agentActivities, planMode
-        case messages, info, stats
+        case info, stats
         case scriptType, state, exitCode
         case active
     }
@@ -246,9 +245,10 @@ enum WsOutgoing: Decodable {
                 doneContextWindowTokens = nil
             }
             let donePendingToolName = try container.decodeIfPresent(String.self, forKey: .pendingToolName)
-            // messageId is the persisted assistant message id for this turn; used
-            // to append the optimistic message and dedup the next REST fetch.
-            let doneMessageId = try container.decode(String.self, forKey: .messageId)
+            // messageId is present only when the turn persisted a message; its
+            // presence is the single signal that the turn had displayable content
+            // (used to append the optimistic message and dedup the next REST fetch).
+            let doneMessageId = try container.decodeIfPresent(String.self, forKey: .messageId)
             self = .done(sessionId: doneSessionId, messageId: doneMessageId, durationMs: doneDuration,
                          inputTokens: doneInputTokens, outputTokens: doneOutputTokens,
                          contextUsedTokens: doneContextUsedTokens,
@@ -294,11 +294,6 @@ enum WsOutgoing: Decodable {
             )
         case "user_message":
             self = .userMessage(message: try container.decode(ChatMessage.self, forKey: .message))
-        case "history":
-            self = .history(
-                messages: try container.decode([ChatMessage].self, forKey: .messages),
-                sessionId: try container.decodeIfPresent(String.self, forKey: .sessionId)
-            )
         case "branch_info":
             self = .branchInfo(info: try container.decode(BranchInfo.self, forKey: .info))
         case "diff_stats":

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -69,7 +69,11 @@ enum ToolInputResult: Encodable {
 // MARK: - WsIncoming (Frontend -> Backend)
 
 enum WsIncoming: Encodable {
-    case switchSession(sessionId: String)
+    // sessionId is OPTIONAL (PRD #254): `switch_session` with no sessionId is a
+    // deterministic focus pull on the workspace's active session. Used on first
+    // open of an already-subscribed streaming workspace, where the client has no
+    // session id yet but must still pull the in-flight snapshot.
+    case switchSession(sessionId: String?)
     case userMessage(content: String, images: [ImageAttachment]?, fileMentions: [FileMention]?, options: MessageOptions?, sessionId: String?)
     case stop(sessionId: String?)
     case toolInputResponse(requestId: String, toolName: String, result: ToolInputResult, sessionId: String?)
@@ -79,7 +83,7 @@ enum WsIncoming: Encodable {
         switch self {
         case .switchSession(let sessionId):
             try container.encode("switch_session", forKey: .type)
-            try container.encode(sessionId, forKey: .sessionId)
+            try container.encodeIfPresent(sessionId, forKey: .sessionId)
         case .userMessage(let content, let images, let fileMentions, let options, let sessionId):
             try container.encode("user_message", forKey: .type)
             try container.encode(content, forKey: .content)

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -114,10 +114,13 @@ enum WsOutgoing: Decodable {
     case agentActivity(sessionId: String, activity: AgentActivity)
     case toolInputRequired(sessionId: String, requestId: String, toolName: String, toolUseId: String, input: String)
     case toolInputResolved(sessionId: String)
-    case done(sessionId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
+    case done(sessionId: String, messageId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
     case error(message: String, sessionId: String?)
-    case cancelled(sessionId: String, errorDetail: String?, userInitiated: Bool?, durationMs: Int?)
+    case cancelled(sessionId: String, messageId: String?, errorDetail: String?, userInitiated: Bool?, durationMs: Int?)
     case status(status: WorkspaceStatus, sessionId: String?, streaming: Bool?, streamingStartedAt: Double?, lockedProvider: String?)
+    // Live/history split (PRD #254): one consolidated in-flight snapshot with
+    // replace semantics. Applied by replacing the session's stream accumulators.
+    case streamSnapshot(sessionId: String, text: String, thinking: String, toolCalls: [ToolCall], agentActivities: [AgentActivity], planMode: Bool, streamingStartedAt: Double)
     case userMessage(message: ChatMessage)
     case history(messages: [ChatMessage], sessionId: String?)
     case branchInfo(info: BranchInfo)
@@ -131,8 +134,10 @@ enum WsOutgoing: Decodable {
         case activity
         case parentToolUseId, toolUseId, requestId, toolName
         case durationMs, inputTokens, outputTokens, contextUsedTokens, contextWindowTokens, pendingToolName
+        case messageId
         case errorDetail, userInitiated
         case message, status, streaming, streamingStartedAt, lockedProvider
+        case thinking, toolCalls, agentActivities, planMode
         case messages, info, stats
         case scriptType, state, exitCode
         case active
@@ -237,7 +242,10 @@ enum WsOutgoing: Decodable {
                 doneContextWindowTokens = nil
             }
             let donePendingToolName = try container.decodeIfPresent(String.self, forKey: .pendingToolName)
-            self = .done(sessionId: doneSessionId, durationMs: doneDuration,
+            // messageId is the persisted assistant message id for this turn; used
+            // to append the optimistic message and dedup the next REST fetch.
+            let doneMessageId = try container.decode(String.self, forKey: .messageId)
+            self = .done(sessionId: doneSessionId, messageId: doneMessageId, durationMs: doneDuration,
                          inputTokens: doneInputTokens, outputTokens: doneOutputTokens,
                          contextUsedTokens: doneContextUsedTokens,
                          contextWindowTokens: doneContextWindowTokens,
@@ -249,6 +257,8 @@ enum WsOutgoing: Decodable {
             )
         case "cancelled":
             let cancelledSid = try container.decode(String.self, forKey: .sessionId)
+            // messageId is present only when the cancelled turn persisted a message.
+            let cancelledMessageId = try container.decodeIfPresent(String.self, forKey: .messageId)
             let cancelledErrorDetail = try container.decodeIfPresent(String.self, forKey: .errorDetail)
             let cancelledUserInitiated = try container.decodeIfPresent(Bool.self, forKey: .userInitiated)
             let cancelledDuration: Int?
@@ -259,7 +269,7 @@ enum WsOutgoing: Decodable {
             } else {
                 cancelledDuration = nil
             }
-            self = .cancelled(sessionId: cancelledSid, errorDetail: cancelledErrorDetail, userInitiated: cancelledUserInitiated, durationMs: cancelledDuration)
+            self = .cancelled(sessionId: cancelledSid, messageId: cancelledMessageId, errorDetail: cancelledErrorDetail, userInitiated: cancelledUserInitiated, durationMs: cancelledDuration)
         case "status":
             self = .status(
                 status: try container.decode(WorkspaceStatus.self, forKey: .status),
@@ -267,6 +277,16 @@ enum WsOutgoing: Decodable {
                 streaming: try container.decodeIfPresent(Bool.self, forKey: .streaming),
                 streamingStartedAt: try container.decodeIfPresent(Double.self, forKey: .streamingStartedAt),
                 lockedProvider: try container.decodeIfPresent(String.self, forKey: .lockedProvider)
+            )
+        case "stream_snapshot":
+            self = .streamSnapshot(
+                sessionId: try container.decode(String.self, forKey: .sessionId),
+                text: try container.decode(String.self, forKey: .text),
+                thinking: try container.decode(String.self, forKey: .thinking),
+                toolCalls: try container.decode([ToolCall].self, forKey: .toolCalls),
+                agentActivities: try container.decode([AgentActivity].self, forKey: .agentActivities),
+                planMode: try container.decode(Bool.self, forKey: .planMode),
+                streamingStartedAt: try container.decode(Double.self, forKey: .streamingStartedAt)
             )
         case "user_message":
             self = .userMessage(message: try container.decode(ChatMessage.self, forKey: .message))

--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -166,8 +166,39 @@ final class APIClient {
         try await get(path: "/api/workspaces/\(workspaceId)/sessions")
     }
 
-    func fetchMessages(workspaceId: String, sessionId: String) async throws -> [ChatMessage] {
-        try await get(path: "/api/workspaces/\(workspaceId)/sessions/\(sessionId)/messages")
+    /// Fetch a REST history page (PRD #254): `{ messages, hasMore }`. `limit`
+    /// caps the window (backend default 200, max 1000); `before` is a message-id
+    /// cursor returning the window immediately before that message (exclusive).
+    /// The next page's cursor is `messages.first?.id`.
+    func fetchMessages(
+        workspaceId: String,
+        sessionId: String,
+        limit: Int? = nil,
+        before: String? = nil
+    ) async throws -> MessagesPage {
+        var query: [URLQueryItem] = []
+        if let limit { query.append(URLQueryItem(name: "limit", value: String(limit))) }
+        if let before { query.append(URLQueryItem(name: "before", value: before)) }
+        var path = "/api/workspaces/\(workspaceId)/sessions/\(sessionId)/messages"
+        if !query.isEmpty {
+            var components = URLComponents()
+            components.queryItems = query
+            if let suffix = components.percentEncodedQuery {
+                path += "?\(suffix)"
+            }
+        }
+        return try await get(path: path)
+    }
+
+    /// Fetch the full, untruncated output for a single tool/activity id from
+    /// history (PRD #254 expand-on-demand). Resolves a ToolCall id or a
+    /// command_execution activity id; 404s when absent.
+    func fetchToolOutput(workspaceId: String, sessionId: String, toolId: String) async throws -> String {
+        struct ToolOutputResponse: Decodable { let output: String }
+        let resp: ToolOutputResponse = try await get(
+            path: "/api/workspaces/\(workspaceId)/sessions/\(sessionId)/tools/\(pathSegment(toolId))/output"
+        )
+        return resp.output
     }
 
     func createSession(workspaceId: String) async throws -> SessionMetadata {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -28,6 +28,30 @@ final class ConversationStore {
         outgoingTimestampFormatter.string(from: Date())
     }
 
+    /// Decide whether a `messages.count` change should scroll the chat to the
+    /// bottom (PRD #254 "Load earlier" fix). A PREPEND (load-earlier) inserts
+    /// older messages at index 0, which ALSO grows `messages.count` — scrolling
+    /// on it would yank the user back to the bottom and make the feature
+    /// unusable. An APPEND (new message / streaming finalize) must still scroll.
+    ///
+    /// Distinguisher: an append leaves `messages.first?.id` unchanged; a prepend
+    /// changes it. The first-ever population (`prevFirstId == nil`) and a list
+    /// becoming empty are treated as scroll-to-bottom so opening a chat lands at
+    /// the latest turn.
+    static func shouldScrollToBottom(
+        prevFirstId: String?,
+        newFirstId: String?,
+        prevCount: Int,
+        newCount: Int
+    ) -> Bool {
+        // No growth (or a shrink, e.g. clear on switch) — nothing to chase.
+        guard newCount > prevCount else { return false }
+        // Initial population from empty: land at the bottom.
+        guard let prevFirstId else { return true }
+        // Append keeps the head stable; prepend replaces it. Only scroll on append.
+        return prevFirstId == newFirstId
+    }
+
     // MARK: - Public state
 
     /// Send closure wired by HubStatusMonitor to the workspace's WS connection.
@@ -300,22 +324,6 @@ final class ConversationStore {
             sessionStreams[sid]?.activeAgentActivities = []
             sessionStreams[sid]?.pendingToolInputs = []
 
-        case .history(let msgs, let incomingSessionId):
-            let historySessionId = incomingSessionId ?? msgs.first?.sessionId ?? sessionId
-            // Only update messages for the active session
-            guard historySessionId == nil || sessionId == nil || historySessionId == sessionId else { return }
-
-            // Always apply history — it contains finalized turns only.
-            // Streaming content lives in sessionStreams and is appended
-            // separately by displayMessages.
-            messages = msgs
-            bumpHistoryToken(for: historySessionId)
-            sessionId = historySessionId ?? sessionId
-
-            // Derive pending tool inputs from history only when not actively
-            // streaming (during streaming, live WS tool inputs take precedence).
-            applyDerivedPendingToolInputs(from: msgs, for: historySessionId)
-
         case .branchInfo(let info):
             branchInfo = info
 
@@ -371,6 +379,32 @@ final class ConversationStore {
         sessionId = value
     }
 
+    /// Refetch REST history for the currently focused session and replace the
+    /// window (PRD #254 reconnect message-loss fix). After the live/REST split a
+    /// reconnect only re-pulls the live `stream_snapshot`, which the backend
+    /// sends only while the session is STILL streaming — so a turn that COMPLETED
+    /// while the app was backgrounded is never delivered until the user manually
+    /// re-opens the session. Pulling REST history on reconnect closes that gap.
+    ///
+    /// Honors the same focus / history-token guards as `ChatView.loadMessages`
+    /// so a slow refetch cannot clobber newer state: the token is observed at
+    /// start and re-checked before applying, and the focus must be unchanged.
+    /// `fetch` is injected so this is testable without a live network.
+    func refetchFocusedHistory(
+        fetch: (_ sessionId: String) async throws -> MessagesPage
+    ) async {
+        guard let sessionId else { return }
+        let tokenAtStart = beginHistoryRequest(for: sessionId)
+        do {
+            let page = try await fetch(sessionId)
+            guard self.sessionId == sessionId else { return }
+            guard historyToken(for: sessionId) == tokenAtStart else { return }
+            applyMessagesPage(page)
+        } catch {
+            // Best-effort — live WS state and the previous window remain.
+        }
+    }
+
     /// Apply a REST history page as the message window for `sessionId` (PRD
     /// #254): replace `messages` with the page and record `hasMore` so the
     /// "Load earlier" affordance reflects whether older turns exist. History
@@ -379,12 +413,12 @@ final class ConversationStore {
     func applyMessagesPage(_ page: MessagesPage) {
         messages = page.messages
         hasMoreEarlier = page.hasMore
-        // REST is now the single source of truth for history, so the pending
-        // question / plan-approval derivation that used to live on the WS
-        // `.history` handler must also run here (PRD #254 Finding #3) — else a
-        // session parked on an AskUserQuestion/ExitPlanMode shows no answer
-        // sheet on open. Skipped while the focused session is actively
-        // streaming, where live WS tool inputs win (mirrors web `set_history`).
+        // REST is the single source of truth for history (the WS `history` event
+        // was removed), so the pending question / plan-approval derivation runs
+        // here (PRD #254 Finding #3) — else a session parked on an
+        // AskUserQuestion/ExitPlanMode shows no answer sheet on open. Skipped
+        // while the focused session is actively streaming, where live WS tool
+        // inputs win (mirrors web `set_history`).
         applyDerivedPendingToolInputs(from: page.messages, for: sessionId)
     }
 
@@ -506,6 +540,9 @@ final class ConversationStore {
         guard let stream = sessionStreams[sid] else { return }
 
         let isActive = sid == sessionId
+        // `hasContent` only decides the cancelled bubble shape (content vs the
+        // "Stopped" placeholder). For `done`, the presence of `messageId` is the
+        // single signal that the turn had displayable content (mirrors web).
         let hasContent = !stream.currentText.isEmpty || !stream.activeToolCalls.isEmpty
             || !stream.activeAgentActivities.isEmpty || !stream.currentThinking.isEmpty
 
@@ -516,6 +553,10 @@ final class ConversationStore {
         sessionStreams.removeValue(forKey: sid)
 
         guard isActive else { return }
+
+        // An empty `done` omits messageId — append nothing. The `cancelled` path
+        // still shows a "Stopped" bubble even without a messageId.
+        if !cancelled && messageId == nil { return }
 
         // Dedup by server id: if REST already brought this message in (or a
         // re-delivered done fires twice), do not append a second copy.
@@ -559,10 +600,10 @@ final class ConversationStore {
     }
 
     /// Derive pending tool inputs from a loaded history window and store them on
-    /// the session's stream slot (PRD #254 Finding #3). Shared by the WS
-    /// `.history` handler and the REST `applyMessagesPage` path so both hydrate
-    /// the answer sheet identically. Skipped when the session is actively
-    /// streaming: live WS tool inputs take precedence (mirrors web's
+    /// the session's stream slot (PRD #254 Finding #3). Driven by the REST
+    /// `applyMessagesPage` path (REST is the single source of history). Skipped
+    /// when the session is actively streaming: live WS tool inputs take
+    /// precedence (mirrors web's
     /// `set_history`, which only derives when not streaming).
     private func applyDerivedPendingToolInputs(from msgs: [ChatMessage], for sid: String?) {
         let stream = sid.flatMap { sessionStreams[$0] }

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -474,10 +474,11 @@ final class ConversationStore {
 
     /// Normalize a `stream_snapshot` tool's output to the unified scalar shape
     /// (PRD #254 Finding #5): a snapshot tool that already completed carries a
-    /// non-empty full `output`, so compute its scalars exactly like
-    /// `tool_result`. Tools still running (no output) pass through unchanged.
+    /// full `output` (possibly empty ""), so compute its scalars exactly like
+    /// `tool_result` whenever output is present. Tools still running (nil
+    /// output) pass through unchanged.
     private func normalizeToolCallOutput(_ tc: ToolCall) -> ToolCall {
-        guard let output = tc.output, !output.isEmpty else { return tc }
+        guard let output = tc.output else { return tc }
         return withComputedOutputScalars(tc, output: output)
     }
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -38,7 +38,7 @@ final class ConversationStore {
     /// changes it. The first-ever population (`prevFirstId == nil`) and a list
     /// becoming empty are treated as scroll-to-bottom so opening a chat lands at
     /// the latest turn.
-    static func shouldScrollToBottom(
+    nonisolated static func shouldScrollToBottom(
         prevFirstId: String?,
         newFirstId: String?,
         prevCount: Int,

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -168,13 +168,7 @@ final class ConversationStore {
             // Live = full output; compute the truncation scalars ONCE and store
             // them in the unified shape so the collapsed view reads scalars
             // instead of re-parsing the body, matching history (PRD #254).
-            let scalars = computeOutputScalars(output)
-            sessionStreams[sid]?.activeToolCalls[idx] = ToolCall(
-                id: tc.id, name: tc.name, input: tc.input,
-                output: output, parentToolUseId: tc.parentToolUseId,
-                outputPreview: scalars.preview, outputLineCount: scalars.lineCount,
-                outputByteLength: scalars.byteLength, outputTruncated: scalars.truncated
-            )
+            sessionStreams[sid]?.activeToolCalls[idx] = withComputedOutputScalars(tc, output: output)
 
         case .agentActivity(let sid, let activity):
             upsertAgentActivity(activity, for: sid)
@@ -277,7 +271,13 @@ final class ConversationStore {
                 stream.isStreaming = true
                 stream.currentText = text
                 stream.currentThinking = thinking
-                stream.activeToolCalls = toolCalls
+                // Normalize snapshot tool outputs the SAME way `tool_result`
+                // does (PRD #254 Finding #5): a snapshot tool that already
+                // completed carries a full `output`, so compute its
+                // preview/lineCount/byteLength (truncated = false) once here. The
+                // collapsed view then reads scalars instead of re-parsing the
+                // body, identical to a tool that completes after focus.
+                stream.activeToolCalls = toolCalls.map(normalizeToolCallOutput)
                 stream.activeAgentActivities = agentActivities
                 stream.agentPlanMode = planMode
                 stream.streamingStartedAt = parseStartedAt(startedAt)
@@ -314,16 +314,7 @@ final class ConversationStore {
 
             // Derive pending tool inputs from history only when not actively
             // streaming (during streaming, live WS tool inputs take precedence).
-            let activeStream = historySessionId.flatMap { sessionStreams[$0] }
-            if activeStream?.isStreaming != true {
-                let derived = derivePendingToolInputsFromHistory(msgs)
-                if let sid = historySessionId {
-                    if activeStream != nil || !derived.isEmpty {
-                        ensureStream(for: sid, streaming: false)
-                        sessionStreams[sid]?.pendingToolInputs = derived
-                    }
-                }
-            }
+            applyDerivedPendingToolInputs(from: msgs, for: historySessionId)
 
         case .branchInfo(let info):
             branchInfo = info
@@ -388,6 +379,13 @@ final class ConversationStore {
     func applyMessagesPage(_ page: MessagesPage) {
         messages = page.messages
         hasMoreEarlier = page.hasMore
+        // REST is now the single source of truth for history, so the pending
+        // question / plan-approval derivation that used to live on the WS
+        // `.history` handler must also run here (PRD #254 Finding #3) — else a
+        // session parked on an AskUserQuestion/ExitPlanMode shows no answer
+        // sheet on open. Skipped while the focused session is actively
+        // streaming, where live WS tool inputs win (mirrors web `set_history`).
+        applyDerivedPendingToolInputs(from: page.messages, for: sessionId)
     }
 
     /// Prepend an older REST page ahead of the current window (PRD #254 "Load
@@ -458,6 +456,29 @@ final class ConversationStore {
             stream.activeAgentActivities.append(activity)
         }
         sessionStreams[sid] = stream
+    }
+
+    /// Return a copy of `tc` whose `output` is `output` and whose lazy-output
+    /// scalars are computed from it (PRD #254). The single place that turns a
+    /// full live output into the unified scalar shape; shared by `tool_result`
+    /// and the `stream_snapshot` normalization so both agree byte-for-byte.
+    private func withComputedOutputScalars(_ tc: ToolCall, output: String) -> ToolCall {
+        let scalars = computeOutputScalars(output)
+        return ToolCall(
+            id: tc.id, name: tc.name, input: tc.input,
+            output: output, parentToolUseId: tc.parentToolUseId,
+            outputPreview: scalars.preview, outputLineCount: scalars.lineCount,
+            outputByteLength: scalars.byteLength, outputTruncated: scalars.truncated
+        )
+    }
+
+    /// Normalize a `stream_snapshot` tool's output to the unified scalar shape
+    /// (PRD #254 Finding #5): a snapshot tool that already completed carries a
+    /// non-empty full `output`, so compute its scalars exactly like
+    /// `tool_result`. Tools still running (no output) pass through unchanged.
+    private func normalizeToolCallOutput(_ tc: ToolCall) -> ToolCall {
+        guard let output = tc.output, !output.isEmpty else { return tc }
+        return withComputedOutputScalars(tc, output: output)
     }
 
     private func hasTerminalAssistantMessage(for sid: String) -> Bool {
@@ -533,6 +554,25 @@ final class ConversationStore {
                 durationMs: nil
             )
             messages.append(msg)
+        }
+    }
+
+    /// Derive pending tool inputs from a loaded history window and store them on
+    /// the session's stream slot (PRD #254 Finding #3). Shared by the WS
+    /// `.history` handler and the REST `applyMessagesPage` path so both hydrate
+    /// the answer sheet identically. Skipped when the session is actively
+    /// streaming: live WS tool inputs take precedence (mirrors web's
+    /// `set_history`, which only derives when not streaming).
+    private func applyDerivedPendingToolInputs(from msgs: [ChatMessage], for sid: String?) {
+        let stream = sid.flatMap { sessionStreams[$0] }
+        guard stream?.isStreaming != true else { return }
+        let derived = derivePendingToolInputsFromHistory(msgs)
+        guard let sid else { return }
+        // Only touch the slot if there is something to set or a slot already
+        // exists — avoid creating an empty stream slot for nothing.
+        if stream != nil || !derived.isEmpty {
+            ensureStream(for: sid, streaming: false)
+            sessionStreams[sid]?.pendingToolInputs = derived
         }
     }
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -36,6 +36,14 @@ final class ConversationStore {
 
     var messages: [ChatMessage] = []
 
+    /// Whether older messages exist before `messages.first` (PRD #254). Driven
+    /// by the REST history page's `hasMore`; gates the "Load earlier" button.
+    var hasMoreEarlier = false
+
+    /// True while a "Load earlier messages" fetch is in flight (prevents
+    /// overlapping prepends and double-tap).
+    var isLoadingEarlier = false
+
     /// Session currently displayed in chat.
     var sessionId: String?
 
@@ -157,9 +165,15 @@ final class ConversationStore {
             guard let stream = sessionStreams[sid],
                   let idx = stream.activeToolCalls.firstIndex(where: { $0.id == toolUseId }) else { return }
             let tc = stream.activeToolCalls[idx]
+            // Live = full output; compute the truncation scalars ONCE and store
+            // them in the unified shape so the collapsed view reads scalars
+            // instead of re-parsing the body, matching history (PRD #254).
+            let scalars = computeOutputScalars(output)
             sessionStreams[sid]?.activeToolCalls[idx] = ToolCall(
                 id: tc.id, name: tc.name, input: tc.input,
-                output: output, parentToolUseId: tc.parentToolUseId
+                output: output, parentToolUseId: tc.parentToolUseId,
+                outputPreview: scalars.preview, outputLineCount: scalars.lineCount,
+                outputByteLength: scalars.byteLength, outputTruncated: scalars.truncated
             )
 
         case .agentActivity(let sid, let activity):
@@ -179,16 +193,23 @@ final class ConversationStore {
             // A client (possibly another device) answered or dismissed the question.
             sessionStreams[sid]?.pendingToolInputs = []
 
-        case .done(let sid, let durationMs, let inputTokens, let outputTokens,
+        case .done(let sid, let messageId, let durationMs, let inputTokens, let outputTokens,
                    let contextUsedTokens, let contextWindowTokens, _):
-            finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: false,
+            // Finalize using the server-persisted message id so the next REST
+            // fetch dedups by id rather than duplicating a UUID-stamped turn
+            // (PRD #254).
+            finalizeMessage(sessionId: sid, messageId: messageId, durationMs: durationMs,
+                            cancelled: false,
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             contextUsedTokens: contextUsedTokens,
                             contextWindowTokens: contextWindowTokens)
             onTurnCompleted?(sid)
 
-        case .cancelled(let sid, let errorDetail, _, let durationMs):
-            finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: true, errorDetail: errorDetail)
+        case .cancelled(let sid, let messageId, let errorDetail, _, let durationMs):
+            // messageId is present only when the cancelled turn persisted a
+            // message; otherwise fall back to a local id.
+            finalizeMessage(sessionId: sid, messageId: messageId, durationMs: durationMs,
+                            cancelled: true, errorDetail: errorDetail)
             onTurnCompleted?(sid)
 
         case .error(let message, let errorSessionId):
@@ -245,6 +266,24 @@ final class ConversationStore {
             if sessionId == nil, let incomingSessionId {
                 sessionId = incomingSessionId
             }
+
+        case .streamSnapshot(let sid, let text, let thinking, let toolCalls,
+                             let agentActivities, let planMode, let startedAt):
+            // Consolidated in-flight catch-up (PRD #254): REPLACE the session's
+            // stream accumulators (idempotent — safe on reconnect / re-focus).
+            // Live deltas continue to append after this.
+            ensureStream(for: sid)
+            if var stream = sessionStreams[sid] {
+                stream.isStreaming = true
+                stream.currentText = text
+                stream.currentThinking = thinking
+                stream.activeToolCalls = toolCalls
+                stream.activeAgentActivities = agentActivities
+                stream.agentPlanMode = planMode
+                stream.streamingStartedAt = parseStartedAt(startedAt)
+                sessionStreams[sid] = stream
+            }
+            sessionId = sessionId ?? sid
 
         case .userMessage(let msg):
             let sid = msg.sessionId
@@ -341,10 +380,32 @@ final class ConversationStore {
         sessionId = value
     }
 
+    /// Apply a REST history page as the message window for `sessionId` (PRD
+    /// #254): replace `messages` with the page and record `hasMore` so the
+    /// "Load earlier" affordance reflects whether older turns exist. History
+    /// holds finalized turns only; live streaming content lives in
+    /// `sessionStreams` and is appended by `displayMessages`.
+    func applyMessagesPage(_ page: MessagesPage) {
+        messages = page.messages
+        hasMoreEarlier = page.hasMore
+    }
+
+    /// Prepend an older REST page ahead of the current window (PRD #254 "Load
+    /// earlier messages"). Dedups by id so a message already present is not
+    /// duplicated, then updates `hasMoreEarlier` from the older page.
+    func prependEarlier(_ page: MessagesPage) {
+        let existingIds = Set(messages.map(\.id))
+        let older = page.messages.filter { !existingIds.contains($0.id) }
+        messages.insert(contentsOf: older, at: 0)
+        hasMoreEarlier = page.hasMore
+    }
+
     func prepareSessionSwitch(_ newSessionId: String) {
         let previousSessionId = sessionId
         sessionId = newSessionId
         messages = []
+        hasMoreEarlier = false
+        isLoadingEarlier = false
         lockedProvider = nil
         bumpHistoryToken(for: previousSessionId)
         bumpHistoryToken(for: newSessionId)
@@ -358,6 +419,8 @@ final class ConversationStore {
         guard sessionId == removedSessionId else { return }
 
         messages = []
+        hasMoreEarlier = false
+        isLoadingEarlier = false
         lockedProvider = nil
 
         if let fallbackSessionId, fallbackSessionId != removedSessionId {
@@ -407,7 +470,14 @@ final class ConversationStore {
         return false
     }
 
-    private func finalizeMessage(sessionId sid: String, durationMs: Int?, cancelled: Bool,
+    /// Finalize a streamed turn into history. The optimistic message is stamped
+    /// with the server-persisted `messageId` (PRD #254) so the next REST fetch
+    /// dedups by id; for a `cancelled` turn with no persisted id we fall back to
+    /// a local UUID. Appends are deduped by id so a re-delivered `done` (e.g.
+    /// after reconnect) never doubles the bubble. The empty-turn `done` edge is
+    /// guarded: a turn with no displayable content produces no empty bubble.
+    private func finalizeMessage(sessionId sid: String, messageId: String?,
+                                 durationMs: Int?, cancelled: Bool,
                                  errorDetail: String? = nil,
                                  inputTokens: Int? = nil, outputTokens: Int? = nil,
                                  contextUsedTokens: Int? = nil, contextWindowTokens: Int? = nil) {
@@ -423,40 +493,46 @@ final class ConversationStore {
         // captured above, so it survives this removal.
         sessionStreams.removeValue(forKey: sid)
 
-        if isActive {
-            if hasContent {
-                let msg = ChatMessage(
-                    id: UUID().uuidString,
-                    sessionId: sid,
-                    role: .assistant,
-                    content: stream.currentText,
-                    images: nil,
-                    toolCalls: stream.activeToolCalls.isEmpty ? nil : stream.activeToolCalls,
-                    agentActivities: stream.activeAgentActivities.isEmpty ? nil : stream.activeAgentActivities,
-                    thinkingContent: stream.currentThinking.isEmpty ? nil : stream.currentThinking,
-                    timestamp: Self.outgoingTimestampFormatter.string(from: Date()),
-                    cancelled: cancelled ? true : nil,
-                    errorDetail: errorDetail,
-                    durationMs: durationMs,
-                    inputTokens: inputTokens,
-                    outputTokens: outputTokens,
-                    contextUsedTokens: contextUsedTokens,
-                    contextWindowTokens: contextWindowTokens
-                )
-                messages.append(msg)
-            } else if cancelled {
-                let msg = ChatMessage(
-                    id: UUID().uuidString,
-                    sessionId: sid,
-                    role: .assistant,
-                    content: "",
-                    images: nil, toolCalls: nil, thinkingContent: nil,
-                    timestamp: Self.outgoingTimestampFormatter.string(from: Date()),
-                    cancelled: true, errorDetail: errorDetail,
-                    durationMs: nil
-                )
-                messages.append(msg)
-            }
+        guard isActive else { return }
+
+        // Dedup by server id: if REST already brought this message in (or a
+        // re-delivered done fires twice), do not append a second copy.
+        if let messageId, messages.contains(where: { $0.id == messageId }) { return }
+
+        if hasContent {
+            let msg = ChatMessage(
+                id: messageId ?? UUID().uuidString,
+                sessionId: sid,
+                role: .assistant,
+                content: stream.currentText,
+                images: nil,
+                toolCalls: stream.activeToolCalls.isEmpty ? nil : stream.activeToolCalls,
+                agentActivities: stream.activeAgentActivities.isEmpty ? nil : stream.activeAgentActivities,
+                thinkingContent: stream.currentThinking.isEmpty ? nil : stream.currentThinking,
+                timestamp: Self.outgoingTimestampFormatter.string(from: Date()),
+                cancelled: cancelled ? true : nil,
+                errorDetail: errorDetail,
+                durationMs: durationMs,
+                inputTokens: inputTokens,
+                outputTokens: outputTokens,
+                contextUsedTokens: contextUsedTokens,
+                contextWindowTokens: contextWindowTokens
+            )
+            messages.append(msg)
+        } else if cancelled {
+            // A stopped turn with no output still shows a "Stopped" bubble.
+            // An empty `done` (no content) intentionally shows nothing.
+            let msg = ChatMessage(
+                id: messageId ?? UUID().uuidString,
+                sessionId: sid,
+                role: .assistant,
+                content: "",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: Self.outgoingTimestampFormatter.string(from: Date()),
+                cancelled: true, errorDetail: errorDetail,
+                durationMs: nil
+            )
+            messages.append(msg)
         }
     }
 

--- a/ios/HiveMobile/Stores/ConversationStoreCache.swift
+++ b/ios/HiveMobile/Stores/ConversationStoreCache.swift
@@ -28,12 +28,4 @@ final class ConversationStoreCache {
     func evict(_ workspaceId: String) {
         stores.removeValue(forKey: workspaceId)
     }
-
-    /// Clear all streaming state from every cached store.
-    /// Called before force-reconnect so bootstrap data writes into a clean slate.
-    func clearAllStreamingState() {
-        for store in stores.values {
-            store.sessionStreams.removeAll()
-        }
-    }
 }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -97,8 +97,8 @@ final class HubStatusMonitor {
         }
     }
 
-    /// Refetch REST history for every store with a focused session after a
-    /// (re)connect (PRD #254 reconnect message-loss fix). `refocusFocusedSessions`
+    /// Refetch REST history for the visible focused session after a (re)connect
+    /// (PRD #254 reconnect message-loss fix). `refocusFocusedSessions`
     /// only re-pulls the LIVE snapshot (`switch_session` → `stream_snapshot`),
     /// and the backend sends that snapshot only while the session is STILL
     /// streaming. A turn that COMPLETED while the app was backgrounded/disconnected
@@ -107,14 +107,20 @@ final class HubStatusMonitor {
     /// here closes that gap.
     ///
     /// Invoked AFTER `refocusFocusedSessions` so ordering is sync → refocus →
-    /// refetch. Each store's `refetchFocusedHistory` honors the focus and
-    /// history-token guards, so a stale refetch can't clobber newer state.
+    /// refetch. Only the currently visible chat is refetched; cached background
+    /// stores will load history when opened. This keeps reconnects from turning
+    /// into one REST request per previously visited workspace, which can exhaust
+    /// the backend's per-IP rate limit on mobile.
     fileprivate func refetchFocusedHistory() async {
-        for (workspaceId, store) in storeCache.stores {
-            guard store.sessionId != nil else { continue }
-            await store.refetchFocusedHistory { sessionId in
-                try await self.apiClient.fetchMessages(workspaceId: workspaceId, sessionId: sessionId)
-            }
+        guard let workspaceId = viewingWorkspaceId,
+              let sessionId = viewingSessionId,
+              let store = storeCache.stores[workspaceId],
+              store.sessionId == sessionId else {
+            return
+        }
+
+        await store.refetchFocusedHistory { focusedSessionId in
+            try await self.apiClient.fetchMessages(workspaceId: workspaceId, sessionId: focusedSessionId)
         }
     }
 
@@ -500,9 +506,10 @@ private final class HubConnection {
                 _ = await self.send(.syncWorkspaces(workspaceIds: Array(workspaceIds)))
             }
             await self.monitor?.refocusFocusedSessions()
-            // After the live re-pull, ALSO refetch REST history so a turn that
-            // COMPLETED while backgrounded (no live snapshot) is recovered. Order
-            // is sync → refocus → refetch; the refetch honors focus/token guards.
+            // After the live re-pull, ALSO refetch REST history for the visible
+            // chat so a turn that COMPLETED while backgrounded (no live snapshot)
+            // is recovered. Order is sync → refocus → refetch; the refetch honors
+            // focus/token guards.
             await self.monitor?.refetchFocusedHistory()
         }
     }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -70,6 +70,19 @@ final class HubStatusMonitor {
         }
     }
 
+    /// Re-pull focus after a (re)connect by re-sending `switch_session` for any
+    /// store that currently has a focused session (PRD #254). The backend
+    /// activates the session and replays `status` + `stream_snapshot`, so the
+    /// in-flight turn is recovered deterministically. Snapshot apply is REPLACE,
+    /// so this is safe to issue on every reconnect.
+    fileprivate func refocusFocusedSessions() {
+        for store in storeCache.stores.values {
+            guard let sessionId = store.sessionId else { continue }
+            let send = store.send
+            Task { _ = await send?(.switchSession(sessionId: sessionId)) }
+        }
+    }
+
     // MARK: - Public accessors
 
     func isStreaming(_ workspaceId: String) -> Bool {
@@ -334,15 +347,17 @@ final class HubStatusMonitor {
     // MARK: - App lifecycle
 
     /// Force a full WS reconnect to get fresh bootstrap data for all workspaces.
-    /// Used by pull-to-refresh so the backend re-sends status, history, branch_info,
-    /// diff_stats, and script_status for every subscribed workspace.
+    /// Used by pull-to-refresh so the backend re-sends status, branch_info,
+    /// diff_stats, and script_status for every subscribed workspace (history is
+    /// REST-only now, PRD #254; the reconnect path re-pulls focus for live turns).
     func forceRefresh() {
         hubConnection?.forceReconnect()
     }
 
     /// Called when the app returns to foreground after a non-trivial background period.
-    /// Clears stale streaming state and forces an immediate hub reconnect so the
-    /// backend bootstrap (status + history) writes into a clean slate.
+    /// Forces an immediate hub reconnect; the reconnect path re-pulls focus so the
+    /// backend replays status + a consolidated stream_snapshot for the live turn
+    /// (PRD #254), recovering in-flight content without clearing accumulators.
     func appDidBecomeActive() {
         // Snapshot workspace IDs that had any streaming session
         streamingBeforeBackground = Set(streamingSessions.keys)
@@ -431,10 +446,11 @@ private final class HubConnection {
         task.resume()
         backoff = 1
 
-        // Clear stale streaming state and re-wire send closures on all existing stores.
-        // Without clearing, the bootstrap snapshot would be appended to pre-disconnect
-        // accumulated data, causing duplicate tool calls and garbled text.
-        monitor?.storeCache.clearAllStreamingState()
+        // Re-wire send closures on all existing stores so they hit the new
+        // connection. The pre-disconnect "clear all streaming state" hack is
+        // gone (PRD #254): the consolidated `stream_snapshot` now REPLACES the
+        // session's accumulators idempotently, so re-pulling focus after
+        // reconnect cannot duplicate tool calls or garble text.
         monitor?.rewireAllSendClosures()
 
         startReceiving()
@@ -444,6 +460,12 @@ private final class HubConnection {
         if let workspaceIds = monitor?.subscribedWorkspaceIds {
             sendSyncWorkspaces(Array(workspaceIds))
         }
+
+        // Re-pull focus for any session currently displayed: re-sending
+        // switch_session makes the backend replay status + stream_snapshot for
+        // the live turn, so reconnect deterministically recovers in-flight
+        // content (PRD #254) instead of relying on the old clear-then-bootstrap.
+        monitor?.refocusFocusedSessions()
     }
 
     // MARK: - Receive loop
@@ -508,11 +530,11 @@ private final class HubConnection {
                 for: workspaceId
             )
 
-        case .done(let sessionId, _, _, _, _, _, _):
+        case .done(let sessionId, _, _, _, _, _, _, _):
             monitor?.didReceiveStreaming(false, for: workspaceId, sessionId: sessionId)
             monitor?.didReceiveDone(for: workspaceId, sessionId: sessionId, markWorkspaceCompleted: true)
 
-        case .cancelled(let sessionId, _, let userInitiated, _):
+        case .cancelled(let sessionId, _, _, let userInitiated, _):
             // Clear streaming for this session but only mark failed background turns as unread.
             monitor?.didReceiveStreaming(false, for: workspaceId, sessionId: sessionId)
             if userInitiated != true {

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -70,16 +70,30 @@ final class HubStatusMonitor {
         }
     }
 
-    /// Re-pull focus after a (re)connect by re-sending `switch_session` for any
-    /// store that currently has a focused session (PRD #254). The backend
-    /// activates the session and replays `status` + `stream_snapshot`, so the
-    /// in-flight turn is recovered deterministically. Snapshot apply is REPLACE,
-    /// so this is safe to issue on every reconnect.
-    fileprivate func refocusFocusedSessions() {
-        for store in storeCache.stores.values {
-            guard let sessionId = store.sessionId else { continue }
+    /// Re-pull focus after a (re)connect by re-sending `switch_session` (PRD
+    /// #254). The backend activates the session and replays `status` +
+    /// `stream_snapshot`, so the in-flight turn is recovered deterministically.
+    /// Snapshot apply is REPLACE, so this is safe to issue on every reconnect.
+    ///
+    /// Always pulls on focus: with the known session id when the store has one,
+    /// and with NO sessionId for a store that has not adopted a session id yet
+    /// but whose workspace is streaming (first-visit / eagerly-created store) —
+    /// a sessionId-less `switch_session` is a deterministic pull on the
+    /// workspace's active session.
+    ///
+    /// `async` so the caller can `await` it AFTER `sync_workspaces` lands: the
+    /// refocus pull must never race ahead of the subscription (the backend
+    /// serializes per-socket messages, so awaited ordering is sufficient).
+    fileprivate func refocusFocusedSessions() async {
+        for (workspaceId, store) in storeCache.stores {
             let send = store.send
-            Task { _ = await send?(.switchSession(sessionId: sessionId)) }
+            if let sessionId = store.sessionId {
+                _ = await send?(.switchSession(sessionId: sessionId))
+            } else if isStreaming(workspaceId) {
+                // Unknown session id but the workspace is streaming: pull the
+                // active session by omitting the id.
+                _ = await send?(.switchSession(sessionId: nil))
+            }
         }
     }
 
@@ -456,16 +470,21 @@ private final class HubConnection {
         startReceiving()
         startPinging()
 
-        // Send sync_workspaces to subscribe to all tracked workspaces
-        if let workspaceIds = monitor?.subscribedWorkspaceIds {
-            sendSyncWorkspaces(Array(workspaceIds))
+        // Order matters (PRD #254 Finding #2): sync_workspaces (subscription)
+        // MUST land before the focus re-pull. Awaiting the sync send and only
+        // THEN the refocus keeps both on this socket's serialized queue in the
+        // right order, so the refocus pull can never race ahead of (or precede)
+        // the subscription. Re-sending switch_session makes the backend replay
+        // status + stream_snapshot for the live turn, so reconnect
+        // deterministically recovers in-flight content instead of relying on the
+        // old clear-then-bootstrap.
+        Task { [weak self] in
+            guard let self else { return }
+            if let workspaceIds = self.monitor?.subscribedWorkspaceIds {
+                _ = await self.send(.syncWorkspaces(workspaceIds: Array(workspaceIds)))
+            }
+            await self.monitor?.refocusFocusedSessions()
         }
-
-        // Re-pull focus for any session currently displayed: re-sending
-        // switch_session makes the backend replay status + stream_snapshot for
-        // the live turn, so reconnect deterministically recovers in-flight
-        // content (PRD #254) instead of relying on the old clear-then-bootstrap.
-        monitor?.refocusFocusedSessions()
     }
 
     // MARK: - Receive loop

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -97,6 +97,27 @@ final class HubStatusMonitor {
         }
     }
 
+    /// Refetch REST history for every store with a focused session after a
+    /// (re)connect (PRD #254 reconnect message-loss fix). `refocusFocusedSessions`
+    /// only re-pulls the LIVE snapshot (`switch_session` → `stream_snapshot`),
+    /// and the backend sends that snapshot only while the session is STILL
+    /// streaming. A turn that COMPLETED while the app was backgrounded/disconnected
+    /// is therefore never delivered over the wire — it stays invisible until the
+    /// user manually switches session or reopens ChatView. Pulling REST history
+    /// here closes that gap.
+    ///
+    /// Invoked AFTER `refocusFocusedSessions` so ordering is sync → refocus →
+    /// refetch. Each store's `refetchFocusedHistory` honors the focus and
+    /// history-token guards, so a stale refetch can't clobber newer state.
+    fileprivate func refetchFocusedHistory() async {
+        for (workspaceId, store) in storeCache.stores {
+            guard store.sessionId != nil else { continue }
+            await store.refetchFocusedHistory { sessionId in
+                try await self.apiClient.fetchMessages(workspaceId: workspaceId, sessionId: sessionId)
+            }
+        }
+    }
+
     // MARK: - Public accessors
 
     func isStreaming(_ workspaceId: String) -> Bool {
@@ -326,11 +347,6 @@ final class HubStatusMonitor {
 
     fileprivate func didReceiveActivity(_ event: WsOutgoing, for workspaceId: String) {
         switch event {
-        case .history(let messages, _):
-            guard let latest = messages.compactMap({ parseTimestamp($0.timestamp) }).max() else {
-                return
-            }
-            markActivity(for: workspaceId, at: latest)
         case .status(_, _, let streaming, _, _):
             if streaming == true {
                 markActivity(for: workspaceId)
@@ -484,6 +500,10 @@ private final class HubConnection {
                 _ = await self.send(.syncWorkspaces(workspaceIds: Array(workspaceIds)))
             }
             await self.monitor?.refocusFocusedSessions()
+            // After the live re-pull, ALSO refetch REST history so a turn that
+            // COMPLETED while backgrounded (no live snapshot) is recovered. Order
+            // is sync → refocus → refetch; the refetch honors focus/token guards.
+            await self.monitor?.refetchFocusedHistory()
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -21,10 +21,9 @@ struct ChatActivityRowLabel: View {
     var isExpanded: Bool?
     var accessoryIcons: [String] = []
     var executing = false
-    @State private var pulse = false
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(alignment: .center, spacing: 6) {
             if let isExpanded {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 8, weight: .semibold))
@@ -107,18 +106,47 @@ struct ChatActivityRowLabel: View {
             }
 
             if executing {
-                // Theme-colored, position-stable pulse (matches the web's
-                // `bg-primary animate-pulse` and the TaskTracker in-progress dot).
-                Circle()
-                    .fill(Color.accentColor)
-                    .frame(width: 5, height: 5)
-                    .opacity(pulse ? 1 : 0.4)
-                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
-                    .onAppear { pulse = true }
+                ExecutingPulseDot()
             }
         }
         .padding(.vertical, 3)
         .contentShape(Rectangle())
+    }
+}
+
+private struct ExecutingPulseDot: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let size: CGFloat = 5
+    private let period: TimeInterval = 1.6
+
+    var body: some View {
+        Group {
+            if reduceMotion {
+                dot(opacity: 1)
+            } else {
+                TimelineView(.animation) { timeline in
+                    dot(opacity: opacity(at: timeline.date))
+                }
+            }
+        }
+        .frame(width: size, height: size, alignment: .center)
+        .fixedSize()
+        .accessibilityHidden(true)
+    }
+
+    private func dot(opacity: Double) -> some View {
+        Circle()
+            .fill(Color.accentColor)
+            .frame(width: size, height: size)
+            .opacity(opacity)
+    }
+
+    private func opacity(at date: Date) -> Double {
+        let progress = (date.timeIntervalSinceReferenceDate / period)
+            .truncatingRemainder(dividingBy: 1)
+        let wave = (cos(progress * .pi * 2) + 1) / 2
+        return 0.4 + wave * 0.6
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -13,6 +13,8 @@ struct ChatView: View {
     @State private var fastModeEnabled = false
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
+    /// Debounce handle that coalesces rapid streaming updates into one scroll.
+    @State private var scrollDebounce: Task<Void, Never>?
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -102,7 +104,7 @@ struct ChatView: View {
         VStack(spacing: 0) {
             if isLoading {
                 Spacer()
-            } else if store.displayMessages.isEmpty && !store.isStreaming {
+            } else if store.messages.isEmpty && !store.isStreaming {
                 Spacer()
                 if isBrainWorkspaceId(workspace.id) {
                     BrainSessionEmptyState()
@@ -118,13 +120,44 @@ struct ChatView: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        VStack(spacing: 16) {
-                            ForEach(store.displayMessages) { message in
+                        // LazyVStack builds only the visible rows, so long/heavy
+                        // histories don't construct every bubble up front (PRD #254).
+                        LazyVStack(spacing: 16) {
+                            if store.hasMoreEarlier {
+                                LoadEarlierButton(
+                                    isLoading: store.isLoadingEarlier,
+                                    action: { Task { await loadEarlier() } }
+                                )
+                            }
+
+                            // History rows only. Keyed by id so LazyVStack reuses
+                            // them; they never rebuild on a streaming token because
+                            // the in-flight turn is an isolated sibling view below.
+                            ForEach(store.messages) { message in
                                 if !(message.role == .user && message.content == "Question dismissed.") {
-                                    MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
-                                        .id(message.id)
+                                    MessageBubble(
+                                        message: message,
+                                        pendingToolUseIds: pendingToolUseIds,
+                                        dismissedToolCallIds: dismissedToolCallIds,
+                                        workspaceId: workspace.id
+                                    )
+                                    .id(message.id)
                                 }
                             }
+
+                            // Isolated in-flight bubble: only this view observes the
+                            // streaming accumulators, so per-token updates don't
+                            // invalidate the history rows above (PRD #254). It also
+                            // owns the streaming dependency for scroll, so the parent
+                            // body never re-evaluates per token. Scroll is coalesced
+                            // to ~50 ms via scheduleScroll (debounced).
+                            StreamingMessageView(
+                                store: store,
+                                pendingToolUseIds: pendingToolUseIds,
+                                dismissedToolCallIds: dismissedToolCallIds,
+                                onStreamUpdate: { scheduleScroll(proxy) }
+                            )
+                            .id("streaming-bubble")
 
                             if store.isStreaming {
                                 streamingActivityRow
@@ -141,12 +174,13 @@ struct ChatView: View {
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
                         scrollToBottom(proxy)
                     }
-                    .onChange(of: store.displayMessages.count) {
-                        scrollToBottom(proxy)
+                    .onChange(of: store.messages.count) {
+                        scheduleScroll(proxy)
                     }
-                    .onChange(of: store.currentText) {
-                        scrollToBottom(proxy)
+                    .onChange(of: store.isStreaming) {
+                        scheduleScroll(proxy)
                     }
+                    .onDisappear { scrollDebounce?.cancel() }
                 }
             }
 
@@ -273,13 +307,15 @@ struct ChatView: View {
 
                 let requestToken = store.beginHistoryRequest(for: sessionId)
                 do {
-                    let msgs = try await api.fetchMessages(
+                    let page = try await api.fetchMessages(
                         workspaceId: workspace.id,
                         sessionId: sessionId
                     )
                     guard store.sessionId == sessionId else { return }
                     guard store.historyToken(for: sessionId) == requestToken else { return }
-                    store.messages = msgs
+                    // Replace with the authoritative window; the server-id-stamped
+                    // optimistic turn dedups against this fetch (PRD #254).
+                    store.applyMessagesPage(page)
                 } catch {
                     // Best-effort — streamed messages remain as fallback
                 }
@@ -306,7 +342,7 @@ struct ChatView: View {
         store.setFocusedSessionId(sessionId)
         let requestToken = store.beginHistoryRequest(for: sessionId)
         do {
-            let msgs = try await api.fetchMessages(
+            let page = try await api.fetchMessages(
                 workspaceId: workspace.id,
                 sessionId: sessionId
             )
@@ -315,21 +351,50 @@ struct ChatView: View {
                 isLoading = false
                 return
             }
-            // Skip if a newer event (WS history, send, session switch) arrived while
-            // this REST call was in-flight — their data is more authoritative.
+            // Skip if a newer event (send, session switch) arrived while this REST
+            // call was in-flight — their data is more authoritative.
             guard store.historyToken(for: sessionId) == requestToken else {
                 isLoading = false
                 return
             }
-            // History contains only finalized turns; streaming content lives
-            // in sessionStreams and is appended by displayMessages.
-            store.messages = msgs
+            // History (REST) is the single source of truth for finalized turns;
+            // streaming content lives in sessionStreams and is appended by
+            // displayMessages. `hasMore` gates the "Load earlier" button.
+            store.applyMessagesPage(page)
         } catch is CancellationError {
             // View disappeared
         } catch {
-            // Fall through to WS history
+            // Best-effort; live WS state still renders.
         }
         isLoading = false
+    }
+
+    /// Fetch and prepend the page of messages immediately before the oldest
+    /// loaded message (PRD #254 "Load earlier messages"). Explicit user action;
+    /// guarded against overlapping fetches and stale focus.
+    private func loadEarlier() async {
+        let sessionId = session.sessionId
+        guard store.sessionId == sessionId, store.hasMoreEarlier, !store.isLoadingEarlier else { return }
+        guard let before = store.messages.first?.id else { return }
+        store.isLoadingEarlier = true
+        defer { store.isLoadingEarlier = false }
+        // Observe (don't bump) the history token: a prepend does not invalidate
+        // the current window, but if a full-replace fetch (loadMessages /
+        // onTurnCompleted) lands while ours is in flight it bumps the token and
+        // we drop this prepend (the cursor would be stale anyway).
+        let tokenAtStart = store.historyToken(for: sessionId)
+        do {
+            let page = try await api.fetchMessages(
+                workspaceId: workspace.id,
+                sessionId: sessionId,
+                before: before
+            )
+            guard store.sessionId == sessionId else { return }
+            guard store.historyToken(for: sessionId) == tokenAtStart else { return }
+            store.prependEarlier(page)
+        } catch {
+            // Best-effort — the button stays available for a retry.
+        }
     }
 
     // MARK: - Send
@@ -471,6 +536,17 @@ struct ChatView: View {
         }
     }
 
+    /// Debounced scroll-to-bottom (~50 ms). Rapid streaming updates cancel and
+    /// reschedule, so scrolling runs at most once per tick instead of per token.
+    private func scheduleScroll(_ proxy: ScrollViewProxy) {
+        scrollDebounce?.cancel()
+        scrollDebounce = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            scrollToBottom(proxy)
+        }
+    }
+
     private func formatStreamingElapsed(at date: Date) -> String {
         guard let startedAt = store.streamingStartedAt else {
             return "0.0s"
@@ -484,6 +560,71 @@ struct ChatView: View {
         let secLabel = min > 0 && sec < 10 ? "0\(secFormatted)" : secFormatted
 
         return min > 0 ? "\(min)m \(secLabel)s" : "\(secFormatted)s"
+    }
+}
+
+// MARK: - Streaming Message View (isolated)
+
+/// Renders the in-flight assistant bubble in isolation (PRD #254). Because only
+/// this view reads the per-token streaming accumulators (via
+/// `store.streamingMessage`), the history rows in the parent `LazyVStack` never
+/// rebuild while tokens arrive. It also reports stream updates so the parent can
+/// debounce scroll-to-bottom without depending on `currentText` itself.
+private struct StreamingMessageView: View {
+    let store: ConversationStore
+    var pendingToolUseIds: Set<String> = []
+    var dismissedToolCallIds: Set<String> = []
+    /// Called when the streaming text changes, so the parent can coalesce scroll.
+    var onStreamUpdate: () -> Void = {}
+
+    var body: some View {
+        Group {
+            if let streaming = store.streamingMessage {
+                MessageBubble(
+                    message: streaming,
+                    pendingToolUseIds: pendingToolUseIds,
+                    dismissedToolCallIds: dismissedToolCallIds
+                )
+                // Owning the currentText dependency here keeps it out of the
+                // parent's body, so the parent never re-evaluates per token.
+                .onChange(of: store.currentText) { onStreamUpdate() }
+                .onAppear { onStreamUpdate() }
+            }
+        }
+    }
+}
+
+// MARK: - Load Earlier Button
+
+/// Explicit "Load earlier messages" affordance shown at the top of the list when
+/// older history exists (PRD #254). One tap fetches and prepends a page.
+private struct LoadEarlierButton: View {
+    let isLoading: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 11, weight: .semibold))
+                }
+                Text(isLoading ? "Loading…" : "Load earlier messages")
+                    .font(.system(size: 12, weight: .medium))
+            }
+            .foregroundStyle(WhisperColor.textSecondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .background(Capsule().fill(WhisperColor.surface))
+            .overlay(Capsule().stroke(WhisperColor.border, lineWidth: 1))
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, 4)
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -15,6 +15,7 @@ struct ChatView: View {
     @State private var draftAttachments: [ImageAttachment] = []
     /// Coalesces rapid streaming updates into native scroll operations.
     @State private var scrollTask: Task<Void, Never>?
+    @State private var isPinnedToBottom = true
     /// Previous message head/count, used to tell a prepend (load-earlier) from an
     /// append (new turn) so "Load earlier" doesn't yank the user to the bottom.
     @State private var prevFirstMessageId: String?
@@ -25,6 +26,8 @@ struct ChatView: View {
 
     private let api = APIClient()
     private let draftStore = ChatDraftStore.shared
+    private static let scrollCoordinateSpace = "chat-scroll-space"
+    private static let bottomFollowThreshold: CGFloat = 56
 
     private var lockedProvider: String? {
         if let provider = store.lockedProvider ?? session.lockedProvider {
@@ -150,6 +153,7 @@ struct ChatView: View {
                                         dismissedToolCallIds: dismissedToolCallIds,
                                         workspaceId: workspace.id
                                     )
+                                    .equatable()
                                     .id(message.id)
                                 }
                             }
@@ -164,7 +168,10 @@ struct ChatView: View {
                                 store: store,
                                 pendingToolUseIds: pendingToolUseIds,
                                 dismissedToolCallIds: dismissedToolCallIds,
-                                onStreamUpdate: { scheduleScroll(proxy, animated: false) }
+                                onStreamUpdate: {
+                                    guard isPinnedToBottom else { return }
+                                    scheduleScroll(proxy, animated: false)
+                                }
                             )
                             .id("streaming-bubble")
 
@@ -175,24 +182,51 @@ struct ChatView: View {
                             Color.clear
                                 .frame(height: 1)
                                 .id(bottomAnchorID)
+                                .background(
+                                    GeometryReader { geometry in
+                                        Color.clear.preference(
+                                            key: ChatScrollMetricsKey.self,
+                                            value: ChatScrollMetrics(
+                                                bottomY: geometry.frame(in: .named(Self.scrollCoordinateSpace)).maxY
+                                            )
+                                        )
+                                    }
+                                )
                         }
                         .padding()
                     }
+                    .coordinateSpace(name: Self.scrollCoordinateSpace)
+                    .background(
+                        GeometryReader { geometry in
+                            Color.clear.preference(
+                                key: ChatScrollMetricsKey.self,
+                                value: ChatScrollMetrics(viewportHeight: geometry.size.height)
+                            )
+                        }
+                    )
                     .defaultScrollAnchor(.bottom)
                     .scrollDismissesKeyboard(.interactively)
+                    .onPreferenceChange(ChatScrollMetricsKey.self) { metrics in
+                        guard let viewportHeight = metrics.viewportHeight,
+                              let bottomY = metrics.bottomY else { return }
+                        isPinnedToBottom = bottomY <= viewportHeight + Self.bottomFollowThreshold
+                    }
                     .onAppear {
                         prevFirstMessageId = store.messages.first?.id
                         prevMessageCount = store.messages.count
                         scheduleScroll(proxy, animated: false, delay: .milliseconds(0))
                     }
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
-                        scrollToBottom(proxy)
+                        if isPinnedToBottom {
+                            scrollToBottom(proxy)
+                        }
                     }
                     .onChange(of: store.messages.count) {
                         // Distinguish a prepend (load-earlier) from an append (new
                         // turn): only the latter should scroll to the bottom. A
                         // prepend grows the count but changes the head id, so
                         // chasing the bottom would undo the user's scroll position.
+                        let wasInitialPopulation = prevFirstMessageId == nil && prevMessageCount == 0
                         let shouldScroll = ConversationStore.shouldScrollToBottom(
                             prevFirstId: prevFirstMessageId,
                             newFirstId: store.messages.first?.id,
@@ -201,10 +235,14 @@ struct ChatView: View {
                         )
                         prevFirstMessageId = store.messages.first?.id
                         prevMessageCount = store.messages.count
-                        if shouldScroll { scheduleScroll(proxy) }
+                        if shouldScroll && (wasInitialPopulation || isPinnedToBottom) {
+                            scheduleScroll(proxy)
+                        }
                     }
                     .onChange(of: store.isStreaming) {
-                        scheduleScroll(proxy, animated: false)
+                        if isPinnedToBottom {
+                            scheduleScroll(proxy, animated: false)
+                        }
                     }
                     .onDisappear {
                         scrollTask?.cancel()
@@ -609,11 +647,9 @@ struct ChatView: View {
 
 // MARK: - Streaming Message View (isolated)
 
-/// Renders the in-flight assistant bubble in isolation (PRD #254). Because only
-/// this view reads the per-token streaming accumulators (via
-/// `store.streamingMessage`), the history rows in the parent `LazyVStack` never
-/// rebuild while tokens arrive. It also reports stream updates so the parent can
-/// coalesce scroll-to-bottom without depending on `currentText` itself.
+/// Renders the in-flight assistant bubble in isolation. This child owns the
+/// per-token text dependency, so history rows in the parent `LazyVStack` do not
+/// rebuild while tokens arrive.
 private struct StreamingMessageView: View {
     let store: ConversationStore
     var pendingToolUseIds: Set<String> = []
@@ -622,18 +658,37 @@ private struct StreamingMessageView: View {
     var onStreamUpdate: () -> Void = {}
 
     var body: some View {
-        Group {
-            if let streaming = store.streamingMessage {
-                MessageBubble(
-                    message: streaming,
-                    pendingToolUseIds: pendingToolUseIds,
-                    dismissedToolCallIds: dismissedToolCallIds
-                )
-                // Owning the currentText dependency here keeps it out of the
-                // parent's body, so the parent never re-evaluates per token.
-                .onChange(of: store.currentText) { onStreamUpdate() }
-                .onAppear { onStreamUpdate() }
-            }
+        if store.isStreaming,
+           !store.currentText.isEmpty || !store.currentThinking.isEmpty ||
+            !store.activeToolCalls.isEmpty || !store.activeAgentActivities.isEmpty {
+            StreamingMessageBubble(
+                text: store.currentText,
+                thinking: store.currentThinking,
+                toolCalls: store.activeToolCalls,
+                agentActivities: store.activeAgentActivities,
+                pendingToolUseIds: pendingToolUseIds,
+                dismissedToolCallIds: dismissedToolCallIds,
+                onTextRendered: onStreamUpdate
+            )
+        }
+    }
+}
+
+private struct ChatScrollMetrics: Equatable {
+    var viewportHeight: CGFloat?
+    var bottomY: CGFloat?
+}
+
+private struct ChatScrollMetricsKey: PreferenceKey {
+    static let defaultValue = ChatScrollMetrics()
+
+    static func reduce(value: inout ChatScrollMetrics, nextValue: () -> ChatScrollMetrics) {
+        let next = nextValue()
+        if let viewportHeight = next.viewportHeight {
+            value.viewportHeight = viewportHeight
+        }
+        if let bottomY = next.bottomY {
+            value.bottomY = bottomY
         }
     }
 }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -15,6 +15,10 @@ struct ChatView: View {
     @State private var draftAttachments: [ImageAttachment] = []
     /// Debounce handle that coalesces rapid streaming updates into one scroll.
     @State private var scrollDebounce: Task<Void, Never>?
+    /// Previous message head/count, used to tell a prepend (load-earlier) from an
+    /// append (new turn) so "Load earlier" doesn't yank the user to the bottom.
+    @State private var prevFirstMessageId: String?
+    @State private var prevMessageCount = 0
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -175,7 +179,19 @@ struct ChatView: View {
                         scrollToBottom(proxy)
                     }
                     .onChange(of: store.messages.count) {
-                        scheduleScroll(proxy)
+                        // Distinguish a prepend (load-earlier) from an append (new
+                        // turn): only the latter should scroll to the bottom. A
+                        // prepend grows the count but changes the head id, so
+                        // chasing the bottom would undo the user's scroll position.
+                        let shouldScroll = ConversationStore.shouldScrollToBottom(
+                            prevFirstId: prevFirstMessageId,
+                            newFirstId: store.messages.first?.id,
+                            prevCount: prevMessageCount,
+                            newCount: store.messages.count
+                        )
+                        prevFirstMessageId = store.messages.first?.id
+                        prevMessageCount = store.messages.count
+                        if shouldScroll { scheduleScroll(proxy) }
                     }
                     .onChange(of: store.isStreaming) {
                         scheduleScroll(proxy)

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -326,8 +326,13 @@ struct ChatView: View {
             store.setFocusedSessionId(selectedSessionId)
         } else {
             store.prepareSessionSwitch(selectedSessionId)
-            _ = await store.send?(.switchSession(sessionId: selectedSessionId))
         }
+        // ALWAYS pull on focus (PRD #254). The backend replays status +
+        // stream_snapshot for the active session, so opening an already-
+        // subscribed streaming workspace shows the in-flight turn immediately
+        // instead of an empty bubble until the next delta. Snapshot apply is
+        // REPLACE, so re-pulling a session we already track is idempotent.
+        _ = await store.send?(.switchSession(sessionId: selectedSessionId))
         restoreDraft(for: selectedSessionId)
 
         if selectedModelId.isEmpty {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -13,8 +13,8 @@ struct ChatView: View {
     @State private var fastModeEnabled = false
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
-    /// Debounce handle that coalesces rapid streaming updates into one scroll.
-    @State private var scrollDebounce: Task<Void, Never>?
+    /// Coalesces rapid streaming updates into native scroll operations.
+    @State private var scrollTask: Task<Void, Never>?
     /// Previous message head/count, used to tell a prepend (load-earlier) from an
     /// append (new turn) so "Load earlier" doesn't yank the user to the bottom.
     @State private var prevFirstMessageId: String?
@@ -89,9 +89,14 @@ struct ChatView: View {
         Set(store.pendingToolInputs.map(\.toolUseId))
     }
 
+    private var hasRenderableTranscript: Bool {
+        !store.messages.isEmpty || store.isStreaming
+    }
+
     private var dismissedToolCallIds: Set<String> {
         var ids = Set<String>()
         let msgs = store.messages
+        guard msgs.count > 1 else { return ids }
         for i in 0..<(msgs.count - 1) {
             let msg = msgs[i]
             let next = msgs[i + 1]
@@ -106,7 +111,7 @@ struct ChatView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if isLoading {
+            if isLoading && !hasRenderableTranscript {
                 Spacer()
             } else if store.messages.isEmpty && !store.isStreaming {
                 Spacer()
@@ -154,12 +159,12 @@ struct ChatView: View {
                             // invalidate the history rows above (PRD #254). It also
                             // owns the streaming dependency for scroll, so the parent
                             // body never re-evaluates per token. Scroll is coalesced
-                            // to ~50 ms via scheduleScroll (debounced).
+                            // to ~50 ms via scheduleScroll.
                             StreamingMessageView(
                                 store: store,
                                 pendingToolUseIds: pendingToolUseIds,
                                 dismissedToolCallIds: dismissedToolCallIds,
-                                onStreamUpdate: { scheduleScroll(proxy) }
+                                onStreamUpdate: { scheduleScroll(proxy, animated: false) }
                             )
                             .id("streaming-bubble")
 
@@ -175,6 +180,11 @@ struct ChatView: View {
                     }
                     .defaultScrollAnchor(.bottom)
                     .scrollDismissesKeyboard(.interactively)
+                    .onAppear {
+                        prevFirstMessageId = store.messages.first?.id
+                        prevMessageCount = store.messages.count
+                        scheduleScroll(proxy, animated: false, delay: .milliseconds(0))
+                    }
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
                         scrollToBottom(proxy)
                     }
@@ -194,9 +204,12 @@ struct ChatView: View {
                         if shouldScroll { scheduleScroll(proxy) }
                     }
                     .onChange(of: store.isStreaming) {
-                        scheduleScroll(proxy)
+                        scheduleScroll(proxy, animated: false)
                     }
-                    .onDisappear { scrollDebounce?.cancel() }
+                    .onDisappear {
+                        scrollTask?.cancel()
+                        scrollTask = nil
+                    }
                 }
             }
 
@@ -553,18 +566,28 @@ struct ChatView: View {
                 proxy.scrollTo(bottomAnchorID, anchor: .bottom)
             }
         } else {
-            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
+            var transaction = Transaction()
+            transaction.disablesAnimations = true
+            withTransaction(transaction) {
+                proxy.scrollTo(bottomAnchorID, anchor: .bottom)
+            }
         }
     }
 
-    /// Debounced scroll-to-bottom (~50 ms). Rapid streaming updates cancel and
-    /// reschedule, so scrolling runs at most once per tick instead of per token.
-    private func scheduleScroll(_ proxy: ScrollViewProxy) {
-        scrollDebounce?.cancel()
-        scrollDebounce = Task { @MainActor in
-            try? await Task.sleep(for: .milliseconds(50))
+    /// Coalesced scroll-to-bottom. While streaming, repeated token updates share
+    /// one pending native scroll instead of restarting an animation per token.
+    private func scheduleScroll(
+        _ proxy: ScrollViewProxy,
+        animated: Bool = true,
+        delay: Duration = .milliseconds(50)
+    ) {
+        guard scrollTask == nil else { return }
+        scrollTask = Task { @MainActor in
+            defer { scrollTask = nil }
+            await Task.yield()
+            try? await Task.sleep(for: delay)
             guard !Task.isCancelled else { return }
-            scrollToBottom(proxy)
+            scrollToBottom(proxy, animated: animated)
         }
     }
 
@@ -590,7 +613,7 @@ struct ChatView: View {
 /// this view reads the per-token streaming accumulators (via
 /// `store.streamingMessage`), the history rows in the parent `LazyVStack` never
 /// rebuild while tokens arrive. It also reports stream updates so the parent can
-/// debounce scroll-to-bottom without depending on `currentText` itself.
+/// coalesce scroll-to-bottom without depending on `currentText` itself.
 private struct StreamingMessageView: View {
     let store: ConversationStore
     var pendingToolUseIds: Set<String> = []

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -5,6 +5,9 @@ struct MessageBubble: View {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
+    /// Workspace id, used to fetch a truncated tool's full output on expand
+    /// (PRD #254). Nil disables on-demand fetch (the preview still renders).
+    var workspaceId: String? = nil
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var copied = false
@@ -15,6 +18,16 @@ struct MessageBubble: View {
 
     private var mergedToolCalls: [ToolCall] {
         mergeToolCalls(message.toolCalls ?? [], with: message.agentActivities ?? [])
+    }
+
+    /// Context for fetching a truncated tool's full output on expand (PRD #254).
+    /// Nil for the live streaming bubble (its outputs are already full) or when
+    /// no workspace id is available; in those cases the preview is shown as-is.
+    private var outputFetchContext: ToolOutputFetchContext? {
+        guard message.id != "streaming",
+              let workspaceId,
+              !message.sessionId.isEmpty else { return nil }
+        return ToolOutputFetchContext(workspaceId: workspaceId, sessionId: message.sessionId)
     }
 
     private var visibleActivities: [VisibleAgentActivity] {
@@ -40,7 +53,8 @@ struct MessageBubble: View {
                         toolCalls: tools,
                         pendingToolUseIds: pendingToolUseIds,
                         dismissedToolCallIds: dismissedToolCallIds,
-                        showExecutingState: message.id == "streaming"
+                        showExecutingState: message.id == "streaming",
+                        outputFetch: outputFetchContext
                     )
                 }
 
@@ -333,20 +347,33 @@ private func computeToolStats(_ tool: ToolCall) -> ChatActivityStats? {
         return ChatActivityStats(kind: .diff, added: lineCount, removed: 0)
 
     case "Grep":
-        guard let output = tool.output, !output.isEmpty else { return nil }
-        let lines = output.split(separator: "\n", omittingEmptySubsequences: true)
-        guard !lines.isEmpty else { return nil }
-        return ChatActivityStats(kind: .plain, label: "\(lines.count) result\(lines.count != 1 ? "s" : "")")
+        guard let count = toolOutputLineCount(tool), count > 0 else { return nil }
+        return ChatActivityStats(kind: .plain, label: "\(count) result\(count != 1 ? "s" : "")")
 
     case "Glob":
-        guard let output = tool.output, !output.isEmpty else { return nil }
-        let lines = output.split(separator: "\n", omittingEmptySubsequences: true)
-        guard !lines.isEmpty else { return nil }
-        return ChatActivityStats(kind: .plain, label: "\(lines.count) file\(lines.count != 1 ? "s" : "")")
+        guard let count = toolOutputLineCount(tool), count > 0 else { return nil }
+        return ChatActivityStats(kind: .plain, label: "\(count) file\(count != 1 ? "s" : "")")
 
     default:
         return nil
     }
+}
+
+/// Non-empty line count of a tool's output, preferring the pre-computed scalar
+/// (PRD #254) so the collapsed view never re-parses the full body. Falls back to
+/// counting the preview, then the full output, when scalars are absent.
+///
+/// Note: `outputLineCount` counts newlines + 1 (matching the backend), whereas
+/// the legacy parse split on "\n" dropping empty subsequences. For Grep/Glob the
+/// output is newline-separated rows with no trailing blank line, so both agree;
+/// the scalar is authoritative and avoids parsing.
+private func toolOutputLineCount(_ tool: ToolCall) -> Int? {
+    if let count = tool.outputLineCount { return count }
+    if let preview = tool.outputPreview, !preview.isEmpty {
+        return preview.split(separator: "\n", omittingEmptySubsequences: true).count
+    }
+    guard let output = tool.output, !output.isEmpty else { return nil }
+    return output.split(separator: "\n", omittingEmptySubsequences: true).count
 }
 
 private func getToolDisplay(
@@ -469,6 +496,18 @@ private func getToolDisplay(
 }
 
 private func getOutputSummary(_ tool: ToolCall) -> String? {
+    // Prefer pre-computed scalars (PRD #254): the collapsed summary reads the
+    // exact line count and the preview, never the full (possibly omitted) body.
+    if let lineCount = tool.outputLineCount {
+        guard lineCount > 0 else { return nil }
+        if lineCount > 1 { return "\(lineCount) lines" }
+        // Single line: show it from the preview if short enough.
+        let text = (tool.outputPreview ?? tool.output ?? "")
+            .trimmingCharacters(in: .newlines)
+        if !text.isEmpty, text.count < 60 { return text }
+        return nil
+    }
+    // Fallback for tools without scalars (defensive).
     guard let output = tool.output, !output.isEmpty else { return nil }
     let lines = output.split(separator: "\n", omittingEmptySubsequences: true)
     if lines.count == 1, lines[0].count < 60 { return String(lines[0]) }
@@ -519,6 +558,7 @@ private struct WhisperToolCallsBlock: View {
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
     var showExecutingState = false
+    var outputFetch: ToolOutputFetchContext? = nil
     @State private var groupExpanded = false
 
     private static let hiddenTaskTools: Set<String> = ["TaskUpdate", "TodoList"]
@@ -564,7 +604,8 @@ private struct WhisperToolCallsBlock: View {
                         childrenByParentId: childrenByParentId,
                         isPending: pendingToolUseIds.contains(tool.id),
                         isDismissed: dismissedToolCallIds.contains(tool.id),
-                        showExecutingState: showExecutingState
+                        showExecutingState: showExecutingState,
+                        outputFetch: outputFetch
                     )
                 }
                 .transition(.opacity)
@@ -620,7 +661,23 @@ private struct WhisperToolCallRow: View {
     var isPending = false
     var isDismissed = false
     var showExecutingState = false
+    var outputFetch: ToolOutputFetchContext? = nil
     @State private var isExpanded = false
+    /// Full output fetched on expand for a truncated tool (PRD #254).
+    @State private var fetchedOutput: String?
+    @State private var isFetchingOutput = false
+
+    /// Output to render in the expanded panel: the fetched full body if we have
+    /// it, else the live/untruncated `output`, else the truncated `outputPreview`.
+    private var displayedOutput: String? {
+        fetchedOutput ?? tool.output ?? tool.outputPreview
+    }
+
+    /// True when the body was omitted by the backend (history) and we have not
+    /// yet fetched it — i.e. the panel is currently showing only the preview.
+    private var needsFullOutputFetch: Bool {
+        tool.outputTruncated == true && fetchedOutput == nil && outputFetch != nil
+    }
 
     var body: some View {
         let display = getToolDisplay(
@@ -647,13 +704,18 @@ private struct WhisperToolCallRow: View {
                         DiffContentView(tool: tool)
                     } else if tool.name == "AskUserQuestion" {
                         AskUserQuestionContent(tool: tool)
-                    } else if let output = tool.output, !output.isEmpty, !display.hideOutput {
+                    } else if let output = displayedOutput, !output.isEmpty, !display.hideOutput {
                         ToolContentPanel {
                             VStack(alignment: .leading, spacing: 8) {
-                                Text("OUTPUT")
-                                    .font(WhisperFont.mono(9))
-                                    .foregroundStyle(WhisperColor.textMuted)
-                                    .tracking(1)
+                                HStack(spacing: 6) {
+                                    Text("OUTPUT")
+                                        .font(WhisperFont.mono(9))
+                                        .foregroundStyle(WhisperColor.textMuted)
+                                        .tracking(1)
+                                    if isFetchingOutput {
+                                        ProgressView().controlSize(.mini)
+                                    }
+                                }
                                 Text(output)
                                     .font(WhisperFont.mono(11))
                                     .foregroundStyle(WhisperColor.textSecondary)
@@ -670,7 +732,8 @@ private struct WhisperToolCallRow: View {
                                     tool: child,
                                     children: childrenByParentId[child.id] ?? [],
                                     childrenByParentId: childrenByParentId,
-                                    showExecutingState: showExecutingState
+                                    showExecutingState: showExecutingState,
+                                    outputFetch: outputFetch
                                 )
                             }
                         }
@@ -684,9 +747,57 @@ private struct WhisperToolCallRow: View {
                     }
                 }
                 .transition(.opacity)
+                .task(id: isExpanded) {
+                    // Fetch the full output on first expand of a truncated tool;
+                    // cached process-wide so re-expanding never refetches.
+                    guard isExpanded, needsFullOutputFetch, let ctx = outputFetch else { return }
+                    await loadFullOutput(ctx)
+                }
             }
         }
     }
+
+    /// Resolve the full output for a truncated tool: serve the process cache when
+    /// present, otherwise fetch once via the expand endpoint and cache it.
+    private func loadFullOutput(_ ctx: ToolOutputFetchContext) async {
+        if let cached = ToolOutputCache.shared.value(for: tool.id) {
+            fetchedOutput = cached
+            return
+        }
+        isFetchingOutput = true
+        defer { isFetchingOutput = false }
+        do {
+            let output = try await ToolOutputCache.shared.client.fetchToolOutput(
+                workspaceId: ctx.workspaceId,
+                sessionId: ctx.sessionId,
+                toolId: tool.id
+            )
+            ToolOutputCache.shared.store(output, for: tool.id)
+            fetchedOutput = output
+        } catch {
+            // Leave the preview in place on failure; re-expanding retries.
+        }
+    }
+}
+
+// MARK: - Tool Output Fetch (lazy expand, PRD #254)
+
+/// Identifies where to fetch a truncated tool's full output from history.
+struct ToolOutputFetchContext: Equatable {
+    let workspaceId: String
+    let sessionId: String
+}
+
+/// Process-wide cache of full tool outputs fetched on expand, keyed by tool id.
+/// Keeps a re-expanded (or re-rendered) row from refetching the same body.
+@MainActor
+private final class ToolOutputCache {
+    static let shared = ToolOutputCache()
+    let client = APIClient()
+    private var outputs: [String: String] = [:]
+
+    func value(for toolId: String) -> String? { outputs[toolId] }
+    func store(_ output: String, for toolId: String) { outputs[toolId] = output }
 }
 
 // MARK: - Diff Content View (Edit tool expanded)

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -1,7 +1,7 @@
 import MarkdownUI
 import SwiftUI
 
-struct MessageBubble: View {
+struct MessageBubble: View, Equatable {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
@@ -11,6 +11,13 @@ struct MessageBubble: View {
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var copied = false
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.message == rhs.message &&
+        lhs.pendingToolUseIds == rhs.pendingToolUseIds &&
+        lhs.dismissedToolCallIds == rhs.dismissedToolCallIds &&
+        lhs.workspaceId == rhs.workspaceId
+    }
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -261,6 +268,132 @@ struct MessageBubble: View {
         return display.string(from: date)
     }
 
+}
+
+struct StreamingMessageBubble: View {
+    let text: String
+    let thinking: String
+    let toolCalls: [ToolCall]
+    let agentActivities: [AgentActivity]
+    var pendingToolUseIds: Set<String> = []
+    var dismissedToolCallIds: Set<String> = []
+    var onTextRendered: () -> Void = {}
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            VStack(alignment: .leading, spacing: 6) {
+                if !thinking.isEmpty {
+                    WhisperThinkingBlock(content: thinking)
+                }
+
+                StreamingAssistantText(content: text, onRendered: onTextRendered)
+
+                StreamingToolActivitySection(
+                    toolCalls: toolCalls,
+                    agentActivities: agentActivities,
+                    pendingToolUseIds: pendingToolUseIds,
+                    dismissedToolCallIds: dismissedToolCallIds
+                )
+                .equatable()
+            }
+
+            Spacer(minLength: 40)
+        }
+    }
+}
+
+private struct StreamingAssistantText: View {
+    let content: String
+    var onRendered: () -> Void
+
+    @State private var renderedText = ""
+    @State private var latestText = ""
+    @State private var renderTask: Task<Void, Never>?
+
+    private static let renderInterval: Duration = .milliseconds(90)
+
+    var body: some View {
+        Group {
+            if !renderedText.isEmpty {
+                Text(renderedText)
+                    .font(.system(size: 14))
+                    .foregroundStyle(WhisperColor.text)
+                    .lineSpacing(3)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
+            }
+        }
+        .onAppear {
+            latestText = content
+            if renderedText.isEmpty {
+                renderedText = content
+                onRendered()
+            } else {
+                scheduleFlush()
+            }
+        }
+        .onChange(of: content) { _, newValue in
+            latestText = newValue
+            scheduleFlush()
+        }
+        .onDisappear {
+            renderTask?.cancel()
+            renderTask = nil
+        }
+    }
+
+    private func scheduleFlush() {
+        guard renderTask == nil else { return }
+        renderTask = Task { @MainActor in
+            defer { renderTask = nil }
+
+            while !Task.isCancelled {
+                let snapshot = latestText
+                try? await Task.sleep(for: Self.renderInterval)
+                guard !Task.isCancelled else { return }
+
+                if renderedText != snapshot {
+                    renderedText = snapshot
+                    onRendered()
+                }
+
+                if latestText == snapshot {
+                    return
+                }
+            }
+        }
+    }
+}
+
+private struct StreamingToolActivitySection: View, Equatable {
+    let toolCalls: [ToolCall]
+    let agentActivities: [AgentActivity]
+    let pendingToolUseIds: Set<String>
+    let dismissedToolCallIds: Set<String>
+
+    var body: some View {
+        let tools = mergeToolCalls(toolCalls, with: agentActivities)
+        if !tools.isEmpty {
+            WhisperToolCallsBlock(
+                toolCalls: tools,
+                pendingToolUseIds: pendingToolUseIds,
+                dismissedToolCallIds: dismissedToolCallIds,
+                showExecutingState: true
+            )
+        }
+
+        let activities = visibleAgentActivities(agentActivities)
+        if !activities.isEmpty {
+            AgentActivityList(activities: activities, showExecutingState: true)
+        }
+    }
+
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.toolCalls == rhs.toolCalls &&
+        lhs.agentActivities == rhs.agentActivities &&
+        lhs.pendingToolUseIds == rhs.pendingToolUseIds &&
+        lhs.dismissedToolCallIds == rhs.dismissedToolCallIds
+    }
 }
 
 // MARK: - Tool Display Helpers
@@ -529,7 +662,7 @@ private struct WhisperThinkingBlock: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: "brain", label: "Thinking", detail: isExpanded ? nil : preview)
             }
@@ -591,22 +724,24 @@ private struct WhisperToolCallsBlock: View {
                     isExpanded: groupExpanded,
                     isStreaming: showExecutingState,
                     onToggle: {
-                        withAnimation(.easeInOut(duration: 0.2)) { groupExpanded.toggle() }
+                        groupExpanded.toggle()
                     }
                 )
             }
 
             if !shouldCollapse || groupExpanded {
-                ForEach(rootTools) { tool in
-                    WhisperToolCallRow(
-                        tool: tool,
-                        children: children(for: tool.id),
-                        childrenByParentId: childrenByParentId,
-                        isPending: pendingToolUseIds.contains(tool.id),
-                        isDismissed: dismissedToolCallIds.contains(tool.id),
-                        showExecutingState: showExecutingState,
-                        outputFetch: outputFetch
-                    )
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(rootTools) { tool in
+                        WhisperToolCallRow(
+                            tool: tool,
+                            children: children(for: tool.id),
+                            childrenByParentId: childrenByParentId,
+                            isPending: pendingToolUseIds.contains(tool.id),
+                            isDismissed: dismissedToolCallIds.contains(tool.id),
+                            showExecutingState: showExecutingState,
+                            outputFetch: outputFetch
+                        )
+                    }
                 }
                 .transition(.opacity)
             }
@@ -692,7 +827,7 @@ private struct WhisperToolCallRow: View {
 
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: display.icon, label: display.label, detail: display.detail, stats: display.stats, summary: summary, badgeText: display.badgeText, badgeIcon: display.badgeIcon, executing: display.executing)
             }
@@ -726,7 +861,7 @@ private struct WhisperToolCallRow: View {
                     }
 
                     if !children.isEmpty {
-                        VStack(alignment: .leading, spacing: 2) {
+                        LazyVStack(alignment: .leading, spacing: 2) {
                             ForEach(children) { child in
                                 WhisperToolCallRow(
                                     tool: child,

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -359,14 +359,14 @@ private func computeToolStats(_ tool: ToolCall) -> ChatActivityStats? {
     }
 }
 
-/// Non-empty line count of a tool's output, preferring the pre-computed scalar
+/// Result/file row count of a tool's output, preferring the pre-computed scalar
 /// (PRD #254) so the collapsed view never re-parses the full body. Falls back to
-/// counting the preview, then the full output, when scalars are absent.
+/// counting non-empty preview/full-output rows when scalars are absent.
 ///
-/// Note: `outputLineCount` counts newlines + 1 (matching the backend), whereas
-/// the legacy parse split on "\n" dropping empty subsequences. For Grep/Glob the
-/// output is newline-separated rows with no trailing blank line, so both agree;
-/// the scalar is authoritative and avoids parsing.
+/// Note: `outputLineCount` already excludes a single trailing newline (matching
+/// the shared TS `outputLineCount` primitive), so a body like "a\nb\n" counts as
+/// 2 lines, not 3. The scalar is authoritative and avoids parsing the full body;
+/// the preview/output fallbacks below split on "\n" only when no scalar exists.
 private func toolOutputLineCount(_ tool: ToolCall) -> Int? {
     if let count = tool.outputLineCount { return count }
     if let preview = tool.outputPreview, !preview.isEmpty {
@@ -760,7 +760,7 @@ private struct WhisperToolCallRow: View {
     /// Resolve the full output for a truncated tool: serve the process cache when
     /// present, otherwise fetch once via the expand endpoint and cache it.
     private func loadFullOutput(_ ctx: ToolOutputFetchContext) async {
-        if let cached = ToolOutputCache.shared.value(for: tool.id) {
+        if let cached = ToolOutputCache.shared.value(for: ctx, toolId: tool.id) {
             fetchedOutput = cached
             return
         }
@@ -772,7 +772,7 @@ private struct WhisperToolCallRow: View {
                 sessionId: ctx.sessionId,
                 toolId: tool.id
             )
-            ToolOutputCache.shared.store(output, for: tool.id)
+            ToolOutputCache.shared.store(output, for: ctx, toolId: tool.id)
             fetchedOutput = output
         } catch {
             // Leave the preview in place on failure; re-expanding retries.
@@ -788,16 +788,32 @@ struct ToolOutputFetchContext: Equatable {
     let sessionId: String
 }
 
-/// Process-wide cache of full tool outputs fetched on expand, keyed by tool id.
-/// Keeps a re-expanded (or re-rendered) row from refetching the same body.
+/// Process-wide cache of full tool outputs fetched on expand, keyed by the
+/// session scope (workspaceId + sessionId) plus the tool id. Keying by tool id
+/// alone is unsafe: Codex tool ids are sequential per turn (`item_1`, `item_2`,
+/// …) and so repeat across sessions/workspaces, which would let one session's
+/// `item_1` body be served for a different session's `item_1`. Keeps a
+/// re-expanded (or re-rendered) row from refetching the same body.
 @MainActor
 private final class ToolOutputCache {
     static let shared = ToolOutputCache()
     let client = APIClient()
     private var outputs: [String: String] = [:]
 
-    func value(for toolId: String) -> String? { outputs[toolId] }
-    func store(_ output: String, for toolId: String) { outputs[toolId] = output }
+    /// Composite cache key scoping a tool id to its session. The pure builder
+    /// lives in `Models.swift` (`toolOutputCacheKey`) so it is unit-testable
+    /// without pulling this SwiftUI View into the test module.
+    private func cacheKey(_ context: ToolOutputFetchContext, _ toolId: String) -> String {
+        toolOutputCacheKey(workspaceId: context.workspaceId, sessionId: context.sessionId, toolId: toolId)
+    }
+
+    func value(for context: ToolOutputFetchContext, toolId: String) -> String? {
+        outputs[cacheKey(context, toolId)]
+    }
+
+    func store(_ output: String, for context: ToolOutputFetchContext, toolId: String) {
+        outputs[cacheKey(context, toolId)] = output
+    }
 }
 
 // MARK: - Diff Content View (Edit tool expanded)

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreAgentActivityTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreAgentActivityTests.swift
@@ -72,6 +72,7 @@ struct ConversationStoreAgentActivityTests {
 
         store.handle(.done(
             sessionId: "session-1",
+            messageId: "msg-1",
             durationMs: 1000,
             inputTokens: 10,
             outputTokens: 5,
@@ -104,6 +105,7 @@ struct ConversationStoreAgentActivityTests {
         store.handle(.textDelta(sessionId: "session-1", text: "Done"))
         store.handle(.done(
             sessionId: "session-1",
+            messageId: "msg-1",
             durationMs: 100,
             inputTokens: nil,
             outputTokens: nil,

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreReconnectScrollTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreReconnectScrollTests.swift
@@ -1,0 +1,132 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Covers the two PRD #254 second-audit fixes:
+/// 1. Reconnect refetches REST history so a turn that COMPLETED while
+///    backgrounded (no live snapshot) is recovered.
+/// 2. "Load earlier" (prepend) must NOT scroll to the bottom, while an append
+///    (new turn) still does.
+struct ConversationStoreReconnectScrollTests {
+    private func message(_ id: String, role: MessageRole = .assistant) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            sessionId: "session-1",
+            role: role,
+            content: "msg-\(id)",
+            images: nil,
+            toolCalls: nil,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    // MARK: - #1 reconnect REST refetch
+
+    @Test @MainActor
+    func reconnectRefetchReplacesFocusedHistory() async {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        // Initial window: only the user's prompt is visible (the completed turn
+        // arrived while the app was backgrounded, so it isn't here yet).
+        store.applyMessagesPage(MessagesPage(messages: [message("u1", role: .user)], hasMore: false))
+        #expect(store.messages.count == 1)
+
+        // Reconnect path refetches REST and the page now includes the completed
+        // assistant turn that the live snapshot never delivered.
+        await store.refetchFocusedHistory { sessionId in
+            #expect(sessionId == "session-1")
+            return MessagesPage(
+                messages: [message("u1", role: .user), message("a1")],
+                hasMore: false
+            )
+        }
+
+        #expect(store.messages.map(\.id) == ["u1", "a1"])
+    }
+
+    @Test @MainActor
+    func reconnectRefetchSkipsWhenNoFocusedSession() async {
+        let store = ConversationStore()
+        // No focused session id — nothing to refetch, fetch must not be invoked.
+        var fetchCalled = false
+        await store.refetchFocusedHistory { _ in
+            fetchCalled = true
+            return MessagesPage(messages: [], hasMore: false)
+        }
+        #expect(fetchCalled == false)
+        #expect(store.messages.isEmpty)
+    }
+
+    @Test @MainActor
+    func reconnectRefetchDropsResultWhenHistoryTokenBumpedMidFlight() async {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.applyMessagesPage(MessagesPage(messages: [message("a1")], hasMore: false))
+
+        // Simulate a newer event (send / session switch) bumping the token while
+        // the refetch is in flight: the stale page must be discarded.
+        await store.refetchFocusedHistory { sessionId in
+            store.bumpHistoryToken(for: sessionId)
+            return MessagesPage(messages: [message("stale")], hasMore: false)
+        }
+
+        #expect(store.messages.map(\.id) == ["a1"])
+    }
+
+    @Test @MainActor
+    func reconnectRefetchDropsResultWhenFocusChangedMidFlight() async {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.applyMessagesPage(MessagesPage(messages: [message("a1")], hasMore: false))
+
+        await store.refetchFocusedHistory { _ in
+            // Focus moved to another session before the page lands.
+            store.setFocusedSessionId("session-2")
+            return MessagesPage(messages: [message("stale")], hasMore: false)
+        }
+
+        // session-1 window untouched (the apply guards on unchanged focus).
+        #expect(store.messages.map(\.id) == ["a1"])
+    }
+
+    // MARK: - #2 prepend vs append scroll decision
+
+    @Test
+    func appendScrollsToBottom() {
+        // New turn appended at the tail: head id unchanged, count grew.
+        #expect(ConversationStore.shouldScrollToBottom(
+            prevFirstId: "a1", newFirstId: "a1", prevCount: 3, newCount: 4
+        ) == true)
+    }
+
+    @Test
+    func prependDoesNotScrollToBottom() {
+        // Load-earlier inserts older messages at index 0: head id changed even
+        // though the count grew — must NOT scroll.
+        #expect(ConversationStore.shouldScrollToBottom(
+            prevFirstId: "a1", newFirstId: "older-1", prevCount: 3, newCount: 6
+        ) == false)
+    }
+
+    @Test
+    func initialPopulationScrollsToBottom() {
+        // First history load from empty: prevFirstId is nil — land at the bottom.
+        #expect(ConversationStore.shouldScrollToBottom(
+            prevFirstId: nil, newFirstId: "a1", prevCount: 0, newCount: 5
+        ) == true)
+    }
+
+    @Test
+    func noGrowthDoesNotScroll() {
+        // A clear/replace that shrinks or keeps the count must not chase bottom.
+        #expect(ConversationStore.shouldScrollToBottom(
+            prevFirstId: "a1", newFirstId: "a1", prevCount: 4, newCount: 4
+        ) == false)
+        #expect(ConversationStore.shouldScrollToBottom(
+            prevFirstId: "a1", newFirstId: nil, prevCount: 4, newCount: 0
+        ) == false)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -3,23 +3,34 @@ import Testing
 @testable import HiveMobileStoresCore
 
 struct ConversationStoreSessionTests {
+    /// Seed a session's history via the REST path (the WS `history` event was
+    /// removed in PRD #254): focus the session, then apply a one-message page.
+    @MainActor
+    private func seedHistory(_ store: ConversationStore, sessionId: String) {
+        store.setFocusedSessionId(sessionId)
+        store.applyMessagesPage(MessagesPage(
+            messages: [
+                ChatMessage(
+                    id: "message-1",
+                    sessionId: sessionId,
+                    role: .user,
+                    content: "Hello",
+                    images: nil,
+                    toolCalls: nil,
+                    thinkingContent: nil,
+                    timestamp: "2026-01-01T00:00:00.000Z",
+                    cancelled: nil,
+                    durationMs: nil
+                )
+            ],
+            hasMore: false
+        ))
+    }
+
     @Test @MainActor
     func prepareSessionSwitchClearsVisibleStateAndInvalidatesHistoryTokens() {
         let store = ConversationStore()
-        store.handle(.history(messages: [
-            ChatMessage(
-                id: "message-1",
-                sessionId: "session-1",
-                role: .user,
-                content: "Hello",
-                images: nil,
-                toolCalls: nil,
-                thinkingContent: nil,
-                timestamp: "2026-01-01T00:00:00.000Z",
-                cancelled: nil,
-                durationMs: nil
-            )
-        ], sessionId: "session-1"))
+        seedHistory(store, sessionId: "session-1")
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -58,20 +69,7 @@ struct ConversationStoreSessionTests {
     @Test @MainActor
     func removeActiveSessionStateFallsBackToNextSession() {
         let store = ConversationStore()
-        store.handle(.history(messages: [
-            ChatMessage(
-                id: "message-1",
-                sessionId: "session-1",
-                role: .user,
-                content: "Hello",
-                images: nil,
-                toolCalls: nil,
-                thinkingContent: nil,
-                timestamp: "2026-01-01T00:00:00.000Z",
-                cancelled: nil,
-                durationMs: nil
-            )
-        ], sessionId: "session-1"))
+        seedHistory(store, sessionId: "session-1")
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -103,20 +101,7 @@ struct ConversationStoreSessionTests {
     @Test @MainActor
     func removeActiveSessionStateClearsFocusWithoutFallback() {
         let store = ConversationStore()
-        store.handle(.history(messages: [
-            ChatMessage(
-                id: "message-1",
-                sessionId: "session-1",
-                role: .user,
-                content: "Hello",
-                images: nil,
-                toolCalls: nil,
-                thinkingContent: nil,
-                timestamp: "2026-01-01T00:00:00.000Z",
-                cancelled: nil,
-                durationMs: nil
-            )
-        ], sessionId: "session-1"))
+        seedHistory(store, sessionId: "session-1")
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -138,20 +123,7 @@ struct ConversationStoreSessionTests {
     @Test @MainActor
     func removeBackgroundSessionStateKeepsActiveConversation() {
         let store = ConversationStore()
-        store.handle(.history(messages: [
-            ChatMessage(
-                id: "message-1",
-                sessionId: "session-1",
-                role: .user,
-                content: "Hello",
-                images: nil,
-                toolCalls: nil,
-                thinkingContent: nil,
-                timestamp: "2026-01-01T00:00:00.000Z",
-                cancelled: nil,
-                durationMs: nil
-            )
-        ], sessionId: "session-1"))
+        seedHistory(store, sessionId: "session-1")
         store.handle(.status(
             status: .busy,
             sessionId: "session-2",

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
@@ -237,7 +237,7 @@ struct ConversationStoreStreamSnapshotTests {
     }
 
     @Test @MainActor
-    func emptyDoneTurnProducesNoBubble() {
+    func emptyDoneTurnOmitsMessageIdAndProducesNoBubble() {
         let store = ConversationStore()
         store.setFocusedSessionId("session-1")
         // Stream slot exists but accumulated no displayable content.
@@ -246,9 +246,11 @@ struct ConversationStoreStreamSnapshotTests {
             streaming: true, streamingStartedAt: nil, lockedProvider: nil
         ))
 
+        // Empty turn: the backend persists nothing and omits messageId, so its
+        // absence is the single signal that no bubble should be appended.
         store.handle(.done(
             sessionId: "session-1",
-            messageId: "server-empty-1",
+            messageId: nil,
             durationMs: 10,
             inputTokens: nil, outputTokens: nil,
             contextUsedTokens: nil, contextWindowTokens: nil,

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
@@ -18,6 +18,22 @@ struct ConversationStoreStreamSnapshotTests {
         ))
     }
 
+    private func message(
+        _ id: String, role: MessageRole, content: String = "",
+        sessionId: String = "session-1", toolCalls: [ToolCall]? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id, sessionId: sessionId, role: role, content: content,
+            images: nil, toolCalls: toolCalls, thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z", cancelled: nil, durationMs: nil
+        )
+    }
+
+    private func askUserQuestionTool(_ id: String) -> ToolCall {
+        ToolCall(id: id, name: "AskUserQuestion", input: "{\"question\":\"pick one\"}",
+                 output: nil, parentToolUseId: nil)
+    }
+
     // MARK: - stream_snapshot REPLACE semantics
 
     @Test @MainActor
@@ -352,6 +368,123 @@ struct ConversationStoreStreamSnapshotTests {
 
         // m2 is not duplicated.
         #expect(store.messages.map(\.id) == ["m1", "m2"])
+    }
+
+    // MARK: - applyMessagesPage derives pending tool inputs (Finding #3)
+
+    @Test @MainActor
+    func applyMessagesPageDerivesPendingFromUnansweredQuestion() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        // REST history whose last assistant turn parked on an AskUserQuestion
+        // with no user message after it: opening this session must surface the
+        // answer sheet, so a pending tool input is derived (PRD #254 Finding #3).
+        let page = MessagesPage(messages: [
+            message("u1", role: .user, content: "do the thing"),
+            message("a1", role: .assistant, content: "I need input",
+                    toolCalls: [askUserQuestionTool("tool-ask-1")])
+        ], hasMore: false)
+
+        store.applyMessagesPage(page)
+
+        #expect(store.pendingToolInputs.count == 1)
+        #expect(store.pendingToolInputs.first?.toolName == "AskUserQuestion")
+        #expect(store.pendingToolInputs.first?.toolUseId == "tool-ask-1")
+    }
+
+    @Test @MainActor
+    func applyMessagesPageDerivesNoPendingWhenUserAnswered() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        // A user message AFTER the question means it was already answered — no
+        // pending input should be derived.
+        let page = MessagesPage(messages: [
+            message("a1", role: .assistant, content: "I need input",
+                    toolCalls: [askUserQuestionTool("tool-ask-1")]),
+            message("u1", role: .user, content: "here is my answer")
+        ], hasMore: false)
+
+        store.applyMessagesPage(page)
+
+        #expect(store.pendingToolInputs.isEmpty)
+    }
+
+    @Test @MainActor
+    func applyMessagesPageSkipsDerivationWhileStreaming() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        // The focused session is actively streaming: live WS tool inputs win, so
+        // history derivation is skipped (mirrors web's set_history behavior).
+        store.handle(.status(
+            status: .busy, sessionId: "session-1",
+            streaming: true, streamingStartedAt: nil, lockedProvider: nil
+        ))
+
+        let page = MessagesPage(messages: [
+            message("a1", role: .assistant, content: "I need input",
+                    toolCalls: [askUserQuestionTool("tool-ask-1")])
+        ], hasMore: false)
+
+        store.applyMessagesPage(page)
+
+        #expect(store.pendingToolInputs.isEmpty)
+    }
+
+    // MARK: - stream_snapshot computes output scalars (Finding #5)
+
+    @Test @MainActor
+    func streamSnapshotComputesScalarsForToolWithOutput() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        let output = "line one\nline two\nline three"
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "running tools",
+            thinking: "",
+            toolCalls: [toolCall("tool-1", output: output)],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        // A snapshot tool that already completed carries a full output, so the
+        // store computes the same scalars `tool_result` would (PRD #254 #5):
+        // body preserved (small => untruncated), preview == body, exact line/byte
+        // counts present.
+        let tool = store.activeToolCalls.first
+        #expect(tool?.output == output)
+        #expect(tool?.outputPreview == output)
+        #expect(tool?.outputLineCount == 3)
+        #expect(tool?.outputByteLength == output.utf8.count)
+        #expect(tool?.outputTruncated == false)
+    }
+
+    @Test @MainActor
+    func streamSnapshotLeavesRunningToolWithoutOutputUntouched() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        // A tool still running in the snapshot has no output — it must pass
+        // through with nil scalars (nothing to compute yet).
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "",
+            thinking: "",
+            toolCalls: [toolCall("tool-running")],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        let tool = store.activeToolCalls.first
+        #expect(tool?.output == nil)
+        #expect(tool?.outputPreview == nil)
+        #expect(tool?.outputLineCount == nil)
+        #expect(tool?.outputByteLength == nil)
+        #expect(tool?.outputTruncated == nil)
     }
 
     @Test @MainActor

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
@@ -463,6 +463,32 @@ struct ConversationStoreStreamSnapshotTests {
     }
 
     @Test @MainActor
+    func streamSnapshotComputesZeroScalarsForToolWithEmptyOutput() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        // A completed tool whose output is "" must get the SAME zero scalars the
+        // `tool_result` path computes — not be treated as still-running and left
+        // with nil scalars (PRD #254 #5 audit follow-up).
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "running tools",
+            thinking: "",
+            toolCalls: [toolCall("tool-empty", output: "")],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        let tool = store.activeToolCalls.first
+        #expect(tool?.output == "")
+        #expect(tool?.outputPreview == "")
+        #expect(tool?.outputLineCount == 0)
+        #expect(tool?.outputByteLength == 0)
+        #expect(tool?.outputTruncated == false)
+    }
+
+    @Test @MainActor
     func streamSnapshotLeavesRunningToolWithoutOutputUntouched() {
         let store = ConversationStore()
         store.setFocusedSessionId("session-1")

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamSnapshotTests.swift
@@ -1,0 +1,380 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Tests for the PRD #254 live/history split on iOS: the consolidated
+/// `stream_snapshot` is applied with REPLACE semantics (idempotent on
+/// re-focus/reconnect), and `done`/`cancelled` finalize using the
+/// server-persisted message id so the next REST fetch dedups by id.
+struct ConversationStoreStreamSnapshotTests {
+    private func toolCall(_ id: String, output: String? = nil) -> ToolCall {
+        ToolCall(id: id, name: "Read", input: "{}", output: output, parentToolUseId: nil)
+    }
+
+    private func activity(_ id: String) -> AgentActivity {
+        .commandExecution(.init(
+            id: id, command: "swift test", cwd: nil, status: "completed",
+            output: "ok", exitCode: 0, durationMs: 12
+        ))
+    }
+
+    // MARK: - stream_snapshot REPLACE semantics
+
+    @Test @MainActor
+    func streamSnapshotReplacesAccumulators() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "partial answer",
+            thinking: "reasoning",
+            toolCalls: [toolCall("tool-1", output: "done")],
+            agentActivities: [activity("cmd-1")],
+            planMode: true,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        #expect(store.isStreaming == true)
+        #expect(store.currentText == "partial answer")
+        #expect(store.currentThinking == "reasoning")
+        #expect(store.activeToolCalls.map(\.id) == ["tool-1"])
+        #expect(store.activeAgentActivities.map(\.id) == ["cmd-1"])
+        #expect(store.agentPlanMode == true)
+        #expect(store.streamingStartedAt != nil)
+    }
+
+    @Test @MainActor
+    func streamSnapshotIsIdempotentOnReapply() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        let snapshot: WsOutgoing = .streamSnapshot(
+            sessionId: "session-1",
+            text: "hello world",
+            thinking: "",
+            toolCalls: [toolCall("tool-1", output: "a"), toolCall("tool-2", output: "b")],
+            agentActivities: [activity("cmd-1")],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        )
+
+        // Applying the same snapshot twice (e.g. reconnect re-pull) must REPLACE,
+        // never append — no duplicate text or tool calls.
+        store.handle(snapshot)
+        store.handle(snapshot)
+
+        #expect(store.currentText == "hello world")
+        #expect(store.activeToolCalls.map(\.id) == ["tool-1", "tool-2"])
+        #expect(store.activeAgentActivities.map(\.id) == ["cmd-1"])
+    }
+
+    @Test @MainActor
+    func liveDeltasAppendAfterSnapshot() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "caught up so far",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: " and more"))
+
+        #expect(store.currentText == "caught up so far and more")
+    }
+
+    @Test @MainActor
+    func snapshotForBackgroundSessionDoesNotAdoptFocus() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-active")
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-bg",
+            text: "background work",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        // Focus is unchanged; the background slot still accumulated.
+        #expect(store.sessionId == "session-active")
+        #expect(store.sessionStreams["session-bg"]?.currentText == "background work")
+        #expect(store.currentText == "")
+    }
+
+    // MARK: - Finalization dedup by server message id
+
+    @Test @MainActor
+    func doneFinalizesWithServerMessageId() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "the answer",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        store.handle(.done(
+            sessionId: "session-1",
+            messageId: "server-msg-1",
+            durationMs: 100,
+            inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+
+        // The finalized bubble carries the SERVER id (not a random UUID), so the
+        // next REST history fetch dedups against it.
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.id == "server-msg-1")
+        #expect(store.messages.first?.content == "the answer")
+        #expect(store.sessionStreams["session-1"] == nil)
+    }
+
+    @Test @MainActor
+    func restFetchAfterDoneDoesNotDuplicateById() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "streamed reply",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+        store.handle(.done(
+            sessionId: "session-1",
+            messageId: "server-msg-1",
+            durationMs: 100,
+            inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+        #expect(store.messages.count == 1)
+
+        // REST history returns the authoritative copy with the SAME id; applying
+        // the page replaces the window, so there is exactly one message.
+        let page = MessagesPage(messages: [
+            ChatMessage(
+                id: "server-msg-1", sessionId: "session-1", role: .assistant,
+                content: "streamed reply", images: nil, toolCalls: nil,
+                thinkingContent: nil, timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil, durationMs: 100
+            )
+        ], hasMore: false)
+        store.applyMessagesPage(page)
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.id == "server-msg-1")
+        #expect(store.hasMoreEarlier == false)
+    }
+
+    @Test @MainActor
+    func doneSkipsWhenServerMessageAlreadyPresent() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        // Simulate REST landing first: the authoritative message is already in
+        // the list before `done` fires for the same turn.
+        store.messages = [
+            ChatMessage(
+                id: "server-msg-1", sessionId: "session-1", role: .assistant,
+                content: "already here", images: nil, toolCalls: nil,
+                thinkingContent: nil, timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil, durationMs: 100
+            )
+        ]
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "already here",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        store.handle(.done(
+            sessionId: "session-1",
+            messageId: "server-msg-1",
+            durationMs: 100,
+            inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+
+        // No duplicate appended — dedup by server id.
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.id == "server-msg-1")
+    }
+
+    @Test @MainActor
+    func emptyDoneTurnProducesNoBubble() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        // Stream slot exists but accumulated no displayable content.
+        store.handle(.status(
+            status: .busy, sessionId: "session-1",
+            streaming: true, streamingStartedAt: nil, lockedProvider: nil
+        ))
+
+        store.handle(.done(
+            sessionId: "session-1",
+            messageId: "server-empty-1",
+            durationMs: 10,
+            inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+
+        // The empty-turn edge: no empty bubble materializes.
+        #expect(store.messages.isEmpty)
+        #expect(store.sessionStreams["session-1"] == nil)
+    }
+
+    @Test @MainActor
+    func cancelledWithMessageIdStampsServerId() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "partial before stop",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            planMode: false,
+            streamingStartedAt: 1_700_000_000_000
+        ))
+
+        store.handle(.cancelled(
+            sessionId: "session-1",
+            messageId: "server-cancel-1",
+            errorDetail: nil,
+            userInitiated: true,
+            durationMs: 50
+        ))
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.id == "server-cancel-1")
+        #expect(store.messages.first?.cancelled == true)
+        #expect(store.messages.first?.content == "partial before stop")
+    }
+
+    // MARK: - Load earlier (pagination)
+
+    @Test @MainActor
+    func applyMessagesPageRecordsHasMore() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        let page = MessagesPage(messages: [
+            ChatMessage(
+                id: "m2", sessionId: "session-1", role: .user, content: "second",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:02.000Z", cancelled: nil, durationMs: nil
+            )
+        ], hasMore: true)
+
+        store.applyMessagesPage(page)
+
+        #expect(store.messages.map(\.id) == ["m2"])
+        #expect(store.hasMoreEarlier == true)
+    }
+
+    @Test @MainActor
+    func prependEarlierInsertsOlderMessagesAndUpdatesHasMore() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.applyMessagesPage(MessagesPage(messages: [
+            ChatMessage(
+                id: "m3", sessionId: "session-1", role: .user, content: "third",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:03.000Z", cancelled: nil, durationMs: nil
+            )
+        ], hasMore: true))
+
+        // Older page fetched via ?before=m3.
+        store.prependEarlier(MessagesPage(messages: [
+            ChatMessage(
+                id: "m1", sessionId: "session-1", role: .user, content: "first",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z", cancelled: nil, durationMs: nil
+            ),
+            ChatMessage(
+                id: "m2", sessionId: "session-1", role: .user, content: "second",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:02.000Z", cancelled: nil, durationMs: nil
+            )
+        ], hasMore: false))
+
+        // Older messages are prepended in order, ahead of the existing window.
+        #expect(store.messages.map(\.id) == ["m1", "m2", "m3"])
+        // No more older messages remain.
+        #expect(store.hasMoreEarlier == false)
+    }
+
+    @Test @MainActor
+    func prependEarlierDedupsOverlappingIds() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.applyMessagesPage(MessagesPage(messages: [
+            ChatMessage(
+                id: "m2", sessionId: "session-1", role: .user, content: "second",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:02.000Z", cancelled: nil, durationMs: nil
+            )
+        ], hasMore: true))
+
+        // The older page overlaps on m2 (e.g. a turn finished between fetches).
+        store.prependEarlier(MessagesPage(messages: [
+            ChatMessage(
+                id: "m1", sessionId: "session-1", role: .user, content: "first",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z", cancelled: nil, durationMs: nil
+            ),
+            ChatMessage(
+                id: "m2", sessionId: "session-1", role: .user, content: "second",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:02.000Z", cancelled: nil, durationMs: nil
+            )
+        ], hasMore: false))
+
+        // m2 is not duplicated.
+        #expect(store.messages.map(\.id) == ["m1", "m2"])
+    }
+
+    @Test @MainActor
+    func cancelledWithoutMessageIdStillShowsStoppedBubble() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        // An empty turn that is stopped: no server id, but a "Stopped" bubble is
+        // still useful, so a local id is used (content is empty).
+        store.handle(.status(
+            status: .busy, sessionId: "session-1",
+            streaming: true, streamingStartedAt: nil, lockedProvider: nil
+        ))
+
+        store.handle(.cancelled(
+            sessionId: "session-1",
+            messageId: nil,
+            errorDetail: "stopped",
+            userInitiated: true,
+            durationMs: 50
+        ))
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.cancelled == true)
+        #expect(store.messages.first?.content == "")
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
@@ -136,7 +136,7 @@ struct MessagesPageDecodingTests {
 
     /// A frozen line-count parity case. A struct (not a tuple) keeps the
     /// `arguments:` overload unambiguous across Swift Testing versions.
-    private struct LineCountCase: Sendable {
+    struct LineCountCase: Sendable {
         let input: String
         let expected: Int
     }

--- a/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
@@ -88,7 +88,14 @@ struct MessagesPageDecodingTests {
         #expect(tool.outputLineCount == 9000)
     }
 
-    // MARK: - Live output scalar computation (matches backend)
+    // MARK: - Live output scalar computation
+    //
+    // The TS line-count / byte-length formulas now live once in
+    // @hive/shared/agent-activity (outputLineCount / outputByteLength), consumed
+    // by both backend computeTruncatedField and frontend computeOutputScalars.
+    // iOS keeps its own Swift copy (it cannot import TS); these cases pin that
+    // copy to the same semantics: empty => 0 lines / 0 bytes, line count =
+    // newlines + 1, byte length = UTF-8 bytes.
 
     @Test
     func computesScalarsForEmptyOutput() {

--- a/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Tests for the PRD #254 REST history page shape (`{ messages, hasMore }`) and
+/// the live output-scalar computation, which must match the backend's
+/// `computeTruncatedField` byte-for-byte so live and history tools agree.
+struct MessagesPageDecodingTests {
+    // MARK: - MessagesPage decoding
+
+    @Test
+    func decodesMessagesPageWithHasMore() throws {
+        let data = try #require("""
+        {
+          "messages": [
+            {
+              "id": "msg-1",
+              "sessionId": "session-1",
+              "role": "user",
+              "content": "hello",
+              "timestamp": "2026-01-01T00:00:00.000Z"
+            },
+            {
+              "id": "msg-2",
+              "sessionId": "session-1",
+              "role": "assistant",
+              "content": "hi there",
+              "timestamp": "2026-01-01T00:00:01.000Z"
+            }
+          ],
+          "hasMore": true
+        }
+        """.data(using: .utf8))
+
+        let page = try JSONDecoder().decode(MessagesPage.self, from: data)
+        #expect(page.messages.count == 2)
+        #expect(page.messages.first?.id == "msg-1")
+        #expect(page.hasMore == true)
+        // The next `before` cursor is messages.first?.id.
+        #expect(page.messages.first?.id == "msg-1")
+    }
+
+    @Test
+    func decodesEmptyMessagesPage() throws {
+        let data = try #require("""
+        { "messages": [], "hasMore": false }
+        """.data(using: .utf8))
+
+        let page = try JSONDecoder().decode(MessagesPage.self, from: data)
+        #expect(page.messages.isEmpty)
+        #expect(page.hasMore == false)
+    }
+
+    @Test
+    func decodesHistoryMessageWithTruncatedToolOutput() throws {
+        // A persisted assistant turn as the REST history serializes it: the heavy
+        // tool output is omitted, preview + scalars present.
+        let data = try #require("""
+        {
+          "messages": [
+            {
+              "id": "msg-1",
+              "sessionId": "session-1",
+              "role": "assistant",
+              "content": "ran a command",
+              "timestamp": "2026-01-01T00:00:00.000Z",
+              "toolCalls": [
+                {
+                  "id": "tool-1",
+                  "name": "Bash",
+                  "input": "{}",
+                  "outputPreview": "first lines...",
+                  "outputLineCount": 9000,
+                  "outputByteLength": 300000,
+                  "outputTruncated": true
+                }
+              ]
+            }
+          ],
+          "hasMore": false
+        }
+        """.data(using: .utf8))
+
+        let page = try JSONDecoder().decode(MessagesPage.self, from: data)
+        let tool = try #require(page.messages.first?.toolCalls?.first)
+        #expect(tool.output == nil)
+        #expect(tool.outputTruncated == true)
+        #expect(tool.outputLineCount == 9000)
+    }
+
+    // MARK: - Live output scalar computation (matches backend)
+
+    @Test
+    func computesScalarsForEmptyOutput() {
+        let s = computeOutputScalars("")
+        #expect(s.lineCount == 0)        // empty => 0 lines (matches backend)
+        #expect(s.byteLength == 0)
+        #expect(s.truncated == false)
+        #expect(s.preview == "")
+    }
+
+    @Test
+    func computesScalarsForSingleLine() {
+        let s = computeOutputScalars("hello")
+        #expect(s.lineCount == 1)        // newlines + 1
+        #expect(s.byteLength == 5)
+        #expect(s.truncated == false)
+        #expect(s.preview == "hello")
+    }
+
+    @Test
+    func computesScalarsForMultiLine() {
+        // "a\nb\nc" => 2 newlines + 1 = 3 lines.
+        let s = computeOutputScalars("a\nb\nc")
+        #expect(s.lineCount == 3)
+        #expect(s.byteLength == 5)
+        #expect(s.truncated == false)
+    }
+
+    @Test
+    func computesScalarsWithTrailingNewline() {
+        // "a\nb\n" => 2 newlines + 1 = 3 (matches backend split-based count).
+        let s = computeOutputScalars("a\nb\n")
+        #expect(s.lineCount == 3)
+        #expect(s.byteLength == 4)
+    }
+
+    @Test
+    func computesByteLengthForMultibyteScalars() {
+        // "é" is 2 UTF-8 bytes; "😀" is 4. Byte length is UTF-8, not char count.
+        let s = computeOutputScalars("é😀")
+        #expect(s.byteLength == 6)
+        #expect(s.lineCount == 1)
+        #expect(s.truncated == false)
+    }
+
+    @Test
+    func truncatesOutputOverCapOnByteBoundary() {
+        // 3000 ASCII bytes > 2048 cap => truncated, preview is exactly 2048 bytes.
+        let full = String(repeating: "x", count: 3000)
+        let s = computeOutputScalars(full)
+        #expect(s.truncated == true)
+        #expect(s.byteLength == 3000)
+        #expect(s.lineCount == 1)
+        #expect(Array(s.preview.utf8).count == 2048)
+    }
+
+    @Test
+    func previewNeverSplitsMultibyteScalar() {
+        // Fill just past the cap with 2-byte scalars so the boundary lands mid-
+        // character; the slice must walk back to a scalar boundary (<= 2048).
+        let full = String(repeating: "é", count: 1100) // 2200 bytes
+        let s = computeOutputScalars(full)
+        #expect(s.truncated == true)
+        #expect(s.byteLength == 2200)
+        let previewBytes = Array(s.preview.utf8).count
+        #expect(previewBytes <= 2048)
+        // The preview must be valid UTF-8 made only of whole "é" scalars.
+        #expect(s.preview.allSatisfy { $0 == "é" })
+        #expect(previewBytes % 2 == 0)
+    }
+
+    @Test
+    func outputExactlyAtCapIsNotTruncated() {
+        // byteLength == cap is NOT > cap, so not truncated (boundary check).
+        let full = String(repeating: "x", count: 2048)
+        let s = computeOutputScalars(full)
+        #expect(s.byteLength == 2048)
+        #expect(s.truncated == false)
+        #expect(s.preview == full)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MessagesPageDecodingTests.swift
@@ -94,8 +94,9 @@ struct MessagesPageDecodingTests {
     // @hive/shared/agent-activity (outputLineCount / outputByteLength), consumed
     // by both backend computeTruncatedField and frontend computeOutputScalars.
     // iOS keeps its own Swift copy (it cannot import TS); these cases pin that
-    // copy to the same semantics: empty => 0 lines / 0 bytes, line count =
-    // newlines + 1, byte length = UTF-8 bytes.
+    // copy to the same semantics: empty => 0 lines / 0 bytes; line count drops a
+    // single trailing newline then counts newlines + 1 (so "a\nb\n" => 2, not 3);
+    // byte length = UTF-8 bytes.
 
     @Test
     func computesScalarsForEmptyOutput() {
@@ -126,10 +127,37 @@ struct MessagesPageDecodingTests {
 
     @Test
     func computesScalarsWithTrailingNewline() {
-        // "a\nb\n" => 2 newlines + 1 = 3 (matches backend split-based count).
+        // A single trailing newline is NOT counted (matches the shared TS
+        // `outputLineCount`): "a\nb\n" => body "a\nb" => 2 lines, not 3.
         let s = computeOutputScalars("a\nb\n")
-        #expect(s.lineCount == 3)
+        #expect(s.lineCount == 2)
         #expect(s.byteLength == 4)
+    }
+
+    /// A frozen line-count parity case. A struct (not a tuple) keeps the
+    /// `arguments:` overload unambiguous across Swift Testing versions.
+    private struct LineCountCase: Sendable {
+        let input: String
+        let expected: Int
+    }
+
+    @Test(
+        // Frozen parity with the shared TS `outputLineCount` primitive:
+        //   if s.length === 0 -> 0
+        //   body = s.endsWith("\n") ? s.slice(0,-1) : s
+        //   return body.length === 0 ? 0 : body.split("\n").length
+        arguments: [
+            LineCountCase(input: "", expected: 0),
+            LineCountCase(input: "a", expected: 1),
+            LineCountCase(input: "a\n", expected: 1),
+            LineCountCase(input: "a\nb", expected: 2),
+            LineCountCase(input: "a\nb\n", expected: 2),
+            LineCountCase(input: "\n", expected: 0),
+            LineCountCase(input: "a\n\n", expected: 2),
+        ]
+    )
+    func lineCountMatchesSharedTSPrimitive(_ testCase: LineCountCase) {
+        #expect(computeOutputScalars(testCase.input).lineCount == testCase.expected)
     }
 
     @Test

--- a/ios/Tests/ChatDraftStoreTests/StreamSnapshotDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/StreamSnapshotDecodingTests.swift
@@ -1,0 +1,263 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Wire-format decoding tests for the PRD #254 protocol additions: the
+/// consolidated `stream_snapshot` event, the new lazy-output `ToolCall` /
+/// `command_execution` scalars, the required `done.messageId`, and the optional
+/// `cancelled.messageId`. Kept in sync with backend/frontend types.
+struct StreamSnapshotDecodingTests {
+    private func decodeEvent(_ json: String) throws -> WsOutgoing {
+        let envelope = try decodeHubEnvelope(json)
+        return envelope.event
+    }
+
+    private func decodeHubEnvelope(_ json: String) throws -> HubOutgoing {
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode(HubOutgoing.self, from: data)
+    }
+
+    private func decodeToolCall(_ json: String) throws -> ToolCall {
+        let data = try #require(json.data(using: .utf8))
+        return try JSONDecoder().decode(ToolCall.self, from: data)
+    }
+
+    // MARK: - stream_snapshot
+
+    @Test
+    func decodesStreamSnapshotWithAllFields() throws {
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "stream_snapshot",
+            "sessionId": "session-1",
+            "text": "partial answer",
+            "thinking": "reasoning so far",
+            "toolCalls": [
+              { "id": "tool-1", "name": "Read", "input": "{}", "output": "file contents" }
+            ],
+            "agentActivities": [
+              {
+                "id": "cmd-1",
+                "kind": "command_execution",
+                "command": "swift test",
+                "status": "completed",
+                "output": "ok",
+                "exitCode": 0
+              }
+            ],
+            "planMode": true,
+            "streamingStartedAt": 1700000000000
+          }
+        }
+        """)
+
+        guard case .streamSnapshot(let sid, let text, let thinking, let toolCalls,
+                                   let activities, let planMode, let startedAt) = event else {
+            Issue.record("Expected stream_snapshot event")
+            return
+        }
+        #expect(sid == "session-1")
+        #expect(text == "partial answer")
+        #expect(thinking == "reasoning so far")
+        #expect(toolCalls.map(\.id) == ["tool-1"])
+        #expect(toolCalls.first?.output == "file contents")
+        #expect(activities.map(\.id) == ["cmd-1"])
+        #expect(planMode == true)
+        #expect(startedAt == 1700000000000)
+    }
+
+    @Test
+    func decodesStreamSnapshotWithEmptyCollections() throws {
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "stream_snapshot",
+            "sessionId": "session-1",
+            "text": "",
+            "thinking": "",
+            "toolCalls": [],
+            "agentActivities": [],
+            "planMode": false,
+            "streamingStartedAt": 1700000000000
+          }
+        }
+        """)
+
+        guard case .streamSnapshot(_, let text, _, let toolCalls, let activities, let planMode, _) = event else {
+            Issue.record("Expected stream_snapshot event")
+            return
+        }
+        #expect(text == "")
+        #expect(toolCalls.isEmpty)
+        #expect(activities.isEmpty)
+        #expect(planMode == false)
+    }
+
+    // MARK: - ToolCall lazy-output scalars
+
+    @Test
+    func decodesToolCallWithTruncatedOutputScalars() throws {
+        // History form: full body omitted, preview + exact scalars present.
+        let tool = try decodeToolCall("""
+        {
+          "id": "tool-1",
+          "name": "Bash",
+          "input": "{}",
+          "outputPreview": "first 2KB...",
+          "outputLineCount": 4096,
+          "outputByteLength": 1048576,
+          "outputTruncated": true
+        }
+        """)
+
+        #expect(tool.output == nil)
+        #expect(tool.outputPreview == "first 2KB...")
+        #expect(tool.outputLineCount == 4096)
+        #expect(tool.outputByteLength == 1048576)
+        #expect(tool.outputTruncated == true)
+    }
+
+    @Test
+    func decodesToolCallWithUntruncatedOutputIntact() throws {
+        // Small output: full body kept, truncated == false.
+        let tool = try decodeToolCall("""
+        {
+          "id": "tool-1",
+          "name": "Grep",
+          "input": "{}",
+          "output": "a\\nb\\nc",
+          "outputPreview": "a\\nb\\nc",
+          "outputLineCount": 3,
+          "outputByteLength": 5,
+          "outputTruncated": false
+        }
+        """)
+
+        #expect(tool.output == "a\nb\nc")
+        #expect(tool.outputLineCount == 3)
+        #expect(tool.outputByteLength == 5)
+        #expect(tool.outputTruncated == false)
+    }
+
+    @Test
+    func decodesLegacyToolCallWithoutScalars() throws {
+        // Backwards compatible: a tool with no scalar fields decodes with nils.
+        let tool = try decodeToolCall("""
+        { "id": "tool-1", "name": "Read", "input": "{}", "output": "x" }
+        """)
+
+        #expect(tool.output == "x")
+        #expect(tool.outputPreview == nil)
+        #expect(tool.outputLineCount == nil)
+        #expect(tool.outputByteLength == nil)
+        #expect(tool.outputTruncated == nil)
+    }
+
+    @Test
+    func decodesCommandExecutionWithOutputScalars() throws {
+        let data = try #require("""
+        {
+          "id": "cmd-1",
+          "kind": "command_execution",
+          "command": "cat big.log",
+          "status": "completed",
+          "outputPreview": "head of log...",
+          "outputLineCount": 12000,
+          "outputByteLength": 524288,
+          "outputTruncated": true
+        }
+        """.data(using: .utf8))
+        let activity = try JSONDecoder().decode(AgentActivity.self, from: data)
+
+        guard case .commandExecution(let command) = activity else {
+            Issue.record("Expected command_execution activity")
+            return
+        }
+        #expect(command.output == nil)
+        #expect(command.outputPreview == "head of log...")
+        #expect(command.outputLineCount == 12000)
+        #expect(command.outputByteLength == 524288)
+        #expect(command.outputTruncated == true)
+
+        // The scalars carry through into the derived ToolCall so the collapsed
+        // view reads them instead of the (omitted) body.
+        let tool = try #require(activity.toolCalls.first)
+        #expect(tool.outputLineCount == 12000)
+        #expect(tool.outputTruncated == true)
+        #expect(tool.output == nil)
+    }
+
+    // MARK: - done / cancelled message id
+
+    @Test
+    func decodesDoneWithRequiredMessageId() throws {
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "done",
+            "sessionId": "session-1",
+            "messageId": "server-msg-1",
+            "durationMs": 1200
+          }
+        }
+        """)
+
+        guard case .done(let sid, let messageId, let durationMs, _, _, _, _, _) = event else {
+            Issue.record("Expected done event")
+            return
+        }
+        #expect(sid == "session-1")
+        #expect(messageId == "server-msg-1")
+        #expect(durationMs == 1200)
+    }
+
+    @Test
+    func decodesCancelledWithOptionalMessageIdPresent() throws {
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "cancelled",
+            "sessionId": "session-1",
+            "messageId": "server-cancel-1",
+            "userInitiated": true,
+            "durationMs": 300
+          }
+        }
+        """)
+
+        guard case .cancelled(let sid, let messageId, _, let userInitiated, let durationMs) = event else {
+            Issue.record("Expected cancelled event")
+            return
+        }
+        #expect(sid == "session-1")
+        #expect(messageId == "server-cancel-1")
+        #expect(userInitiated == true)
+        #expect(durationMs == 300)
+    }
+
+    @Test
+    func decodesCancelledWithoutMessageId() throws {
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "cancelled",
+            "sessionId": "session-1",
+            "userInitiated": false
+          }
+        }
+        """)
+
+        guard case .cancelled(_, let messageId, _, let userInitiated, _) = event else {
+            Issue.record("Expected cancelled event")
+            return
+        }
+        #expect(messageId == nil)
+        #expect(userInitiated == false)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/StreamSnapshotDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/StreamSnapshotDecodingTests.swift
@@ -4,8 +4,9 @@ import Testing
 
 /// Wire-format decoding tests for the PRD #254 protocol additions: the
 /// consolidated `stream_snapshot` event, the new lazy-output `ToolCall` /
-/// `command_execution` scalars, the required `done.messageId`, and the optional
-/// `cancelled.messageId`. Kept in sync with backend/frontend types.
+/// `command_execution` scalars, and the optional `done.messageId` /
+/// `cancelled.messageId` (present only when the turn persisted a message). Kept
+/// in sync with backend/frontend types.
 struct StreamSnapshotDecodingTests {
     private func decodeEvent(_ json: String) throws -> WsOutgoing {
         let envelope = try decodeHubEnvelope(json)
@@ -193,7 +194,30 @@ struct StreamSnapshotDecodingTests {
     // MARK: - done / cancelled message id
 
     @Test
-    func decodesDoneWithRequiredMessageId() throws {
+    func decodesDoneWithoutMessageId() throws {
+        // Empty turn: the backend omits messageId entirely.
+        let event = try decodeEvent("""
+        {
+          "workspaceId": "ws-1",
+          "event": {
+            "type": "done",
+            "sessionId": "session-1",
+            "durationMs": 10
+          }
+        }
+        """)
+
+        guard case .done(let sid, let messageId, let durationMs, _, _, _, _, _) = event else {
+            Issue.record("Expected done event")
+            return
+        }
+        #expect(sid == "session-1")
+        #expect(messageId == nil)
+        #expect(durationMs == 10)
+    }
+
+    @Test
+    func decodesDoneWithMessageId() throws {
         let event = try decodeEvent("""
         {
           "workspaceId": "ws-1",

--- a/ios/Tests/ChatDraftStoreTests/ToolOutputCacheKeyTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ToolOutputCacheKeyTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Tests for the PRD #254 tool-output cache key scoping. Codex tool ids are
+/// sequential per turn (`item_1`, `item_2`, …) and so repeat across
+/// sessions/workspaces. The expand-output cache must therefore key by the
+/// session scope (workspaceId + sessionId) plus the tool id, never the tool id
+/// alone — otherwise expanding `item_1` in session A would serve A's body when
+/// expanding `item_1` in session B.
+///
+/// `ToolOutputCache` itself lives in the SwiftUI View layer (excluded from this
+/// test module), so we exercise its pure key builder `toolOutputCacheKey`, which
+/// is the sole source of the cache key.
+struct ToolOutputCacheKeyTests {
+    /// A minimal cache mirroring `ToolOutputCache`'s storage + keying so the
+    /// store/read collision behaviour can be asserted directly.
+    private struct FakeCache {
+        private var outputs: [String: String] = [:]
+
+        mutating func store(_ output: String, workspaceId: String, sessionId: String, toolId: String) {
+            outputs[toolOutputCacheKey(workspaceId: workspaceId, sessionId: sessionId, toolId: toolId)] = output
+        }
+
+        func value(workspaceId: String, sessionId: String, toolId: String) -> String? {
+            outputs[toolOutputCacheKey(workspaceId: workspaceId, sessionId: sessionId, toolId: toolId)]
+        }
+    }
+
+    @Test
+    func sameToolIdDifferentSessionsDoNotCollide() {
+        var cache = FakeCache()
+        let workspace = "ws-1"
+
+        // Session A stores its body under tool id "item_1".
+        cache.store("output-A", workspaceId: workspace, sessionId: "session-A", toolId: "item_1")
+
+        // Session B reads "item_1" — must MISS (forcing the correct fetch),
+        // not return session A's body.
+        #expect(cache.value(workspaceId: workspace, sessionId: "session-B", toolId: "item_1") == nil)
+
+        // Reading back under session A's own context returns A's body.
+        #expect(cache.value(workspaceId: workspace, sessionId: "session-A", toolId: "item_1") == "output-A")
+    }
+
+    @Test
+    func sameToolIdDifferentWorkspacesDoNotCollide() {
+        var cache = FakeCache()
+
+        cache.store("output-W1", workspaceId: "ws-1", sessionId: "s", toolId: "item_1")
+
+        // Same session id + tool id but a different workspace must MISS.
+        #expect(cache.value(workspaceId: "ws-2", sessionId: "s", toolId: "item_1") == nil)
+        #expect(cache.value(workspaceId: "ws-1", sessionId: "s", toolId: "item_1") == "output-W1")
+    }
+
+    @Test
+    func keyIsStableAndScopeSensitive() {
+        let a = toolOutputCacheKey(workspaceId: "ws", sessionId: "s", toolId: "item_1")
+        let aAgain = toolOutputCacheKey(workspaceId: "ws", sessionId: "s", toolId: "item_1")
+        #expect(a == aAgain)
+
+        // Each scope component independently changes the key.
+        #expect(a != toolOutputCacheKey(workspaceId: "ws2", sessionId: "s", toolId: "item_1"))
+        #expect(a != toolOutputCacheKey(workspaceId: "ws", sessionId: "s2", toolId: "item_1"))
+        #expect(a != toolOutputCacheKey(workspaceId: "ws", sessionId: "s", toolId: "item_2"))
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/WsIncomingEncodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/WsIncomingEncodingTests.swift
@@ -1,0 +1,38 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Encoding tests for the PRD #254 Finding #1 "always pull on focus" contract:
+/// `switch_session` must encode WITH `sessionId` when the client knows it, and
+/// must OMIT the key entirely when the id is unknown (a sessionId-less
+/// `switch_session` is a deterministic focus pull on the workspace's active
+/// session). Kept aligned with backend/frontend, where `switch_session.sessionId`
+/// is optional.
+struct WsIncomingEncodingTests {
+    private func encodeToObject(_ message: WsIncoming) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(message)
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try #require(object as? [String: Any])
+    }
+
+    @Test
+    func switchSessionWithKnownIdEncodesSessionId() throws {
+        let object = try encodeToObject(.switchSession(sessionId: "session-1"))
+
+        #expect(object["type"] as? String == "switch_session")
+        #expect(object["sessionId"] as? String == "session-1")
+    }
+
+    @Test
+    func switchSessionWithUnknownIdOmitsSessionId() throws {
+        // First open of an already-subscribed streaming workspace: the client
+        // has no session id yet but must still pull. The encoded payload carries
+        // NO sessionId key (not null) so the backend treats it as a focus pull on
+        // the active session.
+        let object = try encodeToObject(.switchSession(sessionId: nil))
+
+        #expect(object["type"] as? String == "switch_session")
+        #expect(object["sessionId"] == nil)
+        #expect(object.keys.contains("sessionId") == false)
+    }
+}

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -1,5 +1,6 @@
 export interface AgentActivityFile {
   path: string;
+  /** Full unified diff. Bounded by edit size; never truncated in REST history. */
   diff?: string;
   kind?: string;
   status?: string;
@@ -38,7 +39,22 @@ export type AgentActivity =
       command?: string;
       cwd?: string;
       status?: string;
+      /**
+       * Full command output. Present on live activities; OMITTED in REST history
+       * when it exceeds the preview cap (fetch the full body via the tool-output
+       * endpoint, keyed by this activity id). Read `outputPreview`/scalars for
+       * the collapsed view instead. Mirrors the {@link AgentActivityToolCall}
+       * / ToolCall sub-shape.
+       */
       output?: string;
+      /** First ~2 KB of the output (REST history). */
+      outputPreview?: string;
+      /** Exact line count of the FULL output (newlines + 1). */
+      outputLineCount?: number;
+      /** Exact UTF-8 byte length of the FULL output. */
+      outputByteLength?: number;
+      /** True when the full body was omitted because it exceeded the preview cap. */
+      outputTruncated?: boolean;
       exitCode?: number;
       durationMs?: number;
       commandActions?: AgentActivityCommandAction[];

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -23,6 +23,32 @@ export function outputByteLength(s: string): number {
   return new TextEncoder().encode(s).length;
 }
 
+/** Convert provider/native output payloads into the string shape used by Hive. */
+export function normalizeToolOutput(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value === undefined) return "";
+
+  if (Array.isArray(value)) {
+    const textBlocks = value
+      .map((entry) => {
+        if (!entry || typeof entry !== "object") return undefined;
+        const record = entry as Record<string, unknown>;
+        return record.type === "text" && typeof record.text === "string"
+          ? record.text
+          : undefined;
+      })
+      .filter((text): text is string => text !== undefined);
+    if (textBlocks.length > 0) return textBlocks.join("\n\n");
+  }
+
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized ?? String(value);
+  } catch {
+    return String(value);
+  }
+}
+
 export interface AgentActivityFile {
   path: string;
   /** Full unified diff. Bounded by edit size; never truncated in REST history. */

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -5,9 +5,15 @@
 // scalar computation (`computeOutputScalars`). Keeping them here prevents the
 // line-count / byte-length formulas from drifting between packages.
 
-/** Exact line count of a full output string: newlines + 1, 0 when empty. */
+/**
+ * Line count for a full output string after ignoring a single trailing newline
+ * (which command/Grep/Glob output almost always carries).
+ * Examples: ""=>0, "a"=>1, "a\n"=>1, "a\nb"=>2, "a\nb\n"=>2, "\n"=>0, "a\n\n"=>2.
+ */
 export function outputLineCount(s: string): number {
-  return s.length === 0 ? 0 : s.split("\n").length;
+  if (s.length === 0) return 0;
+  const body = s.endsWith("\n") ? s.slice(0, -1) : s;
+  return body.length === 0 ? 0 : body.split("\n").length;
 }
 
 /** Exact UTF-8 byte length of a full output string. */
@@ -68,7 +74,7 @@ export type AgentActivity =
       output?: string;
       /** First ~2 KB of the output (REST history). */
       outputPreview?: string;
-      /** Exact line count of the FULL output (newlines + 1). */
+      /** Line count of the FULL output after ignoring a single trailing newline. */
       outputLineCount?: number;
       /** Exact UTF-8 byte length of the FULL output. */
       outputByteLength?: number;

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -1,3 +1,22 @@
+// ── Output scalar primitives (shared by backend + frontend) ──────────
+//
+// The single source for the two heavy-output scalars used by both the backend
+// REST-history truncation (`computeTruncatedField`) and the frontend live
+// scalar computation (`computeOutputScalars`). Keeping them here prevents the
+// line-count / byte-length formulas from drifting between packages.
+
+/** Exact line count of a full output string: newlines + 1, 0 when empty. */
+export function outputLineCount(s: string): number {
+  return s.length === 0 ? 0 : s.split("\n").length;
+}
+
+/** Exact UTF-8 byte length of a full output string. */
+export function outputByteLength(s: string): number {
+  // TextEncoder is available in both Node (18+) and the browser, so this single
+  // implementation is portable across both consumers.
+  return new TextEncoder().encode(s).length;
+}
+
 export interface AgentActivityFile {
   path: string;
   /** Full unified diff. Bounded by edit size; never truncated in REST history. */


### PR DESCRIPTION
Closes #254.

## Summary

Conversations open near-instantly and live streams catch up deterministically, across web + iOS. Two problems converged onto one surface — how a session is caught up when it becomes visible:

- **Live/history split (Option B):** the WebSocket carries live state only; REST owns message history as the single source of truth (removes the old dual-source-of-truth + its race band-aids).
- **Deterministic in-flight delivery:** a single consolidated `stream_snapshot` event (replace semantics) pulled on focus — fixes the "open a streaming conversation and see an empty bubble until the next delta" bug.
- **Lazy tool outputs:** REST history truncates heavy tool / command outputs to a 2 KB preview + exact scalars and omits the full body; it's fetched on demand when a tool is expanded. This is the real lever for "few-but-heavy" conversations (the weight is inside a handful of large turns, not across many messages).
- **Render:** delta coalescing + isolated streaming view (web); `LazyVStack` + isolated streaming bubble + scroll throttle (iOS); collapsed views read scalars (one render path, no per-render output parsing).

## Audit fixes (2nd commit)

A branch audit found the first-visit catch-up only partially fixed. Addressed here:

- **#1** always pull on focus — `switch_session.sessionId` is now optional; omitting it pulls the workspace's active session, so the *first in-app navigation* into an already-subscribed, streaming workspace catches up immediately (the page-reload path already worked).
- **#2** reconnect ordering — send `sync_workspaces` before the focus re-pull, and serialize per-socket message handling on the backend so the pull lands after subscription (no "Not subscribed" error flash).
- **#3** iOS — REST history re-derives pending `AskUserQuestion` / `ExitPlanMode` inputs (the answer sheet shows again).
- **#5** snapshot tools compute output scalars like `tool_result` (one collapsed-render path).

## Validation

- Backend **1551** + frontend **1454** tests green; root typecheck + lint clean; cross-layer WS protocol-contract passing.
- Live on the dev server: lazy-output collapse → expand-fetch round-trip; and **in-app navigation** into an already-subscribed, streaming, unvisited workspace renders the in-flight snapshot immediately (the exact path a reload-based test would mask).
- iOS compiles and runs its tests on CI (no Swift toolchain in the dev env).

## Deferred (by decision)

- **#4** `file_change` diff truncation — per-file truncation vs per-activity-id fetch is a granularity mismatch; diffs left intact for now (Claude edits carry diffs in tool input anyway).
- **P1** session reads scoped by project + session id, not the owning `workspaceId` — pre-existing, low risk for single-user; a multi-user hardening pass for later.
