### PR TITLE
Fix stale hub reconnect stream cleanup

### DIFF
--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -13,6 +13,11 @@ type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
 const MAX_RECONNECT_DELAY = 30_000;
 const BASE_RECONNECT_DELAY = 1_000;
+// If an "open" hub socket has been silent longer than this, treat it as a
+// possible zombie (a frozen TCP connection after the OS wakes from sleep never
+// fires `onclose`, so the socket stays OPEN while delivering nothing) and force
+// a fresh connection.
+const STALE_THRESHOLD_MS = 30_000;
 
 // ── Hub socket state ────────────────────────────────────────────────
 
@@ -21,6 +26,8 @@ interface HubState {
   status: ConnectionStatus;
   reconnectAttempt: number;
   reconnectTimer: ReturnType<typeof setTimeout> | null;
+  /** Timestamp of the last message received from the hub (liveness signal). */
+  lastMessageAt: number;
 }
 
 // ── Per-workspace subscription data (no socket) ─────────────────────
@@ -44,6 +51,7 @@ class WsTransport {
     status: "disconnected",
     reconnectAttempt: 0,
     reconnectTimer: null,
+    lastMessageAt: 0,
   };
   private subscriptions = new Map<string, WorkspaceSubscription>();
   private subscribedWorkspaceIds = new Set<string>();
@@ -115,6 +123,30 @@ class WsTransport {
     this.teardownHub();
     this.subscriptions.clear();
     this.subscribedWorkspaceIds.clear();
+  }
+
+  /**
+   * Re-establish the hub connection when the current socket may be dead.
+   * After the OS wakes from sleep, a frozen TCP connection never fires
+   * `onclose`, so the socket stays OPEN while silently delivering nothing.
+   * Triggered on window focus: reconnects when the socket is closed, or has
+   * been open but silent for longer than STALE_THRESHOLD_MS. A no-op while a
+   * connection attempt is already in flight or when nothing is subscribed.
+   */
+  forceReconnectIfStale(): void {
+    if (this.subscribedWorkspaceIds.size === 0) return;
+    if (this.hub.ws?.readyState === WebSocket.CONNECTING) return;
+    const isOpen = this.hub.ws?.readyState === WebSocket.OPEN;
+    const isStale = Date.now() - this.hub.lastMessageAt > STALE_THRESHOLD_MS;
+    if (isOpen && !isStale) return;
+    this.teardownHub();
+    // Mark the fresh socket as a reconnect (not a first connect) so onReconnect
+    // listeners fire and stale stream state is cleared before the bootstrap
+    // replays snapshots. Going through ensureHubConnected() would reset
+    // reconnectAttempt to 0 and skip that cleanup.
+    this.hub.reconnectAttempt = 1;
+    this.setHubStatus("connecting");
+    this.openHubSocket();
   }
 
   /** Send a message to the backend for a specific workspace. Returns false if the hub isn't open. */
@@ -252,6 +284,7 @@ class WsTransport {
       if (this.hub.ws !== ws) return;
       const isReconnect = this.hub.reconnectAttempt > 0;
       this.hub.reconnectAttempt = 0;
+      this.hub.lastMessageAt = Date.now();
       // Clear per-session status caches on reconnect (will be repopulated by bootstrap)
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
@@ -270,6 +303,7 @@ class WsTransport {
 
     ws.onmessage = (event) => {
       if (this.hub.ws !== ws) return;
+      this.hub.lastMessageAt = Date.now();
       try {
         const envelope = JSON.parse(event.data as string) as HubOutgoing;
         this.handleIncomingEnvelope(envelope);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,7 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 import "./index.css";
 import { copyToClipboard } from "@/lib/clipboard";
+import { wsTransport } from "@/lib/ws-transport";
 import App from "./App";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 
@@ -44,6 +45,14 @@ if ("__TAURI_INTERNALS__" in window) {
         lastFs = fs;
         setTitlebarVars(fs);
       }
+    });
+
+    // After the OS wakes from sleep the hub WebSocket can be a frozen "open"
+    // socket that never fires onclose, leaving the UI stuck in a stale
+    // streaming state. Regaining window focus forces a fresh connection so the
+    // bootstrap can replay the real session state.
+    win.onFocusChanged(({ payload: focused }) => {
+      if (focused) wsTransport.forceReconnectIfStale();
     });
   });
 }

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -828,4 +828,78 @@ describe("wsTransport", () => {
       expect(wsTransport.hasCachedHistory("unknown")).toBe(false);
     });
   });
+
+  describe("forceReconnectIfStale", () => {
+    it("does not reconnect a healthy, recently-active socket", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+      socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
+
+      wsTransport.forceReconnectIfStale();
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(socket.readyState).toBe(MockWebSocket.OPEN);
+    });
+
+    it("reconnects an open-but-silent socket (zombie after wake from sleep)", () => {
+      wsTransport.connect("ws-1");
+      const first = MockWebSocket.instances[0]!;
+      first.open();
+
+      // Simulate sleep: time passes with no message from the still-"open" socket.
+      vi.advanceTimersByTime(30_001);
+      wsTransport.forceReconnectIfStale();
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+      MockWebSocket.instances[1]!.open();
+      expect(wsTransport.getStatus("ws-1")).toBe("connected");
+    });
+
+    it("reconnects immediately when the socket is closed, skipping backoff wait", () => {
+      wsTransport.connect("ws-1");
+      const first = MockWebSocket.instances[0]!;
+      first.open();
+      first.close();
+
+      // A backoff reconnect is pending but has not fired yet.
+      expect(MockWebSocket.instances).toHaveLength(1);
+
+      wsTransport.forceReconnectIfStale();
+      expect(MockWebSocket.instances).toHaveLength(2);
+
+      // The pending backoff timer was cancelled, so no duplicate socket appears.
+      vi.advanceTimersByTime(5_000);
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("is a no-op when nothing is subscribed", () => {
+      wsTransport.forceReconnectIfStale();
+      expect(MockWebSocket.instances).toHaveLength(0);
+    });
+
+    it("is a no-op while a connection attempt is already in flight", () => {
+      wsTransport.connect("ws-1");
+      expect(MockWebSocket.instances[0]!.readyState).toBe(MockWebSocket.CONNECTING);
+
+      wsTransport.forceReconnectIfStale();
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+
+    it("notifies onReconnect listeners exactly once so stale streams are cleared", () => {
+      wsTransport.connect("ws-1");
+      const first = MockWebSocket.instances[0]!;
+      first.open();
+
+      const onReconnect = vi.fn();
+      wsTransport.onReconnect("ws-1", onReconnect);
+
+      // Zombie socket: silent past the threshold, then window regains focus.
+      vi.advanceTimersByTime(30_001);
+      wsTransport.forceReconnectIfStale();
+      MockWebSocket.instances[1]!.open();
+
+      expect(onReconnect).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- force a fresh hub WebSocket when a Tauri window regains focus with a stale or closed socket
- treat forced stale-socket recovery as a reconnect so stream cleanup listeners run before bootstrap replay
- cover stale reconnect behavior, closed-socket fast reconnect, and reconnect listener notification in ws transport tests

## Verification
- git diff --check
- npm test --workspace @hive/frontend -- ws-transport
- npm run typecheck --workspace @hive/frontend
- npm run lint --workspace @hive/frontend