### PR TITLE
Bound agent command output to prevent OOM crash

### DIFF
--- a/backend/ecosystem.config.cjs
+++ b/backend/ecosystem.config.cjs
@@ -3,6 +3,9 @@ module.exports = {
     name: "hive-backend",
     script: "dist/index.js",
     node_args: "--enable-source-maps",
+    // Safety net: PM2 restarts the process if RSS exceeds this, before V8's
+    // heap limit triggers a fatal OOM. Keep it below the Node heap limit.
+    max_memory_restart: "3G",
     env_production: {
       NODE_ENV: "production",
       HOST: "0.0.0.0",

--- a/backend/src/agents/bounded-output.ts
+++ b/backend/src/agents/bounded-output.ts
@@ -1,0 +1,20 @@
+export const MAX_AGENT_OUTPUT_CHARS = 128 * 1024;
+
+function truncationPrefix(): string {
+  return "[Output truncated by Hive; showing the tail.]\n";
+}
+
+export function boundAgentOutput(output: string | undefined, maxChars = MAX_AGENT_OUTPUT_CHARS): string | undefined {
+  if (output === undefined || output.length <= maxChars) return output;
+  const prefix = truncationPrefix();
+  const tailLength = Math.max(0, maxChars - prefix.length);
+  return `${prefix}${output.slice(-tailLength)}`;
+}
+
+export function appendBoundedAgentOutput(
+  current: string | undefined,
+  delta: string,
+  maxChars = MAX_AGENT_OUTPUT_CHARS,
+): string {
+  return boundAgentOutput(`${current ?? ""}${delta}`, maxChars) ?? "";
+}

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -12,6 +12,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { spawn } from "node:child_process";
+import { MAX_AGENT_OUTPUT_CHARS } from "./bounded-output.js";
 import { ConversationSession } from "./conversation-session.js";
 import * as providerRegistry from "./providers/registry.js";
 import { createAgentRunner, type AgentRunnerFactory } from "./runners/factory.js";
@@ -620,6 +621,64 @@ describe("ConversationSession", () => {
         durationMs: 123,
       },
     ]);
+  });
+
+  it("bounds large command outputs before streaming and persistence", async () => {
+    const largeOutput = "x".repeat(MAX_AGENT_OUTPUT_CHARS + 2048);
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "command_execution_updated",
+        id: "cmd-large",
+        command: "cat huge.log",
+        cwd: "/tmp/test",
+        status: "completed",
+        output: largeOutput,
+        exitCode: 0,
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-large", duration_ms: 12 });
+      fakeRunner.emit("exit", 0, "provider-large");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-large",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "large-command-output-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Read huge log");
+
+    await waitForMessages(messages, "done");
+    const toolResult = messages.find((msg) => msg.type === "tool_result");
+    const activity = messages.find((msg) => msg.type === "agent_activity");
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const persistedOutput = assistant?.toolCalls?.[0]?.output;
+    const persistedActivity = assistant?.agentActivities?.[0];
+
+    expect(toolResult?.type === "tool_result" ? toolResult.output : "").toContain("Output truncated by Hive");
+    expect(toolResult?.type === "tool_result" ? toolResult.output.length : 0).toBeLessThanOrEqual(MAX_AGENT_OUTPUT_CHARS);
+    expect(activity?.type === "agent_activity" && activity.activity.kind === "command_execution"
+      ? activity.activity.output
+      : "").toContain("Output truncated by Hive");
+    expect(persistedOutput).toContain("Output truncated by Hive");
+    expect(persistedOutput?.length).toBeLessThanOrEqual(MAX_AGENT_OUTPUT_CHARS);
+    expect(persistedActivity?.kind === "command_execution" ? persistedActivity.output : "").toContain("Output truncated by Hive");
   });
 
   it("preserves multi-file change activity details and persists them across reload", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -6,6 +6,7 @@ import { workspaceFileRawPath } from "@hive/shared/workspace-files";
 import { nanoid } from "nanoid";
 import sharp from "sharp";
 import { AgentEventNormalizer, type NormalizedAgentEvent } from "./agent-event-normalizer.js";
+import { appendBoundedAgentOutput, boundAgentOutput } from "./bounded-output.js";
 import type { CodexGoalResult, CodexGoalSetParams, CodexGoalStatus } from "./providers/codex-app-server.js";
 import { resolveProvider } from "./providers/registry.js";
 import type { AgentProvider } from "./providers/types.js";
@@ -1086,13 +1087,14 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   private completeToolCall(id: string, output: string): void {
+    const boundedOutput = boundAgentOutput(output) ?? "";
     const tc = this._streamToolCalls.find((t) => t.id === id);
-    if (tc) tc.output = output;
+    if (tc) tc.output = boundedOutput;
     this.emit("message", {
       type: "tool_result",
       sessionId: this.sessionId,
       toolUseId: id,
-      output,
+      output: boundedOutput,
     });
   }
 
@@ -1117,9 +1119,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
         activity.id === event.id && activity.kind === "command_execution",
     );
     const output = event.output !== undefined
