### PR TITLE
Copy out-of-workspace image views into session attachments for preview

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "node:events";
 import { rm, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ChildProcess } from "node:child_process";
-import type { WsOutgoing } from "../types.js";
+import type { AgentActivity, WsOutgoing } from "../types.js";
 
 // Mock child_process.spawn before importing the module under test
 vi.mock("node:child_process", () => ({
@@ -834,6 +834,339 @@ describe("ConversationSession", () => {
     expect(copied.toString()).toBe("fake-png-bytes");
 
     await rm(generatedDir, { recursive: true, force: true });
+  });
+
+  it("copies an out-of-workspace image view into session attachments for preview", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs/promises");
+    const screenshotDir = await fs.mkdtemp(join(os.tmpdir(), "hive-codex-view-"));
+    const screenshotPath = join(screenshotDir, "rouen-light.png");
+    await fs.writeFile(screenshotPath, Buffer.from("fake-screenshot-bytes"));
+
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "image_view_updated",
+        id: "image-1",
+        path: screenshotPath,
+        outsideWorkspace: true,
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-view" });
+      fakeRunner.emit("exit", 0, "provider-view");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-view",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "image-view-copy-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Show screenshot");
+
+    await waitForMessages(messages, "done");
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const activity = assistant?.agentActivities?.[0];
+    expect(activity).toMatchObject({
+      id: "image-1",
+      kind: "image_view",
+      path: screenshotPath,
+    });
+    const imageView = activity as Extract<typeof activity, { kind: "image_view" }> & { imageUrl?: string };
+    expect(imageView.outsideWorkspace).toBeUndefined();
+    expect(imageView.imageUrl).toMatch(
+      /^\/api\/workspaces\/ws-test\/sessions\/image-view-copy-session\/attachments\/view-[\w-]+\.png$/,
+    );
+    const filename = imageView.imageUrl!.split("/").pop()!;
+    const copied = await readFile(
+      join(tempDir, "sessions", "image-view-copy-session", "attachments", filename),
+    );
+    expect(copied.toString()).toBe("fake-screenshot-bytes");
+
+    await rm(screenshotDir, { recursive: true, force: true });
+  });
+
+  it("keeps a copied out-of-workspace image view preview when the same item re-emits", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs/promises");
+    const screenshotDir = await fs.mkdtemp(join(os.tmpdir(), "hive-codex-view-reemit-"));
+    const screenshotPath = join(screenshotDir, "rouen-dark.png");
+    await fs.writeFile(screenshotPath, Buffer.from("fake-screenshot-bytes"));
+
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    const messages: WsOutgoing[] = [];
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "image_view_updated",
+        id: "image-1",
+        path: screenshotPath,
+        outsideWorkspace: true,
+      });
+      void waitForCondition(() =>
+        messages.some((msg) =>
+          msg.type === "agent_activity" &&
+          msg.activity.kind === "image_view" &&
+          Boolean(msg.activity.imageUrl),
+        ),
+      ).then(() => {
+        fakeRunner.emit("agent_event", {
+          type: "image_view_updated",
+          id: "image-1",
+          path: screenshotPath,
+          outsideWorkspace: true,
+        });
+        fakeRunner.emit("result", { type: "result", session_id: "provider-view-reemit" });
+        fakeRunner.emit("exit", 0, "provider-view-reemit");
+      }).catch((err: unknown) => fakeRunner.emit("error", err instanceof Error ? err : new Error(String(err))));
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-view-reemit",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "image-view-reemit-session",
+      runnerFactory,
+    });
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Show screenshot");
+
+    await waitForMessages(messages, "done");
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const imageView = assistant?.agentActivities?.[0] as
+      | (Extract<AgentActivity, { kind: "image_view" }> & { imageUrl?: string })
+      | undefined;
+    expect(imageView?.outsideWorkspace).toBeUndefined();
+    expect(imageView?.imageUrl).toMatch(
+      /^\/api\/workspaces\/ws-test\/sessions\/image-view-reemit-session\/attachments\/view-[\w-]+\.png$/,
+    );
+
+    await rm(screenshotDir, { recursive: true, force: true });
+  });
+
+  it("retries an out-of-workspace image view copy when the file appears on re-emit", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs/promises");
+    const screenshotDir = await fs.mkdtemp(join(os.tmpdir(), "hive-codex-view-retry-"));
+    const screenshotPath = join(screenshotDir, "rouen-settings-dark.png");
+
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "image_view_updated",
+        id: "image-1",
+        path: screenshotPath,
+        outsideWorkspace: true,
+      });
+      void (async () => {
+        await new Promise((resolve) => setTimeout(resolve, 25));
+        await fs.writeFile(screenshotPath, Buffer.from("late-screenshot-bytes"));
+        fakeRunner.emit("agent_event", {
+          type: "image_view_updated",
+          id: "image-1",
+          path: screenshotPath,
+          outsideWorkspace: true,
+        });
+        fakeRunner.emit("result", { type: "result", session_id: "provider-view-retry" });
+        fakeRunner.emit("exit", 0, "provider-view-retry");
+      })().catch((err: unknown) => fakeRunner.emit("error", err instanceof Error ? err : new Error(String(err))));
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-view-retry",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "image-view-retry-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Show screenshot");
+
+    await waitForMessages(messages, "done");
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const imageView = assistant?.agentActivities?.[0] as
+      | (Extract<AgentActivity, { kind: "image_view" }> & { imageUrl?: string })
+      | undefined;
+    expect(imageView?.outsideWorkspace).toBeUndefined();
+    expect(imageView?.imageUrl).toMatch(
+      /^\/api\/workspaces\/ws-test\/sessions\/image-view-retry-session\/attachments\/view-[\w-]+\.png$/,
+    );
+    const filename = imageView!.imageUrl!.split("/").pop()!;
+    const copied = await readFile(
+      join(tempDir, "sessions", "image-view-retry-session", "attachments", filename),
+    );
+    expect(copied.toString()).toBe("late-screenshot-bytes");
+
+    await rm(screenshotDir, { recursive: true, force: true });
+  });
+
+  it("copies an extensionless out-of-workspace image view using the detected image type", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs/promises");
+    const screenshotDir = await fs.mkdtemp(join(os.tmpdir(), "hive-codex-view-extensionless-"));
+    const screenshotPath = join(screenshotDir, "rouen-cache-image");
+    const pngBytes = Buffer.concat([
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]),
+      Buffer.from("fake-extensionless-png"),
+    ]);
+    await fs.writeFile(screenshotPath, pngBytes);
+
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "image_view_updated",
+        id: "image-1",
+        path: screenshotPath,
+        outsideWorkspace: true,
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-view-extensionless" });
+      fakeRunner.emit("exit", 0, "provider-view-extensionless");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-view-extensionless",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "image-view-extensionless-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Show screenshot");
+
+    await waitForMessages(messages, "done");
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const imageView = assistant?.agentActivities?.[0] as
+      | (Extract<AgentActivity, { kind: "image_view" }> & { imageUrl?: string })
+      | undefined;
+    expect(imageView?.imageUrl).toMatch(
+      /^\/api\/workspaces\/ws-test\/sessions\/image-view-extensionless-session\/attachments\/view-[\w-]+\.png$/,
+    );
+    const filename = imageView!.imageUrl!.split("/").pop()!;
+    const copied = await readFile(
+      join(tempDir, "sessions", "image-view-extensionless-session", "attachments", filename),
+    );
+    expect(copied.equals(pngBytes)).toBe(true);
+
+    await rm(screenshotDir, { recursive: true, force: true });
+  });
+
+  it("does not copy an out-of-workspace non-image view into session attachments", async () => {
+    const os = await import("node:os");
+    const fs = await import("node:fs/promises");
+    const tempDataDir = await fs.mkdtemp(join(os.tmpdir(), "hive-codex-view-text-"));
+    const textPath = join(tempDataDir, "notes.txt");
+    await fs.writeFile(textPath, "not an image");
+
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "image_view_updated",
+        id: "image-1",
+        path: textPath,
+        outsideWorkspace: true,
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-view-text" });
+      fakeRunner.emit("exit", 0, "provider-view-text");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-view-text",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "image-view-non-image-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Show text as image");
+
+    await waitForMessages(messages, "done");
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    const imageView = assistant?.agentActivities?.[0] as
+      | (Extract<AgentActivity, { kind: "image_view" }> & { imageUrl?: string })
+      | undefined;
+    expect(imageView).toMatchObject({
+      id: "image-1",
+      kind: "image_view",
+      path: textPath,
+      outsideWorkspace: true,
+    });
+    expect(imageView?.imageUrl).toBeUndefined();
+
+    await rm(tempDataDir, { recursive: true, force: true });
   });
 
   it("streams and persists plan update activities", async () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -50,11 +50,43 @@ const MAX_FINALIZED_TURN_IDS = 256;
 const CODEX_GOAL_OBJECTIVE_MAX_LENGTH = 4000;
 
 /**
- * Cap for copying a Codex-generated image into session attachments. Generated
- * images are normal-sized PNGs; anything larger is almost certainly not a
- * preview-worthy result and is skipped rather than copied wholesale.
+ * Cap for copying an agent-reported image into session attachments. Preview
+ * images are normal-sized PNG/JPEG/WebP/GIF files; anything larger is almost
+ * certainly not a preview-worthy result and is skipped rather than copied
+ * wholesale.
  */
-const MAX_GENERATED_IMAGE_COPY_BYTES = 25 * 1024 * 1024;
+const MAX_IMAGE_PREVIEW_COPY_BYTES = 25 * 1024 * 1024;
+const IMAGE_PREVIEW_EXTENSIONS = new Set([".gif", ".jpeg", ".jpg", ".png", ".webp"]);
+
+function normalizedImagePreviewExtension(ext: string | undefined): string | undefined {
+  const normalized = ext?.toLowerCase();
+  return normalized && IMAGE_PREVIEW_EXTENSIONS.has(normalized) ? normalized : undefined;
+}
+
+async function detectImagePreviewExtension(path: string): Promise<string | undefined> {
+  const fh = await open(path, "r");
+  try {
+    const header = Buffer.alloc(12);
+    const { bytesRead } = await fh.read(header, 0, header.length, 0);
+    const bytes = header.subarray(0, bytesRead);
+    if (bytes.length >= 8 && bytes.subarray(0, 8).equals(Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]))) {
+      return ".png";
+    }
+    if (bytes.length >= 3 && bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) {
+      return ".jpg";
+    }
+    const signature = bytes.toString("ascii", 0, Math.min(bytes.length, 12));
+    if (signature.startsWith("GIF87a") || signature.startsWith("GIF89a")) {
+      return ".gif";
+    }
+    if (bytes.length >= 12 && signature.startsWith("RIFF") && signature.slice(8, 12) === "WEBP") {
+      return ".webp";
+    }
+    return undefined;
+  } finally {
+    await fh.close();
+  }
+}
 
 type CodexGoalCommand =
   | { type: "set"; objective: string }
