### PR TITLE
Fix thinking-level reset on a new conversation's first send

### DIFF
--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -392,11 +392,15 @@ export default function BrainView() {
               onDismissQuestion={() => rejectToolInput("[question_dismissed]")}
               chatInput={
                 // Mount only once sessions have settled so lastRunOptions can
-                // seed the controls; key by session so each switch remounts and
-                // re-seeds cleanly (no syncing effect).
+                // seed the controls. Key by switchCounter (bumped only on an
+                // explicit session/workspace switch) rather than the raw sessionId:
+                // a new conversation adopts its backend id on first send
+                // (undefined -> realId), and keying on sessionId would remount and
+                // re-seed the composer mid-turn, snapping the user's thinking level
+                // back to the default. switchCounter still remounts on real switches.
                 sessionsLoading ? null : (
                 <ChatInput
-                  key={`${BRAIN_WORKSPACE_ID}:${sessionId ?? "new"}`}
+                  key={`${BRAIN_WORKSPACE_ID}:${switchCounter}`}
                   ref={chatInputRef}
                   wsId={BRAIN_WORKSPACE_ID}
                   sessionId={sessionId}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -517,11 +517,15 @@ export default function WorkspaceView() {
             }
             chatInput={
               // Mount only once the sessions list has settled so lastRunOptions
-              // is available to seed the controls; key by session so each
-              // switch remounts and re-seeds cleanly (no syncing effect).
+              // is available to seed the controls. Key by switchCounter (bumped
+              // only on an explicit session/workspace switch) rather than the raw
+              // sessionId: a new conversation adopts its backend id on first send
+              // (undefined -> realId), and keying on sessionId would remount and
+              // re-seed the composer mid-turn, snapping the user's thinking level
+              // back to the default. switchCounter still remounts on real switches.
               sessionsLoading ? null : (
               <ChatInput
-                key={`${wsId}:${sessionId ?? "new"}`}
+                key={`${wsId}:${switchCounter}`}
                 ref={chatInputRef}
                 wsId={wsId}
                 sessionId={sessionId}

--- a/frontend/tests/pages/WorkspaceView.test.tsx
+++ b/frontend/tests/pages/WorkspaceView.test.tsx
@@ -51,6 +51,7 @@ const mocks = vi.hoisted(() => ({
   openTerminalSsh: vi.fn(),
   copyToClipboard: vi.fn(),
   captureConversationTabsProps: vi.fn(),
+  chatInputMounted: vi.fn(),
 }));
 
 vi.mock("@/hooks/useApi", () => ({
@@ -166,45 +167,55 @@ vi.mock("@/components/ChatConversation", () => ({
   ),
 }));
 
-vi.mock("@/components/ChatInput", () => ({
-  default: ({
-    wsId,
-    sessionId,
-    isStreaming,
-    placeholder,
-    queuedMessage,
-    onSend,
-    onQueue,
-  }: {
-    wsId?: string;
-    sessionId?: string;
-    isStreaming?: boolean;
-    placeholder?: string;
-    queuedMessage?: { content: string } | null;
-    onSend?: (content: string) => boolean;
-    onQueue?: (msg: { content: string }) => void;
-  }) => (
-    <div
-      data-testid="chat-input"
-      data-ws-id={wsId ?? ""}
-      data-session-id={sessionId ?? ""}
-      data-has-queue={queuedMessage ? "true" : "false"}
-      data-placeholder={placeholder ?? ""}
-    >
-      chat-input
-      {onSend && (
-        <button type="button" data-testid="chat-send-btn" onClick={() => onSend("queued revision")}>
-          send message
-        </button>
-      )}
-      {isStreaming && onQueue && (
-        <button type="button" data-testid="queue-message-btn" onClick={() => onQueue({ content: "queued msg" })}>
-          queue message
-        </button>
-      )}
-    </div>
-  ),
-}));
+vi.mock("@/components/ChatInput", () => {
+  const React = require("react");
+  return {
+    default: ({
+      wsId,
+      sessionId,
+      isStreaming,
+      placeholder,
+      queuedMessage,
+      onSend,
+      onQueue,
+    }: {
+      wsId?: string;
+      sessionId?: string;
+      isStreaming?: boolean;
+      placeholder?: string;
+      queuedMessage?: { content: string } | null;
+      onSend?: (content: string) => boolean;
+      onQueue?: (msg: { content: string }) => void;
+    }) => {
+      // Fires once per mount; lets tests detect remounts (which reset the
+      // composer toggles) caused by the ChatInput `key` changing.
+      React.useEffect(() => {
+        mocks.chatInputMounted();
+      }, []);
+      return (
+        <div
+          data-testid="chat-input"
+          data-ws-id={wsId ?? ""}
+          data-session-id={sessionId ?? ""}
+          data-has-queue={queuedMessage ? "true" : "false"}
+          data-placeholder={placeholder ?? ""}
+        >
+          chat-input
+          {onSend && (
+            <button type="button" data-testid="chat-send-btn" onClick={() => onSend("queued revision")}>
+              send message
+            </button>
+          )}
+          {isStreaming && onQueue && (
+            <button type="button" data-testid="queue-message-btn" onClick={() => onQueue({ content: "queued msg" })}>
+              queue message
+            </button>
+          )}
+        </div>
+      );
+    },
+  };
+});
 
 vi.mock("@/components/chat/QuestionPanel", () => ({
   default: ({
@@ -437,6 +448,7 @@ describe("WorkspaceView behavior", () => {
     mocks.useWorkspaceLiveData.mockReset();
     mocks.useWorkspaceLiveData.mockReturnValue({ liveData: {}, clearUnread: vi.fn() });
     mocks.captureConversationTabsProps.mockReset();
+    mocks.chatInputMounted.mockReset();
     mocks.openExternal.mockReset();
 
     mocks.useScripts.mockReturnValue({
@@ -1526,6 +1538,82 @@ describe("WorkspaceView behavior", () => {
       "data-placeholder",
       "Enter your plan adjustments here...",
     );
+  });
+
+  // The ChatInput `key` is `${wsId}:${switchCounter}` (not `${wsId}:${sessionId}`).
+  // A brand-new conversation has no backend session id while composing; it adopts
+  // one on the first send (sessionId undefined -> real) WITHOUT bumping
+  // switchCounter. Keying on sessionId would remount the composer mid-turn and
+  // snap the thinking level back to the default. These guard that contract.
+  describe("composer remount key", () => {
+    function renderWorkspaceRerenderable(initialEntry = "/workspaces/ws-1") {
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
+      const wsIds = Object.keys(WORKSPACES);
+      // Build a FRESH tree each render: identical types/positions so React
+      // reconciles (no remount, state preserved) but with new element
+      // references so it actually re-renders and re-reads the mocked hooks.
+      // Reusing one cached element would make React bail out via reference
+      // equality and never pick up the updated useConversation return value.
+      const makeTree = () => (
+        <QueryClientProvider client={queryClient}>
+          <WorkspaceLiveDataProvider workspaceIds={wsIds}>
+            <MemoryRouter initialEntries={[initialEntry]}>
+              <Routes>
+                <Route path="/workspaces/:wsId" element={<WorkspaceView />} />
+                <Route path="/home" element={<div data-testid="home-page">Home page</div>} />
+              </Routes>
+            </MemoryRouter>
+          </WorkspaceLiveDataProvider>
+        </QueryClientProvider>
+      );
+      const result = render(makeTree());
+      return { ...result, rerenderSame: () => result.rerender(makeTree()) };
+    }
+
+    it("does not remount ChatInput when a new conversation adopts its backend session id", async () => {
+      mocks.useConversation.mockReturnValue(
+        buildConversationState({ sessionId: undefined, switchCounter: 7 }),
+      );
+      const { rerenderSame } = renderWorkspaceRerenderable();
+      await screen.findByText("tokyo");
+
+      expect(screen.getByTestId("chat-input")).toHaveAttribute("data-session-id", "");
+      expect(mocks.chatInputMounted).toHaveBeenCalledTimes(1);
+
+      // First send: backend assigns the id (undefined -> real), no explicit switch.
+      mocks.useConversation.mockReturnValue(
+        buildConversationState({ sessionId: "sess-real", switchCounter: 7 }),
+      );
+      act(() => { rerenderSame(); });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-input")).toHaveAttribute("data-session-id", "sess-real");
+      });
+      // Same instance kept alive -> composer toggles survive the first send.
+      expect(mocks.chatInputMounted).toHaveBeenCalledTimes(1);
+    });
+
+    it("remounts ChatInput on an explicit session switch (switchCounter bump)", async () => {
+      mocks.useConversation.mockReturnValue(
+        buildConversationState({ sessionId: "sess-1", switchCounter: 0 }),
+      );
+      const { rerenderSame } = renderWorkspaceRerenderable();
+      await screen.findByText("tokyo");
+      expect(mocks.chatInputMounted).toHaveBeenCalledTimes(1);
+
+      // Switching to another session bumps switchCounter -> remount + re-seed.
+      mocks.useConversation.mockReturnValue(
+        buildConversationState({ sessionId: "sess-2", switchCounter: 1 }),
+      );
+      act(() => { rerenderSame(); });
+
+      await waitFor(() => {
+        expect(screen.getByTestId("chat-input")).toHaveAttribute("data-session-id", "sess-2");
+      });
+      expect(mocks.chatInputMounted).toHaveBeenCalledTimes(2);
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

Sending the **first message of a brand-new conversation** at a non-default thinking level (e.g. `xHigh`) snaps the composer back to the default (`High`) *the instant the message is sent*. The toggle also affects plan/fast mode. The follow-up to #263 — that PR fixed the *switch-between-existing-sessions* case but left this one.

Note the sent message **does** run at the chosen level (the options are captured at submit); it's the selector that resets, so subsequent messages silently fall back to `High`.

## Root cause — a remount, not a persistence gap

`ChatInput` is keyed by `` `${wsId}:${sessionId ?? "new"}` ``, and its toggles are seeded once at mount via `useState` (precedence: per-session store → `lastRunOptions` → default).

A new conversation composes with `sessionId === undefined`. On first send the backend creates the session and returns its id in the WS `status` message; the `useConversation` reducer adopts it (`!state.sessionId && sid` → `undefined → realId`). That flips the `key`, so **`ChatInput` remounts and re-seeds**. At that instant:

- the per-session compose-options store has nothing under the new id — it was never written, because `setStoredComposeOptions` early-returns while `sessionId` is `undefined`; and
- `lastRunOptions` is still stale (it's refreshed only when streaming *ends*).

So the seed falls through to `DEFAULT_THINKING_LEVEL` (`"high"`).

The repro is intermittent precisely because it only happens when the active conversation has no backend id yet (default/empty conversation). Clicking **“+ new conversation”** pre-creates the session, so that path never hit the bug.

## Fix

Key `ChatInput` by `` `${wsId}:${switchCounter}` `` instead. `switchCounter` is bumped **only** on an explicit session/workspace switch (`prepare_session_switch` / `prepare_workspace_switch`), never on id adoption. So:

- first send no longer remounts the composer → the toggles survive, and the existing write-through effect now populates the store under the real id for later switches;
- a genuine session switch still bumps `switchCounter` → remount + clean re-seed, exactly as before.

Applied to both `WorkspaceView` and `BrainView` (identical pattern). The draft-persistence hook is unaffected — it already tracks in-place `sessionId` changes via its own effect rather than relying on the remount.

## Tests

`tests/pages/WorkspaceView.test.tsx` → **`composer remount key`**:
- *does not remount `ChatInput` when a new conversation adopts its backend session id* — asserts the mount count stays at 1 across the `undefined → realId` transition (**fails on the old key**);
- *remounts `ChatInput` on an explicit session switch (`switchCounter` bump)* — asserts a remount on switch so re-seeding still works.

`npm run lint`, `npm run typecheck`, and the full frontend suite pass (the one unrelated `Sidebar.test.tsx` footer-layout failure pre-exists on `main`).