### PR TITLE
Stop tool-summary executing dot from bouncing during streaming

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -21,7 +21,6 @@ struct ChatActivityRowLabel: View {
     var isExpanded: Bool?
     var accessoryIcons: [String] = []
     var executing = false
-    @State private var pulse = false
 
     var body: some View {
         HStack(spacing: 6) {
@@ -107,14 +106,21 @@ struct ChatActivityRowLabel: View {
             }
 
             if executing {
-                // Theme-colored, position-stable pulse (matches the web's
-                // `bg-primary animate-pulse` and the TaskTracker in-progress dot).
-                Circle()
-                    .fill(Color.accentColor)
-                    .frame(width: 5, height: 5)
-                    .opacity(pulse ? 1 : 0.4)
-                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
-                    .onAppear { pulse = true }
+                // Opacity-only pulse, fully decoupled from the animation system so
+                // the dot can NEVER move. The opacity is recomputed every frame by
+                // TimelineView (no animation transaction), and `.transaction` nils
+                // out any animation inherited from ancestors — so streaming relayout
+                // (label/icons growing to its left) repositions the dot instantly
+                // instead of animating it. Matches the web's `bg-primary animate-pulse`.
+                TimelineView(.animation) { context in
+                    let t = context.date.timeIntervalSinceReferenceDate
+                    let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
+                    Circle()
+                        .fill(Color.accentColor)
+                        .frame(width: 5, height: 5)
+                        .opacity(opacity)
+                }
+                .transaction { $0.animation = nil }
             }
         }
         .padding(.vertical, 3)


### PR DESCRIPTION
## Problem

In an iOS conversation, the collapsed tool-summary (shown below the conversation) has a small dot ("pastille") that indicates streaming. It should only **pulse in opacity** — but it kept **bouncing/jittering** continuously during streaming. Multiple previous attempts (tweaking scale→opacity, changing the curve) never fixed it.

## Root cause

The dot is the **last** element of an `HStack`, after the summary label and tool icons. While streaming, those grow as tools arrive, which shifts the dot's frame. There is **no `.animation` on the messages list/container** (verified: `ScrollView` → `LazyVStack` → `ForEach`, none), so position changes *should* be instant.

The culprit was the dot's own modifier:

```swift
.animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true), value: pulse)
```

`repeatForever` keeps a running animation context on the view. So each streaming-driven frame change got interpolated instead of snapping → the dot bounced. The fix is **removing the `.animation` modifier**, not changing its timing — which is why every prior opacity/curve tweak failed.

## Fix

- Drive the opacity pulse with `TimelineView(.animation)` (recomputed per frame, no animation transaction) so **no `.animation` modifier remains** on the dot.
- Add `.transaction { $0.animation = nil }` to reject any inherited animation on the dot's geometry (belt-and-suspenders).

Opacity still pulses; the dot's position is now never animated. Mirrors the web's `bg-primary animate-pulse` (opacity-only).

## Testing

⚠️ No Swift toolchain on the build machine — **not yet verified on device/simulator.** Needs confirmation by streaming a conversation and watching the collapsed tool-summary dot stay put. `cd ios && swift test` for the suite.