### PR TITLE
Stabilize chat streaming recovery across clients

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -406,6 +406,16 @@ export type WsOutgoing =
   | { type: "tool_use"; sessionId: string; id: string; name: string; input: string; parentToolUseId?: string }
   | { type: "tool_result"; sessionId: string; toolUseId: string; output: string }
   | { type: "agent_activity"; sessionId: string; activity: AgentActivity }
+  | {
+      type: "stream_snapshot";
+      sessionId: string;
+      text: string;
+      thinking: string;
+      toolCalls: ToolCall[];
+      agentActivities: AgentActivity[];
+      agentPlanMode: boolean;
+      streamingStartedAt?: number;
+    }
   | { type: "tool_input_required"; sessionId: string; requestId: string; toolName: string; toolUseId: string; input: unknown }
   | { type: "tool_input_resolved"; sessionId: string }
   | {

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -396,7 +396,7 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir).catch(() => {});
   });
 
-  it("replays streaming agent activities during bootstrap", async () => {
+  it("replays streaming snapshot during bootstrap", async () => {
     const fakeClaudePath = join(tempDir, "fake-claude-activity-bootstrap.sh");
     await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
     await chmod(fakeClaudePath, 0o755);
@@ -423,20 +423,91 @@ describe("WS /ws/hub", () => {
 
     await waitForMessage(
       messages,
-      (msgs) => msgs.some((m) => m.type === "agent_activity" && m.activity.id === "cmd-bootstrap"),
+      (msgs) =>
+        msgs.some(
+          (m) =>
+            m.type === "stream_snapshot" &&
+            m.agentActivities.some((activity) => activity.id === "cmd-bootstrap"),
+        ),
     );
 
     expect(messages).toContainEqual({
-      type: "agent_activity",
+      type: "stream_snapshot",
       sessionId: session.sessionId,
-      activity: {
+      text: snapshot.text,
+      thinking: snapshot.thinking,
+      toolCalls: snapshot.toolCalls,
+      agentActivities: [{
         id: "cmd-bootstrap",
         kind: "command_execution",
         command: "npm test",
         status: "inProgress",
         output: "running\n",
-      },
+      }],
+      agentPlanMode: snapshot.agentPlanMode,
+      streamingStartedAt: session.streamingStartedAt ?? undefined,
     });
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  it("replays snapshots and attaches listeners for non-active streaming sessions during bootstrap", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-multi-bootstrap.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    const { session: first } = await getOrCreateSession(wsId, dataDir, slowCmd);
+    first.sendMessage("first session");
+    const firstSnapshot = first.getStreamingSnapshot();
+    if (!firstSnapshot) throw new Error("Expected first streaming snapshot");
+    vi.spyOn(first, "getStreamingSnapshot").mockReturnValue({
+      ...firstSnapshot,
+      text: "first snapshot",
+    });
+
+    const second = await createNewSession(wsId, dataDir, slowCmd);
+    second.sendMessage("second session");
+    const secondSnapshot = second.getStreamingSnapshot();
+    if (!secondSnapshot) throw new Error("Expected second streaming snapshot");
+    vi.spyOn(second, "getStreamingSnapshot").mockReturnValue({
+      ...secondSnapshot,
+      text: "second snapshot",
+    });
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+
+    await waitForMessage(
+      messages,
+      (msgs) =>
+        msgs.some(
+          (m) =>
+            m.type === "stream_snapshot" &&
+            m.sessionId === first.sessionId &&
+            m.text === "first snapshot",
+        ) &&
+        msgs.some(
+          (m) =>
+            m.type === "stream_snapshot" &&
+            m.sessionId === second.sessionId &&
+            m.text === "second snapshot",
+        ),
+    );
+
+    const marker = messages.length;
+    first.emit("message", { type: "text_delta", sessionId: first.sessionId, text: " later" });
+
+    await waitForMessage(
+      messages,
+      (msgs) =>
+        msgs.slice(marker).some(
+          (m) => m.type === "text_delta" && m.sessionId === first.sessionId && m.text === " later",
+        ),
+    );
 
     ws.close();
     await local.app.close();

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -186,46 +186,23 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     // Replay in-progress streaming content so late-connecting clients see
     // text, thinking, and tool calls accumulated since the turn started.
-    if (session.status === "streaming") {
-      const snapshot = session.getStreamingSnapshot();
-      if (snapshot) {
-        const sid = session.sessionId;
-        if (snapshot.thinking) {
-          sendToHub(hub, workspaceId, { type: "thinking", sessionId: sid, text: snapshot.thinking });
-        }
-        if (snapshot.text) {
-          sendToHub(hub, workspaceId, { type: "text_delta", sessionId: sid, text: snapshot.text });
-        }
-        for (const tc of snapshot.toolCalls) {
-          sendToHub(hub, workspaceId, {
-            type: "tool_use",
-            sessionId: sid,
-            id: tc.id,
-            name: tc.name,
-            input: tc.input,
-            parentToolUseId: tc.parentToolUseId,
-          });
-          if (tc.output) {
-            sendToHub(hub, workspaceId, {
-              type: "tool_result",
-              sessionId: sid,
-              toolUseId: tc.id,
-              output: tc.output,
-            });
-          }
-        }
-        for (const activity of snapshot.agentActivities) {
-          sendToHub(hub, workspaceId, {
-            type: "agent_activity",
-            sessionId: sid,
-            activity,
-          });
-        }
-        if (snapshot.agentPlanMode) {
-          sendToHub(hub, workspaceId, { type: "plan_mode_changed", sessionId: sid, active: true });
-        }
-      }
-    }
+    sendStreamingSnapshot(hub, workspaceId, session);
+  };
+
+  const sendStreamingSnapshot = (hub: HubSocket, workspaceId: string, session: ActiveSession): void => {
+    if (session.status !== "streaming") return;
+    const snapshot = session.getStreamingSnapshot();
+    if (!snapshot) return;
+    sendToHub(hub, workspaceId, {
+      type: "stream_snapshot",
+      sessionId: session.sessionId,
+      text: snapshot.text,
+      thinking: snapshot.thinking,
+      toolCalls: snapshot.toolCalls,
+      agentActivities: snapshot.agentActivities,
+      agentPlanMode: snapshot.agentPlanMode,
+      ...(session.streamingStartedAt ? { streamingStartedAt: session.streamingStartedAt } : {}),
+    });
   };
 
   const detachSessionTracking = (channel: WorkspaceChannel, sessionId: string): void => {
@@ -328,6 +305,9 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       for (const streamingId of getStreamingSessionIds(wsId)) {
         if (streamingId !== session.sessionId) {
           const streamingSession = getSessionById(wsId, streamingId);
+          if (streamingSession) {
+            attachSessionListeners(wsId, channel, streamingSession);
+          }
           sendToHub(hub, wsId, {
             type: "status",
             status: "busy",
@@ -337,6 +317,9 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
               ? { streamingStartedAt: streamingSession.streamingStartedAt }
               : {}),
           });
+          if (streamingSession) {
+            sendStreamingSnapshot(hub, wsId, streamingSession);
+          }
         }
       }
     } else {

--- a/frontend/src/components/ConversationTabs.tsx
+++ b/frontend/src/components/ConversationTabs.tsx
@@ -273,7 +273,7 @@ export function ConversationTabs({
 
   return (
     <>
-      <div className="flex h-9 items-center gap-1 px-2">
+      <div className="relative z-10 flex h-9 items-center gap-1 px-2 shadow-[0_6px_12px_-4px_rgba(0,0,0,0.1)]">
         {/* Pinned file/diff takeover tab — stays put while conversations scroll. */}
         {openFile && (
           <button

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -225,6 +225,30 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       });
     }
 
+    case "stream_snapshot": {
+      const sid = action.sessionId;
+      const existing = state.sessionStreams[sid] ?? { ...emptyStreamState };
+      const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
+      return {
+        ...state,
+        sessionId: state.sessionId ?? sid,
+        sessionStreams: {
+          ...state.sessionStreams,
+          [sid]: {
+            ...existing,
+            currentText: action.text,
+            currentThinking: action.thinking,
+            activeToolCalls: action.toolCalls,
+            activeAgentActivities: action.agentActivities,
+            isStreaming: true,
+            streamingStartedAt: backendStartedAt ?? existing.streamingStartedAt ?? Date.now(),
+            pendingToolInputs: [],
+            agentPlanMode: action.agentPlanMode,
+          },
+        },
+      };
+    }
+
     case "done": {
       const sid = action.sessionId || state.sessionId;
       if (!sid) return state;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -404,6 +404,16 @@ export type WsOutgoing =
   | { type: "tool_use"; sessionId: string; id: string; name: string; input: string; parentToolUseId?: string }
   | { type: "tool_result"; sessionId: string; toolUseId: string; output: string }
   | { type: "agent_activity"; sessionId: string; activity: AgentActivity }
+  | {
+      type: "stream_snapshot";
+      sessionId: string;
+      text: string;
+      thinking: string;
+      toolCalls: ToolCall[];
+      agentActivities: AgentActivity[];
+      agentPlanMode: boolean;
+      streamingStartedAt?: number;
+    }
   | { type: "tool_input_required"; sessionId: string; requestId: string; toolName: string; toolUseId: string; input: unknown }
   | { type: "tool_input_resolved"; sessionId: string }
   | {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2004,6 +2004,67 @@ describe("useConversation", () => {
     expect(result.current.isStreaming).toBe(true);
   });
 
+  it("replaces accumulated stream content when a stream snapshot is replayed", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result, rerender } = renderHook(
+      ({ wsId }) => useConversation(wsId),
+      { initialProps: { wsId: "ws-1" } },
+    );
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "user_message",
+        message: {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "hello",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      });
+      __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Before " });
+    });
+
+    rerender({ wsId: "ws-2" });
+    __wsMock.setReplay("ws-1", [
+      { type: "status", status: "busy", sessionId: "sess-1", streaming: true },
+      {
+        type: "stream_snapshot",
+        sessionId: "sess-1",
+        text: "Before after",
+        thinking: "Canonical thinking",
+        toolCalls: [{
+          id: "tool-1",
+          name: "Read",
+          input: "{}",
+          output: "file contents",
+        }],
+        agentActivities: [{
+          id: "plan-1",
+          kind: "plan_update",
+          steps: [{ text: "Inspect", status: "completed" }],
+        }],
+        agentPlanMode: true,
+        streamingStartedAt: 1_700_000_002_000,
+      },
+    ]);
+
+    rerender({ wsId: "ws-1" });
+
+    expect(result.current.sessionId).toBe("sess-1");
+    expect(result.current.currentStreamingText).toBe("Before after");
+    expect(result.current.currentThinking).toBe("Canonical thinking");
+    expect(result.current.activeToolCalls).toEqual([
+      expect.objectContaining({ id: "tool-1", output: "file contents" }),
+    ]);
+    expect(result.current.activeAgentActivities).toEqual([
+      expect.objectContaining({ id: "plan-1" }),
+    ]);
+    expect(result.current.agentPlanMode).toBe(true);
+    expect(result.current.streamingStartedAt).toBe(1_700_000_002_000);
+    expect(result.current.isStreaming).toBe(true);
+  });
+
   it("full reset clears sessionStreams when workspaceId becomes undefined", async () => {
     const { __wsMock } = await getWsMock();
     const { result, rerender } = renderHook(

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -112,6 +112,9 @@ enum WsOutgoing: Decodable {
     case toolUse(sessionId: String, id: String, name: String, input: String, parentToolUseId: String?)
     case toolResult(sessionId: String, toolUseId: String, output: String)
     case agentActivity(sessionId: String, activity: AgentActivity)
+    case streamSnapshot(sessionId: String, text: String, thinking: String, toolCalls: [ToolCall],
+                        agentActivities: [AgentActivity], agentPlanMode: Bool,
+                        streamingStartedAt: Double?)
     case toolInputRequired(sessionId: String, requestId: String, toolName: String, toolUseId: String, input: String)
     case toolInputResolved(sessionId: String)
     case done(sessionId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
@@ -129,6 +132,7 @@ enum WsOutgoing: Decodable {
     private enum CodingKeys: String, CodingKey {
         case type, sessionId, text, id, name, input, output
         case activity
+        case thinking, toolCalls, agentActivities, agentPlanMode
         case parentToolUseId, toolUseId, requestId, toolName
         case durationMs, inputTokens, outputTokens, contextUsedTokens, contextWindowTokens, pendingToolName
         case errorDetail, userInitiated
@@ -171,6 +175,16 @@ enum WsOutgoing: Decodable {
             self = .agentActivity(
                 sessionId: try container.decode(String.self, forKey: .sessionId),
                 activity: try container.decode(AgentActivity.self, forKey: .activity)
+            )
+        case "stream_snapshot":
+            self = .streamSnapshot(
+                sessionId: try container.decode(String.self, forKey: .sessionId),
+                text: try container.decodeIfPresent(String.self, forKey: .text) ?? "",
+                thinking: try container.decodeIfPresent(String.self, forKey: .thinking) ?? "",
+                toolCalls: try container.decodeIfPresent([ToolCall].self, forKey: .toolCalls) ?? [],
+                agentActivities: try container.decodeIfPresent([AgentActivity].self, forKey: .agentActivities) ?? [],
+                agentPlanMode: try container.decodeIfPresent(Bool.self, forKey: .agentPlanMode) ?? false,
+                streamingStartedAt: try container.decodeIfPresent(Double.self, forKey: .streamingStartedAt)
             )
         case "tool_input_required":
             let sessionId = try container.decode(String.self, forKey: .sessionId)

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -78,29 +78,6 @@ final class ConversationStore {
     var activeAgentActivities: [AgentActivity] { activeStream?.activeAgentActivities ?? [] }
     var pendingToolInputs: [PendingToolInput] { activeStream?.pendingToolInputs ?? [] }
 
-    /// The in-progress assistant message shown during streaming
-    var streamingMessage: ChatMessage? {
-        guard let stream = activeStream,
-              stream.isStreaming,
-              !stream.currentText.isEmpty || !stream.currentThinking.isEmpty ||
-                !stream.activeToolCalls.isEmpty || !stream.activeAgentActivities.isEmpty else {
-            return nil
-        }
-        return ChatMessage(
-            id: "streaming",
-            sessionId: sessionId ?? "",
-            role: .assistant,
-            content: stream.currentText,
-            images: nil,
-            toolCalls: stream.activeToolCalls.isEmpty ? nil : stream.activeToolCalls,
-            agentActivities: stream.activeAgentActivities.isEmpty ? nil : stream.activeAgentActivities,
-            thinkingContent: stream.currentThinking.isEmpty ? nil : stream.currentThinking,
-            timestamp: Self.outgoingTimestampFormatter.string(from: Date()),
-            cancelled: nil,
-            durationMs: nil
-        )
-    }
-
     /// Derived task tracking state from task tools and Codex plan updates.
     var tasksState: TasksState {
         deriveTasks(
@@ -124,14 +101,6 @@ final class ConversationStore {
             from: messages,
             activeToolCalls: activeStream?.activeToolCalls ?? []
         )
-    }
-
-    /// All messages to display: history + streaming message if active
-    var displayMessages: [ChatMessage] {
-        if let streaming = streamingMessage {
-            return messages + [streaming]
-        }
-        return messages
     }
 
     // MARK: - Event handling
@@ -283,8 +252,8 @@ final class ConversationStore {
             guard historySessionId == nil || sessionId == nil || historySessionId == sessionId else { return }
 
             // Always apply history — it contains finalized turns only.
-            // Streaming content lives in sessionStreams and is appended
-            // separately by displayMessages.
+            // Streaming content lives in sessionStreams and is rendered as a
+            // separate in-progress bubble by the chat view.
             messages = msgs
             bumpHistoryToken(for: historySessionId)
             sessionId = historySessionId ?? sessionId
@@ -433,10 +402,10 @@ final class ConversationStore {
         let hasContent = !stream.currentText.isEmpty || !stream.activeToolCalls.isEmpty
             || !stream.activeAgentActivities.isEmpty || !stream.currentThinking.isEmpty
 
-        // Remove stream slot FIRST so displayMessages never shows both the
-        // finalized message (in `messages`) and the streaming ghost (from
-        // `streamingMessage`). The local `stream` is a value-type copy
-        // captured above, so it survives this removal.
+        // Remove stream slot FIRST so the chat view never shows both the
+        // finalized message (in `messages`) and the in-progress streaming
+        // bubble (derived from `sessionStreams`) at once. The local `stream`
+        // is a value-type copy captured above, so it survives this removal.
         sessionStreams.removeValue(forKey: sid)
 
         if isActive {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -165,6 +165,22 @@ final class ConversationStore {
         case .agentActivity(let sid, let activity):
             upsertAgentActivity(activity, for: sid)
 
+        case .streamSnapshot(let sid, let text, let thinking, let toolCalls,
+                             let agentActivities, let agentPlanMode, let startedAt):
+            var stream = sessionStreams[sid] ?? SessionStreamState()
+            stream.currentText = text
+            stream.currentThinking = thinking
+            stream.activeToolCalls = toolCalls
+            stream.activeAgentActivities = agentActivities
+            stream.isStreaming = true
+            stream.streamingStartedAt = startedAt.map(parseStartedAt) ?? stream.streamingStartedAt ?? Date()
+            stream.pendingToolInputs = []
+            stream.agentPlanMode = agentPlanMode
+            sessionStreams[sid] = stream
+            if sessionId == nil {
+                sessionId = sid
+            }
+
         case .toolInputRequired(let sid, let requestId, let toolName, let toolUseId, let input):
             if sessionStreams[sid] == nil && hasTerminalAssistantMessage(for: sid) {
                 return

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -308,7 +308,8 @@ final class HubStatusMonitor {
             if streaming == true {
                 markActivity(for: workspaceId)
             }
-        case .branchInfo, .diffStats, .scriptStatus, .planModeChanged:
+        case .branchInfo, .diffStats, .scriptStatus, .planModeChanged,
+             .streamSnapshot(_, _, _, _, _, _, _):
             break
         default:
             markActivity(for: workspaceId)
@@ -518,6 +519,10 @@ private final class HubConnection {
             if userInitiated != true {
                 monitor?.didReceiveDone(for: workspaceId, sessionId: sessionId, markWorkspaceCompleted: false)
             }
+
+        case .streamSnapshot(let sessionId, _, _, _, _, _, _):
+            monitor?.didReceiveStreaming(true, for: workspaceId, sessionId: sessionId)
+            monitor?.ensureStoreExists(for: workspaceId)
 
         default:
             break

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -19,7 +19,6 @@ struct ChatView: View {
     @State private var pendingStreamingThinking = ""
     @State private var lastStreamingRenderAt = Date.distantPast
     @State private var streamingRenderTask: Task<Void, Never>?
-    @State private var scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
     @State private var isNearScrollBottom = true
 
     @Environment(ModelCatalog.self) private var modelCatalog
@@ -124,61 +123,66 @@ struct ChatView: View {
                 }
                 Spacer()
             } else {
-                ScrollView {
-                    LazyVStack(spacing: 16) {
-                        ForEach(store.messages) { message in
-                            if !(message.role == .user && message.content == "Question dismissed.") {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(spacing: 16) {
+                            ForEach(store.messages) { message in
+                                if !(message.role == .user && message.content == "Question dismissed.") {
+                                    MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
+                                        .id(message.id)
+                                }
+                            }
+
+                            if let message = streamingMessage {
                                 MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                                     .id(message.id)
                             }
-                        }
 
-                        if let message = streamingMessage {
-                            MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
-                                .id(message.id)
-                        }
+                            if store.isStreaming {
+                                streamingActivityRow
+                            }
 
-                        if store.isStreaming {
-                            streamingActivityRow
+                            Color.clear
+                                .frame(height: 1)
+                                .id(bottomAnchorID)
                         }
+                        .padding()
                     }
-                    .scrollTargetLayout()
-                    .padding()
-                }
-                .scrollPosition($scrollPosition, anchor: .bottom)
-                .scrollDismissesKeyboard(.interactively)
-                .onScrollGeometryChange(for: Bool.self) { geometry in
-                    geometry.contentSize.height - geometry.visibleRect.maxY < Self.scrollBottomTolerance
-                } action: { _, isNearBottom in
-                    isNearScrollBottom = isNearBottom
-                }
-                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.messages.count) {
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.currentText) {
-                    scheduleStreamingRender(text: store.currentText)
-                }
-                .onChange(of: renderedStreamingText) {
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.currentThinking) {
-                    scheduleStreamingRender(thinking: store.currentThinking)
-                }
-                .onChange(of: renderedStreamingThinking) {
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.activeToolCalls.count) {
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.activeAgentActivities.count) {
-                    scrollToBottomIfNeeded()
-                }
-                .onChange(of: store.isStreaming) { _, isStreaming in
-                    if isStreaming {
-                        scrollToBottomIfNeeded()
+                    .defaultScrollAnchor(.bottom)
+                    .scrollDismissesKeyboard(.interactively)
+                    .onScrollGeometryChange(for: Bool.self) { geometry in
+                        geometry.contentSize.height - geometry.visibleRect.maxY < Self.scrollBottomTolerance
+                    } action: { _, isNearBottom in
+                        isNearScrollBottom = isNearBottom
+                    }
+                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.messages.count) {
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.currentText) {
+                        scheduleStreamingRender(text: store.currentText)
+                    }
+                    .onChange(of: renderedStreamingText) {
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.currentThinking) {
+                        scheduleStreamingRender(thinking: store.currentThinking)
+                    }
+                    .onChange(of: renderedStreamingThinking) {
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.activeToolCalls.count) {
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.activeAgentActivities.count) {
+                        scrollToBottomIfNeeded(proxy)
+                    }
+                    .onChange(of: store.isStreaming) { _, isStreaming in
+                        if isStreaming {
+                            scrollToBottomIfNeeded(proxy)
+                        }
                     }
                 }
             }
@@ -578,9 +582,12 @@ struct ChatView: View {
         applySessionRunOptions()
     }
 
-    private func scrollToBottomIfNeeded() {
+    private static let bottomAnchorID = "chat-bottom-anchor"
+    private var bottomAnchorID: String { Self.bottomAnchorID }
+
+    private func scrollToBottomIfNeeded(_ proxy: ScrollViewProxy) {
         guard isNearScrollBottom else { return }
-        scrollPosition.scrollTo(edge: .bottom)
+        proxy.scrollTo(bottomAnchorID, anchor: .bottom)
     }
 
     private func formatStreamingElapsed(at date: Date) -> String {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -161,14 +161,8 @@ struct ChatView: View {
                     .onChange(of: store.messages.count) {
                         scrollToBottomIfNeeded(proxy)
                     }
-                    .onChange(of: store.currentText) {
-                        scheduleStreamingRender(text: store.currentText)
-                    }
                     .onChange(of: renderedStreamingText) {
                         scrollToBottomIfNeeded(proxy)
-                    }
-                    .onChange(of: store.currentThinking) {
-                        scheduleStreamingRender(thinking: store.currentThinking)
                     }
                     .onChange(of: renderedStreamingThinking) {
                         scrollToBottomIfNeeded(proxy)
@@ -256,14 +250,14 @@ struct ChatView: View {
                 planModeEnabled = active
             }
         }
-        .onChange(of: store.isStreaming) { _, isStreaming in
-            if isStreaming {
-                pendingStreamingText = store.currentText
-                pendingStreamingThinking = store.currentThinking
-                applyPendingStreamingRender()
-            } else {
-                resetStreamingRender()
-            }
+        .onChange(of: store.currentText) { _, text in
+            scheduleStreamingRender(text: text)
+        }
+        .onChange(of: store.currentThinking) { _, thinking in
+            scheduleStreamingRender(thinking: thinking)
+        }
+        .onChange(of: store.isStreaming) { _, _ in
+            syncStreamingRenderFromStore()
         }
         .onChange(of: lockedProvider) { _, newProvider in
             guard let newProvider, !selectedModelId.isEmpty else { return }
@@ -361,6 +355,16 @@ struct ChatView: View {
         lastStreamingRenderAt = .distantPast
     }
 
+    private func syncStreamingRenderFromStore() {
+        if store.isStreaming {
+            pendingStreamingText = store.currentText
+            pendingStreamingThinking = store.currentThinking
+            applyPendingStreamingRender()
+        } else {
+            resetStreamingRender()
+        }
+    }
+
     private var streamingActivityRow: some View {
         TimelineView(.periodic(from: .now, by: 0.1)) { timeline in
             HStack(spacing: 6) {
@@ -416,6 +420,7 @@ struct ChatView: View {
             store.prepareSessionSwitch(selectedSessionId)
             _ = await store.send?(.switchSession(sessionId: selectedSessionId))
         }
+        syncStreamingRenderFromStore()
         restoreDraft(for: selectedSessionId)
 
         if selectedModelId.isEmpty {
@@ -423,6 +428,7 @@ struct ChatView: View {
         }
 
         await loadMessages()
+        syncStreamingRenderFromStore()
     }
 
     private func loadMessages() async {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -13,6 +13,12 @@ struct ChatView: View {
     @State private var fastModeEnabled = false
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
+    @State private var renderedStreamingText = ""
+    @State private var renderedStreamingThinking = ""
+    @State private var pendingStreamingText = ""
+    @State private var pendingStreamingThinking = ""
+    @State private var lastStreamingRenderAt = Date.distantPast
+    @State private var streamingRenderTask: Task<Void, Never>?
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -102,7 +108,7 @@ struct ChatView: View {
         VStack(spacing: 0) {
             if isLoading {
                 Spacer()
-            } else if store.displayMessages.isEmpty && !store.isStreaming {
+            } else if store.messages.isEmpty && streamingMessage == nil && !store.isStreaming {
                 Spacer()
                 if isBrainWorkspaceId(workspace.id) {
                     BrainSessionEmptyState()
@@ -118,12 +124,18 @@ struct ChatView: View {
             } else {
                 ScrollViewReader { proxy in
                     ScrollView {
-                        VStack(spacing: 16) {
-                            ForEach(store.displayMessages) { message in
+                        LazyVStack(spacing: 16) {
+                            ForEach(store.messages) { message in
                                 if !(message.role == .user && message.content == "Question dismissed.") {
                                     MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                                         .id(message.id)
                                 }
+                            }
+
+                            if let message = streamingMessage {
+                                MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
+                                    .id(message.id)
+                                    .animation(.easeOut(duration: 0.12), value: renderedStreamingText.count)
                             }
 
                             if store.isStreaming {
@@ -141,10 +153,19 @@ struct ChatView: View {
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
                         scrollToBottom(proxy)
                     }
-                    .onChange(of: store.displayMessages.count) {
+                    .onChange(of: store.messages.count) {
                         scrollToBottom(proxy)
                     }
                     .onChange(of: store.currentText) {
+                        scheduleStreamingRender(text: store.currentText)
+                    }
+                    .onChange(of: renderedStreamingText) {
+                        scrollToBottom(proxy)
+                    }
+                    .onChange(of: store.currentThinking) {
+                        scheduleStreamingRender(thinking: store.currentThinking)
+                    }
+                    .onChange(of: renderedStreamingThinking) {
                         scrollToBottom(proxy)
                     }
                 }
@@ -219,6 +240,15 @@ struct ChatView: View {
                 planModeEnabled = active
             }
         }
+        .onChange(of: store.isStreaming) { _, isStreaming in
+            if isStreaming {
+                pendingStreamingText = store.currentText
+                pendingStreamingThinking = store.currentThinking
+                applyPendingStreamingRender(animated: false)
+            } else {
+                resetStreamingRender()
+            }
+        }
         .onChange(of: lockedProvider) { _, newProvider in
             guard let newProvider, !selectedModelId.isEmpty else { return }
             let currentProvider = selectedModelId.split(separator: ":").first.map(String.init) ?? ""
@@ -229,6 +259,7 @@ struct ChatView: View {
             }
         }
         .onDisappear {
+            streamingRenderTask?.cancel()
             saveCurrentDraft()
             store.onTurnCompleted = nil
             if projectStore.statusMonitor.viewingWorkspaceId == workspace.id,
@@ -239,6 +270,89 @@ struct ChatView: View {
     }
 
     // MARK: - Streaming Activity
+
+    private static let streamingRenderInterval: TimeInterval = 0.05
+
+    private var streamingMessage: ChatMessage? {
+        guard store.isStreaming else { return nil }
+        let hasContent = !renderedStreamingText.isEmpty || !renderedStreamingThinking.isEmpty
+            || !store.activeToolCalls.isEmpty || !store.activeAgentActivities.isEmpty
+        guard hasContent else { return nil }
+
+        return ChatMessage(
+            id: "streaming",
+            sessionId: store.sessionId ?? "",
+            role: .assistant,
+            content: renderedStreamingText,
+            images: nil,
+            toolCalls: store.activeToolCalls.isEmpty ? nil : store.activeToolCalls,
+            agentActivities: store.activeAgentActivities.isEmpty ? nil : store.activeAgentActivities,
+            thinkingContent: renderedStreamingThinking.isEmpty ? nil : renderedStreamingThinking,
+            timestamp: ConversationStore.timestamp(),
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    private func scheduleStreamingRender(text: String? = nil, thinking: String? = nil) {
+        if let text {
+            pendingStreamingText = text
+        }
+        if let thinking {
+            pendingStreamingThinking = thinking
+        }
+
+        let elapsed = Date().timeIntervalSince(lastStreamingRenderAt)
+        if elapsed >= Self.streamingRenderInterval {
+            streamingRenderTask?.cancel()
+            streamingRenderTask = nil
+            applyPendingStreamingRender(animated: true)
+            return
+        }
+
+        guard streamingRenderTask == nil else { return }
+
+        let delay = Self.streamingRenderInterval - elapsed
+        let milliseconds = Int64(max(1, (delay * 1000).rounded(.up)))
+        streamingRenderTask = Task {
+            do {
+                try await Task.sleep(for: .milliseconds(milliseconds))
+            } catch {
+                return
+            }
+
+            await MainActor.run {
+                applyPendingStreamingRender(animated: true)
+                streamingRenderTask = nil
+            }
+        }
+    }
+
+    private func applyPendingStreamingRender(animated: Bool) {
+        lastStreamingRenderAt = Date()
+        let update = {
+            renderedStreamingText = pendingStreamingText
+            renderedStreamingThinking = pendingStreamingThinking
+        }
+
+        if animated {
+            withAnimation(.easeOut(duration: 0.12)) {
+                update()
+            }
+        } else {
+            update()
+        }
+    }
+
+    private func resetStreamingRender() {
+        streamingRenderTask?.cancel()
+        streamingRenderTask = nil
+        pendingStreamingText = ""
+        pendingStreamingThinking = ""
+        renderedStreamingText = ""
+        renderedStreamingThinking = ""
+        lastStreamingRenderAt = .distantPast
+    }
 
     private var streamingActivityRow: some View {
         TimelineView(.periodic(from: .now, by: 0.1)) { timeline in

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -452,7 +452,7 @@ struct ChatView: View {
                 return
             }
             // History contains only finalized turns; streaming content lives
-            // in sessionStreams and is appended by displayMessages.
+            // in sessionStreams and is rendered as a separate in-progress bubble.
             store.messages = msgs
         } catch is CancellationError {
             // View disappeared

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -135,7 +135,6 @@ struct ChatView: View {
                             if let message = streamingMessage {
                                 MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                                     .id(message.id)
-                                    .animation(.easeOut(duration: 0.12), value: renderedStreamingText.count)
                             }
 
                             if store.isStreaming {
@@ -244,7 +243,7 @@ struct ChatView: View {
             if isStreaming {
                 pendingStreamingText = store.currentText
                 pendingStreamingThinking = store.currentThinking
-                applyPendingStreamingRender(animated: false)
+                applyPendingStreamingRender()
             } else {
                 resetStreamingRender()
             }
@@ -306,7 +305,7 @@ struct ChatView: View {
         if elapsed >= Self.streamingRenderInterval {
             streamingRenderTask?.cancel()
             streamingRenderTask = nil
-            applyPendingStreamingRender(animated: true)
+            applyPendingStreamingRender()
             return
         }
 
@@ -322,26 +321,16 @@ struct ChatView: View {
             }
 
             await MainActor.run {
-                applyPendingStreamingRender(animated: true)
+                applyPendingStreamingRender()
                 streamingRenderTask = nil
             }
         }
     }
 
-    private func applyPendingStreamingRender(animated: Bool) {
+    private func applyPendingStreamingRender() {
         lastStreamingRenderAt = Date()
-        let update = {
-            renderedStreamingText = pendingStreamingText
-            renderedStreamingThinking = pendingStreamingThinking
-        }
-
-        if animated {
-            withAnimation(.easeOut(duration: 0.12)) {
-                update()
-            }
-        } else {
-            update()
-        }
+        renderedStreamingText = pendingStreamingText
+        renderedStreamingThinking = pendingStreamingThinking
     }
 
     private func resetStreamingRender() {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -288,6 +288,9 @@ struct ChatView: View {
 
         if store.sessionId == selectedSessionId {
             store.setFocusedSessionId(selectedSessionId)
+            if projectStore.statusMonitor.isStreaming(workspaceId: workspace.id, sessionId: selectedSessionId) {
+                _ = await store.send?(.switchSession(sessionId: selectedSessionId))
+            }
         } else {
             store.prepareSessionSwitch(selectedSessionId)
             _ = await store.send?(.switchSession(sessionId: selectedSessionId))

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -19,6 +19,8 @@ struct ChatView: View {
     @State private var pendingStreamingThinking = ""
     @State private var lastStreamingRenderAt = Date.distantPast
     @State private var streamingRenderTask: Task<Void, Never>?
+    @State private var scrollPosition = ScrollPosition(idType: String.self, edge: .bottom)
+    @State private var isNearScrollBottom = true
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -122,50 +124,61 @@ struct ChatView: View {
                 }
                 Spacer()
             } else {
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        LazyVStack(spacing: 16) {
-                            ForEach(store.messages) { message in
-                                if !(message.role == .user && message.content == "Question dismissed.") {
-                                    MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
-                                        .id(message.id)
-                                }
-                            }
-
-                            if let message = streamingMessage {
+                ScrollView {
+                    LazyVStack(spacing: 16) {
+                        ForEach(store.messages) { message in
+                            if !(message.role == .user && message.content == "Question dismissed.") {
                                 MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
                                     .id(message.id)
                             }
-
-                            if store.isStreaming {
-                                streamingActivityRow
-                            }
-
-                            Color.clear
-                                .frame(height: 1)
-                                .id(bottomAnchorID)
                         }
-                        .padding()
+
+                        if let message = streamingMessage {
+                            MessageBubble(message: message, pendingToolUseIds: pendingToolUseIds, dismissedToolCallIds: dismissedToolCallIds)
+                                .id(message.id)
+                        }
+
+                        if store.isStreaming {
+                            streamingActivityRow
+                        }
                     }
-                    .defaultScrollAnchor(.bottom)
-                    .scrollDismissesKeyboard(.interactively)
-                    .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
-                        scrollToBottom(proxy)
-                    }
-                    .onChange(of: store.messages.count) {
-                        scrollToBottom(proxy)
-                    }
-                    .onChange(of: store.currentText) {
-                        scheduleStreamingRender(text: store.currentText)
-                    }
-                    .onChange(of: renderedStreamingText) {
-                        scrollToBottom(proxy)
-                    }
-                    .onChange(of: store.currentThinking) {
-                        scheduleStreamingRender(thinking: store.currentThinking)
-                    }
-                    .onChange(of: renderedStreamingThinking) {
-                        scrollToBottom(proxy)
+                    .scrollTargetLayout()
+                    .padding()
+                }
+                .scrollPosition($scrollPosition, anchor: .bottom)
+                .scrollDismissesKeyboard(.interactively)
+                .onScrollGeometryChange(for: Bool.self) { geometry in
+                    geometry.contentSize.height - geometry.visibleRect.maxY < Self.scrollBottomTolerance
+                } action: { _, isNearBottom in
+                    isNearScrollBottom = isNearBottom
+                }
+                .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.messages.count) {
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.currentText) {
+                    scheduleStreamingRender(text: store.currentText)
+                }
+                .onChange(of: renderedStreamingText) {
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.currentThinking) {
+                    scheduleStreamingRender(thinking: store.currentThinking)
+                }
+                .onChange(of: renderedStreamingThinking) {
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.activeToolCalls.count) {
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.activeAgentActivities.count) {
+                    scrollToBottomIfNeeded()
+                }
+                .onChange(of: store.isStreaming) { _, isStreaming in
+                    if isStreaming {
+                        scrollToBottomIfNeeded()
                     }
                 }
             }
@@ -271,6 +284,7 @@ struct ChatView: View {
     // MARK: - Streaming Activity
 
     private static let streamingRenderInterval: TimeInterval = 0.05
+    private static let scrollBottomTolerance: CGFloat = 96
 
     private var streamingMessage: ChatMessage? {
         guard store.isStreaming else { return nil }
@@ -564,17 +578,9 @@ struct ChatView: View {
         applySessionRunOptions()
     }
 
-    private static let bottomAnchorID = "chat-bottom-anchor"
-    private var bottomAnchorID: String { Self.bottomAnchorID }
-
-    private func scrollToBottom(_ proxy: ScrollViewProxy, animated: Bool = true) {
-        if animated {
-            withAnimation(.easeOut(duration: 0.15)) {
-                proxy.scrollTo(bottomAnchorID, anchor: .bottom)
-            }
-        } else {
-            proxy.scrollTo(bottomAnchorID, anchor: .bottom)
-        }
+    private func scrollToBottomIfNeeded() {
+        guard isNearScrollBottom else { return }
+        scrollPosition.scrollTo(edge: .bottom)
     }
 
     private func formatStreamingElapsed(at date: Date) -> String {

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -513,6 +513,18 @@ private struct WhisperThinkingBlock: View {
 // MARK: - Whisper Tool Calls Block
 
 private let collapseThreshold = 3
+private let hiddenTaskToolNames: Set<String> = ["TaskUpdate", "TodoList"]
+
+private struct ToolCallTree {
+    let rootTools: [ToolCall]
+    let childrenByParentId: [String: [ToolCall]]
+
+    init(toolCalls: [ToolCall]) {
+        let visibleTools = toolCalls.filter { !hiddenTaskToolNames.contains($0.name) }
+        rootTools = visibleTools.filter { $0.parentToolUseId == nil }
+        childrenByParentId = buildChildrenMap(visibleTools)
+    }
+}
 
 private struct WhisperToolCallsBlock: View {
     let toolCalls: [ToolCall]
@@ -521,33 +533,14 @@ private struct WhisperToolCallsBlock: View {
     var showExecutingState = false
     @State private var groupExpanded = false
 
-    private static let hiddenTaskTools: Set<String> = ["TaskUpdate", "TodoList"]
-
-    private var visibleTools: [ToolCall] {
-        toolCalls.filter { !Self.hiddenTaskTools.contains($0.name) }
-    }
-
-    private var rootTools: [ToolCall] {
-        visibleTools.filter { $0.parentToolUseId == nil }
-    }
-
-    private func children(for parentId: String) -> [ToolCall] {
-        visibleTools.filter { $0.parentToolUseId == parentId }
-    }
-
-    private var childrenByParentId: [String: [ToolCall]] {
-        buildChildrenMap(visibleTools)
-    }
-
-    private var shouldCollapse: Bool {
-        rootTools.count >= collapseThreshold
-    }
-
     var body: some View {
+        let tree = ToolCallTree(toolCalls: toolCalls)
+        let shouldCollapse = tree.rootTools.count >= collapseThreshold
+
         VStack(alignment: .leading, spacing: 2) {
             if shouldCollapse {
                 CollapsedToolSummary(
-                    tools: rootTools,
+                    tools: tree.rootTools,
                     isExpanded: groupExpanded,
                     isStreaming: showExecutingState,
                     onToggle: {
@@ -557,11 +550,11 @@ private struct WhisperToolCallsBlock: View {
             }
 
             if !shouldCollapse || groupExpanded {
-                ForEach(rootTools) { tool in
+                ForEach(tree.rootTools) { tool in
                     WhisperToolCallRow(
                         tool: tool,
-                        children: children(for: tool.id),
-                        childrenByParentId: childrenByParentId,
+                        children: tree.childrenByParentId[tool.id] ?? [],
+                        childrenByParentId: tree.childrenByParentId,
                         isPending: pendingToolUseIds.contains(tool.id),
                         isDismissed: dismissedToolCallIds.contains(tool.id),
                         showExecutingState: showExecutingState

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -46,7 +46,6 @@ struct ConversationStoreSessionTests {
 
         #expect(store.sessionId == "session-2")
         #expect(store.messages.isEmpty)
-        #expect(store.displayMessages.isEmpty)
         #expect(store.lockedProvider == nil)
         #expect(store.historyToken(for: "session-1") == previousToken + 1)
         #expect(store.historyToken(for: "session-2") == newToken + 1)
@@ -129,7 +128,6 @@ struct ConversationStoreSessionTests {
 
         #expect(store.sessionId == nil)
         #expect(store.messages.isEmpty)
-        #expect(store.displayMessages.isEmpty)
         #expect(store.lockedProvider == nil)
         #expect(store.sessionStreams["session-1"] == nil)
         #expect(store.historyToken(for: "session-1") == 0)
@@ -281,6 +279,88 @@ struct ConversationStoreSessionTests {
         #expect(activities.count == 1)
         #expect(agentPlanMode == true)
         #expect(startedAt == 1_700_000_002_000.0)
+    }
+
+    @Test @MainActor
+    func streamSnapshotAdoptsSessionWhenNoneFocused() {
+        let store = ConversationStore()
+        #expect(store.sessionId == nil)
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "Recovered mid-turn",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: 1_700_000_002_000.0
+        ))
+
+        #expect(store.sessionId == "session-1")
+        #expect(store.isStreaming == true)
+        #expect(store.currentText == "Recovered mid-turn")
+        #expect(store.streamingStartedAt != nil)
+    }
+
+    @Test @MainActor
+    func streamSnapshotForBackgroundSessionDoesNotStealFocus() {
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy, sessionId: "session-A", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+        #expect(store.sessionId == "session-A")
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-B",
+            text: "Background streaming",
+            thinking: "",
+            toolCalls: [],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: nil
+        ))
+
+        #expect(store.sessionId == "session-A")
+        #expect(store.sessionStreams["session-B"]?.currentText == "Background streaming")
+        #expect(store.sessionStreams["session-B"]?.isStreaming == true)
+        #expect(store.currentText == "")
+    }
+
+    @Test @MainActor
+    func streamSnapshotReplacesBackgroundAccumulationAfterSwitch() {
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy, sessionId: "session-A", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+        store.handle(.status(
+            status: .busy, sessionId: "session-B", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-B", text: "partial "))
+        store.handle(.textDelta(sessionId: "session-B", text: "delta"))
+        #expect(store.sessionStreams["session-B"]?.currentText == "partial delta")
+
+        store.prepareSessionSwitch("session-B")
+        #expect(store.sessionId == "session-B")
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-B",
+            text: "partial delta and more",
+            thinking: "Reasoning",
+            toolCalls: [
+                ToolCall(id: "tool-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+            ],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: 1_700_000_002_000.0
+        ))
+
+        #expect(store.currentText == "partial delta and more")
+        #expect(store.currentThinking == "Reasoning")
+        #expect(store.activeToolCalls.first?.output == "ok")
+        #expect(store.isStreaming == true)
     }
 
     @Test @MainActor

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -200,6 +200,90 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func streamSnapshotReplacesAccumulatedStreamingState() {
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "Before "))
+        store.handle(.thinking(sessionId: "session-1", text: "old thinking"))
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "Before after",
+            thinking: "Canonical thinking",
+            toolCalls: [
+                ToolCall(
+                    id: "tool-1",
+                    name: "Read",
+                    input: "{}",
+                    output: "file contents",
+                    parentToolUseId: nil
+                )
+            ],
+            agentActivities: [
+                .planUpdate(.init(
+                    id: "plan-1",
+                    steps: [.init(text: "Inspect", status: "completed")]
+                ))
+            ],
+            agentPlanMode: true,
+            streamingStartedAt: 1_700_000_002_000.0
+        ))
+
+        #expect(store.isStreaming == true)
+        #expect(store.currentText == "Before after")
+        #expect(store.currentThinking == "Canonical thinking")
+        #expect(store.activeToolCalls.first?.id == "tool-1")
+        #expect(store.activeToolCalls.first?.output == "file contents")
+        #expect(store.activeAgentActivities.count == 1)
+        #expect(store.agentPlanMode == true)
+    }
+
+    @Test @MainActor
+    func decodesStreamSnapshotEvent() throws {
+        let json = Data("""
+        {
+          "type": "stream_snapshot",
+          "sessionId": "session-1",
+          "text": "Hello",
+          "thinking": "Reasoning",
+          "toolCalls": [
+            { "id": "tool-1", "name": "Read", "input": "{}", "output": "done" }
+          ],
+          "agentActivities": [
+            {
+              "id": "plan-1",
+              "kind": "plan_update",
+              "steps": [{ "text": "Inspect", "status": "completed" }]
+            }
+          ],
+          "agentPlanMode": true,
+          "streamingStartedAt": 1700000002000
+        }
+        """.utf8)
+
+        let event = try JSONDecoder().decode(WsOutgoing.self, from: json)
+
+        guard case .streamSnapshot(let sessionId, let text, let thinking, let toolCalls,
+                                   let activities, let agentPlanMode, let startedAt) = event else {
+            Issue.record("Expected stream snapshot")
+            return
+        }
+        #expect(sessionId == "session-1")
+        #expect(text == "Hello")
+        #expect(thinking == "Reasoning")
+        #expect(toolCalls.first?.output == "done")
+        #expect(activities.count == 1)
+        #expect(agentPlanMode == true)
+        #expect(startedAt == 1_700_000_002_000.0)
+    }
+
+    @Test @MainActor
     func toolInputResolvedClearsPendingToolInputs() throws {
         let store = ConversationStore()
         store.handle(.status(


### PR DESCRIPTION
## Summary
- replay active streaming snapshots on WebSocket bootstrap so clients can recover in-progress turns after reconnects or session switches
- stabilize iOS chat streaming rendering, scroll behavior, and stream-state rehydration across foreground/background sessions
- align stream snapshot protocol types across backend, frontend, and iOS, with coverage for timestamp and plan-mode state
- keep the conversation tab header visually separated with the subtle shadow from the original PR

## Testing
- npm ci
- npm run lint
- npm run typecheck
- npm test
- npm run build --workspace=backend
- npm run build --workspace=frontend

## Notes
- iOS CI could not be reproduced locally in this Linux workspace because swift and xcodebuild are unavailable.
- GitHub Actions jobs are currently blocked before startup by the account billing/spending-limit annotation, not by code failures.