### PR TITLE
Fix user message bubbles overflowing on long unbreakable strings

### DIFF
--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -20,7 +20,8 @@ function renderContentWithMentions(
   const atMatches = content.match(AT_MENTION_RE);
   const atMentions = atMatches ? [...new Set(atMatches)] : [];
 
-  if (!mentions?.length && atMentions.length === 0) return <p className="whitespace-pre-wrap">{content}</p>;
+  if (!mentions?.length && atMentions.length === 0)
+    return <p className="whitespace-pre-wrap wrap-anywhere">{content}</p>;
 
   const segments = splitByAllMentions(content, mentions, atMentions).map((segment, i) => {
     if (segment.mention) {
@@ -49,7 +50,7 @@ function renderContentWithMentions(
     return <span key={i}>{segment.text}</span>;
   });
 
-  return <p className="whitespace-pre-wrap">{segments}</p>;
+  return <p className="whitespace-pre-wrap wrap-anywhere">{segments}</p>;
 }
 
 interface ChatMessageProps {


### PR DESCRIPTION
## Problem

User message bubbles blew past their `max-w-[85%]` when the content contained a long token with no break opportunity (e.g. a URL or a hex string like `pool=0x4461...0xc8`). This caused the bubble to grow to nearly full width and sometimes forced horizontal scrolling to read the end.

`whitespace-pre-wrap` only wraps on whitespace, so an unbreakable token has nothing to break on. Worse, the bubble lives in a flex item whose default `min-width: auto` expands to the token's min-content width — overriding `max-w-[85%]`.

## Fix

Add `wrap-anywhere` (`overflow-wrap: anywhere`) to the user message paragraphs in `renderContentWithMentions`. This:
- breaks long unbreakable tokens to fit the available width, and
- shrinks the min-content size so the flex item respects `max-w-[85%]`.

Chosen over `break-words` (doesn't reduce min-content → bubble could still overflow) and `break-all` (would break normal words mid-token). Normal prose still wraps between words.

## Verification

Isolated repro of the exact DOM/CSS structure confirms: long hex string now wraps inside the 85% bubble, short messages still hug their content. `npm run typecheck` and `npm run lint` pass clean.

Scope is user bubbles only; assistant markdown already handles code/long tokens via `ChatToolUse`.