### PR TITLE
UI/UX fixes: message bubble wrapping, sidebar header actions, mention highlight alignment

### DIFF
--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -20,7 +20,8 @@ function renderContentWithMentions(
   const atMatches = content.match(AT_MENTION_RE);
   const atMentions = atMatches ? [...new Set(atMatches)] : [];
 
-  if (!mentions?.length && atMentions.length === 0) return <p className="whitespace-pre-wrap">{content}</p>;
+  if (!mentions?.length && atMentions.length === 0)
+    return <p className="whitespace-pre-wrap wrap-anywhere">{content}</p>;
 
   const segments = splitByAllMentions(content, mentions, atMentions).map((segment, i) => {
     if (segment.mention) {
@@ -49,7 +50,7 @@ function renderContentWithMentions(
     return <span key={i}>{segment.text}</span>;
   });
 
-  return <p className="whitespace-pre-wrap">{segments}</p>;
+  return <p className="whitespace-pre-wrap wrap-anywhere">{segments}</p>;
 }
 
 interface ChatMessageProps {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -3,6 +3,7 @@ import { getNextRun, formatTimeUntil } from "@/lib/cron";
 import {
   AlertCircle,
   Brain,
+  FolderGit2,
   FolderPlus,
   Loader2,
   Settings,
@@ -11,7 +12,7 @@ import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { Group, Panel, useDefaultLayout } from "react-resizable-panels";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Skeleton } from "@/components/ui/skeleton";
-import { TooltipProvider } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -109,6 +110,35 @@ export function collectVisiblePrWorkspaceIds({
   if (activeWsId) visible.add(activeWsId);
 
   return [...visible];
+}
+
+function SidebarHeaderAction({
+  icon,
+  label,
+  onClick,
+  disabled = false,
+}: {
+  icon: React.ReactNode;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="flex items-center justify-center rounded p-0.5 text-muted-foreground/70 transition-colors hover:bg-sidebar-accent/50 hover:text-sidebar-foreground disabled:pointer-events-none disabled:opacity-40"
+          onClick={onClick}
+          disabled={disabled}
+          aria-label={label}
+        >
+          {icon}
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">{label}</TooltipContent>
+    </Tooltip>
+  );
 }
 
 const sidebarPanelScrollClassName =
@@ -497,15 +527,7 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
   };
 
   const footerActions = (
-    <div className="flex items-center justify-between px-2 py-1.5">
-      <button
-        type="button"
-        className="inline-flex items-center gap-1.5 rounded px-1.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-sidebar-accent/40 hover:text-sidebar-foreground"
-        onClick={onAddProject}
-      >
-        <FolderPlus className="h-3.5 w-3.5 shrink-0" />
-        Add repository
-      </button>
+    <div className="flex items-center justify-end px-2 py-1.5">
       <Link
         to="/settings"
         state={{ from: pathname }}
@@ -589,15 +611,25 @@ export default function Sidebar({ onAddProject, onAddAutomation }: SidebarProps)
       <SidebarSectionHeader
         label="Workspaces"
         className="mb-1"
-        onAdd={() => {
-          if (!hasInitialHydration) return;
-          setIsCreatingFolder(true);
-          setNewFolderName("");
-        }}
-        addLabel="New folder"
-        addDisabled={!hasInitialHydration}
-        addIcon={<FolderPlus className="h-4 w-4" />}
-        addButtonClassName="rounded p-0.5 hover:bg-sidebar-accent/50"
+        actions={
+          <>
+            <SidebarHeaderAction
+              icon={<FolderGit2 className="h-4 w-4" />}
+              label="Add repository"
+              onClick={onAddProject}
+            />
+            <SidebarHeaderAction
+              icon={<FolderPlus className="h-4 w-4" />}
+              label="New folder"
+              disabled={!hasInitialHydration}
+              onClick={() => {
+                if (!hasInitialHydration) return;
+                setIsCreatingFolder(true);
+                setNewFolderName("");
+              }}
+            />
+          </>
+        }
       />
 
       <SidebarFolderComposer

--- a/frontend/src/components/chat/MentionHighlightOverlay.tsx
+++ b/frontend/src/components/chat/MentionHighlightOverlay.tsx
@@ -28,14 +28,27 @@ export function MentionHighlightOverlay({
     const overlay = overlayRef.current;
     if (!textarea || !overlay) return;
 
-    const syncScroll = () => {
+    const sync = () => {
+      // Pin the overlay to the textarea's content box. clientWidth excludes the
+      // scrollbar, so without this the overlay is wider and wraps at different
+      // columns; clientHeight bounds the scrollable range, so without it the
+      // overlay (absolute inset-0, taller than the capped textarea) can't scroll
+      // as far and the marks drift off their tokens. Set the size before
+      // scrollTop so the new range is in effect when we assign the offset.
+      overlay.style.width = `${textarea.clientWidth}px`;
+      overlay.style.height = `${textarea.clientHeight}px`;
       overlay.scrollTop = textarea.scrollTop;
       overlay.scrollLeft = textarea.scrollLeft;
     };
 
-    syncScroll();
-    textarea.addEventListener("scroll", syncScroll);
-    return () => textarea.removeEventListener("scroll", syncScroll);
+    sync();
+    textarea.addEventListener("scroll", sync);
+    const resizeObserver = new ResizeObserver(sync);
+    resizeObserver.observe(textarea);
+    return () => {
+      textarea.removeEventListener("scroll", sync);
+      resizeObserver.disconnect();
+    };
   }, [textareaRef, totalMentions]);
 
   if (totalMentions === 0) return null;
@@ -46,7 +59,7 @@ export function MentionHighlightOverlay({
   return (
     <div
       ref={overlayRef}
-      className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-3 py-3 text-sm leading-normal"
+      className="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words px-3 py-3 text-sm"
       style={{ wordWrap: "break-word" }}
       aria-hidden="true"
     >

--- a/frontend/src/components/sidebar/SidebarHeaders.tsx
+++ b/frontend/src/components/sidebar/SidebarHeaders.tsx
@@ -118,6 +118,8 @@ interface SidebarSectionHeaderProps {
   className?: string;
   addIcon?: React.ReactNode;
   addButtonClassName?: string;
+  /** Custom action buttons rendered in the header's action slot, replacing the default add button. */
+  actions?: React.ReactNode;
 }
 
 export function SidebarSectionHeader({
@@ -129,12 +131,16 @@ export function SidebarSectionHeader({
   className,
   addIcon,
   addButtonClassName,
+  actions,
 }: SidebarSectionHeaderProps) {
   return (
     <div className={cn("group relative flex w-full items-center", className)}>
       <span className="min-w-0 flex-1 truncate text-[11px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
         {label}
       </span>
+      {actions ? (
+        <div className="flex items-center gap-0.5">{actions}</div>
+      ) : (
       <div className="relative flex h-5 w-5 items-center justify-center">
         {isLoading ? (
           <Loader2 className="h-3.5 w-3.5 animate-spin text-muted-foreground" />
@@ -154,6 +160,7 @@ export function SidebarSectionHeader({
           </button>
         ) : null}
       </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Batch of small UI/UX fixes noticed in daily use.

## 1. Wrap long unbreakable strings in user message bubbles

User message bubbles blew past their `max-w-[85%]` when the content contained a long token with no break opportunity (URL, hex string), causing near-full-width bubbles and horizontal scroll. The flex item's `min-width: auto` expanded to the token's min-content width, overriding the max width.

Fix: add `wrap-anywhere` (`overflow-wrap: anywhere`) to the user message paragraphs — breaks unbreakable tokens and shrinks min-content so the bubble respects its max width. Normal prose still wraps between words.

## 2. Group repository/folder creation as icon buttons in the Workspaces header

"Add repository" lived in the sidebar footer while folder creation opened from a `+` in the Workspaces header — and both used the same `FolderPlus` icon, so the actions were ambiguous.

Both now live in the Workspaces header as small icon buttons with distinct icons and tooltips: **Add repository** (`FolderGit2`, wired to `onAddProject`) and **New folder** (`FolderPlus`, opens the composer; disabled until hydration). `SidebarSectionHeader` gains an optional `actions` slot (backward compatible; Automations keeps its single-button behavior). Footer now holds only Settings. Icon-only buttons carry `aria-label` + Radix tooltip.

## 3. Keep `#`/`@` mention highlights aligned with the textarea on scroll

The highlight overlay is a separate layer synced to the textarea by scrollTop, so its text must mirror the textarea's exactly. Three metric mismatches let the marks drift off their tokens, worst when scrolling a long message:

- `leading-normal` gave the overlay a different line-height than the textarea's `text-sm` → vertical divergence.
- The overlay took full width while the textarea's scrollbar steals ~10px of content width → different wrap columns, accumulating horizontal drift.
- The overlay (`absolute inset-0`) was taller than the `max-h`-capped textarea, so its scroll range was shorter and `scrollTop` clamped short → every line offset once scrolled.

Fix: drop `leading-normal` so both use `text-sm`'s line-height, and pin the overlay's width/height to the textarea's `clientWidth`/`clientHeight`, re-synced via a `ResizeObserver` (the scrollbar only appears once content overflows).

## Verification

- Bubbles: isolated repro of the exact DOM/CSS — long hex string wraps inside the 85% bubble; short messages still hug content.
- Sidebar: ran the app against an isolated dev backend — buttons render with distinct icons, tooltips on hover, New folder opens the composer, Add repository wired to the same handler.
- Mention overlay: measured in the live app — before `taScroll=71 / ovScroll=46`, `clientH 160 vs 198`; after `taScroll=71 / ovScroll=71`, `clientH 160/160`, `maxScroll 84/84`. Highlights land exactly on `@manager`/`@reviewer` at every scroll position.
- `typecheck` and `lint` pass clean.