-      ? event.output
+      ? boundAgentOutput(event.output)
       : event.outputDelta !== undefined
-        ? `${existingActivity?.output ?? ""}${event.outputDelta}`
+        ? appendBoundedAgentOutput(existingActivity?.output, event.outputDelta)
         : existingActivity?.output;
     const commandActions = event.commandActions ?? existingActivity?.commandActions;
     const activity = {
@@ -1153,7 +1155,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     }
 
     const tc = this._streamToolCalls.find((t) => t.id === event.id);
-    const nextOutput = event.output ?? `${tc?.output ?? ""}${event.outputDelta ?? ""}`;
+    const nextOutput = event.output !== undefined
+      ? boundAgentOutput(event.output) ?? ""
+      : appendBoundedAgentOutput(tc?.output, event.outputDelta ?? "");
     if (event.outputDelta !== undefined || event.output !== undefined || event.exitCode !== undefined) {
       this.completeToolCall(event.id, nextOutput || formatNormalizedExitCode(event.exitCode));
     }
@@ -1164,7 +1168,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       (activity): activity is Extract<AgentActivity, { kind: "file_change" }> =>
         activity.id === event.id && activity.kind === "file_change",
     );
-    const files = normalizeActivityFiles(event, existingActivity?.files);
+    const files = normalizeActivityFiles(event, existingActivity?.files)
+      .map((file) => ({ ...file, diff: boundAgentOutput(file.diff) }));
     this.upsertAgentActivity({
       id: event.id,
       kind: "file_change",
@@ -1172,10 +1177,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       files,
     });
 
-    const combinedDiff = files.map((file) => file.diff).filter(Boolean).join("\n");
+    const combinedDiff = boundAgentOutput(files.map((file) => file.diff).filter(Boolean).join("\n")) ?? "";
     const input = JSON.stringify({
       filename: files[0]?.path ?? event.path ?? "",
-      diff: combinedDiff || event.diff || "",
+      diff: combinedDiff || boundAgentOutput(event.diff) || "",
       status: event.status,
       files,
     });

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -7,6 +7,7 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { spawn } from "node:child_process";
+import { MAX_AGENT_OUTPUT_CHARS } from "../bounded-output.js";
 import { CodexAppServerSession } from "./codex-app-server.js";
 
 const mockSpawn = vi.mocked(spawn);
@@ -2464,6 +2465,29 @@ describe("CodexAppServerSession normalized events", () => {
         steps: [{ text: "Run tests", status: "completed" }],
       },
     ]);
