### PR TITLE
Resolve Codex image paths against turn cwd

### DIFF
--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -937,6 +937,60 @@ describe("CodexAppServerSession normalized events", () => {
     }]);
   });
 
+  it("resolves relative image view paths against the turn cwd", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "imageView",
+          id: "image-1",
+          path: "vesu.png",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([{
+      type: "image_view_updated",
+      id: "image-1",
+      path: "/tmp/project/vesu.png",
+      relativePath: "vesu.png",
+    }]);
+  });
+
+  it("flags relative image view paths outside the workspace", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "imageView",
+          id: "image-1",
+          path: "../elsewhere.png",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([{
+      type: "image_view_updated",
+      id: "image-1",
+      path: "/tmp/elsewhere.png",
+      outsideWorkspace: true,
+    }]);
+  });
+
   it("keeps sub-agent image views and generations out of the main stream", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
@@ -1082,6 +1136,37 @@ describe("CodexAppServerSession normalized events", () => {
         relativePath: "generated/logo.png",
       },
     ]);
+  });
+
+  it("resolves relative image generation saved paths against the turn cwd", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "imageGeneration",
+          id: "gen-1",
+          status: "completed",
+          savedPath: "generated/logo.png",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([{
+      type: "image_generation_updated",
+      id: "gen-1",
+      status: "completed",
+      revisedPrompt: undefined,
+      result: undefined,
+      savedPath: "/tmp/project/generated/logo.png",
+      relativePath: "generated/logo.png",
+    }]);
   });
 
   it("drops oversized inline image generation results", async () => {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -933,18 +933,21 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         if (parentToolUseId) break;
         const imageItem = item as Extract<ThreadItem, { type: "imageView" }>;
         if (!imageItem.path) break;
+        const imagePath = resolveAppServerFilePath(imageItem.path, this.currentCwd);
         this.emit("agent_event", {
           type: "image_view_updated",
           id: imageItem.id,
-          path: imageItem.path,
-          ...relativizeWorkspacePath(imageItem.path, this.currentCwd),
+          path: imagePath,
+          ...relativizeWorkspacePath(imagePath, this.currentCwd),
         });
         break;
       }
       case "imageGeneration": {
         if (parentToolUseId) break;
         const generationItem = item as Extract<ThreadItem, { type: "imageGeneration" }>;
-        const savedPath = generationItem.savedPath ?? undefined;
+        const savedPath = generationItem.savedPath
+          ? resolveAppServerFilePath(generationItem.savedPath, this.currentCwd)
+          : undefined;
         const result = generationItem.result;
         this.emit("agent_event", {
           type: "image_generation_updated",
@@ -1410,17 +1413,26 @@ function usageFromTokenUsage(value: TokenUsage | undefined): {
 }
 
 /**
- * Resolve an App Server absolute image path against the current turn cwd.
- * Inside the workspace -> repo-relative path usable with the raw-file API
- * (which enforces repo safety); outside -> flagged so the UI never builds a
- * preview URL for arbitrary disk paths. Unknown cwd -> neither.
+ * Resolve an App Server image path for disk access. Codex may report either an
+ * absolute path or a path relative to the turn cwd.
+ */
+function resolveAppServerFilePath(path: string, cwd: string | undefined): string {
+  if (isAbsolute(path)) return resolve(path);
+  return cwd ? resolve(cwd, path) : path;
+}
+
+/**
+ * Resolve an App Server image path against the current turn cwd. Inside the
+ * workspace -> repo-relative path usable with the raw-file API (which enforces
+ * repo safety); outside -> flagged so the UI never builds a preview URL for
+ * arbitrary disk paths. Unknown cwd -> neither.
  */
 function relativizeWorkspacePath(
   path: string,
   cwd: string | undefined,
 ): { relativePath?: string; outsideWorkspace?: boolean } {
   if (!cwd) return {};
-  const relativePath = relative(resolve(cwd), resolve(path));
+  const relativePath = relative(resolve(cwd), resolveAppServerFilePath(path, cwd));
   if (!relativePath || relativePath.startsWith("..") || isAbsolute(relativePath)) {
     return { outsideWorkspace: true };
   }

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -13,13 +13,14 @@ import {
 } from "@/components/ai-elements/prompt-input";
 import type { ChatMessage, CompletionItem, FileMention, ImageAttachment, MessageOptions, QueuedMessage, ThinkingLevel } from "@/types";
 import { cn } from "@/lib/utils";
-import { BrainIcon, BookOpenIcon, PlusIcon, SquareIcon, ZapIcon } from "lucide-react";
+import { BookOpenIcon, PlusIcon, SquareIcon, ZapIcon } from "lucide-react";
 import { AttachmentPreview } from "@/components/chat/AttachmentPreview";
 import { AutocompletePopup } from "@/components/chat/AutocompletePopup";
 import { FileAutocompletePopup } from "@/components/chat/FileAutocompletePopup";
 import { MentionHighlightOverlay } from "@/components/chat/MentionHighlightOverlay";
 import { ContextRing } from "@/components/chat/ContextRing";
 import { ModelSelector } from "@/components/chat/ModelSelector";
+import { ThinkingSelector } from "@/components/chat/ThinkingSelector";
 import { useCompletions } from "@/hooks/useCompletions";
 import { useFileCompletions } from "@/hooks/useFileCompletions";
 import { useContextUsage } from "@/hooks/useContextUsage";
@@ -58,16 +59,6 @@ interface AutocompleteState {
   query: string;
   triggerIndex: number;
 }
-
-const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
-  none: "None",
-  minimal: "Min",
-  low: "Low",
-  medium: "Med",
-  high: "High",
-  xhigh: "xHigh",
-  max: "Max",
-};
 
 const DEFAULT_THINKING_LEVEL: ThinkingLevel = "high";
 
@@ -316,15 +307,6 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     [autocomplete, filteredItems, fileResults, selectedIndex, selectItem, selectFileItem],
   );
 
-  const cycleThinkingLevel = useCallback(() => {
-    setThinkingLevel((current) => {
-      if (thinkingLevels.length === 0) return current;
-      const idx = thinkingLevels.indexOf(current);
-      if (idx === -1) return thinkingLevels[0];
-      return thinkingLevels[(idx + 1) % thinkingLevels.length];
-    });
-  }, [thinkingLevels]);
-
   const handleSubmit = ({ text, files }: PromptInputMessage) => {
     const trimmed = text.trim();
     if (!trimmed && files.length === 0) return;
@@ -420,16 +402,12 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
               lockedProvider={lockedProvider}
             />
             {supportsThinking && (
-              <PromptInputButton
-                aria-label={`Thinking: ${THINKING_LEVEL_LABELS[effectiveThinkingLevel]}`}
-                variant="ghost"
-                size="xs"
-                onClick={cycleThinkingLevel}
-                className={cn("h-5 text-[11px] transition-colors", activeStyle)}
-              >
-                <BrainIcon className="size-3" />
-                {THINKING_LEVEL_LABELS[effectiveThinkingLevel]}
-              </PromptInputButton>
+              <ThinkingSelector
+                levels={thinkingLevels}
+                selectedLevel={effectiveThinkingLevel}
+                onSelect={setThinkingLevel}
+                className={activeStyle}
+              />
             )}
             {supportsPlanMode && (
               <PromptInputButton

--- a/frontend/src/components/chat/ThinkingSelector.tsx
+++ b/frontend/src/components/chat/ThinkingSelector.tsx
@@ -1,0 +1,86 @@
+import { BrainIcon, CheckIcon } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { PromptInputButton } from "@/components/ai-elements/prompt-input";
+import type { ThinkingLevel } from "@/types";
+import { cn } from "@/lib/utils";
+
+const THINKING_LEVEL_LABELS: Record<ThinkingLevel, string> = {
+  none: "None",
+  minimal: "Min",
+  low: "Low",
+  medium: "Med",
+  high: "High",
+  xhigh: "xHigh",
+  max: "Max",
+};
+
+interface ThinkingSelectorProps {
+  levels: ThinkingLevel[];
+  selectedLevel: ThinkingLevel;
+  onSelect: (level: ThinkingLevel) => void;
+  className?: string;
+}
+
+export function ThinkingSelector({
+  levels,
+  selectedLevel,
+  onSelect,
+  className,
+}: ThinkingSelectorProps) {
+  const label = THINKING_LEVEL_LABELS[selectedLevel] ?? selectedLevel;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <PromptInputButton
+          aria-label={`Thinking: ${label}`}
+          variant="ghost"
+          size="xs"
+          className={cn("h-5 text-[11px] gap-1 transition-colors", className)}
+        >
+          <BrainIcon className="size-3" />
+          {label}
+        </PromptInputButton>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side="top"
+        align="start"
+        className="w-36 border-border/30 p-0"
+      >
+        <div className="flex items-center gap-1.5 bg-muted/70 px-3 py-1.5">
+          <BrainIcon className="size-2.5 text-muted-foreground" />
+          <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+            Thinking
+          </span>
+        </div>
+        <DropdownMenuGroup className="p-1">
+          {levels.map((level) => {
+            const isSelected = level === selectedLevel;
+
+            return (
+              <DropdownMenuItem
+                key={level}
+                onClick={() => onSelect(level)}
+                className={cn(
+                  "gap-2 rounded-sm",
+                  isSelected
+                    ? "bg-primary/10 text-primary focus:bg-primary/10 focus:text-primary"
+                    : "focus:bg-accent focus:text-accent-foreground",
+                )}
+              >
+                <span className="flex-1">{THINKING_LEVEL_LABELS[level] ?? level}</span>
+                {isSelected && <CheckIcon className="size-3.5 text-primary" />}
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuGroup>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -167,12 +167,12 @@ describe("ChatInput", () => {
     expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("cycles thinking level and toggles plan mode", async () => {
+  it("selects thinking level from the dropdown and toggles plan mode", async () => {
     const user = userEvent.setup();
     const { onSend } = renderChatInput();
 
-    // Claude levels=[low,medium,high,xhigh,max]; default is "high"; one click cycles to "xhigh".
     await user.click(screen.getByRole("button", { name: /^Thinking:/ }));
+    await user.click(screen.getByRole("menuitem", { name: "xHigh" }));
     await user.click(screen.getByRole("button", { name: "Toggle plan mode" }));
     await user.type(screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands"), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
@@ -222,17 +222,15 @@ describe("ChatInput", () => {
     }, undefined);
   });
 
-  it("cycles thinking level back to default after a full rotation", async () => {
+  it("can select the default thinking level from the dropdown", async () => {
     const user = userEvent.setup();
     const { onSend } = renderChatInput();
 
-    // Claude levels=[low,medium,high,xhigh,max] — 5 clicks from "high" returns to "high".
     const thinkingButton = () => screen.getByRole("button", { name: /^Thinking:/ });
     await user.click(thinkingButton());
+    await user.click(screen.getByRole("menuitem", { name: "Max" }));
     await user.click(thinkingButton());
-    await user.click(thinkingButton());
-    await user.click(thinkingButton());
-    await user.click(thinkingButton());
+    await user.click(screen.getByRole("menuitem", { name: "High" }));
     await user.type(screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands"), "hello");
     await user.click(screen.getByRole("button", { name: "Send" }));
 

--- a/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.thinking-persistence.test.tsx
@@ -67,8 +67,9 @@ describe("ChatInput thinking-level persistence", () => {
     // Default seed is "high" → "High".
     expect(screen.getByRole("button", { name: /Thinking: High/i })).toBeInTheDocument();
 
-    // One click cycles "high" -> "xhigh" -> shows "xHigh".
+    // Select xHigh from the thinking dropdown.
     await user.click(screen.getByRole("button", { name: /Thinking: High/i }));
+    await user.click(screen.getByRole("menuitem", { name: "xHigh" }));
     expect(screen.getByRole("button", { name: /Thinking: xHigh/i })).toBeInTheDocument();
 
     unmount();


### PR DESCRIPTION
## Summary
- Resolve relative Codex app-server image paths against the active turn cwd before emitting image activities
- Preserve the existing raw-file vs session-attachment split after path normalization
- Add regression coverage for relative image views, outside-workspace relative paths, and relative generated image saved paths

## Tests
- npm --workspace @hive/backend test -- src/agents/providers/codex-app-server.test.ts
- npm --workspace @hive/backend run lint
- npm --workspace @hive/backend run typecheck
- git diff --check