### PR TITLE
Cache conversation history per session to stop switch-back reloads

### DIFF
--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -563,8 +563,8 @@ export function useConversation(workspaceId: string | undefined) {
     historyRequestTokenRef.current = historyRequestToken;
 
     dispatch({ type: "prepare_workspace_switch" });
-    // Pre-set sessionId so the reducer's mismatch guard rejects replayed history
-    // for a different session (e.g. from stale lastHistory in the WS transport cache).
+    // Pre-set sessionId so the reducer's mismatch guard keeps only this session's
+    // history when the transport replays its per-session cache on resubscribe.
     if (savedSession) {
       dispatch({ type: "prepare_session_switch", sessionId: savedSession });
     }
@@ -603,10 +603,10 @@ export function useConversation(workspaceId: string | undefined) {
       historyRequestTokenRef.current += 1;
     }
 
-    // REST fallback — only needed on first visit when no cached history exists.
-    // On switch-back the transport cache is kept fresh (see effect below), so
-    // the WS replay already provides current messages.
-    if (!wsTransport.hasCachedHistory(workspaceId)) {
+    // REST fallback — only needed on first visit when no cached history exists
+    // for the session we're restoring. On switch-back the transport cache is kept
+    // fresh (see effect below), so the WS replay already provides current messages.
+    if (!wsTransport.hasCachedHistory(workspaceId, savedSession)) {
       void (async () => {
         try {
           const url = savedSession
@@ -698,6 +698,13 @@ export function useConversation(workspaceId: string | undefined) {
   const switchSession = useCallback((sessionId: string) => {
     if (!workspaceId) return;
     dispatch({ type: "prepare_session_switch", sessionId });
+    // Restore the target session's messages instantly from the transport cache so
+    // switching back to a previously-viewed conversation doesn't flash an empty
+    // reload. The switch_session round-trip below still reconciles with the backend.
+    const cached = wsTransport.getCachedHistory(workspaceId, sessionId);
+    if (cached) {
+      dispatch({ type: "history", sessionId, messages: cached.messages });
+    }
     dispatch({ type: "status", status: "busy", sessionId, streaming: false });
     historyRequestTokenRef.current += 1;
     const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId });

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -14,6 +14,11 @@ type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 const MAX_RECONNECT_DELAY = 30_000;
 const BASE_RECONNECT_DELAY = 1_000;
 
+/** Resolve the session a history message belongs to (undefined if session-less). */
+function historySessionKey(msg: HistoryMessage): string | undefined {
+  return msg.sessionId ?? msg.messages[0]?.sessionId;
+}
+
 // ── Hub socket state ────────────────────────────────────────────────
 
 interface HubState {
@@ -31,7 +36,8 @@ interface WorkspaceSubscription {
   statusListeners: Set<StatusListener>;
   lastStatus?: StatusMessage;
   lastStatusBySession: Map<string, StatusMessage>;
-  lastHistory?: HistoryMessage;
+  /** Latest message history per session, so switching between sessions replays instantly. */
+  lastHistoryBySession: Map<string, HistoryMessage>;
   lastDiffStats?: DiffStatsMessage;
   lastBranchInfo?: BranchInfoMessage;
   /** Messages received while no handler was subscribed. Replayed on next onMessage(). */
@@ -80,15 +86,29 @@ class WsTransport {
     this.sendSyncWorkspaces();
   }
 
-  /** Update the cached history so switch-back replays are fresh. */
+  /** Update the cached history for its session so switch-back replays are fresh. */
   updateCachedHistory(workspaceId: string, historyMsg: HistoryMessage): void {
     const sub = this.subscriptions.get(workspaceId);
-    if (sub) sub.lastHistory = historyMsg;
+    if (!sub) return;
+    const sessionId = historySessionKey(historyMsg);
+    if (sessionId) sub.lastHistoryBySession.set(sessionId, historyMsg);
   }
 
-  /** Check whether cached history exists for a workspace. */
-  hasCachedHistory(workspaceId: string): boolean {
-    return this.subscriptions.get(workspaceId)?.lastHistory !== undefined;
+  /** Return the cached history for a specific session, if any. */
+  getCachedHistory(workspaceId: string, sessionId: string): HistoryMessage | undefined {
+    return this.subscriptions.get(workspaceId)?.lastHistoryBySession.get(sessionId);
+  }
+
+  /**
+   * Check whether cached history exists. With a sessionId, checks that session;
+   * without one, checks whether any session has cached history.
+   */
+  hasCachedHistory(workspaceId: string, sessionId?: string): boolean {
+    const sub = this.subscriptions.get(workspaceId);
+    if (!sub) return false;
+    return sessionId !== undefined
+      ? sub.lastHistoryBySession.has(sessionId)
+      : sub.lastHistoryBySession.size > 0;
   }
 
   /** Clear cached status/history for a workspace (e.g. after session deletion). */
@@ -97,7 +117,7 @@ class WsTransport {
     if (!sub) return;
     sub.lastStatus = undefined;
     sub.lastStatusBySession.clear();
-    sub.lastHistory = undefined;
+    sub.lastHistoryBySession.clear();
     sub.lastBranchInfo = undefined;
     sub.messageBuffer = [];
   }
@@ -140,8 +160,8 @@ class WsTransport {
     } else if (sub.lastStatus) {
       handler(sub.lastStatus);
     }
-    if (sub.lastHistory) {
-      handler(sub.lastHistory);
+    for (const historyMsg of sub.lastHistoryBySession.values()) {
+      handler(historyMsg);
     }
     if (sub.lastDiffStats) {
       handler(sub.lastDiffStats);
@@ -202,6 +222,7 @@ class WsTransport {
       reconnectListeners: new Set<() => void>(),
       statusListeners: new Set<StatusListener>(),
       lastStatusBySession: new Map(),
+      lastHistoryBySession: new Map(),
       messageBuffer: [],
     };
     this.subscriptions.set(workspaceId, created);
@@ -312,7 +333,8 @@ class WsTransport {
         sub.lastStatusBySession.clear();
       }
     } else if (msg.type === "history") {
-      sub.lastHistory = msg;
+      const sessionId = historySessionKey(msg);
+      if (sessionId) sub.lastHistoryBySession.set(sessionId, msg);
     } else if (msg.type === "diff_stats") {
       sub.lastDiffStats = msg;
     } else if (msg.type === "branch_info") {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -39,6 +39,12 @@ vi.mock("@/lib/ws-transport", () => {
   const bufferedFlags = new Map<string, boolean>();
   const cachedHistories = new Map<string, WsOutgoing>();
 
+  const histKey = (workspaceId: string, sessionId: string) => `${workspaceId}::${sessionId}`;
+  const sessionKeyOf = (msg: WsOutgoing): string | undefined => {
+    if (msg.type !== "history") return undefined;
+    return msg.sessionId ?? msg.messages[0]?.sessionId;
+  };
+
   const getSet = <T,>(source: Map<string, Set<T>>, workspaceId: string) => {
     const existing = source.get(workspaceId);
     if (existing) return existing;
@@ -88,11 +94,21 @@ vi.mock("@/lib/ws-transport", () => {
     },
     getStatus: (workspaceId: string) => statuses.get(workspaceId) ?? "disconnected",
     updateCachedHistory: vi.fn((workspaceId: string, historyMsg: WsOutgoing) => {
-      cachedHistories.set(workspaceId, historyMsg);
+      const sessionId = sessionKeyOf(historyMsg);
+      if (sessionId) cachedHistories.set(histKey(workspaceId, sessionId), historyMsg);
     }),
-    hasCachedHistory: vi.fn((workspaceId: string) => cachedHistories.has(workspaceId)),
+    getCachedHistory: vi.fn((workspaceId: string, sessionId: string) =>
+      cachedHistories.get(histKey(workspaceId, sessionId)),
+    ),
+    hasCachedHistory: vi.fn((workspaceId: string, sessionId?: string) => {
+      if (sessionId !== undefined) return cachedHistories.has(histKey(workspaceId, sessionId));
+      const prefix = `${workspaceId}::`;
+      for (const key of cachedHistories.keys()) if (key.startsWith(prefix)) return true;
+      return false;
+    }),
     clearCachedData: vi.fn((workspaceId: string) => {
-      cachedHistories.delete(workspaceId);
+      const prefix = `${workspaceId}::`;
+      for (const key of [...cachedHistories.keys()]) if (key.startsWith(prefix)) cachedHistories.delete(key);
       replayMessages.delete(workspaceId);
       bufferedFlags.delete(workspaceId);
     }),
@@ -116,6 +132,7 @@ vi.mock("@/lib/ws-transport", () => {
       wsTransport.send.mockClear();
       wsTransport.onMessage.mockClear();
       wsTransport.updateCachedHistory.mockClear();
+      wsTransport.getCachedHistory.mockClear();
       wsTransport.hasCachedHistory.mockClear();
       wsTransport.clearCachedData.mockClear();
     },
@@ -129,9 +146,11 @@ vi.mock("@/lib/ws-transport", () => {
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
     updateCachedHistoryMock: wsTransport.updateCachedHistory,
+    getCachedHistoryMock: wsTransport.getCachedHistory,
     hasCachedHistoryMock: wsTransport.hasCachedHistory,
     setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => {
-      cachedHistories.set(workspaceId, historyMsg);
+      const sessionId = sessionKeyOf(historyMsg);
+      if (sessionId) cachedHistories.set(histKey(workspaceId, sessionId), historyMsg);
     },
   };
 
@@ -149,6 +168,7 @@ const getWsMock = async () =>
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
       updateCachedHistoryMock: ReturnType<typeof vi.fn>;
+      getCachedHistoryMock: ReturnType<typeof vi.fn>;
       hasCachedHistoryMock: ReturnType<typeof vi.fn>;
       setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => void;
     };
@@ -1306,6 +1326,41 @@ describe("useConversation", () => {
     ]);
     expect(result.current.sessionId).toBe("sess-2");
     expect(result.current.isStreaming).toBe(false);
+  });
+
+  it("restores cached messages synchronously when switching to a previously-viewed session", async () => {
+    const { __wsMock } = await getWsMock();
+    __wsMock.setCachedHistory("ws-1", {
+      type: "history",
+      sessionId: "sess-2",
+      messages: [
+        {
+          id: "cached-1",
+          sessionId: "sess-2",
+          role: "assistant",
+          content: "restored instantly",
+          timestamp: "2026-02-12T00:00:01.000Z",
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useConversation("ws-1"));
+
+    act(() => {
+      result.current.switchSession("sess-2");
+    });
+
+    // Messages appear immediately from cache — no WS round-trip / empty flash.
+    expect(result.current.sessionId).toBe("sess-2");
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({ id: "cached-1", content: "restored instantly" }),
+    ]);
+    expect(__wsMock.getCachedHistoryMock).toHaveBeenCalledWith("ws-1", "sess-2");
+    // It still asks the backend to reconcile.
+    expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+      type: "switch_session",
+      sessionId: "sess-2",
+    });
   });
 
   it("keeps target session visible and sets an error when switch_session send fails", async () => {

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { wsTransport } from "@/lib/ws-transport";
+import type { HistoryMessage } from "@/lib/ws-transport";
 import type { WsOutgoing, HubOutgoing } from "@/types";
 
 class MockWebSocket {
@@ -639,7 +640,7 @@ describe("wsTransport", () => {
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
 
       socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
-      socket.hubMessage("ws-1", { type: "history", messages: [] } as WsOutgoing);
+      socket.hubMessage("ws-1", { type: "history", sessionId: "s1", messages: [] } as WsOutgoing);
       socket.hubMessage("ws-1", {
         type: "diff_stats",
         stats: { committed: [], uncommitted: [] },
@@ -696,7 +697,7 @@ describe("wsTransport", () => {
       const first: WsOutgoing[] = [];
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
       socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
-      socket.hubMessage("ws-1", { type: "history", messages: [] } as WsOutgoing);
+      socket.hubMessage("ws-1", { type: "history", sessionId: "s1", messages: [] } as WsOutgoing);
       unsubscribe();
 
       socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "buffered" });
@@ -804,6 +805,7 @@ describe("wsTransport", () => {
       MockWebSocket.instances[0]!.open();
       wsTransport.updateCachedHistory("ws-1", {
         type: "history",
+        sessionId: "s1",
         messages: [],
       });
       expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
@@ -814,6 +816,7 @@ describe("wsTransport", () => {
       MockWebSocket.instances[0]!.open();
       wsTransport.updateCachedHistory("ws-1", {
         type: "history",
+        sessionId: "s1",
         messages: [],
       });
       wsTransport.clearCachedData("ws-1");
@@ -826,6 +829,100 @@ describe("wsTransport", () => {
         messages: [],
       });
       expect(wsTransport.hasCachedHistory("unknown")).toBe(false);
+    });
+  });
+
+  describe("per-session history cache", () => {
+    const historyFor = (sessionId: string, text: string): HistoryMessage => ({
+      type: "history",
+      sessionId,
+      messages: [
+        {
+          id: `${sessionId}-m`,
+          sessionId,
+          role: "user",
+          content: text,
+          timestamp: "2026-02-20T00:00:00.000Z",
+        },
+      ],
+    });
+
+    it("caches history per session and replays every session on resubscribe", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+
+      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
+      wsTransport.updateCachedHistory("ws-1", historyFor("sess-2", "two"));
+
+      const replayed: WsOutgoing[] = [];
+      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
+
+      const histories = replayed.filter((m) => m.type === "history");
+      expect(histories).toEqual(expect.arrayContaining([
+        historyFor("sess-1", "one"),
+        historyFor("sess-2", "two"),
+      ]));
+      expect(histories).toHaveLength(2);
+    });
+
+    it("getCachedHistory returns the cached history for a specific session", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+
+      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
+      wsTransport.updateCachedHistory("ws-1", historyFor("sess-2", "two"));
+
+      expect(wsTransport.getCachedHistory("ws-1", "sess-2")).toEqual(historyFor("sess-2", "two"));
+      expect(wsTransport.getCachedHistory("ws-1", "unknown")).toBeUndefined();
+      expect(wsTransport.getCachedHistory("unknown-ws", "sess-1")).toBeUndefined();
+    });
+
+    it("hasCachedHistory is session-specific when a sessionId is given", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+
+      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
+
+      expect(wsTransport.hasCachedHistory("ws-1", "sess-1")).toBe(true);
+      expect(wsTransport.hasCachedHistory("ws-1", "sess-2")).toBe(false);
+      // Without a sessionId it reports whether any session is cached.
+      expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+    });
+
+    it("does not overwrite another session's cache when a new session history arrives", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      socket.hubMessage("ws-1", historyFor("sess-1", "one") as WsOutgoing);
+      socket.hubMessage("ws-1", historyFor("sess-2", "two") as WsOutgoing);
+
+      expect(wsTransport.getCachedHistory("ws-1", "sess-1")).toEqual(historyFor("sess-1", "one"));
+      expect(wsTransport.getCachedHistory("ws-1", "sess-2")).toEqual(historyFor("sess-2", "two"));
+    });
+
+    it("keys incoming history by its first message when no top-level sessionId is present", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      socket.hubMessage("ws-1", {
+        type: "history",
+        messages: [
+          { id: "m1", sessionId: "sess-9", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
+        ],
+      } as WsOutgoing);
+
+      expect(wsTransport.hasCachedHistory("ws-1", "sess-9")).toBe(true);
+    });
+
+    it("ignores session-less history (no sessionId and empty messages)", () => {
+      wsTransport.connect("ws-1");
+      MockWebSocket.instances[0]!.open();
+
+      wsTransport.updateCachedHistory("ws-1", { type: "history", messages: [] });
+
+      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## Problem

Switching the active session **within a workspace** and coming back flashed a full chat reload, while switching **workspace** and back did not. The inconsistency creates UI glitches when bouncing between conversations.

## Root cause

The WS transport cached chat history in a single per-workspace slot (`lastHistory`), and `useConversation`'s subscribe effect (dep `[workspaceId]`) only replayed it on **workspace** switch — never on **session** switch. A session switch cleared `messages` then waited for the async `switch_session` backend round-trip, leaving an empty frame.

Workspace switch-back looked fine because the effect re-ran and replayed the cache synchronously; session switch never re-ran that effect.

## Fix (frontend-only, ~25 prod lines)

- **`ws-transport.ts`**: promote `lastHistory` → `lastHistoryBySession: Map<sessionId, HistoryMessage>` (mirrors the existing `lastStatusBySession` pattern). Adds `getCachedHistory(wsId, sessionId)`, makes `hasCachedHistory` session-aware, and replays every cached session on resubscribe (the reducer's mismatch guard keeps only the active one).
- **`useConversation.ts`**: `switchSession` now dispatches the target session's cached history **synchronously** before the `switch_session` round-trip reconciles. `prepare_session_switch` + the cached `history` dispatch batch into one React commit, so there is no empty render between them.

Reducer untouched. The single-slot cache previously required a defensive workaround (stale-history mismatch); per-session keying removes that class of staleness.

## Verification

- `typecheck` + `lint` clean; full frontend suite **1435 tests pass** (added 6 transport per-session tests + 1 hook test proving synchronous restore; updated tests that relied on session-less caching).
- **Live A/B** against the dev servers with a MutationObserver measuring message count during a switch-back:

  | | min messages during switch-back |
  |---|---|
  | Fix enabled | **16** (18→16, never empties) |
  | Fix disabled (temporary toggle) | **1** (18→1→16 = the flash) |

  The flash reappears exactly when the synchronous replay is removed and disappears when restored — causal, not correlational.

Note: the backend workspace bootstrap already replays history for **all** sessions on subscribe, so the per-session client cache is fully pre-warmed — the data was always there; the old single-slot cache just overwrote it and `switchSession` didn't use it.