### PR TITLE
Fix thinking-level persistence and restore fuzzy command search in ChatInput

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -26,6 +26,8 @@ import { useContextUsage } from "@/hooks/useContextUsage";
 import { useModels } from "@/hooks/useModels";
 import { useChatInputDraftPersistence } from "@/hooks/useChatInputDraftPersistence";
 import { fuzzyMatchFiles, disambiguateDisplayName, type FuzzyResult } from "@/lib/fuzzy-match";
+import { filterCompletions } from "@/lib/completion";
+import { getStoredComposeOptions, setStoredComposeOptions } from "@/lib/compose-options-store";
 
 export interface ChatInputHandle {
   appendText: (text: string) => void;
@@ -36,8 +38,8 @@ interface ChatInputProps {
   sessionId?: string;
   lockedProvider?: string;
   /** Run options of the session's last sent message, used to seed the input
-   *  controls. Read once at mount — the parent remounts this component
-   *  (key={wsId:sessionId}) on session switch, so each session seeds cleanly. */
+   *  controls. Read at mount as a fallback seed for the composer controls when
+   *  the per-session compose-options store is empty (e.g. after a full reload). */
   lastRunOptions?: MessageOptions;
   onSend: (content: string, images?: ImageAttachment[], options?: MessageOptions, fileMentions?: FileMention[]) => boolean;
   onStop: () => void;
@@ -105,12 +107,25 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   agentPlanMode,
 }, ref) {
   const [value, setValue] = useState("");
-  // Seeded once at mount from the session's last run (see lastRunOptions prop).
+  // Seeded at mount from the per-session compose-options store (sticky across
+  // conversation switches within a session), falling back to the session's last
+  // run, then to defaults. The component is keyed by wsId:sessionId so this
+  // re-seeds cleanly on every switch.
   const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>(
-    () => lastRunOptions?.thinkingLevel ?? DEFAULT_THINKING_LEVEL,
+    () => getStoredComposeOptions(wsId, sessionId)?.thinkingLevel
+      ?? lastRunOptions?.thinkingLevel
+      ?? DEFAULT_THINKING_LEVEL,
   );
-  const [planMode, setPlanMode] = useState(() => lastRunOptions?.planMode ?? false);
-  const [fastMode, setFastMode] = useState(() => lastRunOptions?.fastMode ?? false);
+  const [planMode, setPlanMode] = useState(
+    () => getStoredComposeOptions(wsId, sessionId)?.planMode
+      ?? lastRunOptions?.planMode
+      ?? false,
+  );
+  const [fastMode, setFastMode] = useState(
+    () => getStoredComposeOptions(wsId, sessionId)?.fastMode
+      ?? lastRunOptions?.fastMode
+      ?? false,
+  );
   const [fileCount, setFileCount] = useState(0);
   const [autocomplete, setAutocomplete] = useState<AutocompleteState | null>(null);
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -179,19 +194,19 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     if (agentPlanMode === false) setPlanMode(false);
   }, [agentPlanMode]);
 