@@ -229,6 +261,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   private _agentPlanMode = false;
   private finalizedCodexAppServerTurnIds = new Set<string>();
   private copiedGeneratedImageIds = new Set<string>();
+  private copiedImageViewIds = new Set<string>();
+  private pendingImageViewIds = new Set<string>();
+  private retryImageViewPaths = new Map<string, string>();
   private pendingImageAttachments: Promise<void>[] = [];
 
   constructor(config: ConversationSessionConfig) {
@@ -1186,14 +1221,32 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   private handleImageViewEvent(event: Extract<NormalizedAgentEvent, { type: "image_view_updated" }>): void {
+    const existingActivity = this._streamAgentActivities.find(
+      (activity): activity is Extract<AgentActivity, { kind: "image_view" }> =>
+        activity.id === event.id && activity.kind === "image_view",
+    );
+    const relativePath = event.relativePath ?? existingActivity?.relativePath;
+    const imageUrl = relativePath
+      ? workspaceFileRawPath(this.workspaceId, relativePath)
+      : existingActivity?.imageUrl;
+    const outsideWorkspace = imageUrl ? undefined : event.outsideWorkspace ?? existingActivity?.outsideWorkspace;
     this.upsertAgentActivity({
       id: event.id,
       kind: "image_view",
       path: event.path,
-      relativePath: event.relativePath,
-      imageUrl: event.relativePath ? workspaceFileRawPath(this.workspaceId, event.relativePath) : undefined,
-      outsideWorkspace: event.outsideWorkspace,
+      relativePath,
+      imageUrl,
+      outsideWorkspace,
     });
+
+    if (!imageUrl && outsideWorkspace && !this.copiedImageViewIds.has(event.id)) {
+      if (this.pendingImageViewIds.has(event.id)) {
+        this.retryImageViewPaths.set(event.id, event.path);
+        return;
+      }
+      const activities = this._streamAgentActivities;
+      this.pendingImageAttachments.push(this.attachImageViewWithRetries(activities, event.id, event.path));
+    }
   }
 
   private handleImageGenerationEvent(
@@ -1233,38 +1286,99 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   }
 
   /**
-   * Copy a Codex-generated image (saved outside the workspace) into the session
-   * attachments dir and re-emit the activity with a served preview URL. Best
-   * effort: a failed copy leaves the activity without a preview rather than
-   * surfacing an error. `finalizeTurn` awaits these before persisting so the URL
-   * lands in the saved message.
+   * Copy an image reported outside the workspace into the session attachments
+   * dir and re-emit the activity with a served preview URL. Best effort: a
+   * failed copy leaves the activity without a preview rather than surfacing an
+   * error. `finalizeTurn` awaits these before persisting so the URL lands in the
+   * saved message.
    */
   private async attachGeneratedImage(
     activities: AgentActivity[],
     activityId: string,
     savedPath: string,
   ): Promise<void> {
+    const imageUrl = await this.copyImagePreviewToAttachment(savedPath, "gen", ".png");
+    if (!imageUrl) return;
+    this.applyImagePreviewUrl(activities, activityId, "image_generation", imageUrl);
+  }
+
+  private async attachImageView(
+    activities: AgentActivity[],
+    activityId: string,
+    imagePath: string,
+  ): Promise<boolean> {
+    const imageUrl = await this.copyImagePreviewToAttachment(imagePath, "view");
+    if (!imageUrl) return false;
+    return this.applyImagePreviewUrl(activities, activityId, "image_view", imageUrl);
+  }
+
+  private async attachImageViewWithRetries(
+    activities: AgentActivity[],
+    activityId: string,
+    imagePath: string,
+  ): Promise<void> {
+    this.pendingImageViewIds.add(activityId);
+    let nextPath: string | undefined = imagePath;
     try {
-      const info = await stat(savedPath);
-      if (!info.isFile() || info.size > MAX_GENERATED_IMAGE_COPY_BYTES) return;
+      while (nextPath && !this.copiedImageViewIds.has(activityId)) {
+        const copied = await this.attachImageView(activities, activityId, nextPath);
+        if (copied) {
+          this.copiedImageViewIds.add(activityId);
+          this.retryImageViewPaths.delete(activityId);
+          break;
+        }
+        nextPath = this.retryImageViewPaths.get(activityId);
+        this.retryImageViewPaths.delete(activityId);
+      }
+    } finally {
+      this.pendingImageViewIds.delete(activityId);
+    }
+  }
+
+  private async copyImagePreviewToAttachment(
+    sourcePath: string,
+    prefix: string,
+    fallbackExtension?: string,
+  ): Promise<string | undefined> {
+    try {
+      const info = await stat(sourcePath);
+      if (!info.isFile() || info.size > MAX_IMAGE_PREVIEW_COPY_BYTES) return undefined;
+      const ext = normalizedImagePreviewExtension(extname(sourcePath))
+        ?? await detectImagePreviewExtension(sourcePath)
+        ?? normalizedImagePreviewExtension(fallbackExtension);
+      if (!ext || !IMAGE_PREVIEW_EXTENSIONS.has(ext)) return undefined;
+
       const attachmentsDir = join(this.sessionDir, "attachments");
       await mkdir(attachmentsDir, { recursive: true });
-      const ext = extname(savedPath) || ".png";
-      const filename = `gen-${nanoid(8)}${ext}`;
-      await copyFile(savedPath, join(attachmentsDir, filename));
-
-      const activity = activities.find(
-        (item): item is Extract<AgentActivity, { kind: "image_generation" }> =>
-          item.id === activityId && item.kind === "image_generation",
-      );
-      if (!activity) return;
-      // Mutate in place: the same object is referenced by the captured array and
-      // the message persisted in finalizeTurn, so this URL reaches both.
-      activity.imageUrl = this.attachmentUrl(filename);
-      this.emit("message", { type: "agent_activity", sessionId: this.sessionId, activity: cloneAgentActivity(activity) });
+      const filename = `${prefix}-${nanoid(8)}${ext}`;
+      await copyFile(sourcePath, join(attachmentsDir, filename));
+      return this.attachmentUrl(filename);
     } catch {
       // Preview is optional — keep the activity as-is when the copy fails.
+      return undefined;
     }
+  }
+
+  private applyImagePreviewUrl(
+    activities: AgentActivity[],
+    activityId: string,
+    kind: "image_generation" | "image_view",
+    imageUrl: string,
+  ): boolean {
+    const activity = activities.find(
+      (item): item is Extract<AgentActivity, { kind: typeof kind }> =>
+        item.id === activityId && item.kind === kind,
+    );
+    if (!activity) return false;
+
+    // Mutate in place: the same object is referenced by the captured array and
+    // the message persisted in finalizeTurn, so this URL reaches both.
+    activity.imageUrl = imageUrl;
+    if (activity.kind === "image_view") {
+      activity.outsideWorkspace = undefined;
+    }
+    this.emit("message", { type: "agent_activity", sessionId: this.sessionId, activity: cloneAgentActivity(activity) });
+    return true;
   }
 
   /** API path serving a session attachment (image previews, generated images). */
@@ -1348,7 +1462,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     this.stopReason = null;
     this.runner = null;
 
-    // Capture per-turn accumulators (and any pending generated-image copies)
+    // Capture per-turn accumulators (and any pending image preview copies)
     // before resetting, so the deferred persist below still sees this turn's
     // content even though new arrays are installed synchronously.
     const streamText = this._streamText;
@@ -1374,7 +1488,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
 
     void (async () => {
       try {
-        // Wait for generated-image copies so their served preview URLs are baked
+        // Wait for image preview copies so their served preview URLs are baked
         // into the persisted activities before the message is written.
         if (pendingImageAttachments.length > 0) {
           await Promise.allSettled(pendingImageAttachments);


### PR DESCRIPTION
## What

Out-of-workspace image **views** (e.g. Codex screenshots saved to its own cache outside the repo) now get copied into the session attachments dir and rendered inline in chat, the same way generated images already were. Previously they only showed an "outside the workspace" placeholder with no preview.

## How

- Extracted `copyImagePreviewToAttachment` + `applyImagePreviewUrl` so the generated-image and image-view paths share the stat/size/extension/copy/emit logic instead of duplicating it.
- **Re-emit safety:** `handleImageViewEvent` now carries forward `relativePath`/`imageUrl`/`outsideWorkspace` from the existing activity. Codex dispatches the same item on both `item/started` and `item/completed`, and `upsertAgentActivity` replaces the entry — without carry-forward the second emit wiped a copied preview URL and the dedup guard blocked a re-copy.
- **Transient failure:** an image view is marked copied only on success, with a retry on later re-emit, so a not-yet-flushed file isn't permanently skipped.
- **Extensionless paths:** when the extension is missing or non-image, the image type is detected from magic bytes (PNG/JPEG/GIF/WebP) so previews still work.
- Copies stay gated by an image-extension allowlist and the existing size cap.

## Tests

`backend/src/agents/conversation-session.test.ts`:
- copies an out-of-workspace image view into attachments
- keeps the copied preview when the same item re-emits (clobber regression)
- retries the copy when the file appears on re-emit
- copies an extensionless view using the detected image type
- does not copy a non-image view

`npm run lint`, `npx tsc --noEmit`, and the targeted test file (148 tests) all pass.
