### PR TITLE
Keep chat stream visible during hub resync

### DIFF
--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -34,6 +34,11 @@ const emptyStreamState: SessionStreamState = {
   pendingToolInputs: [],
 };
 
+// Spread into any authoritative/terminal reducer result to end the hub-reconnect
+// resync window. Centralized so a new terminal case cannot silently leak a stale
+// deferredStatus into the next turn.
+const RESYNC_CLEARED = { isResyncing: false, deferredStatus: undefined } as const;
+
 interface ConversationState {
   messages: ChatMessage[];
   sessionStreams: Record<string, SessionStreamState>;
@@ -147,14 +152,80 @@ function hasTerminalAssistantMessage(state: ConversationState, sid: string): boo
 
 function statusStopsSession(status: StatusMessage | undefined, sessionId: string): boolean {
   if (!status) return false;
-  const streaming = status.streaming ?? (status.status === "idle" ? false : undefined);
+  const streaming = getStatusStreaming(status);
   return streaming === false && (!status.sessionId || status.sessionId === sessionId);
+}
+
+function getStatusStreaming(status: StatusMessage): boolean | undefined {
+  return status.streaming ?? (status.status === "idle" ? false : undefined);
+}
+
+function hasVisibleActiveStream(state: ConversationState): boolean {
+  if (!state.sessionId) return false;
+  return Boolean(state.sessionStreams[state.sessionId]?.isStreaming);
 }
 
 function upsertActivity(activities: AgentActivity[], activity: AgentActivity): AgentActivity[] {
   const index = activities.findIndex((item) => item.id === activity.id);
   if (index < 0) return [...activities, activity];
   return activities.map((item, itemIndex) => itemIndex === index ? activity : item);
+}
+
+function reduceStatus(state: ConversationState, action: StatusMessage): ConversationState {
+  const sid = action.sessionId ?? state.sessionId;
+  const newIsStreaming = getStatusStreaming(action);
+  const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
+
+  let newStreams = state.sessionStreams;
+  if (sid && newIsStreaming !== undefined) {
+    const stream = state.sessionStreams[sid];
+    if (newIsStreaming) {
+      // Ensure a stream slot exists when the session starts or continues streaming.
+      const existing = stream ?? { ...emptyStreamState };
+      newStreams = {
+        ...state.sessionStreams,
+        [sid]: {
+          ...existing,
+          isStreaming: true,
+          // A (re)starting turn means any pending question was answered,
+          // possibly on another client (e.g. iOS).
+          pendingToolInputs: [],
+          // Prefer backend-provided start time so all clients show the same timer.
+          streamingStartedAt: backendStartedAt ?? existing.streamingStartedAt ?? Date.now(),
+        },
+      };
+    } else if (stream) {
+      // Session stopped streaming. If slot has no content, clean up.
+      if (
+        !stream.currentText &&
+        !stream.currentThinking &&
+        stream.activeToolCalls.length === 0 &&
+        stream.activeAgentActivities.length === 0 &&
+        stream.pendingToolInputs.length === 0
+      ) {
+        newStreams = deleteStream(state, sid);
+      } else {
+        newStreams = {
+          ...state.sessionStreams,
+          [sid]: { ...stream, isStreaming: false, streamingStartedAt: null },
+        };
+      }
+    }
+  }
+
+  // Only adopt sessionId from status if we don't have one yet
+  const newSessionId = (!state.sessionId && sid) ? sid : state.sessionId;
+
+  return {
+    ...state,
+    workspaceStatus: action.status,
+    sessionId: newSessionId,
+    sessionStreams: newStreams,
+    // Only update lockedProvider when explicitly present and for the active session.
+    ...(action.lockedProvider !== undefined && sid === newSessionId
+      ? { lockedProvider: action.lockedProvider }
+      : {}),
+  };
 }
 
 function reducer(state: ConversationState, action: Action): ConversationState {
@@ -241,12 +312,15 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const sid = action.sessionId;
       const existing = state.sessionStreams[sid] ?? { ...emptyStreamState };
       const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
+      // Only reflect workspace busy when the snapshot is for the active session.
+      // A background session's snapshot must not flip the active (possibly idle)
+      // session's workspaceStatus, which would block queued-message auto-dequeue.
+      const isActiveSnapshot = sid === (state.sessionId ?? sid);
       return {
         ...state,
-        isResyncing: false,
-        deferredStatus: undefined,
+        ...RESYNC_CLEARED,
         sessionId: state.sessionId ?? sid,
-        workspaceStatus: "busy",
+        ...(isActiveSnapshot ? { workspaceStatus: "busy" as const } : {}),
         sessionStreams: {
           ...state.sessionStreams,
           [sid]: {
@@ -291,15 +365,14 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         };
         return {
           ...state,
-          isResyncing: false,
-          deferredStatus: undefined,
+          ...RESYNC_CLEARED,
           messages: [...state.messages, assistantMsg],
           sessionStreams: newStreams,
         };
       }
       // Background session: just clean up the slot. REST fetch on switch-back
       // will include the completed message.
-      return { ...state, isResyncing: false, deferredStatus: undefined, sessionStreams: newStreams };
+      return { ...state, ...RESYNC_CLEARED, sessionStreams: newStreams };
     }
 
     case "cancelled": {
@@ -331,13 +404,12 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         };
         return {
           ...state,
-          isResyncing: false,
-          deferredStatus: undefined,
+          ...RESYNC_CLEARED,
           messages: [...state.messages, cancelledMsg],
           sessionStreams: newStreams,
         };
       }
-      return { ...state, isResyncing: false, deferredStatus: undefined, sessionStreams: newStreams };
+      return { ...state, ...RESYNC_CLEARED, sessionStreams: newStreams };
     }
 
     case "error":
