### PR TITLE
Recover zombie hub sockets and make reconnect non-destructive

### DIFF
--- a/backend/src/__tests__/e2e.test.ts
+++ b/backend/src/__tests__/e2e.test.ts
@@ -59,7 +59,7 @@ async function connectHub(
     onInit: (clientWs: WebSocket) => {
       clientWs.on("message", (data: Buffer) => {
         const envelope = JSON.parse(data.toString()) as HubOutgoing;
-        if (envelope.workspaceId === workspaceId) {
+        if ("workspaceId" in envelope && envelope.workspaceId === workspaceId) {
           messages.push(envelope.event);
         }
       });

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -720,10 +720,14 @@ export interface UpdateCustomAgentRequest {
 /** Client -> Server (hub-level). */
 export type HubIncoming =
   | { type: "sync_workspaces"; workspaceIds: string[] }
+  // Application-level liveness probe. The browser WebSocket API never exposes
+  // protocol-level ping/pong to JS, so clients send this to actively detect a
+  // frozen-but-OPEN socket (e.g. after the OS wakes from sleep).
+  | { type: "ping" }
   | { workspaceId: string; event: WsIncoming };
 
-/** Server -> Client (hub-level). Every outgoing event is tagged with its workspace. */
-export interface HubOutgoing {
-  workspaceId: string;
-  event: WsOutgoing;
-}
+/** Server -> Client (hub-level). Workspace events are tagged with their workspace. */
+export type HubOutgoing =
+  | { workspaceId: string; event: WsOutgoing }
+  /** Reply to a client `ping` (liveness probe). */
+  | { type: "pong" };

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -24,6 +24,9 @@ import {
 } from "../services/script-runner.js";
 import type { WsOutgoing, HubOutgoing } from "../types.js";
 
+/** Hub envelope carrying a workspace event (excludes hub-level pong frames). */
+type WorkspaceEnvelope = Extract<HubOutgoing, { workspaceId: string }>;
+
 const CONV_CMD = { command: "bash" };
 
 let tempDir: string;
@@ -90,14 +93,14 @@ function connectHub(
 ): {
   wsReady: Promise<WebSocket>;
   messages: WsOutgoing[];
-  allEnvelopes: HubOutgoing[];
+  allEnvelopes: WorkspaceEnvelope[];
 } {
   const queryString = opts?.query
     ? `?${new URLSearchParams(opts.query).toString()}`
     : "";
   const path = `/ws/hub${queryString}`;
   const messages: WsOutgoing[] = [];
-  const allEnvelopes: HubOutgoing[] = [];
+  const allEnvelopes: WorkspaceEnvelope[] = [];
   const targetWsId = workspaceIds[0];
   const wsReady = (opts?.app ?? app).injectWS(
     path,
@@ -106,6 +109,7 @@ function connectHub(
       onInit: (ws) => {
         ws.on("message", (data: Buffer) => {
           const envelope = JSON.parse(data.toString()) as HubOutgoing;
+          if (!("workspaceId" in envelope)) return; // ignore hub-level pong frames
           allEnvelopes.push(envelope);
           if (opts?.collectAll || envelope.workspaceId === targetWsId) {
             messages.push(envelope.event);
@@ -136,13 +140,14 @@ async function connectHubLateListener(
   const path = `/ws/hub${queryString}`;
   const ws = (await (opts?.app ?? app).injectWS(path, { headers: opts?.headers })) as WebSocket;
   const messages: WsOutgoing[] = [];
-  const allEnvelopes: HubOutgoing[] = [];
+  const allEnvelopes: WorkspaceEnvelope[] = [];
   const targetWsId = workspaceIds[0];
 
   // Simulate clients that install message handlers right after websocket init.
   await Promise.resolve();
   ws.on("message", (data: Buffer) => {
     const envelope = JSON.parse(data.toString()) as HubOutgoing;
+    if (!("workspaceId" in envelope)) return; // ignore hub-level pong frames
     allEnvelopes.push(envelope);
     if (envelope.workspaceId === targetWsId) {
       messages.push(envelope.event);
@@ -892,6 +897,26 @@ describe("WS /ws/hub", () => {
     if (errorEnvelope?.event.type === "error") {
       expect(errorEnvelope.event.message).toContain("Invalid JSON");
     }
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
+  it("replies pong to an application-level ping", async () => {
+    await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    const { wsReady } = connectHub([wsId]);
+    const ws = await wsReady;
+
+    const raw: string[] = [];
+    ws.on("message", (data: Buffer) => raw.push(data.toString()));
+
+    ws.send(JSON.stringify({ type: "ping" }));
+
+    const isPong = (s: string): boolean => {
+      try { return (JSON.parse(s) as { type?: string }).type === "pong"; } catch { return false; }
+    };
+    await waitForCondition(() => raw.some(isPong));
+    expect(raw.some(isPong)).toBe(true);
 
     ws.close();
     await endSession(wsId, dataDir);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -611,7 +611,13 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           return;
         }
 
-        if ("type" in parsed && parsed.type === "sync_workspaces") {
+        if ("type" in parsed && parsed.type === "ping") {
+          // Application-level liveness probe: reply immediately so the client
+          // can distinguish a healthy idle socket from a frozen one.
+          if (socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify({ type: "pong" }));
+          }
+        } else if ("type" in parsed && parsed.type === "sync_workspaces") {
           await handleSyncWorkspaces(hub, parsed.workspaceIds);
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -49,8 +49,7 @@ type LocalAction =
   | { type: "clear_chat" }
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
-  | { type: "clear_pending_tool_inputs" }
-  | { type: "_ws_reconnected" };
+  | { type: "clear_pending_tool_inputs" };
 
 type Action = WsOutgoing | LocalAction;
 
@@ -399,14 +398,18 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       let newStreams = state.sessionStreams;
       if (historySessionId && !activeStream?.isStreaming) {
-        if (activeStream || hydratedPendingToolInputs.length > 0) {
+        // History is authoritative for finalized turns. Drop any stale in-progress
+        // stream content (e.g. a turn that completed while the hub socket was a
+        // zombie) so it is not rendered as a duplicate bubble alongside the now-
+        // persisted message. Keep only a slot carrying pending tool inputs (an
+        // unanswered question/plan in the last turn).
+        if (hydratedPendingToolInputs.length > 0) {
           newStreams = {
             ...state.sessionStreams,
-            [historySessionId]: {
-              ...(activeStream ?? { ...emptyStreamState }),
-              pendingToolInputs: hydratedPendingToolInputs,
-            },
+            [historySessionId]: { ...emptyStreamState, pendingToolInputs: hydratedPendingToolInputs },
           };
+        } else if (activeStream) {
+          newStreams = deleteStream(state, historySessionId);
         }
       }
 
@@ -498,13 +501,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "reset":
       return initialState;
 
-    case "_ws_reconnected":
-      // On WS reconnect the backend will re-bootstrap every workspace with a
-      // full streaming snapshot (text, thinking, tool calls). Clear accumulated
-      // stream data so the snapshot won't be *appended* to stale pre-disconnect
-      // content, which would cause duplicate tool calls and garbled text.
-      return { ...state, sessionStreams: {} };
-
     default:
       return state;
   }
@@ -586,10 +582,6 @@ export function useConversation(workspaceId: string | undefined) {
     });
     replayingBuffer = false;
 
-    const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
-      dispatch({ type: "_ws_reconnected" });
-    });
-
     // Tell the backend to activate the saved session and send its bootstrap.
     if (savedSession) {
       const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
@@ -630,7 +622,6 @@ export function useConversation(workspaceId: string | undefined) {
         historyRequestTokenRef.current = historyRequestToken + 1;
       }
       unsubscribe();
-      unsubReconnect();
     };
   }, [workspaceId, syncSessionHistory]);
 

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -13,6 +13,19 @@ type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
 const MAX_RECONNECT_DELAY = 30_000;
 const BASE_RECONNECT_DELAY = 1_000;
+// Application-level heartbeat. The browser WebSocket API never surfaces
+// protocol ping/pong to JS, so a frozen-but-OPEN socket (after OS sleep/wake or
+// a network change) is invisible to onclose. We send our own `ping` and watch
+// for the matching `pong` to detect liveness.
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const PONG_TIMEOUT_MS = 10_000;
+// On window focus / tab visibility / network regain, probe the socket and only
+// reconnect if the probe goes unanswered within this window. Active probing (vs.
+// "reconnect any silent socket") is what avoids reconnecting healthy idle sockets.
+const FOCUS_PROBE_TIMEOUT_MS = 3_000;
+
+/** Narrowed hub envelope carrying a workspace event (the non-pong variant). */
+type WorkspaceEnvelope = { workspaceId: string; event: WsOutgoing };
 
 /** Resolve the session a history message belongs to (undefined if session-less). */
 function historySessionKey(msg: HistoryMessage): string | undefined {
@@ -26,6 +39,9 @@ interface HubState {
   status: ConnectionStatus;
   reconnectAttempt: number;
   reconnectTimer: ReturnType<typeof setTimeout> | null;
+  /** Timestamp of the last `pong` received (liveness signal). */
+  lastPongAt: number;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
 }
 
 // ── Per-workspace subscription data (no socket) ─────────────────────
@@ -50,6 +66,8 @@ class WsTransport {
     status: "disconnected",
     reconnectAttempt: 0,
     reconnectTimer: null,
+    lastPongAt: 0,
+    heartbeatTimer: null,
   };
   private subscriptions = new Map<string, WorkspaceSubscription>();
   private subscribedWorkspaceIds = new Set<string>();
@@ -135,6 +153,32 @@ class WsTransport {
     this.teardownHub();
     this.subscriptions.clear();
     this.subscribedWorkspaceIds.clear();
+  }
+
+  /**
+   * Verify the hub socket is alive and reconnect if it is not. Call on window
+   * focus / tab visibility / network regain — moments when a zombie socket
+   * (frozen OPEN after sleep, never firing onclose) typically surfaces.
+   *
+   * A closed/closing/absent socket reconnects immediately. An OPEN socket is
+   * actively probed with a `ping`; we reconnect only if no `pong` arrives within
+   * FOCUS_PROBE_TIMEOUT_MS. Probing (rather than reconnecting any silent socket)
+   * is what keeps healthy idle conversations from needlessly reconnecting.
+   */
+  probeLiveness(): void {
+    if (this.subscribedWorkspaceIds.size === 0) return;
+    const ws = this.hub.ws;
+    if (!ws || ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+      this.forceReconnect();
+      return;
+    }
+    if (ws.readyState === WebSocket.CONNECTING) return; // attempt already in flight
+    const pongBefore = this.hub.lastPongAt;
+    this.sendPing();
+    setTimeout(() => {
+      if (this.hub.ws !== ws) return; // socket already replaced
+      if (this.hub.lastPongAt === pongBefore) this.forceReconnect();
+    }, FOCUS_PROBE_TIMEOUT_MS);
   }
 
   /** Send a message to the backend for a specific workspace. Returns false if the hub isn't open. */
@@ -273,6 +317,8 @@ class WsTransport {
       if (this.hub.ws !== ws) return;
       const isReconnect = this.hub.reconnectAttempt > 0;
       this.hub.reconnectAttempt = 0;
+      this.hub.lastPongAt = Date.now();
+      this.startHeartbeat();
       // Clear per-session status caches on reconnect (will be repopulated by bootstrap)
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
@@ -293,7 +339,11 @@ class WsTransport {
       if (this.hub.ws !== ws) return;
       try {
         const envelope = JSON.parse(event.data as string) as HubOutgoing;
-        this.handleIncomingEnvelope(envelope);
+        if ("type" in envelope && envelope.type === "pong") {
+          this.hub.lastPongAt = Date.now();
+          return;
+        }
+        this.handleIncomingEnvelope(envelope as WorkspaceEnvelope);
       } catch (err) {
         if (import.meta.env.DEV) {
           console.warn("[ws] Failed to parse message:", err);
@@ -303,6 +353,7 @@ class WsTransport {
 
     ws.onclose = () => {
       if (this.hub.ws !== ws) return;
+      this.stopHeartbeat();
       this.hub.ws = null;
       this.setHubStatus("disconnected");
       if (this.subscribedWorkspaceIds.size > 0) {
@@ -315,7 +366,7 @@ class WsTransport {
     };
   }
 
-  private handleIncomingEnvelope(envelope: HubOutgoing): void {
+  private handleIncomingEnvelope(envelope: WorkspaceEnvelope): void {
     const { workspaceId, event: msg } = envelope;
 
     // Notify global listeners (toast notifications, etc.) regardless of subscription state
@@ -363,6 +414,46 @@ class WsTransport {
     }));
   }
 
+  private sendPing(): void {
+    if (this.hub.ws?.readyState === WebSocket.OPEN) {
+      this.hub.ws.send(JSON.stringify({ type: "ping" }));
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.hub.heartbeatTimer = setInterval(() => {
+      if (!this.hub.ws || this.hub.ws.readyState !== WebSocket.OPEN) return;
+      // No pong since the previous ping window → the socket is a zombie.
+      if (Date.now() - this.hub.lastPongAt > HEARTBEAT_INTERVAL_MS + PONG_TIMEOUT_MS) {
+        this.forceReconnect();
+        return;
+      }
+      this.sendPing();
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.hub.heartbeatTimer) {
+      clearInterval(this.hub.heartbeatTimer);
+      this.hub.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Tear down a (possibly zombie) socket and open a fresh one, marking it as a
+   * reconnect so onReconnect listeners fire. The conversation reducer reconciles
+   * non-destructively from the bootstrap (snapshot replace + history), so this
+   * does not blank the visible stream.
+   */
+  private forceReconnect(): void {
+    if (this.subscribedWorkspaceIds.size === 0) return;
+    this.teardownHub();
+    this.hub.reconnectAttempt = 1;
+    this.setHubStatus("connecting");
+    this.openHubSocket();
+  }
+
   private scheduleHubReconnect(): void {
     if (this.hub.reconnectTimer) return;
     const delay = Math.min(
@@ -379,6 +470,7 @@ class WsTransport {
   }
 
   private teardownHub(): void {
+    this.stopHeartbeat();
     if (this.hub.reconnectTimer) {
       clearTimeout(this.hub.reconnectTimer);
       this.hub.reconnectTimer = null;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,8 +4,22 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 import "./index.css";
 import { copyToClipboard } from "@/lib/clipboard";
+import { wsTransport } from "@/lib/ws-transport";
 import App from "./App";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+// A hub WebSocket can stay readyState OPEN after the OS sleeps/wakes or the
+// network changes, never firing onclose — leaving the UI stuck on stale data.
+// When the user returns (tab visible / window focus / network back), probe the
+// socket; probeLiveness() reconnects only if the probe goes unanswered, so a
+// healthy idle conversation is never needlessly reconnected. Works in both the
+// browser and the Tauri webview (which receives standard focus events).
+const probeHubLiveness = () => wsTransport.probeLiveness();
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") probeHubLiveness();
+});
+window.addEventListener("focus", probeHubLiveness);
+window.addEventListener("online", probeHubLiveness);
 
 // Fallback for streamdown's code block copy button in non-secure contexts
 // where navigator.clipboard is unavailable (HTTP, remote IP).

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -710,8 +710,8 @@ export interface UpdateCustomAgentRequest {
 
 // ── Hub WebSocket protocol (multiplexed) ────────────────────────────
 
-/** Server -> Client (hub-level). Every outgoing event is tagged with its workspace. */
-export interface HubOutgoing {
-  workspaceId: string;
-  event: WsOutgoing;
-}
+/** Server -> Client (hub-level). Workspace events are tagged with their workspace. */
+export type HubOutgoing =
+  | { workspaceId: string; event: WsOutgoing }
+  /** Reply to a client `ping` (liveness probe). */
+  | { type: "pong" };

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2782,4 +2782,81 @@ describe("useConversation", () => {
       expect(assistant?.outputTokens).toBeUndefined();
     });
   });
+
+  describe("non-destructive reconnect resync", () => {
+    it("drops a stale stream slot when authoritative history shows the turn finished", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      // Active stream accumulates content.
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Hello" });
+      });
+      expect(result.current.currentStreamingText).toBe("Hello");
+      expect(result.current.isStreaming).toBe(true);
+
+      // Reconnect bootstrap: the turn completed while the socket was a zombie.
+      // status (provisional) then authoritative history with the finalized turn.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+        __wsMock.emit("ws-1", {
+          type: "history",
+          sessionId: "sess-1",
+          messages: [
+            { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+            { id: "a1", sessionId: "sess-1", role: "assistant", content: "Hello", timestamp: "2026-02-12T00:00:01.000Z" },
+          ],
+        });
+      });
+
+      // No leftover streaming bubble, and the finalized message appears exactly once.
+      expect(result.current.isStreaming).toBe(false);
+      expect(result.current.currentStreamingText).toBe("");
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages.at(-1)?.content).toBe("Hello");
+    });
+
+    it("keeps an active stream and reconciles it via snapshot replace (no wipe)", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Hel" });
+      });
+      expect(result.current.currentStreamingText).toBe("Hel");
+
+      // Reconnect bootstrap for a still-streaming session: status (busy) →
+      // history (finalized turns only) → snapshot (authoritative in-flight state).
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", {
+          type: "history",
+          sessionId: "sess-1",
+          messages: [
+            { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+          ],
+        });
+        __wsMock.emit("ws-1", {
+          type: "stream_snapshot",
+          sessionId: "sess-1",
+          text: "Hello world",
+          thinking: "",
+          toolCalls: [],
+          agentActivities: [],
+          agentPlanMode: false,
+        });
+      });
+
+      expect(result.current.isStreaming).toBe(true);
+      expect(result.current.currentStreamingText).toBe("Hello world");
+    });
+  });
 });

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -925,4 +925,115 @@ describe("wsTransport", () => {
       expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
     });
   });
+
+  describe("heartbeat + liveness", () => {
+    const getPings = (socket: MockWebSocket): unknown[] =>
+      socket.sent
+        .map((s) => { try { return JSON.parse(s); } catch { return null; } })
+        .filter((m) => m?.type === "ping");
+    const sendPong = (socket: MockWebSocket): void =>
+      socket.message(JSON.stringify({ type: "pong" }));
+
+    it("sends an app-level ping on the heartbeat interval", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      expect(getPings(socket)).toHaveLength(0);
+      vi.advanceTimersByTime(25_000);
+      expect(getPings(socket).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("keeps a socket that answers pongs (no reconnect)", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      for (let i = 0; i < 4; i++) {
+        vi.advanceTimersByTime(25_000);
+        sendPong(socket);
+      }
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(socket.readyState).toBe(MockWebSocket.OPEN);
+    });
+
+    it("reconnects a zombie socket that never answers pongs", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      // Silent past HEARTBEAT_INTERVAL_MS + PONG_TIMEOUT_MS (25s + 10s).
+      vi.advanceTimersByTime(60_000);
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("ignores pong frames (does not forward them as workspace events)", () => {
+      const received: WsOutgoing[] = [];
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+      wsTransport.onMessage("ws-1", (msg) => received.push(msg));
+
+      sendPong(socket);
+
+      expect(received).toHaveLength(0);
+    });
+  });
+
+  describe("probeLiveness", () => {
+    const sendPong = (socket: MockWebSocket): void =>
+      socket.message(JSON.stringify({ type: "pong" }));
+
+    it("is a no-op when nothing is subscribed", () => {
+      wsTransport.probeLiveness();
+      expect(MockWebSocket.instances).toHaveLength(0);
+    });
+
+    it("does not reconnect a healthy OPEN socket that answers the probe", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      wsTransport.probeLiveness();
+      vi.advanceTimersByTime(100); // pong round-trips before the probe deadline
+      sendPong(socket);
+      vi.advanceTimersByTime(3_000);
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(socket.readyState).toBe(MockWebSocket.OPEN);
+    });
+
+    it("reconnects an OPEN-but-frozen socket that ignores the probe", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      wsTransport.probeLiveness();
+      vi.advanceTimersByTime(3_000); // no pong arrives within the probe window
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("reconnects immediately when the socket is closed", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+      socket.readyState = MockWebSocket.CLOSED;
+
+      wsTransport.probeLiveness();
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("is a no-op while a connection attempt is already in flight", () => {
+      wsTransport.connect("ws-1");
+      expect(MockWebSocket.instances[0]!.readyState).toBe(MockWebSocket.CONNECTING);
+
+      wsTransport.probeLiveness();
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+  });
 });

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -258,16 +258,22 @@ final class ConversationStore {
             bumpHistoryToken(for: historySessionId)
             sessionId = historySessionId ?? sessionId
 
-            // Derive pending tool inputs from history only when not actively
-            // streaming (during streaming, live WS tool inputs take precedence).
-            let activeStream = historySessionId.flatMap { sessionStreams[$0] }
-            if activeStream?.isStreaming != true {
+            // Reconcile any stale in-progress stream slot for a non-streaming session.
+            // History only carries finalized turns, so when it arrives for a session that
+            // is NOT actively streaming, any leftover stream slot has already been
+            // persisted into `messages` (e.g. the turn finished while the socket was a
+            // backgrounded zombie). Rebuild a CLEAN slot containing only pending tool
+            // inputs (an unanswered question/plan), or drop the stale slot entirely.
+            // During streaming, live WS state takes precedence, so we leave it untouched.
+            let existingStream = historySessionId.flatMap { sessionStreams[$0] }
+            if existingStream?.isStreaming != true, let sid = historySessionId {
                 let derived = derivePendingToolInputsFromHistory(msgs)
-                if let sid = historySessionId {
-                    if activeStream != nil || !derived.isEmpty {
-                        ensureStream(for: sid, streaming: false)
-                        sessionStreams[sid]?.pendingToolInputs = derived
-                    }
+                if !derived.isEmpty {
+                    var rebuilt = SessionStreamState()
+                    rebuilt.pendingToolInputs = derived
+                    sessionStreams[sid] = rebuilt
+                } else if existingStream != nil {
+                    sessionStreams.removeValue(forKey: sid)
                 }
             }
 

--- a/ios/HiveMobile/Stores/ConversationStoreCache.swift
+++ b/ios/HiveMobile/Stores/ConversationStoreCache.swift
@@ -28,12 +28,4 @@ final class ConversationStoreCache {
     func evict(_ workspaceId: String) {
         stores.removeValue(forKey: workspaceId)
     }
-
-    /// Clear all streaming state from every cached store.
-    /// Called before force-reconnect so bootstrap data writes into a clean slate.
-    func clearAllStreamingState() {
-        for store in stores.values {
-            store.sessionStreams.removeAll()
-        }
-    }
 }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -342,8 +342,9 @@ final class HubStatusMonitor {
     }
 
     /// Called when the app returns to foreground after a non-trivial background period.
-    /// Clears stale streaming state and forces an immediate hub reconnect so the
-    /// backend bootstrap (status + history) writes into a clean slate.
+    /// Forces an immediate hub reconnect so the backend bootstrap (status + history)
+    /// re-syncs every workspace. The reconnect is non-destructive: streaming state is
+    /// reconciled silently from bootstrap events rather than wiped (issue #259).
     func appDidBecomeActive() {
         // Snapshot workspace IDs that had any streaming session
         streamingBeforeBackground = Set(streamingSessions.keys)
@@ -432,10 +433,11 @@ private final class HubConnection {
         task.resume()
         backoff = 1
 
-        // Clear stale streaming state and re-wire send closures on all existing stores.
-        // Without clearing, the bootstrap snapshot would be appended to pre-disconnect
-        // accumulated data, causing duplicate tool calls and garbled text.
-        monitor?.storeCache.clearAllStreamingState()
+        // Re-wire send closures on all existing stores so they target the fresh socket.
+        // We deliberately do NOT wipe streaming state here: the reconnect is
+        // non-destructive (issue #259). The visible conversation stays as-is and is
+        // reconciled silently from authoritative bootstrap events (stream_snapshot
+        // replaces active streams; history drops stale finalized stream slots).
         monitor?.rewireAllSendClosures()
 
         startReceiving()

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -364,6 +364,204 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func reconnectBootstrapKeepsActiveStreamAlive() {
+        // Models the non-destructive reconnect (issue #259): the hub no longer wipes
+        // sessionStreams on (re)connect, so an in-progress stream must survive a fresh
+        // bootstrap and be reconciled in place by the authoritative stream_snapshot.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "In progress before reconnect"))
+        store.handle(.toolUse(
+            sessionId: "session-1",
+            id: "tool-1",
+            name: "Read",
+            input: "{}",
+            parentToolUseId: nil
+        ))
+        #expect(store.currentText == "In progress before reconnect")
+        #expect(store.activeToolCalls.count == 1)
+
+        // Reconnect re-bootstraps: a status event reasserts streaming, then the snapshot
+        // replaces the accumulated state. No clear happens in between.
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        // Stream slot is intact immediately after the status re-bootstrap.
+        #expect(store.sessionStreams["session-1"]?.isStreaming == true)
+        #expect(store.sessionStreams["session-1"]?.currentText == "In progress before reconnect")
+        #expect(store.sessionStreams["session-1"]?.activeToolCalls.count == 1)
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "In progress before reconnect, now continued",
+            thinking: "",
+            toolCalls: [
+                ToolCall(id: "tool-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+            ],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: 1_700_000_002_000.0
+        ))
+
+        // Snapshot REPLACED rather than appended — no duplicate tool calls.
+        #expect(store.isStreaming == true)
+        #expect(store.currentText == "In progress before reconnect, now continued")
+        #expect(store.activeToolCalls.count == 1)
+        #expect(store.activeToolCalls.first?.output == "ok")
+    }
+
+    @Test @MainActor
+    func historyDropsStaleNonStreamingStreamSlot() {
+        // A turn finished while the socket was a backgrounded zombie. On reconnect the
+        // status arrives as idle (not streaming) and history carries the finalized turn.
+        // The stale in-progress stream slot must be dropped so it is not rendered as a
+        // duplicate bubble alongside the persisted message (issue #259).
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "Half-finished answer"))
+        #expect(store.sessionStreams["session-1"]?.currentText == "Half-finished answer")
+
+        // The turn is no longer streaming (e.g. idle status from bootstrap).
+        store.handle(.status(
+            status: .idle,
+            sessionId: "session-1",
+            streaming: false,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        #expect(store.sessionStreams["session-1"] != nil)
+
+        // History arrives with the finalized assistant turn (no unanswered question).
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Question",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            ),
+            ChatMessage(
+                id: "message-2",
+                sessionId: "session-1",
+                role: .assistant,
+                content: "Half-finished answer, now complete",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        #expect(store.messages.count == 2)
+        #expect(store.sessionStreams["session-1"] == nil)
+    }
+
+    @Test @MainActor
+    func historyRebuildsCleanSlotWithPendingToolInputs() {
+        // The last finalized assistant turn ends on an unanswered AskUserQuestion. History
+        // must rebuild a CLEAN slot carrying only those pending inputs (no stale streaming
+        // text/tool calls), so the question prompt survives reconnect.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "stale streaming text"))
+        store.handle(.status(
+            status: .idle,
+            sessionId: "session-1",
+            streaming: false,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .assistant,
+                content: "Which option?",
+                images: nil,
+                toolCalls: [
+                    ToolCall(id: "ask-1", name: "AskUserQuestion", input: "{}", output: nil, parentToolUseId: nil)
+                ],
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        let stream = store.sessionStreams["session-1"]
+        #expect(stream != nil)
+        #expect(stream?.currentText == "")
+        #expect(stream?.activeToolCalls.isEmpty == true)
+        #expect(stream?.isStreaming == false)
+        #expect(stream?.pendingToolInputs.count == 1)
+        #expect(stream?.pendingToolInputs.first?.toolName == "AskUserQuestion")
+    }
+
+    @Test @MainActor
+    func historyLeavesActiveStreamingSessionUntouched() {
+        // While a session is actively streaming, history (finalized turns) must not
+        // disturb the live stream slot — live WS state wins.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "Live streaming content"))
+
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Earlier turn",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        #expect(store.sessionStreams["session-1"]?.isStreaming == true)
+        #expect(store.sessionStreams["session-1"]?.currentText == "Live streaming content")
+        #expect(store.messages.count == 1)
+    }
+
+    @Test @MainActor
     func toolInputResolvedClearsPendingToolInputs() throws {
         let store = ConversationStore()
         store.handle(.status(


### PR DESCRIPTION
## Problem

Returning to the desktop app after a Mac sleep/wake (or a network change) often required a full page reload, and sometimes the conversation flashed as if it had been deleted and recreated.

Two root causes, both verified against `main`:

1. **No client-side liveness on web.** The hub WebSocket reconnects only on `ws.onclose`. A frozen TCP connection after sleep stays `readyState === OPEN` and never fires `onclose`, so the UI is stuck on stale data forever. The one recovery path (focus reconnect, #257) was reverted by #261.
2. **Destructive reconnect.** On reconnect the client wiped all in-progress streaming state (`_ws_reconnected → sessionStreams = {}` on web, `clearAllStreamingState()` on iOS), so the active assistant response visibly disappeared and was recreated. This is the behavior #259 calls out, and the reason #257 was reverted.

The `stream_snapshot` already has REPLACE semantics (since #256), so the destructive clear is vestigial.

## Change

Restore zombie-socket recovery **without** the destructive resync.

**Backend** (`types.ts`, `ws/stream.ts`)
- Add an application-level hub `ping` → `pong`. The browser WebSocket API never surfaces protocol ping/pong to JS, so the client needs an app-level probe. `HubOutgoing` becomes a union (`{workspaceId,event}` | `{type:"pong"}`).

**Web** (`lib/ws-transport.ts`, `hooks/useConversation.ts`, `main.tsx`)
- 25s heartbeat; a watchdog reconnects a socket that stays silent past the pong window (background safety net).
- `probeLiveness()` on `visibilitychange` / `focus` / `online`: actively pings and reconnects **only if the probe is unanswered within 3s**. A healthy idle conversation is never needlessly reconnected — this avoids the false positive that sank #257.
- Non-destructive resync (#259): removed the `_ws_reconnected` `sessionStreams` wipe. Active streams reconcile via the `stream_snapshot` REPLACE; the `history` reducer now drops a stale **non-streaming** stream slot (keeping only pending tool inputs), so a turn that finished during the freeze reconciles without a flash.

**iOS** (`HubStatusMonitor.swift`, `ConversationStore.swift`, `ConversationStoreCache.swift`)
- Mirror the non-destructive resync: removed `clearAllStreamingState()` on reconnect; same `history` reconcile rule. iOS keeps its existing `sendPing` heartbeat and foreground `forceReconnect` (its liveness detection was already good).

## Testing

- `npm run lint` + `npm run typecheck` clean (backend + frontend).
- Backend: **1540 tests pass** (adds a hub `ping`→`pong` test).
- Frontend transport + hook suites pass (adds heartbeat, watchdog, `probeLiveness`, and two non-destructive-resync cases). Full frontend suite: only pre-existing unrelated failure is `Sidebar.test.tsx > keeps add repository compact` (fails on baseline too).
- iOS: Swift tests added, **not compiled** (no Swift/Xcode toolchain in this environment) — needs CI.

## Notes

This is Phase 1 of a 3-phase plan. Phase 2 (light WS bootstrap / lazy tool outputs, addressing slow snapshot load — the abandoned #255 direction) and Phase 3 (backend dead-peer `pong`/terminate + removing the half-migrated history-token juggling) are follow-ups.