+  });
+
+  it("bounds the accumulated command output before emitting it", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    const largeOutput = "x".repeat(MAX_AGENT_OUTPUT_CHARS + 2048);
+    proc._stdout.push(JSON.stringify({
+      method: "item/commandExecution/outputDelta",
+      params: { itemId: "cmd-large", delta: largeOutput },
+    }) + "\n");
+
+    const event = events.find((entry) =>
+      (entry as { type?: string; id?: string }).type === "command_execution_updated" &&
+      (entry as { id?: string }).id === "cmd-large"
+    ) as { output?: string; outputDelta?: string } | undefined;
+
+    expect(event?.output).toContain("Output truncated by Hive");
+    expect(event?.output?.length).toBeLessThanOrEqual(MAX_AGENT_OUTPUT_CHARS);
   });
 
   it("ignores plan updates from sub-agent threads", async () => {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -5,6 +5,7 @@ import {
   normalizeAgentActivityCommandActions,
   type AgentActivityCommandAction,
 } from "@hive/shared/agent-activity";
+import { appendBoundedAgentOutput, boundAgentOutput } from "../bounded-output.js";
 import type { NormalizedAgentEvent } from "../agent-event-normalizer.js";
 import type { StreamParserEvent } from "../stream-parser.js";
 import type { ThinkingLevel } from "./types.js";
@@ -644,7 +645,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         const delta = asString(data?.delta);
         if (itemId && delta) {
           const parentToolUseId = this.parentToolUseIdForThread(asString(data?.threadId)) ?? this.toolParentByItemId.get(itemId);
-          const next = `${this.commandOutputs.get(itemId) ?? ""}${delta}`;
+          const next = appendBoundedAgentOutput(this.commandOutputs.get(itemId), delta);
           this.commandOutputs.set(itemId, next);
           if (parentToolUseId) break;
           this.emit("agent_event", {
@@ -664,12 +665,13 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         const itemId = asString(data?.itemId);
         const changes = asArray(data?.changes) as FileUpdateChange[] | undefined;
         if (itemId && changes) {
+          const boundedChanges = boundFileChanges(changes);
           const parentToolUseId = this.parentToolUseIdForThread(asString(data?.threadId)) ?? this.toolParentByItemId.get(itemId);
-          this.fileChanges.set(itemId, changes);
+          this.fileChanges.set(itemId, boundedChanges);
           if (parentToolUseId) {
-            this.emitChildFileChangeTools(itemId, changes, undefined, "started", parentToolUseId);
+            this.emitChildFileChangeTools(itemId, boundedChanges, undefined, "started", parentToolUseId);
           } else {
-            this.emitFileChangeEvents(itemId, changes);
+            this.emitFileChangeEvents(itemId, boundedChanges);
           }
         }
         break;
@@ -842,7 +844,9 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
             command: commandItem.command ?? "",
             cwd: commandItem.cwd,
             status: commandItem.status,
-            output: commandItem.aggregatedOutput ?? this.commandOutputs.get(commandItem.id) ?? formatExitCode(commandItem.exitCode),
+            output: boundAgentOutput(
+              commandItem.aggregatedOutput ?? this.commandOutputs.get(commandItem.id) ?? formatExitCode(commandItem.exitCode),
+            ),
             exitCode: asNullableNumber(commandItem.exitCode),
             durationMs: asNullableNumber(commandItem.durationMs),
             commandActions,
@@ -1148,13 +1152,14 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     phase: "started" | "completed",
     parentToolUseId: string,
   ): void {
-    const diff = changes.map((change) => change.diff).filter(Boolean).join("\n");
+    const files = boundFileChanges(changes);
+    const diff = boundAgentOutput(files.map((change) => change.diff).filter(Boolean).join("\n")) ?? "";
     const path = changes[0]?.path ?? "";
     this.emitToolUse(itemId, "Edit", JSON.stringify({
       filename: path,
       diff,
       status,
-      files: changes.map((change) => ({
+      files: files.map((change) => ({
         filename: change.path ?? "",
         diff: change.diff ?? "",
         kind: formatChangeKind(change.kind),
@@ -1238,7 +1243,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     const files = changes
       .map((change) => ({
         path: change.path ?? "",
-        diff: change.diff,
+        diff: boundAgentOutput(change.diff),
         kind: formatChangeKind(change.kind),
         status,
       }))
@@ -1247,7 +1252,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       type: "file_change_updated",
       id: itemId,
       path: firstChange?.path,
-      diff: changes.map((change) => change.diff).filter(Boolean).join("\n"),
+      diff: boundAgentOutput(changes.map((change) => change.diff).filter(Boolean).join("\n")),
       files,
       status: status ?? (firstChange ? formatChangeKind(firstChange.kind) : undefined),
     });
@@ -1300,7 +1305,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       type: "user",
       message: {
         role: "user",
-        content: [{ type: "tool_result", tool_use_id: id, content: output }],
+        content: [{ type: "tool_result", tool_use_id: id, content: boundAgentOutput(output) ?? "" }],
       },
     });
   }
@@ -1431,6 +1436,13 @@ function formatChangeKind(kind: unknown): string {
   const record = asRecord(kind);
   const type = asString(record?.type);
   return type ?? "update";
+}
+
+function boundFileChanges(changes: FileUpdateChange[]): FileUpdateChange[] {
+  return changes.map((change) => ({
+    ...change,
+    diff: boundAgentOutput(change.diff),
+  }));
 }
 
 function formatUnknown(value: unknown): string {


### PR DESCRIPTION
## Problem

Prod crashed with `FATAL ERROR: Ineffective mark-compacts near heap limit - JavaScript heap out of memory`.

Root cause: within a single agent turn, command output was accumulated **unbounded** in `CodexAppServerSession.commandOutputs`:

```ts
const next = `${this.commandOutputs.get(itemId) ?? ""}${delta}`; // grows without limit
```

`commandOutputs` is cleared per turn, so this is not a cross-turn leak — but a single turn running a verbose command (build, `tail -f`, anything dumping large output) grows this string until the Node heap is exhausted. The `TimeoutNegativeWarning` and `Codex app-server closed` lines in the logs are symptoms of GC starvation, not independent bugs.

## Fix

Bound agent output to **128 KiB** (tail-preserving, with an explicit `Output truncated by Hive` marker) at the two real accumulation points:

- `CodexAppServerSession.commandOutputs` accumulation — the source of the leak.
- `ConversationSession` — provider-agnostic choke point that also persists to `messages.jsonl` (protects the Claude runner too).

Also bound the cheap large-payload paths (final command output, `tool_result` content, file diffs) since `boundAgentOutput` is a no-op for normal-size strings.

A new shared `bounded-output.ts` helper centralizes the logic, with regression tests at the provider and session levels.

## Notes / deliberately out of scope

- An earlier draft added a 16 MiB single-line guard in `json-rpc-stdio.ts`. It was **dropped**: it targets a different failure mode (one giant line) than the one that crashed prod (accumulation of many small deltas), and it risked killing healthy sessions on legitimately large Codex payloads.
- A `max_memory_restart` safety net in PM2 is still recommended as defense-in-depth, but it is not the fix.

## Validation

```
npm --prefix backend run typecheck
npm --prefix backend run lint
npm --prefix backend test -- src/agents/providers/codex-app-server.test.ts src/agents/conversation-session.test.ts
```
All green (192 tests).