@@ -348,63 +420,20 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
     case "status": {
       if (state.isResyncing) {
+        // No visible stream to protect: apply the status now and end resync so a
+        // missing authoritative bootstrap event can't leave us stuck deferring.
+        if (!hasVisibleActiveStream(state)) {
+          return reduceStatus({ ...state, ...RESYNC_CLEARED }, action);
+        }
+        // A live stream is on screen: keep the provisional status pending so we
+        // don't flash an idle UI mid-resync. Resync ends when an authoritative
+        // event (history/snapshot/done/cancelled) arrives. In a rare backend race
+        // where none arrives for this streaming session, the visible stream stays
+        // put and a later reconnect/done reconciles it — no timeout by design.
         return { ...state, deferredStatus: action };
       }
 
-      const sid = action.sessionId ?? state.sessionId;
-      const newIsStreaming = action.streaming ?? (action.status === "idle" ? false : undefined);
-      const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
-
-      let newStreams = state.sessionStreams;
-      if (sid && newIsStreaming !== undefined) {
-        const stream = state.sessionStreams[sid];
-        if (newIsStreaming) {
-          // Session started or is streaming — ensure a slot exists
-          const existing = stream ?? { ...emptyStreamState };
-          newStreams = {
-            ...state.sessionStreams,
-            [sid]: {
-              ...existing,
-              isStreaming: true,
-              // A (re)starting turn means any pending question was answered,
-              // possibly on another client (e.g. iOS).
-              pendingToolInputs: [],
-              // Prefer backend-provided start time so all clients show the same timer.
-              streamingStartedAt: backendStartedAt ?? existing.streamingStartedAt ?? Date.now(),
-            },
-          };
-        } else if (stream) {
-          // Session stopped streaming. If slot has no content, clean up.
-          if (
-            !stream.currentText &&
-            !stream.currentThinking &&
-            stream.activeToolCalls.length === 0 &&
-            stream.activeAgentActivities.length === 0 &&
-            stream.pendingToolInputs.length === 0
-          ) {
-            newStreams = deleteStream(state, sid);
-          } else {
-            newStreams = {
-              ...state.sessionStreams,
-              [sid]: { ...stream, isStreaming: false, streamingStartedAt: null },
-            };
-          }
-        }
-      }
-
-      // Only adopt sessionId from status if we don't have one yet
-      const newSessionId = (!state.sessionId && sid) ? sid : state.sessionId;
-
-      return {
-        ...state,
-        workspaceStatus: action.status,
-        sessionId: newSessionId,
-        sessionStreams: newStreams,
-        // Only update lockedProvider when explicitly present and for the active session.
-        ...(action.lockedProvider !== undefined && sid === newSessionId
-          ? { lockedProvider: action.lockedProvider }
-          : {}),
-      };
+      return reduceStatus(state, action);
     }
 
     case "history": {
@@ -431,8 +460,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
             ...state.sessionStreams,
             [historySessionId]: {
               ...emptyStreamState,
-              isStreaming: false,
-              streamingStartedAt: null,
               pendingToolInputs: hydratedPendingToolInputs,
             },
           };