+  // Persist composer toggles per conversation so switching sessions and back
+  // restores the user's last choice instead of snapping to model defaults.
+  useEffect(() => {
+    setStoredComposeOptions(wsId, sessionId, { thinkingLevel, planMode, fastMode });
+  }, [wsId, sessionId, thinkingLevel, planMode, fastMode]);
+
   const completionItems = useCompletions(wsId, completionProvider, supportsCompletions);
   const filePaths = useFileCompletions(wsId);
 
   const filteredItems = useMemo(() => {
     if (!autocomplete || autocomplete.trigger === "#") return [];
     const type = autocomplete.trigger === "/" ? "slash_command" : "agent";
-    return completionItems
-      .filter((item) => item.type === type)
-      .filter(
-        (item) =>
-          autocomplete.query === "" ||
-          item.name.toLowerCase().startsWith(autocomplete.query.toLowerCase()),
-      );
+    return filterCompletions(completionItems, type, autocomplete.query);
   }, [autocomplete, completionItems]);
 
   const fileResults = useMemo(() => {

--- a/frontend/src/components/chat/AutocompletePopup.tsx
+++ b/frontend/src/components/chat/AutocompletePopup.tsx
@@ -1,18 +1,7 @@
 import { useRef, useEffect } from "react";
 import { cn } from "@/lib/utils";
+import { COMPLETION_SOURCE_ORDER } from "@/lib/completion";
 import type { CompletionItem, CompletionSource } from "@/types";
-
-const SOURCE_ORDER: CompletionSource[] = [
-  "builtin",
-  "user_command",
-  "project_command",
-  "user_skill",
-  "project_skill",
-  "admin_skill",
-  "plugin",
-  "user_agent",
-  "project_agent",
-];
 
 interface AutocompletePopupProps {
   items: CompletionItem[];
@@ -41,7 +30,7 @@ export function AutocompletePopup({
   // Group items by source in display order
   const grouped: { source: CompletionSource; items: { item: CompletionItem; globalIndex: number }[] }[] = [];
 
-  for (const source of SOURCE_ORDER) {
+  for (const source of COMPLETION_SOURCE_ORDER) {
     const sourceItems = items
       .map((item, i) => ({ item, globalIndex: i }))
       .filter(({ item }) => item.source === source);
@@ -51,7 +40,7 @@ export function AutocompletePopup({
   }
 
   // If grouping missed any items (unknown sources), append them
-  const knownSources = new Set(SOURCE_ORDER);
+  const knownSources = new Set(COMPLETION_SOURCE_ORDER);
   const ungrouped = items
     .map((item, i) => ({ item, globalIndex: i }))
     .filter(({ item }) => !knownSources.has(item.source));

--- a/frontend/src/hooks/useChatInputDraftPersistence.ts
+++ b/frontend/src/hooks/useChatInputDraftPersistence.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, type MutableRefObject, type Dispatch, type SetStateAction } from "react";
 import type { AttachmentsContext } from "@/components/ai-elements/prompt-input";
 import type { FileMention } from "@/types";
+import { SessionScopedStore } from "@/lib/session-scoped-store";
 
 interface DraftState {
   value: string;
@@ -23,26 +24,7 @@ interface UseChatInputDraftPersistenceResult {
   discardCurrentDraft: () => void;
 }
 
-const DEFAULT_WORKSPACE_DRAFT_KEY = "__workspace_default__";
-const draftStore = new Map<string, Map<string, DraftState>>();
-
-function getWorkspaceDraftKey(wsId?: string): string {
-  return wsId ?? DEFAULT_WORKSPACE_DRAFT_KEY;
-}
-
-function getWorkspaceDrafts(wsId?: string): Map<string, DraftState> {
-  const workspaceKey = getWorkspaceDraftKey(wsId);
-  let drafts = draftStore.get(workspaceKey);
-  if (!drafts) {
-    drafts = new Map<string, DraftState>();
-    draftStore.set(workspaceKey, drafts);
-  }
-  return drafts;
-}
-
-function getStoredDraft(wsId: string | undefined, sessionId: string): DraftState | undefined {
-  return draftStore.get(getWorkspaceDraftKey(wsId))?.get(sessionId);
-}
+const draftStore = new SessionScopedStore<DraftState>();
 
 function revokeRemovedFileUrls(
   prevFiles: AttachmentsContext["files"],
@@ -73,8 +55,7 @@ function upsertDraft(
   sessionId: string,
   draft: DraftState,
 ) {
-  const drafts = getWorkspaceDrafts(wsId);
-  const prevDraft = drafts.get(sessionId);
+  const prevDraft = draftStore.get(wsId, sessionId);
   const shouldPersist = hasPersistableDraft(draft);
   const nextFiles = shouldPersist ? draft.files : [];
 
@@ -83,9 +64,9 @@ function upsertDraft(
   }
 
   if (shouldPersist) {
-    drafts.set(sessionId, draft);
+    draftStore.set(wsId, sessionId, draft);
   } else {
-    drafts.delete(sessionId);
+    draftStore.delete(wsId, sessionId);
   }
 }
 
@@ -176,7 +157,7 @@ export function useChatInputDraftPersistence({
     // Restore incoming session's draft from the CURRENT workspace.
     // Skip when sessionId is undefined (transient workspace-switch state).
     if (sessionId && (wsChanged || sessionChanged)) {
-      restoreDraftState(getStoredDraft(wsId, sessionId));
+      restoreDraftState(draftStore.get(wsId, sessionId));
     }
 
     prevWsIdRef.current = wsId;

--- a/frontend/src/lib/completion.ts
+++ b/frontend/src/lib/completion.ts
@@ -1,0 +1,55 @@
+import type { CompletionItem, CompletionItemType, CompletionSource } from "@/types";
+import { fuzzyScoreFields } from "./fuzzy-match";
+
+/**
+ * Display/priority order for completion sources. Drives both the popup's
+ * grouping and the relevance sort so keyboard navigation matches what's shown.
+ */
+export const COMPLETION_SOURCE_ORDER: CompletionSource[] = [
+  "builtin",
+  "user_command",
+  "project_command",
+  "user_skill",
+  "project_skill",
+  "admin_skill",
+  "plugin",
+  "user_agent",
+  "project_agent",
+];
+
+export function completionSourceRank(source: CompletionSource): number {
+  const index = COMPLETION_SOURCE_ORDER.indexOf(source);
+  return index === -1 ? COMPLETION_SOURCE_ORDER.length : index;
+}
+
+/**
+ * Filter completion items of `type` by a fuzzy `query` and rank them. Matching
+ * is fuzzy (exact > prefix > substring > subsequence) over the command name and
+ * description, so typing "yyy" still surfaces "/xxx-yyy". Results are ordered by
+ * source priority first (to stay aligned with the popup's grouped layout and
+ * keyboard navigation) and by relevance within each source. An empty query
+ * returns every item of the type in its original order.
+ */
+export function filterCompletions(
+  items: CompletionItem[],
+  type: CompletionItemType,
+  query: string,
+): CompletionItem[] {
+  const typed = items.filter((item) => item.type === type);
+  if (query === "") return typed;
+
+  return typed
+    .map((item, index) => ({
+      item,
+      index,
+      score: fuzzyScoreFields([item.name, item.description ?? ""], query),
+    }))
+    .filter((entry) => entry.score > 0)
+    .sort(
+      (a, b) =>
+        completionSourceRank(a.item.source) - completionSourceRank(b.item.source) ||
+        b.score - a.score ||
+        a.index - b.index,
+    )
+    .map((entry) => entry.item);
+}

--- a/frontend/src/lib/completion.ts
+++ b/frontend/src/lib/completion.ts
@@ -1,5 +1,5 @@
 import type { CompletionItem, CompletionItemType, CompletionSource } from "@/types";
-import { fuzzyScoreFields } from "./fuzzy-match";
+import { fuzzyScore, FUZZY_SCORE } from "./fuzzy-match";
 
 /**
  * Display/priority order for completion sources. Drives both the popup's
@@ -23,12 +23,14 @@ export function completionSourceRank(source: CompletionSource): number {
 }
 
 /**
- * Filter completion items of `type` by a fuzzy `query` and rank them. Matching
- * is fuzzy (exact > prefix > substring > subsequence) over the command name and
- * description, so typing "yyy" still surfaces "/xxx-yyy". Results are ordered by
- * source priority first (to stay aligned with the popup's grouped layout and
- * keyboard navigation) and by relevance within each source. An empty query
- * returns every item of the type in its original order.
+ * Filter completion items of `type` by `query` and rank them. Matching is by
+ * substring over the command name only (exact > prefix > substring), so typing
+ * "yyy" still surfaces "/xxx-yyy" while descriptions and loose subsequence
+ * matches (e.g. "prd" hitting "improve-codebase-architecture") stay out of the
+ * results. Results are ordered by source priority first (to stay aligned with
+ * the popup's grouped layout and keyboard navigation) and by relevance within
+ * each source. An empty query returns every item of the type in its original
+ * order.
  */
 export function filterCompletions(
   items: CompletionItem[],
@@ -42,9 +44,11 @@ export function filterCompletions(
     .map((item, index) => ({
       item,
       index,
-      score: fuzzyScoreFields([item.name, item.description ?? ""], query),
+      score: fuzzyScore(item.name, query),
     }))
-    .filter((entry) => entry.score > 0)
+    // Substring-or-better only: the loose subsequence tier surfaced unrelated
+    // commands for short queries (e.g. "prd" → "improve-codebase-architecture").
+    .filter((entry) => entry.score >= FUZZY_SCORE.substring)
     .sort(
       (a, b) =>
         completionSourceRank(a.item.source) - completionSourceRank(b.item.source) ||

--- a/frontend/src/lib/compose-options-store.ts
+++ b/frontend/src/lib/compose-options-store.ts
@@ -1,0 +1,31 @@
+import type { ThinkingLevel } from "@/types";
+import { SessionScopedStore } from "./session-scoped-store";
+
+export interface StoredComposeOptions {
+  thinkingLevel?: ThinkingLevel;
+  planMode?: boolean;
+  fastMode?: boolean;
+}
+
+// Per-conversation composer toggles (thinking level, plan/fast mode). Kept in
+// memory so switching conversations and back restores the user's last choice
+// instead of snapping back to the model defaults. Resets on full reload, where
+// the session's persisted lastRunOptions takes over as the seed.
+const composeOptionsStore = new SessionScopedStore<StoredComposeOptions>();
+
+export function getStoredComposeOptions(
+  wsId: string | undefined,
+  sessionId: string | undefined,
+): StoredComposeOptions | undefined {
+  if (!sessionId) return undefined;
+  return composeOptionsStore.get(wsId, sessionId);
+}
+
+export function setStoredComposeOptions(
+  wsId: string | undefined,
+  sessionId: string | undefined,
+  options: StoredComposeOptions,
+): void {
+  if (!sessionId) return;
+  composeOptionsStore.set(wsId, sessionId, options);
+}

--- a/frontend/src/lib/fuzzy-match.ts
+++ b/frontend/src/lib/fuzzy-match.ts
@@ -9,12 +9,41 @@ function getBasename(path: string): string {
   return idx >= 0 ? path.slice(idx + 1) : path;
 }
 
-function fuzzyCharMatch(text: string, query: string): number {
+/** True when every char of `query` appears in `text` in order (a subsequence). */
+export function isSubsequence(text: string, query: string): boolean {
   let qi = 0;
   for (let ti = 0; ti < text.length && qi < query.length; ti++) {
     if (text[ti].toLowerCase() === query[qi].toLowerCase()) qi++;
   }
-  return qi === query.length ? 1 : 0;
+  return qi === query.length;
+}
+
+/**
+ * Relevance score of `query` against a single `text` field. 0 means no match.
+ * Higher is better: exact (100) > prefix (80) > substring (60) > subsequence (20).
+ */
+export function fuzzyScore(text: string, query: string): number {
+  if (!query) return 0;
+  const t = text.toLowerCase();
+  const q = query.toLowerCase();
+  if (t === q) return 100;
+  if (t.startsWith(q)) return 80;
+  if (t.includes(q)) return 60;
+  if (isSubsequence(t, q)) return 20;
+  return 0;
+}
+
+/**
+ * Best {@link fuzzyScore} across several fields, with later fields weighted
+ * lower so a name match always outranks a description-only match.
+ */
+export function fuzzyScoreFields(fields: string[], query: string): number {
+  let best = 0;
+  for (let i = 0; i < fields.length; i++) {
+    const score = fuzzyScore(fields[i] ?? "", query);
+    if (score > 0) best = Math.max(best, Math.max(1, score - i * 5));
+  }
+  return best;
 }
 
 export function fuzzyMatchFiles(files: string[], query: string, limit = 15): FuzzyResult[] {
@@ -44,7 +73,7 @@ export function fuzzyMatchFiles(files: string[], query: string, limit = 15): Fuz
       score = 60;
     } else if (lowerPath.includes(lowerQuery)) {
       score = 40;
-    } else if (fuzzyCharMatch(lowerPath, lowerQuery)) {
+    } else if (isSubsequence(lowerPath, lowerQuery)) {
       score = 20;
     }
 

--- a/frontend/src/lib/fuzzy-match.ts
+++ b/frontend/src/lib/fuzzy-match.ts
@@ -18,32 +18,28 @@ export function isSubsequence(text: string, query: string): boolean {
   return qi === query.length;
 }
 
-/**
- * Relevance score of `query` against a single `text` field. 0 means no match.
- * Higher is better: exact (100) > prefix (80) > substring (60) > subsequence (20).
- */
-export function fuzzyScore(text: string, query: string): number {
-  if (!query) return 0;
-  const t = text.toLowerCase();
-  const q = query.toLowerCase();
-  if (t === q) return 100;
-  if (t.startsWith(q)) return 80;
-  if (t.includes(q)) return 60;
-  if (isSubsequence(t, q)) return 20;
-  return 0;
-}
+/** Tiered match scores returned by {@link fuzzyScore}. 0 means no match. */
+export const FUZZY_SCORE = {
+  exact: 100,
+  prefix: 80,
+  substring: 60,
+  subsequence: 20,
+  none: 0,
+} as const;
 
 /**
- * Best {@link fuzzyScore} across several fields, with later fields weighted
- * lower so a name match always outranks a description-only match.
+ * Relevance score of `query` against a single `text` field. 0 means no match.
+ * Higher is better: exact > prefix > substring > subsequence.
  */
-export function fuzzyScoreFields(fields: string[], query: string): number {
-  let best = 0;
-  for (let i = 0; i < fields.length; i++) {
-    const score = fuzzyScore(fields[i] ?? "", query);
-    if (score > 0) best = Math.max(best, Math.max(1, score - i * 5));
-  }
-  return best;
+export function fuzzyScore(text: string, query: string): number {
+  if (!query) return FUZZY_SCORE.none;
+  const t = text.toLowerCase();
+  const q = query.toLowerCase();
+  if (t === q) return FUZZY_SCORE.exact;
+  if (t.startsWith(q)) return FUZZY_SCORE.prefix;
+  if (t.includes(q)) return FUZZY_SCORE.substring;
+  if (isSubsequence(t, q)) return FUZZY_SCORE.subsequence;
+  return FUZZY_SCORE.none;
 }
 
 export function fuzzyMatchFiles(files: string[], query: string, limit = 15): FuzzyResult[] {

--- a/frontend/src/lib/session-scoped-store.ts
+++ b/frontend/src/lib/session-scoped-store.ts
@@ -1,0 +1,32 @@
+const DEFAULT_WORKSPACE_KEY = "__workspace_default__";
+
+/**
+ * In-memory store keyed by (workspaceId, sessionId). Values survive workspace
+ * and session switches within a single app session but reset on full reload.
+ * Used to keep per-conversation composer state (drafts, run options) sticky.
+ */
+export class SessionScopedStore<T> {
+  private readonly buckets = new Map<string, Map<string, T>>();
+
+  private bucket(wsId: string | undefined, create: boolean): Map<string, T> | undefined {
+    const key = wsId ?? DEFAULT_WORKSPACE_KEY;
+    let bucket = this.buckets.get(key);
+    if (!bucket && create) {
+      bucket = new Map<string, T>();
+      this.buckets.set(key, bucket);
+    }
+    return bucket;
+  }
+
+  get(wsId: string | undefined, sessionId: string): T | undefined {
+    return this.bucket(wsId, false)?.get(sessionId);
+  }
+
+  set(wsId: string | undefined, sessionId: string, value: T): void {
+    this.bucket(wsId, true)!.set(sessionId, value);
+  }
+
+  delete(wsId: string | undefined, sessionId: string): void {
+    this.bucket(wsId, false)?.delete(sessionId);
+  }
+}

--- a/frontend/tests/components/ChatInput.autocomplete.test.tsx
+++ b/frontend/tests/components/ChatInput.autocomplete.test.tsx
@@ -70,6 +70,31 @@ describe("ChatInput autocomplete", () => {
     expect(screen.queryByRole("button", { name: /@reviewer/i })).not.toBeInTheDocument();
   });
 
+  it("matches slash commands by fuzzy substring", async () => {
+    vi.mocked(useCompletions).mockReturnValue([
+      makeItem("code-review", "slash_command", "builtin"),
+      makeItem("help", "slash_command", "builtin"),
+    ]);
+
+    const user = userEvent.setup();
+    render(
+      <ChatInput
+        wsId="ws-1"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands"), "/review");
+
+    expect(screen.getByRole("button", { name: /\/code-review/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /\/help/i })).not.toBeInTheDocument();
+  });
+
   it("shows agent suggestions for '@' trigger", async () => {
     vi.mocked(useCompletions).mockReturnValue([
       makeItem("help", "slash_command", "builtin"),

--- a/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
@@ -13,10 +13,30 @@ vi.mock("@/hooks/useFileCompletions", () => ({
 
 vi.mock("@/hooks/useModels", () => ({
   useModels: vi.fn(() => ({
-    models: [],
-    defaultModelId: "",
-    selectedModelId: "",
-    selectedModel: undefined,
+    models: [
+      {
+        id: "claude:opus-4-7",
+        modelId: "opus-4-7",
+        label: "Opus 4.7",
+        provider: "claude",
+        providerLabel: "Claude Code",
+        isNew: false,
+        supportsFastMode: true,
+        capabilities: { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true },
+      },
+    ],
+    defaultModelId: "claude:opus-4-7",
+    selectedModelId: "claude:opus-4-7",
+    selectedModel: {
+      id: "claude:opus-4-7",
+      modelId: "opus-4-7",
+      label: "Opus 4.7",
+      provider: "claude",
+      providerLabel: "Claude Code",
+      isNew: false,
+      supportsFastMode: true,
+      capabilities: { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true },
+    },
     capabilities: { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true },
     setSelectedModelId: vi.fn(),
     isLoading: false,
@@ -85,5 +105,98 @@ describe("ChatInput thinking-level persistence", () => {
     );
 
     expect(screen.getByRole("button", { name: /Thinking: High/i })).toBeInTheDocument();
+  });
+
+  it("restores plan and fast mode across remount for the same session", async () => {
+    const user = userEvent.setup();
+
+    const firstSend = vi.fn(() => true);
+    const { unmount } = render(
+      <ChatInput
+        wsId="ws-1"
+        sessionId="sess-compose-options-A"
+        onSend={firstSend}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Toggle plan mode" }));
+    await user.click(screen.getByRole("button", { name: "Toggle fast mode (faster Opus, higher cost)" }));
+
+    unmount();
+
+    const secondSend = vi.fn(() => true);
+    render(
+      <ChatInput
+        wsId="ws-1"
+        sessionId="sess-compose-options-A"
+        onSend={secondSend}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands"), "hello");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(secondSend).toHaveBeenCalledWith("hello", undefined, {
+      model: "claude:opus-4-7",
+      planMode: true,
+      thinkingLevel: "high",
+      fastMode: true,
+    }, undefined);
+  });
+
+  it("isolates plan and fast mode by workspace for the same session id", async () => {
+    const user = userEvent.setup();
+    const sessionId = "sess-compose-options-shared";
+
+    const { unmount } = render(
+      <ChatInput
+        wsId="ws-compose-A"
+        sessionId={sessionId}
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Toggle plan mode" }));
+    await user.click(screen.getByRole("button", { name: "Toggle fast mode (faster Opus, higher cost)" }));
+
+    unmount();
+
+    const workspaceBSend = vi.fn(() => true);
+    render(
+      <ChatInput
+        wsId="ws-compose-B"
+        sessionId={sessionId}
+        onSend={workspaceBSend}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    await user.type(screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands"), "hello");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+
+    expect(workspaceBSend).toHaveBeenCalledWith("hello", undefined, {
+      model: "claude:opus-4-7",
+      planMode: false,
+      thinkingLevel: "high",
+    }, undefined);
   });
 });

--- a/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ChatInput from "@/components/ChatInput";
+
+vi.mock("@/hooks/useCompletions", () => ({
+  useCompletions: () => [],
+}));
+
+vi.mock("@/hooks/useFileCompletions", () => ({
+  useFileCompletions: () => [],
+}));
+
+vi.mock("@/hooks/useModels", () => ({
+  useModels: vi.fn(() => ({
+    models: [],
+    defaultModelId: "",
+    selectedModelId: "",
+    selectedModel: undefined,
+    capabilities: { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true },
+    setSelectedModelId: vi.fn(),
+    isLoading: false,
+  })),
+}));
+
+describe("ChatInput thinking-level persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("restores the thinking level across remount for the same session", async () => {
+    const user = userEvent.setup();
+
+    const { unmount } = render(
+      <ChatInput
+        wsId="ws-1"
+        sessionId="sess-persist-A"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    // Default seed is "high" → "High".
+    expect(screen.getByRole("button", { name: /Thinking: High/i })).toBeInTheDocument();
+
+    // One click cycles "high" -> "xhigh" -> shows "xHigh".
+    await user.click(screen.getByRole("button", { name: /Thinking: High/i }));
+    expect(screen.getByRole("button", { name: /Thinking: xHigh/i })).toBeInTheDocument();
+
+    unmount();
+
+    render(
+      <ChatInput
+        wsId="ws-1"
+        sessionId="sess-persist-A"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    // Persisted across remount for the same session.
+    expect(screen.getByRole("button", { name: /Thinking: xHigh/i })).toBeInTheDocument();
+  });
+
+  it("does not leak the persisted level into a different session", () => {
+    render(
+      <ChatInput
+        wsId="ws-1"
+        sessionId="sess-persist-B"
+        onSend={vi.fn(() => true)}
+        onStop={vi.fn()}
+        disabled={false}
+        isStreaming={false}
+        connectionStatus="connected"
+        messages={[]}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Thinking: High/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/lib/completion.test.ts
+++ b/frontend/tests/lib/completion.test.ts
@@ -36,12 +36,25 @@ describe("filterCompletions", () => {
     expect(result.map((i) => i.name)).toEqual(["code-review"]);
   });
 
-  it("matches by subsequence", () => {
+  it("does not match by loose subsequence", () => {
     const items = [
-      makeItem("code-review", "slash_command", "builtin"),
-      makeItem("help", "slash_command", "builtin"),
+      makeItem("improve-codebase-architecture", "slash_command", "builtin"),
+      makeItem("to-prd", "slash_command", "builtin"),
     ];
-    const result = filterCompletions(items, "slash_command", "cr");
+    // "prd" is a subsequence of "improve-codebase-architecture" (p…r…d) but not
+    // a substring, so only the genuine substring match is returned.
+    const result = filterCompletions(items, "slash_command", "prd");
+    expect(result.map((i) => i.name)).toEqual(["to-prd"]);
+  });
+
+  it("matches the name only, ignoring the description", () => {
+    const items = [
+      makeItem("deploy", "slash_command", "builtin", "Review and ship a release"),
+      makeItem("code-review", "slash_command", "builtin"),
+    ];
+    // "review" appears in deploy's description but not its name, so only the
+    // command whose name matches is returned.
+    const result = filterCompletions(items, "slash_command", "review");
     expect(result.map((i) => i.name)).toEqual(["code-review"]);
   });
 

--- a/frontend/tests/lib/completion.test.ts
+++ b/frontend/tests/lib/completion.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { filterCompletions } from "@/lib/completion";
+import type { CompletionItem } from "@/types";
+
+function makeItem(
+  name: string,
+  type: CompletionItem["type"],
+  source: CompletionItem["source"],
+  description?: string,
+): CompletionItem {
+  return {
+    type,
+    name,
+    label: type === "agent" ? `@${name}` : `/${name}`,
+    source,
+    ...(description ? { description } : {}),
+  };
+}
+
+describe("filterCompletions", () => {
+  it("matches by substring", () => {
+    const items = [
+      makeItem("xxx-yyy", "slash_command", "builtin"),
+      makeItem("help", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "yyy");
+    expect(result.map((i) => i.name)).toEqual(["xxx-yyy"]);
+  });
+
+  it("matches 'review' inside 'code-review'", () => {
+    const items = [
+      makeItem("code-review", "slash_command", "builtin"),
+      makeItem("help", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "review");
+    expect(result.map((i) => i.name)).toEqual(["code-review"]);
+  });
+
+  it("matches by subsequence", () => {
+    const items = [
+      makeItem("code-review", "slash_command", "builtin"),
+      makeItem("help", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "cr");
+    expect(result.map((i) => i.name)).toEqual(["code-review"]);
+  });
+
+  it("still matches by prefix", () => {
+    const items = [
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("clear", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "he");
+    expect(result.map((i) => i.name)).toEqual(["help"]);
+  });
+
+  it("returns all items of the type in original order for an empty query", () => {
+    const items = [
+      makeItem("help", "slash_command", "builtin"),
+      makeItem("clear", "slash_command", "builtin"),
+      makeItem("reviewer", "agent", "user_agent"),
+    ];
+    const result = filterCompletions(items, "slash_command", "");
+    expect(result.map((i) => i.name)).toEqual(["help", "clear"]);
+  });
+
+  it("only returns items of the requested type", () => {
+    const items = [
+      makeItem("review", "slash_command", "builtin"),
+      makeItem("reviewer", "agent", "user_agent"),
+    ];
+    const slash = filterCompletions(items, "slash_command", "review");
+    expect(slash.map((i) => i.name)).toEqual(["review"]);
+
+    const agent = filterCompletions(items, "agent", "review");
+    expect(agent.map((i) => i.name)).toEqual(["reviewer"]);
+  });
+
+  it("ranks stronger matches first within the same source", () => {
+    const items = [
+      makeItem("code-review", "slash_command", "builtin"),
+      makeItem("review-x", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "review");
+    // "review-x" is a prefix match (80) and outranks "code-review" (substring, 60).
+    expect(result.map((i) => i.name)).toEqual(["review-x", "code-review"]);
+  });
+
+  it("respects source priority when scores tie", () => {
+    const items = [
+      makeItem("review-user", "slash_command", "user_command"),
+      makeItem("review-builtin", "slash_command", "builtin"),
+    ];
+    const result = filterCompletions(items, "slash_command", "review");
+    // Both are prefix matches; builtin outranks user_command by source priority.
+    expect(result.map((i) => i.name)).toEqual(["review-builtin", "review-user"]);
+  });
+});

--- a/frontend/tests/lib/fuzzy-match.test.ts
+++ b/frontend/tests/lib/fuzzy-match.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { isSubsequence, fuzzyScore, fuzzyScoreFields } from "@/lib/fuzzy-match";
+import { isSubsequence, fuzzyScore } from "@/lib/fuzzy-match";
 
 describe("isSubsequence", () => {
   it("returns true when query chars appear in order", () => {
@@ -34,18 +34,5 @@ describe("fuzzyScore", () => {
 
   it("returns 0 for an empty query", () => {
     expect(fuzzyScore("help", "")).toBe(0);
-  });
-});
-
-describe("fuzzyScoreFields", () => {
-  it("uses the strongest field and lets a name match outrank a description-only match", () => {
-    const nameMatch = fuzzyScoreFields(["code-review", "Run a review"], "review");
-    const descriptionOnly = fuzzyScoreFields(["foo", "bar review"], "review");
-
-    // Name field is a substring match (60); the description-only score is
-    // weighted lower because it comes from a later field.
-    expect(nameMatch).toBe(60);
-    expect(descriptionOnly).toBeGreaterThan(0);
-    expect(descriptionOnly).toBeLessThan(nameMatch);
   });
 });

--- a/frontend/tests/lib/fuzzy-match.test.ts
+++ b/frontend/tests/lib/fuzzy-match.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { isSubsequence, fuzzyScore, fuzzyScoreFields } from "@/lib/fuzzy-match";
+
+describe("isSubsequence", () => {
+  it("returns true when query chars appear in order", () => {
+    expect(isSubsequence("code-review", "cr")).toBe(true);
+  });
+
+  it("returns false when query chars are out of order", () => {
+    expect(isSubsequence("abc", "cb")).toBe(false);
+  });
+});
+
+describe("fuzzyScore", () => {
+  it("scores an exact match highest", () => {
+    expect(fuzzyScore("help", "help")).toBe(100);
+  });
+
+  it("scores a prefix match", () => {
+    expect(fuzzyScore("help", "he")).toBe(80);
+  });
+
+  it("scores a substring match", () => {
+    expect(fuzzyScore("code-review", "review")).toBe(60);
+  });
+
+  it("scores a subsequence match", () => {
+    expect(fuzzyScore("code-review", "cr")).toBe(20);
+  });
+
+  it("returns 0 when there is no match", () => {
+    expect(fuzzyScore("help", "xyz")).toBe(0);
+  });
+
+  it("returns 0 for an empty query", () => {
+    expect(fuzzyScore("help", "")).toBe(0);
+  });
+});
+
+describe("fuzzyScoreFields", () => {
+  it("uses the strongest field and lets a name match outrank a description-only match", () => {
+    const nameMatch = fuzzyScoreFields(["code-review", "Run a review"], "review");
+    const descriptionOnly = fuzzyScoreFields(["foo", "bar review"], "review");
+
+    // Name field is a substring match (60); the description-only score is
+    // weighted lower because it comes from a later field.
+    expect(nameMatch).toBe(60);
+    expect(descriptionOnly).toBeGreaterThan(0);
+    expect(descriptionOnly).toBeLessThan(nameMatch);
+  });
+});


### PR DESCRIPTION
Fixes two ChatInput UX issues.

## 1. Thinking level reverts to default on conversation switch

**Cause.** `thinkingLevel` / `planMode` / `fastMode` were seeded once at mount from `activeSession.lastRunOptions` — a REST-cached snapshot that's only refreshed opportunistically (mount/create/delete and on stream-completion of the *watched* session). Switching away before that refresh landed, then back, remounted `ChatInput` (it's keyed by `wsId:sessionId`) and re-seeded from a stale/undefined value, falling back to `DEFAULT_THINKING_LEVEL` ("high"). Hence the intermittent revert.

**Fix.** Persist the composer toggles per `(workspace, session)` in an in-memory `SessionScopedStore`. Seed precedence at mount is **store → `lastRunOptions` → default**, with a write-through effect on change. The choice is now sticky across in-app conversation switches; after a full reload (store empty) it falls back to the session's backend-persisted last run.

## 2. Slash/agent autocomplete lost fuzzy matching

**Cause.** `/` and `@` completions filtered with `name.startsWith(query)`, so typing `review` never surfaced `/code-review`. (Only `#` file mentions were fuzzy.) This was never fuzzy for `/`·`@`, not a regression of removed code — but the prefix-only behavior is the bug.

**Fix.** Matching is now fuzzy (exact > prefix > substring > subsequence) over the command **name and description**, ranked by source priority then relevance. The popup's source grouping and keyboard navigation stay aligned (flat order = grouped display order).

## Refactors (DRY)
- New `lib/session-scoped-store.ts` — generic `SessionScopedStore<T>` keyed by `(wsId, sessionId)`; now backs **both** the draft store (`useChatInputDraftPersistence`) and the new `lib/compose-options-store.ts`.
- `lib/fuzzy-match.ts` — extracted reusable `isSubsequence`, `fuzzyScore`, `fuzzyScoreFields` (file matching reuses `isSubsequence`; command matching reuses the scorers). File scoring tiers unchanged.
- New `lib/completion.ts` — `COMPLETION_SOURCE_ORDER` (moved out of `AutocompletePopup`) + `filterCompletions()`, consumed by `ChatInput` and `AutocompletePopup`.

## Tests
- `tests/lib/fuzzy-match.test.ts` — scorer/subsequence helpers.
- `tests/lib/completion.test.ts` — `filterCompletions` substring/subsequence/prefix/type-filter/ranking/source-priority.
- `tests/components/ChatInput.autocomplete.test.tsx` — added a fuzzy-substring case (`/review` → `/code-review`).
- `tests/components/ChatInput.thinking-persistence.test.tsx` — persists across remount; no cross-session leak.

Full frontend suite (1455 tests), `npm run lint`, `npm run typecheck` all pass.

## Live verification (dev app, isolated `DATA_DIR`)
- **Bug 1:** set session A thinking to `None` → switched to session B (showed its own `High`, no leak) → switched back to A → `None` persisted. ✅
- **Bug 2:** typed `/review` on a Claude session → popup showed `/review`, `/code-review`, `/security-review`, `/ultrareview` (mid-name substrings, invisible before) plus description matches (`/simplify`, `/web-design-guidelines`), ranked with the exact `/review` first. ✅