@@ -443,8 +470,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       return {
         ...state,
-        isResyncing: false,
-        deferredStatus: undefined,
+        ...RESYNC_CLEARED,
         messages: action.messages,
         error: undefined,
         sessionId: historySessionId ?? state.sessionId,
@@ -502,8 +528,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
-        isResyncing: false,
-        deferredStatus: undefined,
+        ...RESYNC_CLEARED,
         sessionId: action.sessionId,
         error: undefined,
         lockedProvider: undefined,
@@ -515,8 +540,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
-        isResyncing: false,
-        deferredStatus: undefined,
+        ...RESYNC_CLEARED,
         sessionId: undefined,
         workspaceStatus: undefined,
         error: undefined,
@@ -531,8 +555,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         ...state,
         messages: [],
         sessionStreams: sid ? deleteStream(state, sid) : {},
-        isResyncing: false,
-        deferredStatus: undefined,
+        ...RESYNC_CLEARED,
         error: undefined,
         sessionId: undefined,
       };

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -4,6 +4,8 @@ import { wsTransport } from "@/lib/ws-transport";
 import type { HistoryMessage } from "@/lib/ws-transport";
 import { api } from "@/hooks/useApi";
 
+type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
+
 export interface PendingToolInput {
   requestId: string;
   toolName: string;
@@ -35,6 +37,8 @@ const emptyStreamState: SessionStreamState = {
 interface ConversationState {
   messages: ChatMessage[];
   sessionStreams: Record<string, SessionStreamState>;
+  isResyncing: boolean;
+  deferredStatus?: StatusMessage;
   workspaceStatus?: "idle" | "busy";
   error?: string;
   sessionId?: string;
@@ -50,13 +54,15 @@ type LocalAction =
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
   | { type: "clear_pending_tool_inputs" }
-  | { type: "_ws_reconnected" };
+  | { type: "_ws_resync_started" };
 
 type Action = WsOutgoing | LocalAction;
 
 const initialState: ConversationState = {
   messages: [],
   sessionStreams: {},
+  isResyncing: false,
+  deferredStatus: undefined,
   workspaceStatus: undefined,
   error: undefined,
   sessionId: undefined,
@@ -137,6 +143,12 @@ function hasTerminalAssistantMessage(state: ConversationState, sid: string): boo
     return message.role === "assistant";
   }
   return false;
+}
+
+function statusStopsSession(status: StatusMessage | undefined, sessionId: string): boolean {
+  if (!status) return false;
+  const streaming = status.streaming ?? (status.status === "idle" ? false : undefined);
+  return streaming === false && (!status.sessionId || status.sessionId === sessionId);
 }
 
 function upsertActivity(activities: AgentActivity[], activity: AgentActivity): AgentActivity[] {
@@ -231,7 +243,10 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
       return {
         ...state,
+        isResyncing: false,
+        deferredStatus: undefined,
         sessionId: state.sessionId ?? sid,
+        workspaceStatus: "busy",
         sessionStreams: {
           ...state.sessionStreams,
           [sid]: {
@@ -276,13 +291,15 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         };
         return {
           ...state,
+          isResyncing: false,
+          deferredStatus: undefined,
           messages: [...state.messages, assistantMsg],
           sessionStreams: newStreams,
         };
       }
       // Background session: just clean up the slot. REST fetch on switch-back
       // will include the completed message.
-      return { ...state, sessionStreams: newStreams };
+      return { ...state, isResyncing: false, deferredStatus: undefined, sessionStreams: newStreams };
     }
 
     case "cancelled": {
@@ -314,11 +331,13 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         };
         return {
           ...state,
+          isResyncing: false,
+          deferredStatus: undefined,
           messages: [...state.messages, cancelledMsg],
           sessionStreams: newStreams,
         };
       }
-      return { ...state, sessionStreams: newStreams };
+      return { ...state, isResyncing: false, deferredStatus: undefined, sessionStreams: newStreams };
     }
 
     case "error":
@@ -328,6 +347,10 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return { ...state, error: action.message };
 
     case "status": {
+      if (state.isResyncing) {
+        return { ...state, deferredStatus: action };
+      }
+
       const sid = action.sessionId ?? state.sessionId;
       const newIsStreaming = action.streaming ?? (action.status === "idle" ? false : undefined);
       const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
@@ -393,29 +416,43 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       // Derive pending tool inputs from history, unless the session has an active stream
       const activeStream = historySessionId ? state.sessionStreams[historySessionId] : undefined;
-      const hydratedPendingToolInputs = activeStream?.isStreaming
+      const deferredStop = historySessionId
+        ? statusStopsSession(state.deferredStatus, historySessionId)
+        : false;
+      const streamStillActive = Boolean(activeStream?.isStreaming && !deferredStop);
+      const hydratedPendingToolInputs = streamStillActive && activeStream
         ? activeStream.pendingToolInputs
         : derivePendingToolInputsFromHistory(action.messages);
 
       let newStreams = state.sessionStreams;
-      if (historySessionId && !activeStream?.isStreaming) {
-        if (activeStream || hydratedPendingToolInputs.length > 0) {
+      if (historySessionId && !streamStillActive) {
+        if (hydratedPendingToolInputs.length > 0) {
           newStreams = {
             ...state.sessionStreams,
             [historySessionId]: {
-              ...(activeStream ?? { ...emptyStreamState }),
+              ...emptyStreamState,
+              isStreaming: false,
+              streamingStartedAt: null,
               pendingToolInputs: hydratedPendingToolInputs,
             },
           };
+        } else if (activeStream) {
+          newStreams = deleteStream(state, historySessionId);
         }
       }
 
       return {
         ...state,
+        isResyncing: false,
+        deferredStatus: undefined,
         messages: action.messages,
         error: undefined,
         sessionId: historySessionId ?? state.sessionId,
         sessionStreams: newStreams,
+        workspaceStatus: state.deferredStatus?.status ?? state.workspaceStatus,
+        ...(state.deferredStatus?.lockedProvider !== undefined
+          ? { lockedProvider: state.deferredStatus.lockedProvider }
+          : {}),
       };
     }
 
@@ -465,6 +502,8 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
+        isResyncing: false,
+        deferredStatus: undefined,
         sessionId: action.sessionId,
         error: undefined,
         lockedProvider: undefined,
@@ -476,6 +515,8 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       return {
         ...state,
         messages: [],
+        isResyncing: false,
+        deferredStatus: undefined,
         sessionId: undefined,
         workspaceStatus: undefined,
         error: undefined,
@@ -490,6 +531,8 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         ...state,
         messages: [],
         sessionStreams: sid ? deleteStream(state, sid) : {},
+        isResyncing: false,
+        deferredStatus: undefined,
         error: undefined,
         sessionId: undefined,
       };
@@ -498,12 +541,11 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "reset":
       return initialState;
 
-    case "_ws_reconnected":
-      // On WS reconnect the backend will re-bootstrap every workspace with a
-      // full streaming snapshot (text, thinking, tool calls). Clear accumulated
-      // stream data so the snapshot won't be *appended* to stale pre-disconnect
-      // content, which would cause duplicate tool calls and garbled text.
-      return { ...state, sessionStreams: {} };
+    case "_ws_resync_started":
+      // Keep the last visible stream intact until the backend provides an
+      // authoritative history/snapshot/final event. Status-only bootstrap
+      // messages are provisional and must not create an empty intermediate UI.
+      return { ...state, isResyncing: true, deferredStatus: undefined };
 
     default:
       return state;
@@ -587,7 +629,7 @@ export function useConversation(workspaceId: string | undefined) {
     replayingBuffer = false;
 
     const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
-      dispatch({ type: "_ws_reconnected" });
+      dispatch({ type: "_ws_resync_started" });
     });
 
     // Tell the backend to activate the saved session and send its bootstrap.

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -141,9 +141,9 @@ class WsTransport {
     if (isOpen && !isStale) return;
     this.teardownHub();
     // Mark the fresh socket as a reconnect (not a first connect) so onReconnect
-    // listeners fire and stale stream state is cleared before the bootstrap
-    // replays snapshots. Going through ensureHubConnected() would reset
-    // reconnectAttempt to 0 and skip that cleanup.
+    // listeners fire before the backend bootstrap replays authoritative state.
+    // Going through ensureHubConnected() would reset reconnectAttempt to 0 and
+    // skip that notification.
     this.hub.reconnectAttempt = 1;
     this.setHubStatus("connecting");
     this.openHubSocket();
@@ -289,9 +289,9 @@ class WsTransport {
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
       }
-      // On reconnect, notify all listeners to clear stale streaming state before
-      // the bootstrap replays full snapshots. Without this, the snapshot events
-      // would be appended to pre-disconnect accumulated data, causing duplicates.
+      // On reconnect, notify listeners before the bootstrap replays full
+      // snapshots. Conversation state decides how to reconcile this without
+      // creating an empty intermediate UI.
       if (isReconnect) {
         for (const sub of this.subscriptions.values()) {
           for (const listener of sub.reconnectListeners) listener();

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/lib/ws-transport", () => {
       statusListeners.clear();
       reconnectListeners.clear();
     }),
-    send: vi.fn((_workspaceId: string, _message: unknown) => true),
+    send: vi.fn(() => true),
     onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
       getSet(messageHandlers, workspaceId).add(handler);
       for (const msg of replayMessages.get(workspaceId) ?? []) {
@@ -1434,7 +1434,7 @@ describe("useConversation", () => {
       __wsMock.emit("ws-1", {
         type: "branch_info",
         info: { name: "feat/new", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
-      } as any);
+      });
     });
 
     expect(result.current.workspaceStatus).toBe("busy");
@@ -1935,7 +1935,7 @@ describe("useConversation", () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockResolvedValue([]);
-    const { result, rerender } = renderHook(
+    const { rerender } = renderHook(
       ({ wsId }) => useConversation(wsId),
       { initialProps: { wsId: "ws-1" } },
     );

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2179,6 +2179,46 @@ describe("useConversation", () => {
     expect(result.current.messages.map((message) => message.content)).toEqual(["start", "Final answer"]);
   });
 
+  it("lets status finish reconnect resync when no visible stream is active", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-1",
+        streaming: false,
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("idle");
+    expect(result.current.isStreaming).toBe(false);
+
+    act(() => {
+      __wsMock.reconnect("ws-1");
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-1",
+        streaming: false,
+        lockedProvider: "codex",
+      });
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-1",
+        streaming: true,
+        streamingStartedAt: 1_700_000_005_000,
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.lockedProvider).toBe("codex");
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.streamingStartedAt).toBe(1_700_000_005_000);
+  });
+
   it("keeps stream visible when history arrives before stream_snapshot during resync", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderHook(() => useConversation("ws-1"));
@@ -2288,6 +2328,43 @@ describe("useConversation", () => {
         durationMs: 123,
       }),
     );
+  });
+
+  it("does not flip the active idle session busy when a background session snapshot arrives", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    // Active session is idle.
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-1",
+        streaming: false,
+      });
+    });
+
+    expect(result.current.sessionId).toBe("sess-1");
+    expect(result.current.workspaceStatus).toBe("idle");
+
+    // A different (background) session replays a streaming snapshot during bootstrap.
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "stream_snapshot",
+        sessionId: "sess-2",
+        text: "background work",
+        thinking: "",
+        toolCalls: [],
+        agentActivities: [],
+        agentPlanMode: false,
+        streamingStartedAt: 1_700_000_006_000,
+      });
+    });
+
+    // Active session must stay idle so queued-message auto-dequeue is not blocked.
+    expect(result.current.workspaceStatus).toBe("idle");
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentStreamingText).toBe("");
   });
 
   it("full reset clears sessionStreams when workspaceId becomes undefined", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -35,6 +35,7 @@ vi.mock("@/lib/ws-transport", () => {
   const statuses = new Map<string, ConnectionStatus>();
   const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
   const statusListeners = new Map<string, Set<() => void>>();
+  const reconnectListeners = new Map<string, Set<() => void>>();
   const replayMessages = new Map<string, WsOutgoing[]>();
   const bufferedFlags = new Map<string, boolean>();
   const cachedHistories = new Map<string, WsOutgoing>();
@@ -65,6 +66,7 @@ vi.mock("@/lib/ws-transport", () => {
       statuses.clear();
       messageHandlers.clear();
       statusListeners.clear();
+      reconnectListeners.clear();
     }),
     send: vi.fn((_workspaceId: string, _message: unknown) => true),
     onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
@@ -77,8 +79,9 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: bufferedFlags.get(workspaceId) ?? false,
       };
     }),
-    onReconnect: vi.fn((_workspaceId: string, _callback: () => void) => {
-      return () => {};
+    onReconnect: vi.fn((workspaceId: string, callback: () => void) => {
+      getSet(reconnectListeners, workspaceId).add(callback);
+      return () => { getSet(reconnectListeners, workspaceId).delete(callback); };
     }),
     subscribe: (workspaceId: string, listener: () => void) => {
       getSet(statusListeners, workspaceId).add(listener);
@@ -102,10 +105,14 @@ vi.mock("@/lib/ws-transport", () => {
     emit: (workspaceId: string, msg: WsOutgoing) => {
       for (const handler of messageHandlers.get(workspaceId) ?? []) handler(msg);
     },
+    reconnect: (workspaceId: string) => {
+      for (const listener of reconnectListeners.get(workspaceId) ?? []) listener();
+    },
     reset: () => {
       statuses.clear();
       messageHandlers.clear();
       statusListeners.clear();
+      reconnectListeners.clear();
       replayMessages.clear();
       bufferedFlags.clear();
       cachedHistories.clear();
@@ -115,6 +122,7 @@ vi.mock("@/lib/ws-transport", () => {
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
       wsTransport.onMessage.mockClear();
+      wsTransport.onReconnect.mockClear();
       wsTransport.updateCachedHistory.mockClear();
       wsTransport.hasCachedHistory.mockClear();
       wsTransport.clearCachedData.mockClear();
@@ -142,6 +150,7 @@ const getWsMock = async () =>
   (await import("@/lib/ws-transport")) as unknown as {
     __wsMock: {
       emit: (workspaceId: string, msg: WsOutgoing) => void;
+      reconnect: (workspaceId: string) => void;
       reset: () => void;
       setReplay: (workspaceId: string, messages: WsOutgoing[]) => void;
       setBuffered: (workspaceId: string, value: boolean) => void;
@@ -2063,6 +2072,222 @@ describe("useConversation", () => {
     expect(result.current.agentPlanMode).toBe(true);
     expect(result.current.streamingStartedAt).toBe(1_700_000_002_000);
     expect(result.current.isStreaming).toBe(true);
+  });
+
+  it("keeps active stream visible after reconnect until final history arrives", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-1",
+        streaming: true,
+        streamingStartedAt: 1_700_000_003_000,
+      });
+      __wsMock.emit("ws-1", {
+        type: "user_message",
+        message: {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "start",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      });
+      __wsMock.emit("ws-1", { type: "thinking", sessionId: "sess-1", text: "Thinking" });
+      __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Partial" });
+      __wsMock.emit("ws-1", {
+        type: "tool_use",
+        sessionId: "sess-1",
+        id: "tool-1",
+        name: "Read",
+        input: "{}",
+      });
+      __wsMock.emit("ws-1", {
+        type: "agent_activity",
+        sessionId: "sess-1",
+        activity: {
+          id: "cmd-1",
+          kind: "command_execution",
+          command: "npm test",
+          status: "inProgress",
+        },
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.streamingStartedAt).toBe(1_700_000_003_000);
+    expect(result.current.currentStreamingText).toBe("Partial");
+    expect(result.current.currentThinking).toBe("Thinking");
+    expect(result.current.activeToolCalls).toEqual([expect.objectContaining({ id: "tool-1" })]);
+    expect(result.current.activeAgentActivities).toEqual([expect.objectContaining({ id: "cmd-1" })]);
+
+    act(() => {
+      __wsMock.reconnect("ws-1");
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "idle",
+        sessionId: "sess-1",
+        streaming: false,
+        lockedProvider: "codex",
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.streamingStartedAt).toBe(1_700_000_003_000);
+    expect(result.current.currentStreamingText).toBe("Partial");
+    expect(result.current.currentThinking).toBe("Thinking");
+    expect(result.current.activeToolCalls).toEqual([expect.objectContaining({ id: "tool-1" })]);
+    expect(result.current.activeAgentActivities).toEqual([expect.objectContaining({ id: "cmd-1" })]);
+    expect(result.current.lockedProvider).toBeUndefined();
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "history",
+        sessionId: "sess-1",
+        messages: [
+          {
+            id: "u1",
+            sessionId: "sess-1",
+            role: "user",
+            content: "start",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+          {
+            id: "a1",
+            sessionId: "sess-1",
+            role: "assistant",
+            content: "Final answer",
+            timestamp: "2026-02-12T00:00:01.000Z",
+          },
+        ],
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("idle");
+    expect(result.current.lockedProvider).toBe("codex");
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.streamingStartedAt).toBeNull();
+    expect(result.current.currentStreamingText).toBe("");
+    expect(result.current.currentThinking).toBe("");
+    expect(result.current.activeToolCalls).toEqual([]);
+    expect(result.current.activeAgentActivities).toEqual([]);
+    expect(result.current.messages.map((message) => message.content)).toEqual(["start", "Final answer"]);
+  });
+
+  it("keeps stream visible when history arrives before stream_snapshot during resync", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-1",
+        streaming: true,
+        streamingStartedAt: 1_700_000_004_000,
+      });
+      __wsMock.emit("ws-1", {
+        type: "user_message",
+        message: {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "start",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      });
+      __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Before " });
+    });
+
+    act(() => {
+      __wsMock.reconnect("ws-1");
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-1",
+        streaming: true,
+        streamingStartedAt: 1_700_000_004_000,
+      });
+      __wsMock.emit("ws-1", {
+        type: "history",
+        sessionId: "sess-1",
+        messages: [
+          {
+            id: "u1",
+            sessionId: "sess-1",
+            role: "user",
+            content: "start",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+        ],
+      });
+    });
+
+    expect(result.current.workspaceStatus).toBe("busy");
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.streamingStartedAt).toBe(1_700_000_004_000);
+    expect(result.current.currentStreamingText).toBe("Before ");
+    expect(result.current.messages.map((message) => message.content)).toEqual(["start"]);
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "stream_snapshot",
+        sessionId: "sess-1",
+        text: "Before after",
+        thinking: "",
+        toolCalls: [{
+          id: "tool-1",
+          name: "Read",
+          input: "{}",
+          output: "file contents",
+        }],
+        agentActivities: [],
+        agentPlanMode: false,
+        streamingStartedAt: 1_700_000_004_000,
+      });
+    });
+
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.currentStreamingText).toBe("Before after");
+    expect(result.current.activeToolCalls).toEqual([
+      expect.objectContaining({ id: "tool-1", output: "file contents" }),
+    ]);
+  });
+
+  it("finalizes preserved stream when done arrives during reconnect resync", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "user_message",
+        message: {
+          id: "u1",
+          sessionId: "sess-1",
+          role: "user",
+          content: "start",
+          timestamp: "2026-02-12T00:00:00.000Z",
+        },
+      });
+      __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Preserved" });
+      __wsMock.reconnect("ws-1");
+      __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 123 });
+    });
+
+    expect(result.current.isStreaming).toBe(false);
+    expect(result.current.currentStreamingText).toBe("");
+    expect(result.current.messages.at(-1)).toEqual(
+      expect.objectContaining({
+        role: "assistant",
+        content: "Preserved",
+        durationMs: 123,
+      }),
+    );
   });
 
   it("full reset clears sessionStreams when workspaceId becomes undefined", async () => {

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -886,7 +886,7 @@ describe("wsTransport", () => {
       expect(MockWebSocket.instances).toHaveLength(1);
     });
 
-    it("notifies onReconnect listeners exactly once so stale streams are cleared", () => {
+    it("notifies onReconnect listeners exactly once before bootstrap replay", () => {
       wsTransport.connect("ws-1");
       const first = MockWebSocket.instances[0]!;
       first.open();


### PR DESCRIPTION
## Summary

- Keep the visible chat stream intact when the hub reconnects and backend bootstrap starts.
- Treat reconnect `status` events as provisional inside `useConversation`, then reconcile atomically on `history`, `stream_snapshot`, `done`, or `cancelled`.
- Update reconnect tests/comments so the transport only owns reconnect notification, not conversation cleanup.

Closes #259.

## Verification

- `cd frontend && npm test -- useConversation.test.tsx ws-transport.test.ts`
- `cd frontend && npm run typecheck`
- `cd frontend && npm run lint`
- `cd frontend && npm run build`

`npm run build` passes with the existing Vite large chunk warning.
