### PR TITLE
Streaming flow overhaul: zombie-socket recovery + REST-owned history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ Core model: Project -> Workspace -> Session. Projects are bare repositories; wor
 - Validate repository URLs with `validateRepositoryUrl()` before cloning.
 - Keep WebSocket protocol types aligned across `backend/src/types.ts`, `frontend/src/types.ts`, and `ios/HiveMobile/Models/WebSocketTypes.swift`.
 - When adding a WS event, update backend dispatch, frontend reducers/cache invalidation, iOS stores, and tests.
+- Conversation history is REST-owned for web and iOS. Keep session message endpoints, frontend React Query history, iOS per-session history cache, and WS live bootstrap (`historyViaRest`, `status`, `stream_snapshot`) aligned; keep WS `history` only as a legacy fallback.
 - When adding a provider, implement `AgentProvider`, register it in `providers/registry.ts`, expose capabilities, and add a stream adapter when the CLI format differs from Claude.
 - Keep provider capability fields synchronized across backend, frontend, and iOS models.
 - Automation actions reference Team agents by `agentId`; keep model, thinking level, system prompt, git-context injection, and read-only settings on the agent definition, not on each automation.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -55,12 +55,13 @@ ping 100.x.x.x
 
 ### Prerequisites
 
-The backend runs preflight checks on startup and exits with a clear error if any dependency is missing:
+The backend runs preflight checks on startup. It exits with a clear error if a required dependency is missing; optional dependencies only disable related features:
 
 - **Node.js >= 20**
 - **Git >= 2.17** (worktree support)
 - **Claude CLI** installed and authenticated (`claude` command)
-- **GitHub CLI** (`gh`) — optional but required for PR status and GitHub OAuth from the app
+- **GitHub CLI** (`gh`) installed (startup preflight requirement; authenticate it before GitHub-backed flows)
+- **Codex CLI** (`codex`) optional for OpenAI model support
 
 ### Clone and build
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Hive can run as a local web app, a Tauri desktop app connected to a local or rem
 **Agent workspaces**
 - Clone or create git-backed projects, then create isolated workspaces from them.
 - Run Claude and Codex sessions with provider-aware model selection and per-session provider locking.
-- Keep up to 4 sessions per workspace, with history replay, queued follow-up messages, unread indicators, and interrupt/stop handling.
-- Stream assistant text, thinking, tool calls, file changes, diagnostics, tasks, images, plan updates, branch info, diff stats, and script status over the multiplexed hub WebSocket.
+- Keep up to 4 sessions per workspace, with REST-fetched per-session history, queued follow-up messages, unread indicators, and interrupt/stop handling.
+- Stream live assistant text, thinking, tool calls, file changes, diagnostics, tasks, images, plan updates, branch info, diff stats, and script status over the multiplexed hub WebSocket.
 - Attach images to chat messages; backend resizes and stores attachments per session.
 - Browse workspace files, preview raw files, inspect inline diffs, paste selected diff comments into prompts, and use `#file`, `/command`, and `@agent` autocomplete.
 - Open a conversation tab as a full-pane interactive terminal (login shell in the worktree) from the workspace empty state. A tab commits to terminal before its first message and cannot revert; multiple terminal tabs per workspace are allowed. Terminal tabs are a desktop surface and are hidden on iOS.
@@ -281,9 +281,10 @@ Hub:
 
 - Endpoint: `ws://<host>/ws/hub`
 - Auth: `Authorization: Bearer <token>`, `x-hive-token`, or `?token=<token>`
-- Client sends `sync_workspaces`, `user_message`, `stop`, and `tool_input_response`.
-- Server wraps events as `{ workspaceId, event }`.
-- Current server events include `status`, `history`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `agent_activity`, `tool_input_required`, `tool_input_resolved`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `script_status`, and `plan_mode_changed`.
+- Clients send hub-level `sync_workspaces` and `ping`; workspace events include `switch_session`, `user_message`, `stop`, and `tool_input_response`.
+- `sync_workspaces` accepts `historyViaRest`. Web and iOS send `true`, so finalized conversation history is fetched over REST (`GET /api/workspaces/:wsId/sessions/:sessionId/messages`) while the hub bootstrap sends status and live stream snapshots only. Absent or `false` keeps the legacy WS `history` bootstrap.
+- Server wraps workspace events as `{ workspaceId, event }`; hub pings receive `{ type: "pong" }`.
+- Current server workspace events include `status`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `agent_activity`, `stream_snapshot`, `tool_input_required`, `tool_input_resolved`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `script_status`, `browser_status`, `plan_mode_changed`, and legacy `history`.
 
 Script stream:
 

--- a/backend/src/__tests__/e2e.test.ts
+++ b/backend/src/__tests__/e2e.test.ts
@@ -59,7 +59,7 @@ async function connectHub(
     onInit: (clientWs: WebSocket) => {
       clientWs.on("message", (data: Buffer) => {
         const envelope = JSON.parse(data.toString()) as HubOutgoing;
-        if (envelope.workspaceId === workspaceId) {
+        if ("workspaceId" in envelope && envelope.workspaceId === workspaceId) {
           messages.push(envelope.event);
         }
       });

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -18,6 +18,7 @@ import {
   activateSession,
   hardDeleteSession,
   getSpecificSessionMessages,
+  getDefaultSessionId,
   stopAllSessions,
   _clearActiveSessions,
   setNotifier,
@@ -115,6 +116,38 @@ async function writeSessionFixture(
     );
   }
 }
+
+describe("getDefaultSessionId", () => {
+  it("returns undefined when the workspace has no non-empty conversation", async () => {
+    await writeSessionFixture("empty-1", wsId, { metadata: { messageCount: 0 } });
+    expect(await getDefaultSessionId(wsId, dataDir)).toBeUndefined();
+  });
+
+  it("skips a newer empty session and opens the most-recent non-empty chat", async () => {
+    await writeSessionFixture("empty-new", wsId, {
+      metadata: { messageCount: 0, updatedAt: "2026-02-20T00:00:00.000Z" },
+    });
+    await writeSessionFixture("has-msgs", wsId, {
+      metadata: { messageCount: 2, updatedAt: "2026-02-10T00:00:00.000Z" },
+      messages: [
+        { id: "u1", sessionId: "has-msgs", role: "user", content: "hi", timestamp: "2026-02-10T00:00:00.000Z" },
+        { id: "a1", sessionId: "has-msgs", role: "assistant", content: "yo", timestamp: "2026-02-10T00:00:01.000Z" },
+      ],
+    });
+    expect(await getDefaultSessionId(wsId, dataDir)).toBe("has-msgs");
+  });
+
+  it("never returns a terminal session", async () => {
+    await writeSessionFixture("term", wsId, {
+      metadata: { messageCount: 5, kind: "terminal", updatedAt: "2026-02-20T00:00:00.000Z" },
+    });
+    await writeSessionFixture("chat", wsId, {
+      metadata: { messageCount: 1, updatedAt: "2026-02-10T00:00:00.000Z" },
+      messages: [{ id: "u1", sessionId: "chat", role: "user", content: "hi", timestamp: "2026-02-10T00:00:00.000Z" }],
+    });
+    expect(await getDefaultSessionId(wsId, dataDir)).toBe("chat");
+  });
+});
 
 describe("getOrCreateSession", () => {
   it("creates a session and sets workspace to busy", async () => {

--- a/backend/src/agents/agent-manager.test.ts
+++ b/backend/src/agents/agent-manager.test.ts
@@ -137,6 +137,21 @@ describe("getDefaultSessionId", () => {
     expect(await getDefaultSessionId(wsId, dataDir)).toBe("has-msgs");
   });
 
+  it("skips an active empty loaded session and opens the most-recent non-empty chat", async () => {
+    const { session: emptyActive } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    expect(emptyActive.metadata.messageCount).toBe(0);
+
+    await writeSessionFixture("has-msgs", wsId, {
+      metadata: { messageCount: 2, updatedAt: "2026-02-10T00:00:00.000Z" },
+      messages: [
+        { id: "u1", sessionId: "has-msgs", role: "user", content: "hi", timestamp: "2026-02-10T00:00:00.000Z" },
+        { id: "a1", sessionId: "has-msgs", role: "assistant", content: "yo", timestamp: "2026-02-10T00:00:01.000Z" },
+      ],
+    });
+
+    expect(await getDefaultSessionId(wsId, dataDir)).toBe("has-msgs");
+  });
+
   it("never returns a terminal session", async () => {
     await writeSessionFixture("term", wsId, {
       metadata: { messageCount: 5, kind: "terminal", updatedAt: "2026-02-20T00:00:00.000Z" },

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -606,6 +606,33 @@ export async function listWorkspaceSessions(
   return sessions;
 }
 
+/**
+ * Resolve the session a fresh client should open for this workspace, WITHOUT
+ * reading any message bodies (metadata only). Order: in-memory active/most-recent
+ * loaded session, else the persisted active session if it has content, else the
+ * most-recently-updated non-empty chat. Empty and terminal sessions are skipped
+ * so a first open lands on real history instead of a blank "new conversation".
+ * Returns undefined only when the workspace has no non-empty conversation.
+ */
+export async function getDefaultSessionId(
+  wsId: string,
+  dataDir = getDataDir(),
+): Promise<string | undefined> {
+  const active = getActiveSession(wsId) ?? getMostRecentlyUpdatedLoadedSession(wsId);
+  if (active && active.metadata.kind !== "terminal") return active.sessionId;
+
+  const sessions = await listWorkspaceSessions(wsId, dataDir); // sorted updatedAt-desc
+  const nonEmptyChats = sessions.filter((s) => s.kind !== "terminal" && s.messageCount > 0);
+  if (nonEmptyChats.length === 0) return undefined;
+
+  const result = await getWorkspace(wsId, dataDir);
+  const persistedActive = result?.workspace.activeSessionId;
+  if (persistedActive && nonEmptyChats.some((s) => s.sessionId === persistedActive)) {
+    return persistedActive;
+  }
+  return nonEmptyChats[0].sessionId;
+}
+
 /** Create a new session and mark it active without stopping other loaded sessions. */
 export async function createNewSession(
   wsId: string,

--- a/backend/src/agents/agent-manager.ts
+++ b/backend/src/agents/agent-manager.ts
@@ -129,14 +129,36 @@ function getActiveSession(wsId: string): ConversationSession | undefined {
   return getLoadedSessionById(wsId, activeSessionId);
 }
 
+function getMostRecentLoadedSession(
+  wsId: string,
+  predicate: (session: ConversationSession) => boolean,
+): ConversationSession | undefined {
+  const sessions = getLoadedSessions(wsId).filter(predicate);
+  if (sessions.length === 0) return undefined;
+  const sorted = sortByUpdatedAtDesc(sessions.map((s) => s.metadata));
+  return sorted[0] ? getLoadedSessionById(wsId, sorted[0].sessionId) : undefined;
+}
+
 function getMostRecentlyUpdatedLoadedSession(wsId: string): ConversationSession | undefined {
   // Terminal sessions are never the active chat session: they render a shell,
   // not a conversation, and silently no-op sendMessage. Skip them here so they
   // are never auto-promoted to active.
-  const sessions = getLoadedSessions(wsId).filter((s) => s.metadata.kind !== "terminal");
-  if (sessions.length === 0) return undefined;
-  const sorted = sortByUpdatedAtDesc(sessions.map((s) => s.metadata));
-  return sorted[0] ? getLoadedSessionById(wsId, sorted[0].sessionId) : undefined;
+  return getMostRecentLoadedSession(wsId, (s) => s.metadata.kind !== "terminal");
+}
+
+function isPersistedDefaultSessionCandidate(meta: SessionMetadata): boolean {
+  return meta.kind !== "terminal" && meta.messageCount > 0;
+}
+
+export function isLoadedDefaultSessionCandidate(session: ConversationSession): boolean {
+  return session.metadata.kind !== "terminal" && (
+    session.metadata.messageCount > 0 ||
+    session.status === "streaming"
+  );
+}
+
+function getMostRecentlyUpdatedDefaultLoadedSession(wsId: string): ConversationSession | undefined {
+  return getMostRecentLoadedSession(wsId, isLoadedDefaultSessionCandidate);
 }
 
 async function persistWorkspaceSessionState(
@@ -608,21 +630,25 @@ export async function listWorkspaceSessions(
 
 /**
  * Resolve the session a fresh client should open for this workspace, WITHOUT
- * reading any message bodies (metadata only). Order: in-memory active/most-recent
- * loaded session, else the persisted active session if it has content, else the
- * most-recently-updated non-empty chat. Empty and terminal sessions are skipped
- * so a first open lands on real history instead of a blank "new conversation".
+ * reading any message bodies (metadata only). Order: default-worthy in-memory
+ * active/most-recent loaded session, else the persisted active session if it
+ * has content, else the most-recently-updated non-empty chat. Empty idle and
+ * terminal sessions are skipped so a first open lands on real history instead
+ * of a blank "new conversation".
  * Returns undefined only when the workspace has no non-empty conversation.
  */
 export async function getDefaultSessionId(
   wsId: string,
   dataDir = getDataDir(),
 ): Promise<string | undefined> {
-  const active = getActiveSession(wsId) ?? getMostRecentlyUpdatedLoadedSession(wsId);
-  if (active && active.metadata.kind !== "terminal") return active.sessionId;
+  const active = getActiveSession(wsId);
+  if (active && isLoadedDefaultSessionCandidate(active)) return active.sessionId;
+
+  const loaded = getMostRecentlyUpdatedDefaultLoadedSession(wsId);
+  if (loaded) return loaded.sessionId;
 
   const sessions = await listWorkspaceSessions(wsId, dataDir); // sorted updatedAt-desc
-  const nonEmptyChats = sessions.filter((s) => s.kind !== "terminal" && s.messageCount > 0);
+  const nonEmptyChats = sessions.filter(isPersistedDefaultSessionCandidate);
   if (nonEmptyChats.length === 0) return undefined;
 
   const result = await getWorkspace(wsId, dataDir);

--- a/backend/src/agents/brain-manager.ts
+++ b/backend/src/agents/brain-manager.ts
@@ -244,6 +244,17 @@ export async function listBrainSessions(dataDir = getDataDir()): Promise<Session
   return sortByUpdatedAtDesc(sessions);
 }
 
+/** Session a fresh client should open for the Brain (metadata only — no message
+ *  bodies). In-memory active/most-recent, else the most-recently-updated
+ *  non-empty session, else undefined. Mirrors agent-manager.getDefaultSessionId. */
+export async function getDefaultBrainSessionId(dataDir = getDataDir()): Promise<string | undefined> {
+  const active = getActiveSession() ?? getMostRecentlyUpdatedLoadedSession();
+  if (active) return active.sessionId;
+
+  const sessions = await listBrainSessions(dataDir); // sorted updatedAt-desc
+  return sessions.find((s) => s.messageCount > 0)?.sessionId;
+}
+
 /** Create a new Brain session and make it active. Enforces the shared session cap. */
 export async function createNewBrainSession(
   dataDir = getDataDir(),

--- a/backend/src/agents/session-dispatch.ts
+++ b/backend/src/agents/session-dispatch.ts
@@ -33,6 +33,16 @@ export function getSession(wsId: string): ConversationSession | undefined {
   return isBrain(wsId) ? brainManager.getBrainSession() : workspaceManager.getSession(wsId);
 }
 
+export function isLoadedDefaultSessionCandidate(
+  wsId: string,
+  session: ConversationSession,
+): boolean {
+  // The Brain has a single shared session and no terminal/empty-skip concept:
+  // getDefaultBrainSessionId always resolves the active session, so a loaded
+  // brain session is always its own default. Keep this in sync with that.
+  return isBrain(wsId) || workspaceManager.isLoadedDefaultSessionCandidate(session);
+}
+
 export function getSessionById(wsId: string, sessionId: string): ConversationSession | undefined {
   return isBrain(wsId)
     ? brainManager.getBrainSessionById(sessionId)

--- a/backend/src/agents/session-dispatch.ts
+++ b/backend/src/agents/session-dispatch.ts
@@ -78,6 +78,16 @@ export async function listWorkspaceSessions(
     : workspaceManager.listWorkspaceSessions(wsId, dataDir);
 }
 
+/** Session a fresh client should open for a workspace (metadata only). */
+export async function getDefaultSessionId(
+  wsId: string,
+  dataDir = getDataDir(),
+): Promise<string | undefined> {
+  return isBrain(wsId)
+    ? brainManager.getDefaultBrainSessionId(dataDir)
+    : workspaceManager.getDefaultSessionId(wsId, dataDir);
+}
+
 export async function createNewSession(
   wsId: string,
   dataDir = getDataDir(),

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -719,7 +719,10 @@ export interface UpdateCustomAgentRequest {
 
 /** Client -> Server (hub-level). */
 export type HubIncoming =
-  | { type: "sync_workspaces"; workspaceIds: string[] }
+  // `historyViaRest`: client fetches finalized history over REST (React Query),
+  // so the server skips the heavy `history` bootstrap event for this hub. Absent
+  // / false keeps the legacy behavior (e.g. iOS until it migrates).
+  | { type: "sync_workspaces"; workspaceIds: string[]; historyViaRest?: boolean }
   // Application-level liveness probe. The browser WebSocket API never exposes
   // protocol-level ping/pong to JS, so clients send this to actively detect a
   // frozen-but-OPEN socket (e.g. after the OS wakes from sleep).

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -721,7 +721,7 @@ export interface UpdateCustomAgentRequest {
 export type HubIncoming =
   // `historyViaRest`: client fetches finalized history over REST (React Query),
   // so the server skips the heavy `history` bootstrap event for this hub. Absent
-  // / false keeps the legacy behavior (e.g. iOS until it migrates).
+  // / false keeps the legacy behavior for clients that still rely on WS history.
   | { type: "sync_workspaces"; workspaceIds: string[]; historyViaRest?: boolean }
   // Application-level liveness probe. The browser WebSocket API never exposes
   // protocol-level ping/pong to JS, so clients send this to actively detect a

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -720,10 +720,14 @@ export interface UpdateCustomAgentRequest {
 /** Client -> Server (hub-level). */
 export type HubIncoming =
   | { type: "sync_workspaces"; workspaceIds: string[] }
+  // Application-level liveness probe. The browser WebSocket API never exposes
+  // protocol-level ping/pong to JS, so clients send this to actively detect a
+  // frozen-but-OPEN socket (e.g. after the OS wakes from sleep).
+  | { type: "ping" }
   | { workspaceId: string; event: WsIncoming };
 
-/** Server -> Client (hub-level). Every outgoing event is tagged with its workspace. */
-export interface HubOutgoing {
-  workspaceId: string;
-  event: WsOutgoing;
-}
+/** Server -> Client (hub-level). Workspace events are tagged with their workspace. */
+export type HubOutgoing =
+  | { workspaceId: string; event: WsOutgoing }
+  /** Reply to a client `ping` (liveness probe). */
+  | { type: "pong" };

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -24,6 +24,9 @@ import {
 } from "../services/script-runner.js";
 import type { WsOutgoing, HubOutgoing } from "../types.js";
 
+/** Hub envelope carrying a workspace event (excludes hub-level pong frames). */
+type WorkspaceEnvelope = Extract<HubOutgoing, { workspaceId: string }>;
+
 const CONV_CMD = { command: "bash" };
 
 let tempDir: string;
@@ -90,14 +93,14 @@ function connectHub(
 ): {
   wsReady: Promise<WebSocket>;
   messages: WsOutgoing[];
-  allEnvelopes: HubOutgoing[];
+  allEnvelopes: WorkspaceEnvelope[];
 } {
   const queryString = opts?.query
     ? `?${new URLSearchParams(opts.query).toString()}`
     : "";
   const path = `/ws/hub${queryString}`;
   const messages: WsOutgoing[] = [];
-  const allEnvelopes: HubOutgoing[] = [];
+  const allEnvelopes: WorkspaceEnvelope[] = [];
   const targetWsId = workspaceIds[0];
   const wsReady = (opts?.app ?? app).injectWS(
     path,
@@ -106,6 +109,7 @@ function connectHub(
       onInit: (ws) => {
         ws.on("message", (data: Buffer) => {
           const envelope = JSON.parse(data.toString()) as HubOutgoing;
+          if (!("workspaceId" in envelope)) return; // ignore hub-level pong frames
           allEnvelopes.push(envelope);
           if (opts?.collectAll || envelope.workspaceId === targetWsId) {
             messages.push(envelope.event);
@@ -136,13 +140,14 @@ async function connectHubLateListener(
   const path = `/ws/hub${queryString}`;
   const ws = (await (opts?.app ?? app).injectWS(path, { headers: opts?.headers })) as WebSocket;
   const messages: WsOutgoing[] = [];
-  const allEnvelopes: HubOutgoing[] = [];
+  const allEnvelopes: WorkspaceEnvelope[] = [];
   const targetWsId = workspaceIds[0];
 
   // Simulate clients that install message handlers right after websocket init.
   await Promise.resolve();
   ws.on("message", (data: Buffer) => {
     const envelope = JSON.parse(data.toString()) as HubOutgoing;
+    if (!("workspaceId" in envelope)) return; // ignore hub-level pong frames
     allEnvelopes.push(envelope);
     if (envelope.workspaceId === targetWsId) {
       messages.push(envelope.event);
@@ -892,6 +897,26 @@ describe("WS /ws/hub", () => {
     if (errorEnvelope?.event.type === "error") {
       expect(errorEnvelope.event.message).toContain("Invalid JSON");
     }
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
+  it("replies pong to an application-level ping", async () => {
+    await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    const { wsReady } = connectHub([wsId]);
+    const ws = await wsReady;
+
+    const raw: string[] = [];
+    ws.on("message", (data: Buffer) => raw.push(data.toString()));
+
+    ws.send(JSON.stringify({ type: "ping" }));
+
+    const isPong = (s: string): boolean => {
+      try { return (JSON.parse(s) as { type?: string }).type === "pong"; } catch { return false; }
+    };
+    await waitForCondition(() => raw.some(isPong));
+    expect(raw.some(isPong)).toBe(true);
 
     ws.close();
     await endSession(wsId, dataDir);

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -11,6 +11,7 @@ import {
   getOrCreateSession,
   getSessionById,
   createNewSession,
+  convertSessionToTerminal,
   sendMessage,
   hardDeleteSession,
   endSession,
@@ -72,8 +73,12 @@ function hubEvent(workspaceId: string, event: object): string {
 }
 
 /** Send sync_workspaces via a hub WebSocket. */
-function syncWorkspaces(ws: WebSocket, workspaceIds: string[]): void {
-  ws.send(JSON.stringify({ type: "sync_workspaces", workspaceIds }));
+function syncWorkspaces(ws: WebSocket, workspaceIds: string[], historyViaRest?: boolean): void {
+  ws.send(JSON.stringify({
+    type: "sync_workspaces",
+    workspaceIds,
+    ...(historyViaRest !== undefined ? { historyViaRest } : {}),
+  }));
 }
 
 /**
@@ -89,6 +94,8 @@ function connectHub(
     query?: Record<string, string>;
     /** If set, collect ALL workspace messages (unfiltered). Default: first workspace. */
     collectAll?: boolean;
+    /** Subscribe as a REST-history client (no `history` frames over the WS). */
+    historyViaRest?: boolean;
   },
 ): {
   wsReady: Promise<WebSocket>;
@@ -117,7 +124,7 @@ function connectHub(
         });
         // Subscribe to workspaces after the connection is established
         ws.on("open", () => {
-          syncWorkspaces(ws, workspaceIds);
+          syncWorkspaces(ws, workspaceIds, opts?.historyViaRest);
         });
       },
     },
@@ -225,6 +232,37 @@ function waitForCondition(
       reject(new Error("Timeout waiting for condition"));
     }, timeoutMs);
   });
+}
+
+async function writePersistedChatSession(
+  sessionId: string,
+  content: string,
+  updatedAt = "2026-02-10T00:00:01.000Z",
+): Promise<void> {
+  const sessionDir = join(dataDir, projectId, "sessions", sessionId);
+  await mkdir(sessionDir, { recursive: true });
+  await writeFile(
+    join(sessionDir, "metadata.json"),
+    JSON.stringify({
+      sessionId,
+      workspaceId: wsId,
+      createdAt: "2026-02-10T00:00:00.000Z",
+      updatedAt,
+      messageCount: 1,
+    }),
+    "utf-8",
+  );
+  await writeFile(
+    join(sessionDir, "messages.jsonl"),
+    JSON.stringify({
+      id: "m-1",
+      sessionId,
+      role: "assistant",
+      content,
+      timestamp: "2026-02-10T00:00:00.000Z",
+    }) + "\n",
+    "utf-8",
+  );
 }
 
 describe("WS /ws/hub", () => {
@@ -336,6 +374,138 @@ describe("WS /ws/hub", () => {
     }
 
     ws.close();
+  });
+
+  it("bootstraps the default non-empty chat when the active loaded session is empty", async () => {
+    const { session: emptyActive } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    const defaultSessionId = "sess-default-non-empty";
+    await writePersistedChatSession(defaultSessionId, "persisted default response");
+
+    const { wsReady, messages } = connectHub([wsId]);
+    const ws = await wsReady;
+
+    await waitForMessage(
+      messages,
+      (msgs) =>
+        msgs.some((m) => m.type === "status") &&
+        msgs.some((m) => m.type === "history"),
+    );
+
+    const status = messages.find((m) => m.type === "status");
+    expect(status).toEqual({
+      type: "status",
+      status: "idle",
+      streaming: false,
+      sessionId: defaultSessionId,
+    });
+    expect(status).not.toEqual(expect.objectContaining({ sessionId: emptyActive.sessionId }));
+
+    const history = messages.find((m) => m.type === "history");
+    expect(history).toBeDefined();
+    if (history?.type === "history") {
+      expect(history.sessionId).toBe(defaultSessionId);
+      expect(history.messages).toEqual([
+        expect.objectContaining({
+          content: "persisted default response",
+          sessionId: defaultSessionId,
+        }),
+      ]);
+    }
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
+  it("redirects a historyViaRest client to the default chat via status only, without a WS history frame", async () => {
+    await getOrCreateSession(wsId, dataDir, CONV_CMD); // empty active session
+    const defaultSessionId = "sess-default-rest";
+    await writePersistedChatSession(defaultSessionId, "persisted default for rest client");
+
+    const { wsReady, messages } = connectHub([wsId], { historyViaRest: true });
+    const ws = await wsReady;
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+    // Give a (mistaken) history frame a chance to arrive before asserting absence.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const status = messages.find((m) => m.type === "status");
+    expect(status).toEqual({
+      type: "status",
+      status: "idle",
+      streaming: false,
+      sessionId: defaultSessionId,
+    });
+    expect(messages.some((m) => m.type === "history")).toBe(false);
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
+  it("bootstraps the default non-empty chat when the active loaded session is terminal", async () => {
+    const { session: terminalActive } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
+    await convertSessionToTerminal(wsId, terminalActive.sessionId, dataDir);
+    const defaultSessionId = "sess-default-after-terminal";
+    await writePersistedChatSession(defaultSessionId, "persisted chat after terminal");
+
+    const { wsReady, messages } = connectHub([wsId]);
+    const ws = await wsReady;
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+
+    const status = messages.find((m) => m.type === "status");
+    expect(status).toEqual({
+      type: "status",
+      status: "idle",
+      streaming: false,
+      sessionId: defaultSessionId,
+    });
+    expect(status).not.toEqual(expect.objectContaining({ sessionId: terminalActive.sessionId }));
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
+  it("bootstraps a streaming default session as busy (never idle) when the active session is empty", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-stream-default.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    // A streaming session, then a fresh empty active session layered on top.
+    const streaming = await createNewSession(wsId, dataDir, slowCmd);
+    streaming.sendMessage("keep me streaming");
+    await waitForCondition(() => streaming.status === "streaming");
+    const emptyActive = await createNewSession(wsId, dataDir, slowCmd);
+    expect(emptyActive.metadata.messageCount).toBe(0);
+
+    const { wsReady, messages } = connectHub([wsId], { app: local.app });
+    const ws = await wsReady;
+
+    await waitForMessage(
+      messages,
+      (msgs) =>
+        msgs.some(
+          (m) => m.type === "status" && m.sessionId === streaming.sessionId && m.streaming === true,
+        ),
+    );
+    // Let any (mistaken) idle status for the streaming default arrive.
+    await new Promise((r) => setTimeout(r, 50));
+
+    const defaultStatuses = messages.filter(
+      (m) => m.type === "status" && m.sessionId === streaming.sessionId,
+    );
+    expect(defaultStatuses.length).toBeGreaterThan(0);
+    for (const m of defaultStatuses) {
+      if (m.type === "status") {
+        expect(m.status).toBe("busy");
+        expect(m.streaming).toBe(true);
+      }
+    }
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
   });
 
   it("sends idle status + history when session exists but is not streaming", async () => {

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -922,6 +922,32 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir);
   });
 
+  it("skips the history bootstrap when the client opts into historyViaRest", async () => {
+    await getOrCreateSession(wsId, dataDir, CONV_CMD);
+
+    const received: WsOutgoing[] = [];
+    const ws = (await app.injectWS("/ws/hub", {}, {
+      onInit: (clientWs: WebSocket) => {
+        clientWs.on("message", (data: Buffer) => {
+          const env = JSON.parse(data.toString()) as HubOutgoing;
+          if ("workspaceId" in env && env.workspaceId === wsId) received.push(env.event);
+        });
+        clientWs.on("open", () => {
+          clientWs.send(JSON.stringify({ type: "sync_workspaces", workspaceIds: [wsId], historyViaRest: true }));
+        });
+      },
+    })) as WebSocket;
+
+    await waitForCondition(() => received.some((m) => m.type === "status"));
+    await new Promise((r) => setTimeout(r, 150));
+
+    expect(received.some((m) => m.type === "status")).toBe(true);
+    expect(received.some((m) => m.type === "history")).toBe(false);
+
+    ws.close();
+    await endSession(wsId, dataDir);
+  });
+
   it("handles stop command without error", async () => {
     await getOrCreateSession(wsId, dataDir, CONV_CMD);
     const { wsReady, messages } = connectHub([wsId]);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -6,6 +6,7 @@ import {
   getSessionById,
   getOrCreateSession,
   getSessionMessages,
+  getDefaultSessionId,
   getStreamingSessionIds,
   stopStreaming,
 } from "../agents/session-dispatch.js";
@@ -327,7 +328,17 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         }
       }
     } else {
-      sendToHub(hub, wsId, { type: "status", status: "idle", streaming: false });
+      // No session loaded in memory. Tell the client which session to open
+      // (persisted active / most-recent non-empty chat) so a first visit lands
+      // on real history instead of a blank "new conversation" — resolved from
+      // metadata only, without shipping the history over the WS.
+      const defaultSessionId = await getDefaultSessionId(wsId, dataDir).catch(() => undefined);
+      sendToHub(hub, wsId, {
+        type: "status",
+        status: "idle",
+        streaming: false,
+        ...(defaultSessionId ? { sessionId: defaultSessionId } : {}),
+      });
       if (!hub.historyViaRest) {
         try {
           const messages = await getSessionMessages(wsId, dataDir);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -6,8 +6,10 @@ import {
   getSessionById,
   getOrCreateSession,
   getSessionMessages,
+  getSpecificSessionMessages,
   getDefaultSessionId,
   getStreamingSessionIds,
+  isLoadedDefaultSessionCandidate,
   stopStreaming,
 } from "../agents/session-dispatch.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
@@ -302,53 +304,82 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
   // ── Workspace bootstrap (sent to one hub socket on subscribe) ─────
 
   const sendWorkspaceBootstrap = async (hub: HubSocket, wsId: string, channel: WorkspaceChannel): Promise<void> => {
-    const session = getSession(wsId);
-
-    if (session) {
-      attachSessionListeners(wsId, channel, session);
-      await sendSessionBootstrap(hub, wsId, session);
+    const sendStreamingBootstraps = (primarySessionId?: string): void => {
       for (const streamingId of getStreamingSessionIds(wsId)) {
-        if (streamingId !== session.sessionId) {
-          const streamingSession = getSessionById(wsId, streamingId);
-          if (streamingSession) {
-            attachSessionListeners(wsId, channel, streamingSession);
-          }
-          sendToHub(hub, wsId, {
-            type: "status",
-            status: "busy",
-            sessionId: streamingId,
-            streaming: true,
-            ...(streamingSession?.streamingStartedAt
-              ? { streamingStartedAt: streamingSession.streamingStartedAt }
-              : {}),
-          });
-          if (streamingSession) {
-            sendStreamingSnapshot(hub, wsId, streamingSession);
-          }
+        if (streamingId === primarySessionId) continue;
+        const streamingSession = getSessionById(wsId, streamingId);
+        if (streamingSession) {
+          attachSessionListeners(wsId, channel, streamingSession);
+        }
+        sendToHub(hub, wsId, {
+          type: "status",
+          status: "busy",
+          sessionId: streamingId,
+          streaming: true,
+          ...(streamingSession?.streamingStartedAt
+            ? { streamingStartedAt: streamingSession.streamingStartedAt }
+            : {}),
+        });
+        if (streamingSession) {
+          sendStreamingSnapshot(hub, wsId, streamingSession);
         }
       }
+    };
+
+    const session = getSession(wsId);
+    const sessionIsDefaultCandidate = session
+      ? isLoadedDefaultSessionCandidate(wsId, session)
+      : false;
+    const defaultSessionId = !session || !sessionIsDefaultCandidate
+      ? await getDefaultSessionId(wsId, dataDir).catch(() => undefined)
+      : undefined;
+
+    if (session && (sessionIsDefaultCandidate || !defaultSessionId)) {
+      attachSessionListeners(wsId, channel, session);
+      await sendSessionBootstrap(hub, wsId, session);
+      sendStreamingBootstraps(session.sessionId);
     } else {
-      // No session loaded in memory. Tell the client which session to open
-      // (persisted active / most-recent non-empty chat) so a first visit lands
-      // on real history instead of a blank "new conversation" — resolved from
-      // metadata only, without shipping the history over the WS.
-      const defaultSessionId = await getDefaultSessionId(wsId, dataDir).catch(() => undefined);
-      sendToHub(hub, wsId, {
-        type: "status",
-        status: "idle",
-        streaming: false,
-        ...(defaultSessionId ? { sessionId: defaultSessionId } : {}),
-      });
-      if (!hub.historyViaRest) {
-        try {
-          const messages = await getSessionMessages(wsId, dataDir);
-          if (messages.length > 0) {
-            const firstSessionId = messages[0]?.sessionId;
-            sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
+      // The in-memory active session is empty/idle, so we steer a fresh client
+      // to a different default chat. Still attach the active chat session's
+      // listeners: a client that stays on it (instead of adopting the redirect)
+      // must keep receiving its live events, as it did before this redirect.
+      if (session && session.metadata.kind !== "terminal") {
+        attachSessionListeners(wsId, channel, session);
+      }
+
+      const defaultSession = defaultSessionId ? getSessionById(wsId, defaultSessionId) : undefined;
+      if (defaultSession) {
+        // The default chat is already loaded: bootstrap it as the primary
+        // session so its listeners are attached and its real status/snapshot are
+        // sent — a streaming default must not be announced as idle first.
+        attachSessionListeners(wsId, channel, defaultSession);
+        await sendSessionBootstrap(hub, wsId, defaultSession);
+        sendStreamingBootstraps(defaultSession.sessionId);
+      } else {
+        // No default-worthy chat is loaded in memory. Tell the client which
+        // session to open (persisted active / most-recent non-empty chat) so a
+        // first visit lands on real history instead of a blank "new conversation"
+        // — resolved from metadata only, without shipping history over the WS.
+        sendToHub(hub, wsId, {
+          type: "status",
+          status: "idle",
+          streaming: false,
+          ...(defaultSessionId ? { sessionId: defaultSessionId } : {}),
+        });
+        if (!hub.historyViaRest) {
+          try {
+            const messages = defaultSessionId
+              ? await getSpecificSessionMessages(wsId, defaultSessionId, dataDir)
+              : await getSessionMessages(wsId, dataDir);
+            if (messages.length > 0) {
+              const firstSessionId = messages[0]?.sessionId;
+              sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
+            }
+          } catch {
+            // Ignore missing/corrupt persisted history.
           }
-        } catch {
-          // Ignore missing/corrupt persisted history.
         }
+        sendStreamingBootstraps();
       }
     }
 

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -611,7 +611,13 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           return;
         }
 
-        if ("type" in parsed && parsed.type === "sync_workspaces") {
+        if ("type" in parsed && parsed.type === "ping") {
+          // Application-level liveness probe: reply immediately so the client
+          // can distinguish a healthy idle socket from a frozen one.
+          if (socket.readyState === socket.OPEN) {
+            socket.send(JSON.stringify({ type: "pong" }));
+          }
+        } else if ("type" in parsed && parsed.type === "sync_workspaces") {
           await handleSyncWorkspaces(hub, parsed.workspaceIds);
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -39,6 +39,8 @@ type ActiveSession = NonNullable<ReturnType<typeof getSession>>;
 interface HubSocket {
   ws: WebSocket;
   subscribedWorkspaces: Set<string>;
+  /** Client fetches finalized history over REST, so skip the `history` bootstrap event. */
+  historyViaRest: boolean;
 }
 
 interface WorkspaceChannel {
@@ -178,8 +180,10 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       lockedProvider: session.metadata.lockedProvider,
     });
     try {
-      const messages = await session.getMessages();
-      sendToHub(hub, workspaceId, { type: "history", sessionId: session.sessionId, messages });
+      if (!hub.historyViaRest) {
+        const messages = await session.getMessages();
+        sendToHub(hub, workspaceId, { type: "history", sessionId: session.sessionId, messages });
+      }
     } catch {
       // History load failure is non-fatal.
     }
@@ -324,14 +328,16 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
     } else {
       sendToHub(hub, wsId, { type: "status", status: "idle", streaming: false });
-      try {
-        const messages = await getSessionMessages(wsId, dataDir);
-        if (messages.length > 0) {
-          const firstSessionId = messages[0]?.sessionId;
-          sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
+      if (!hub.historyViaRest) {
+        try {
+          const messages = await getSessionMessages(wsId, dataDir);
+          if (messages.length > 0) {
+            const firstSessionId = messages[0]?.sessionId;
+            sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
+          }
+        } catch {
+          // Ignore missing/corrupt persisted history.
         }
-      } catch {
-        // Ignore missing/corrupt persisted history.
       }
     }
 
@@ -574,7 +580,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         return;
       }
 
-      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set() };
+      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set(), historyViaRest: false };
       hubSockets.add(hub);
 
       const pingTimer = setInterval(() => {
@@ -618,6 +624,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             socket.send(JSON.stringify({ type: "pong" }));
           }
         } else if ("type" in parsed && parsed.type === "sync_workspaces") {
+          if (parsed.historyViaRest !== undefined) hub.historyViaRest = parsed.historyViaRest;
           await handleSyncWorkspaces(hub, parsed.workspaceIds);
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -192,7 +192,19 @@ export default function ChatConversation({
   }, [messages]);
 
   return (
-    <Conversation className={`flex-1${isHydrating ? " invisible" : ""}`} resize={settled ? "smooth" : "instant"}>
+    <Conversation
+      // Remount the scroll container on every switch. use-stick-to-bottom keeps
+      // its `isAtBottom`/`escapedFromLock` state on the mounted instance, so once
+      // the user scrolls up in one conversation that "escaped" state persists into
+      // the next one and its ResizeObserver bails out of scroll-to-bottom (it only
+      // re-sticks when already at the bottom). A fresh mount resets that state and
+      // re-runs `initial="instant"`, so each conversation reliably opens at the
+      // newest message. switchCounter is bumped only on real session/workspace
+      // switches, never on streaming, so this never remounts mid-conversation.
+      key={switchCounter}
+      className={`flex-1${isHydrating ? " invisible" : ""}`}
+      resize={settled ? "smooth" : "instant"}
+    >
       {error && (
         <div className="border-b bg-destructive/10 px-4 py-2 text-sm text-destructive">
           {error}

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -101,8 +101,8 @@ export default function ChatConversation({
   // 6. After settling → resize="smooth" for normal interaction
   //
   // Uses React's "set state during render" pattern to detect workspace switches
-  // synchronously, even when React 18 batches the switch dispatch with the WS
-  // history replay into a single render (which broke the old useEffect approach).
+  // synchronously, even when React batches the switch dispatch with REST history
+  // hydration into a single render (which broke the old useEffect approach).
   const [prevSwitchCounter, setPrevSwitchCounter] = useState(switchCounter);
   const [hydrated, setHydrated] = useState(false);
   const [settled, setSettled] = useState(false);

--- a/frontend/src/components/chat/ThinkingSelector.tsx
+++ b/frontend/src/components/chat/ThinkingSelector.tsx
@@ -60,7 +60,9 @@ export function ThinkingSelector({
           </span>
         </div>
         <DropdownMenuGroup className="p-1">
-          {levels.map((level) => {
+          {/* Render highest level first so the menu reads Max → Low top-to-bottom.
+              Copy before reversing to avoid mutating the caller's array. */}
+          {[...levels].reverse().map((level) => {
             const isSelected = level === selectedLevel;
 
             return (

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -49,8 +49,7 @@ type LocalAction =
   | { type: "clear_chat" }
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
-  | { type: "clear_pending_tool_inputs" }
-  | { type: "_ws_reconnected" };
+  | { type: "clear_pending_tool_inputs" };
 
 type Action = WsOutgoing | LocalAction;
 
@@ -399,14 +398,18 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       let newStreams = state.sessionStreams;
       if (historySessionId && !activeStream?.isStreaming) {
-        if (activeStream || hydratedPendingToolInputs.length > 0) {
+        // History is authoritative for finalized turns. Drop any stale in-progress
+        // stream content (e.g. a turn that completed while the hub socket was a
+        // zombie) so it is not rendered as a duplicate bubble alongside the now-
+        // persisted message. Keep only a slot carrying pending tool inputs (an
+        // unanswered question/plan in the last turn).
+        if (hydratedPendingToolInputs.length > 0) {
           newStreams = {
             ...state.sessionStreams,
-            [historySessionId]: {
-              ...(activeStream ?? { ...emptyStreamState }),
-              pendingToolInputs: hydratedPendingToolInputs,
-            },
+            [historySessionId]: { ...emptyStreamState, pendingToolInputs: hydratedPendingToolInputs },
           };
+        } else if (activeStream) {
+          newStreams = deleteStream(state, historySessionId);
         }
       }
 
@@ -498,13 +501,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "reset":
       return initialState;
 
-    case "_ws_reconnected":
-      // On WS reconnect the backend will re-bootstrap every workspace with a
-      // full streaming snapshot (text, thinking, tool calls). Clear accumulated
-      // stream data so the snapshot won't be *appended* to stale pre-disconnect
-      // content, which would cause duplicate tool calls and garbled text.
-      return { ...state, sessionStreams: {} };
-
     default:
       return state;
   }
@@ -586,10 +582,6 @@ export function useConversation(workspaceId: string | undefined) {
     });
     replayingBuffer = false;
 
-    const unsubReconnect = wsTransport.onReconnect(workspaceId, () => {
-      dispatch({ type: "_ws_reconnected" });
-    });
-
     // Tell the backend to activate the saved session and send its bootstrap.
     if (savedSession) {
       const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
@@ -630,7 +622,6 @@ export function useConversation(workspaceId: string | undefined) {
         historyRequestTokenRef.current = historyRequestToken + 1;
       }
       unsubscribe();
-      unsubReconnect();
     };
   }, [workspaceId, syncSessionHistory]);
 

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -1,8 +1,13 @@
 import { useEffect, useCallback, useReducer, useRef, useSyncExternalStore } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import type { AgentActivity, ChatMessage, FileMention, ImageAttachment, MessageOptions, ToolCall, WsOutgoing, QuestionAnswer, QuestionInput } from "@/types";
 import { wsTransport } from "@/lib/ws-transport";
-import type { HistoryMessage } from "@/lib/ws-transport";
-import { api } from "@/hooks/useApi";
+import {
+  useSessionMessages,
+  getCachedSessionMessages,
+  appendCachedSessionMessage,
+  invalidateSessionMessages,
+} from "@/hooks/useSessionMessages";
 
 export interface PendingToolInput {
   requestId: string;
@@ -32,8 +37,10 @@ const emptyStreamState: SessionStreamState = {
   pendingToolInputs: [],
 };
 
+// Finalized messages are owned by React Query (see useSessionMessages). The
+// reducer below tracks LIVE state only: per-session in-progress streams, status,
+// pending tool inputs, and the active session id.
 interface ConversationState {
-  messages: ChatMessage[];
   sessionStreams: Record<string, SessionStreamState>;
   workspaceStatus?: "idle" | "busy";
   error?: string;
@@ -49,12 +56,14 @@ type LocalAction =
   | { type: "clear_chat" }
   | { type: "prepare_session_switch"; sessionId: string }
   | { type: "prepare_workspace_switch" }
-  | { type: "clear_pending_tool_inputs" };
+  | { type: "clear_pending_tool_inputs" }
+  // Reconcile live stream slots against newly-loaded REST history (derive a
+  // pending question from the last turn / drop a stale finished stream slot).
+  | { type: "reconcile_history"; sessionId: string; messages: ChatMessage[] };
 
 type Action = WsOutgoing | LocalAction;
 
 const initialState: ConversationState = {
-  messages: [],
   sessionStreams: {},
   workspaceStatus: undefined,
   error: undefined,
@@ -68,6 +77,10 @@ function parseToolInput(input: string): unknown {
   } catch {
     return {};
   }
+}
+
+function newMessageId(): string {
+  return self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
 }
 
 function normalizeStreamingStartedAt(raw: number | undefined): number | undefined {
@@ -102,6 +115,62 @@ function derivePendingToolInputsFromHistory(messages: ChatMessage[]): PendingToo
     }));
 }
 
+/** Whether the last message for a session is a terminal assistant turn. */
+function lastMessageIsTerminalAssistant(messages: ChatMessage[], sid: string): boolean {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.sessionId && message.sessionId !== sid) continue;
+    return message.role === "assistant";
+  }
+  return false;
+}
+
+/** Build the finalized assistant message from a stream slot on done/cancelled. */
+function buildFinalizedMessage(
+  stream: SessionStreamState,
+  sid: string,
+  msg: Extract<WsOutgoing, { type: "done" } | { type: "cancelled" }>,
+): ChatMessage | null {
+  const hasOutput = stream.currentText.length > 0 || stream.activeToolCalls.length > 0;
+  const toolCalls = stream.activeToolCalls.length > 0 ? stream.activeToolCalls : undefined;
+  const agentActivities = stream.activeAgentActivities.length > 0 ? stream.activeAgentActivities : undefined;
+  const thinkingContent = stream.currentThinking || undefined;
+
+  if (msg.type === "cancelled") {
+    const hasActivity = stream.activeAgentActivities.length > 0;
+    const hasThinking = stream.currentThinking.length > 0;
+    // Ignore a stale cancelled with no accumulated data.
+    if (!stream.isStreaming && !hasOutput && !hasActivity && !hasThinking) return null;
+    return {
+      id: newMessageId(),
+      sessionId: sid,
+      role: "assistant",
+      content: hasOutput ? stream.currentText : CANCELLED_NO_OUTPUT_MESSAGE,
+      toolCalls,
+      agentActivities,
+      thinkingContent,
+      timestamp: new Date().toISOString(),
+      cancelled: true,
+    };
+  }
+
+  return {
+    id: newMessageId(),
+    sessionId: sid,
+    role: "assistant",
+    content: stream.currentText,
+    toolCalls,
+    agentActivities,
+    thinkingContent,
+    timestamp: new Date().toISOString(),
+    durationMs: msg.durationMs,
+    inputTokens: msg.inputTokens,
+    outputTokens: msg.outputTokens,
+    contextUsedTokens: msg.contextUsedTokens,
+    contextWindowTokens: msg.contextWindowTokens,
+  };
+}
+
 /** Return or create the stream slot for an explicit stream start. */
 function getOrInitStream(streams: Record<string, SessionStreamState>, sid: string): SessionStreamState {
   return streams[sid] ?? { ...emptyStreamState, isStreaming: true, streamingStartedAt: Date.now() };
@@ -129,15 +198,6 @@ function deleteStream(state: ConversationState, sid: string): Record<string, Ses
   return copy;
 }
 
-function hasTerminalAssistantMessage(state: ConversationState, sid: string): boolean {
-  for (let i = state.messages.length - 1; i >= 0; i--) {
-    const message = state.messages[i];
-    if (message.sessionId && message.sessionId !== sid) continue;
-    return message.role === "assistant";
-  }
-  return false;
-}
-
 function upsertActivity(activities: AgentActivity[], activity: AgentActivity): AgentActivity[] {
   const index = activities.findIndex((item) => item.id === activity.id);
   if (index < 0) return [...activities, activity];
@@ -149,13 +209,10 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "user_message": {
       const sid = action.message.sessionId || state.sessionId;
       if (!sid) return state;
-      // Only add to messages if this is the active session
       const isActive = !state.sessionId || sid === state.sessionId;
-      const alreadyExists = state.messages.some((m) => m.id === action.message.id);
       const stream = getOrInitStream(state.sessionStreams, sid);
       return {
         ...state,
-        messages: isActive && !alreadyExists ? [...state.messages, action.message] : state.messages,
         sessionStreams: {
           ...state.sessionStreams,
           [sid]: {
@@ -249,75 +306,24 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     }
 
     case "done": {
+      // The finalized message is appended to the React Query cache by the WS
+      // handler before this dispatch; here we only clear the live slot.
       const sid = action.sessionId || state.sessionId;
-      if (!sid) return state;
-      const stream = state.sessionStreams[sid];
-      if (!stream) return state;
-
-      const isActive = sid === state.sessionId;
-      const newStreams = deleteStream(state, sid);
-
-      if (isActive) {
-        const assistantMsg: ChatMessage = {
-          id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
-          sessionId: sid,
-          role: "assistant",
-          content: stream.currentText,
-          toolCalls: stream.activeToolCalls.length > 0 ? stream.activeToolCalls : undefined,
-          agentActivities: stream.activeAgentActivities.length > 0 ? stream.activeAgentActivities : undefined,
-          thinkingContent: stream.currentThinking || undefined,
-          timestamp: new Date().toISOString(),
-          durationMs: action.durationMs,
-          inputTokens: action.inputTokens,
-          outputTokens: action.outputTokens,
-          contextUsedTokens: action.contextUsedTokens,
-          contextWindowTokens: action.contextWindowTokens,
-        };
-        return {
-          ...state,
-          messages: [...state.messages, assistantMsg],
-          sessionStreams: newStreams,
-        };
-      }
-      // Background session: just clean up the slot. REST fetch on switch-back
-      // will include the completed message.
-      return { ...state, sessionStreams: newStreams };
+      if (!sid || !state.sessionStreams[sid]) return state;
+      return { ...state, sessionStreams: deleteStream(state, sid) };
     }
 
     case "cancelled": {
       const sid = action.sessionId || state.sessionId;
       if (!sid) return state;
       const stream = state.sessionStreams[sid];
-      const isActive = sid === state.sessionId;
-
-      // Ignore stale cancelled events when there's no stream data.
       if (!stream) return state;
       const hasOutput = stream.currentText.length > 0 || stream.activeToolCalls.length > 0;
       const hasActivity = stream.activeAgentActivities.length > 0;
       const hasThinking = stream.currentThinking.length > 0;
+      // Ignore stale cancelled events when there's no stream data.
       if (!stream.isStreaming && !hasOutput && !hasActivity && !hasThinking) return state;
-
-      const newStreams = deleteStream(state, sid);
-
-      if (isActive) {
-        const cancelledMsg: ChatMessage = {
-          id: self.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2),
-          sessionId: sid,
-          role: "assistant",
-          content: hasOutput ? stream.currentText : CANCELLED_NO_OUTPUT_MESSAGE,
-          toolCalls: stream.activeToolCalls.length > 0 ? stream.activeToolCalls : undefined,
-          agentActivities: stream.activeAgentActivities.length > 0 ? stream.activeAgentActivities : undefined,
-          thinkingContent: stream.currentThinking || undefined,
-          timestamp: new Date().toISOString(),
-          cancelled: true,
-        };
-        return {
-          ...state,
-          messages: [...state.messages, cancelledMsg],
-          sessionStreams: newStreams,
-        };
-      }
-      return { ...state, sessionStreams: newStreams };
+      return { ...state, sessionStreams: deleteStream(state, sid) };
     }
 
     case "error":
@@ -335,7 +341,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       if (sid && newIsStreaming !== undefined) {
         const stream = state.sessionStreams[sid];
         if (newIsStreaming) {
-          // Session started or is streaming — ensure a slot exists
           const existing = stream ?? { ...emptyStreamState };
           newStreams = {
             ...state.sessionStreams,
@@ -345,12 +350,10 @@ function reducer(state: ConversationState, action: Action): ConversationState {
               // A (re)starting turn means any pending question was answered,
               // possibly on another client (e.g. iOS).
               pendingToolInputs: [],
-              // Prefer backend-provided start time so all clients show the same timer.
               streamingStartedAt: backendStartedAt ?? existing.streamingStartedAt ?? Date.now(),
             },
           };
         } else if (stream) {
-          // Session stopped streaming. If slot has no content, clean up.
           if (
             !stream.currentText &&
             !stream.currentThinking &&
@@ -368,7 +371,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         }
       }
 
-      // Only adopt sessionId from status if we don't have one yet
       const newSessionId = (!state.sessionId && sid) ? sid : state.sessionId;
 
       return {
@@ -376,58 +378,43 @@ function reducer(state: ConversationState, action: Action): ConversationState {
         workspaceStatus: action.status,
         sessionId: newSessionId,
         sessionStreams: newStreams,
-        // Only update lockedProvider when explicitly present and for the active session.
         ...(action.lockedProvider !== undefined && sid === newSessionId
           ? { lockedProvider: action.lockedProvider }
           : {}),
       };
     }
 
-    case "history": {
-      const historySessionId = action.sessionId ?? action.messages[0]?.sessionId ?? state.sessionId;
-      // Only update messages for the active session
-      if (historySessionId && state.sessionId && historySessionId !== state.sessionId) {
-        return state;
-      }
+    case "reconcile_history": {
+      const sid = action.sessionId;
+      if (!sid || (state.sessionId && sid !== state.sessionId)) return state;
+      const activeStream = state.sessionStreams[sid];
+      // During an active stream the live WS state wins — leave it untouched.
+      if (activeStream?.isStreaming) return state;
 
-      // Derive pending tool inputs from history, unless the session has an active stream
-      const activeStream = historySessionId ? state.sessionStreams[historySessionId] : undefined;
-      const hydratedPendingToolInputs = activeStream?.isStreaming
-        ? activeStream.pendingToolInputs
-        : derivePendingToolInputsFromHistory(action.messages);
-
-      let newStreams = state.sessionStreams;
-      if (historySessionId && !activeStream?.isStreaming) {
-        // History is authoritative for finalized turns. Drop any stale in-progress
-        // stream content (e.g. a turn that completed while the hub socket was a
-        // zombie) so it is not rendered as a duplicate bubble alongside the now-
-        // persisted message. Keep only a slot carrying pending tool inputs (an
-        // unanswered question/plan in the last turn).
-        if (hydratedPendingToolInputs.length > 0) {
-          newStreams = {
+      const derived = derivePendingToolInputsFromHistory(action.messages);
+      if (derived.length > 0) {
+        return {
+          ...state,
+          sessionStreams: {
             ...state.sessionStreams,
-            [historySessionId]: { ...emptyStreamState, pendingToolInputs: hydratedPendingToolInputs },
-          };
-        } else if (activeStream) {
-          newStreams = deleteStream(state, historySessionId);
-        }
+            [sid]: { ...emptyStreamState, pendingToolInputs: derived },
+          },
+        };
       }
-
-      return {
-        ...state,
-        messages: action.messages,
-        error: undefined,
-        sessionId: historySessionId ?? state.sessionId,
-        sessionStreams: newStreams,
-      };
+      // No pending question and a stale finished slot lingers → drop it so it is
+      // not rendered as a duplicate bubble alongside the now-persisted message.
+      if (activeStream) {
+        return { ...state, sessionStreams: deleteStream(state, sid) };
+      }
+      return state;
     }
 
     case "tool_input_required": {
+      // The terminal-assistant guard (ignore a question already closed in
+      // history) lives in the WS handler, which has the REST messages.
       const sid = action.sessionId || state.sessionId;
       if (!sid) return state;
-      const stream = state.sessionStreams[sid];
-      if (!stream && hasTerminalAssistantMessage(state, sid)) return state;
-      const nextStream = stream ?? { ...emptyStreamState };
+      const nextStream = state.sessionStreams[sid] ?? { ...emptyStreamState };
       return {
         ...state,
         sessionStreams: {
@@ -446,7 +433,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     }
 
     case "tool_input_resolved": {
-      // A client (possibly another device) answered or dismissed the question.
       const stream = state.sessionStreams[action.sessionId];
       if (!stream || stream.pendingToolInputs.length === 0) return state;
       return updateStream(state, action.sessionId, { pendingToolInputs: [] });
@@ -467,7 +453,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "prepare_session_switch":
       return {
         ...state,
-        messages: [],
         sessionId: action.sessionId,
         error: undefined,
         lockedProvider: undefined,
@@ -478,7 +463,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
     case "prepare_workspace_switch":
       return {
         ...state,
-        messages: [],
         sessionId: undefined,
         workspaceStatus: undefined,
         error: undefined,
@@ -491,7 +475,6 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const sid = state.sessionId;
       return {
         ...state,
-        messages: [],
         sessionStreams: sid ? deleteStream(state, sid) : {},
         error: undefined,
         sessionId: undefined,
@@ -525,24 +508,18 @@ function sessionIdField(id: string | undefined): { sessionId: string } | Record<
 
 export function useConversation(workspaceId: string | undefined) {
   const [state, dispatch] = useReducer(reducer, initialState);
-  const historyRequestTokenRef = useRef(0);
-  // Track latest sessionId so effect cleanup can read it (refs update during render, before effects).
+  const queryClient = useQueryClient();
+
+  // Finalized messages for the active session — owned by React Query (REST).
+  const { messages } = useSessionMessages(workspaceId, state.sessionId);
+
+  // Track latest state so the WS handler (set up once per workspace) can read the
+  // current stream content and session id without re-subscribing.
+  const stateRef = useRef(state);
+  stateRef.current = state;
   const sessionIdRef = useRef<string | undefined>(state.sessionId);
   sessionIdRef.current = state.sessionId;
-  const syncSessionHistory = useCallback(async (sessionId: string) => {
-    if (!workspaceId || !sessionId) return;
-    const historyRequestToken = historyRequestTokenRef.current + 1;
-    historyRequestTokenRef.current = historyRequestToken;
-    try {
-      const messages = await api.get<ChatMessage[]>(
-        `/api/workspaces/${workspaceId}/sessions/${sessionId}/messages`,
-      );
-      if (historyRequestTokenRef.current !== historyRequestToken) return;
-      dispatch({ type: "history", sessionId, messages });
-    } catch {
-      // Best-effort sync. WS state remains the fallback if this request fails.
-    }
-  }, [workspaceId]);
+
   const connectionStatus = useSyncExternalStore(
     (listener) =>
       workspaceId ? wsTransport.subscribe(workspaceId, listener) : () => {},
@@ -555,12 +532,9 @@ export function useConversation(workspaceId: string | undefined) {
       return;
     }
     const savedSession = savedSessionByWorkspace.get(workspaceId);
-    const historyRequestToken = historyRequestTokenRef.current + 1;
-    historyRequestTokenRef.current = historyRequestToken;
 
     dispatch({ type: "prepare_workspace_switch" });
-    // Pre-set sessionId so the reducer's mismatch guard keeps only this session's
-    // history when the transport replays its per-session cache on resubscribe.
+    // Pre-set sessionId so the messages query targets the restored session.
     if (savedSession) {
       dispatch({ type: "prepare_session_switch", sessionId: savedSession });
     }
@@ -569,82 +543,63 @@ export function useConversation(workspaceId: string | undefined) {
 
     // Skip session-less errors during the synchronous buffer replay — they may be
     // stale from a previous visit (buffered while the user was on another workspace).
-    // After onMessage() returns, the flag is cleared and live errors pass through.
     let replayingBuffer = true;
-    const { unsubscribe, hadBufferedMessages } = wsTransport.onMessage(workspaceId, (msg) => {
+    const { unsubscribe } = wsTransport.onMessage(workspaceId, (msg) => {
       if (replayingBuffer && msg.type === "error" && !msg.sessionId) {
         return;
       }
-      dispatch(msg);
-      if ((msg.type === "done" || msg.type === "cancelled") && msg.sessionId) {
-        void syncSessionHistory(msg.sessionId);
+
+      // Ignore a tool_input_required for a question already closed in history
+      // (no live stream, last persisted turn is a terminal assistant).
+      if (msg.type === "tool_input_required") {
+        const sid = msg.sessionId ?? stateRef.current.sessionId;
+        if (sid && !stateRef.current.sessionStreams[sid]) {
+          const cached = getCachedSessionMessages(queryClient, workspaceId, sid);
+          if (cached && lastMessageIsTerminalAssistant(cached, sid)) return;
+        }
       }
+
+      // Append finalized turns to the React Query cache from the live stream
+      // BEFORE the reducer clears the slot, then refetch the authoritative copy.
+      if (msg.type === "done" || msg.type === "cancelled") {
+        const sid = msg.sessionId ?? stateRef.current.sessionId;
+        const stream = sid ? stateRef.current.sessionStreams[sid] : undefined;
+        if (sid && stream) {
+          const finalized = buildFinalizedMessage(stream, sid, msg);
+          if (finalized) appendCachedSessionMessage(queryClient, workspaceId, sid, finalized);
+        }
+        if (sid) invalidateSessionMessages(queryClient, workspaceId, sid);
+      }
+
+      if (msg.type === "user_message") {
+        const sid = msg.message.sessionId ?? stateRef.current.sessionId;
+        appendCachedSessionMessage(queryClient, workspaceId, sid, msg.message);
+      }
+
+      dispatch(msg);
     });
     replayingBuffer = false;
 
-    // Tell the backend to activate the saved session and send its bootstrap.
+    // Tell the backend to activate the saved session and send its (live) bootstrap.
     if (savedSession) {
-      const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
-      if (sent) historyRequestTokenRef.current += 1;
-    }
-
-    // If the transport replayed buffered messages (events that arrived while we were
-    // on another workspace), the reducer already has the most current state. Bump the
-    // token so the async REST fetch won't overwrite it with potentially stale disk data.
-    if (hadBufferedMessages) {
-      historyRequestTokenRef.current += 1;
-    }
-
-    // REST fallback — only needed on first visit when no cached history exists
-    // for the session we're restoring. On switch-back the transport cache is kept
-    // fresh (see effect below), so the WS replay already provides current messages.
-    if (!wsTransport.hasCachedHistory(workspaceId, savedSession)) {
-      void (async () => {
-        try {
-          const url = savedSession
-            ? `/api/workspaces/${workspaceId}/sessions/${savedSession}/messages`
-            : `/api/workspaces/${workspaceId}/session/messages`;
-          const messages = await api.get<ChatMessage[]>(url);
-          if (historyRequestTokenRef.current !== historyRequestToken) return;
-          dispatch({ type: "history", sessionId: savedSession, messages });
-        } catch {
-          // History is still best-effort via websocket replay if API fetch fails.
-        }
-      })();
+      wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
     }
 
     return () => {
-      // Remember which session was active before leaving this workspace.
       if (workspaceId && sessionIdRef.current) {
         savedSessionByWorkspace.set(workspaceId, sessionIdRef.current);
       }
-      if (historyRequestTokenRef.current === historyRequestToken) {
-        historyRequestTokenRef.current = historyRequestToken + 1;
-      }
       unsubscribe();
     };
-  }, [workspaceId, syncSessionHistory]);
+  }, [workspaceId, queryClient]);
 
-  // Keep the transport's cached history fresh so switch-back replays are current.
-  // Fires on history/done/cancelled/user_message — NOT on streaming deltas.
-  // Guard: skip writes when workspaceId just changed — React 18 batching means
-  // state.messages may transiently hold the *previous* workspace's messages before
-  // prepare_workspace_switch commits. Without this, ws-A's messages get written
-  // into ws-B's cache, causing residual chat on switch-back.
-  const prevCacheWorkspaceRef = useRef(workspaceId);
+  // Reconcile live stream slots whenever the REST history for the active session
+  // changes (new fetch). Keyed on the messages reference — does NOT re-run on
+  // unrelated renders, so an imperatively-cleared pending question stays cleared.
   useEffect(() => {
-    if (prevCacheWorkspaceRef.current !== workspaceId) {
-      prevCacheWorkspaceRef.current = workspaceId;
-      return;
-    }
-    if (!workspaceId || !state.sessionId || state.messages.length === 0) return;
-    const historyMsg: HistoryMessage = {
-      type: "history",
-      sessionId: state.sessionId,
-      messages: state.messages,
-    };
-    wsTransport.updateCachedHistory(workspaceId, historyMsg);
-  }, [workspaceId, state.sessionId, state.messages]);
+    if (!state.sessionId) return;
+    dispatch({ type: "reconcile_history", sessionId: state.sessionId, messages });
+  }, [messages, state.sessionId]);
 
   const sendMessage = useCallback((
     content: string,
@@ -670,7 +625,6 @@ export function useConversation(workspaceId: string | undefined) {
       dispatch({ type: "error", message: "Message not sent: disconnected from server." });
       return false;
     }
-    historyRequestTokenRef.current += 1;
     return true;
   }, [workspaceId, state.sessionId]);
 
@@ -688,16 +642,9 @@ export function useConversation(workspaceId: string | undefined) {
 
   const switchSession = useCallback((sessionId: string) => {
     if (!workspaceId) return;
+    // Switching the session re-keys the messages query, which returns cached
+    // history instantly (no empty flash) and revalidates in the background.
     dispatch({ type: "prepare_session_switch", sessionId });
-    // Restore the target session's messages instantly from the transport cache so
-    // switching back to a previously-viewed conversation doesn't flash an empty
-    // reload. The switch_session round-trip below still reconciles with the backend.
-    const cached = wsTransport.getCachedHistory(workspaceId, sessionId);
-    if (cached) {
-      dispatch({ type: "history", sessionId, messages: cached.messages });
-    }
-    dispatch({ type: "status", status: "busy", sessionId, streaming: false });
-    historyRequestTokenRef.current += 1;
     const sent = wsTransport.send(workspaceId, { type: "switch_session", sessionId });
     if (!sent) {
       dispatch({ type: "error", message: "Session switch failed: disconnected from server." });
@@ -719,7 +666,6 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(state.sessionId),
     });
     dispatch({ type: "clear_pending_tool_inputs" });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const batchAnswerQuestions = useCallback(
@@ -738,7 +684,6 @@ export function useConversation(workspaceId: string | undefined) {
         });
       }
       dispatch({ type: "clear_pending_tool_inputs" });
-      historyRequestTokenRef.current += 1;
     },
     [workspaceId, activeStream?.pendingToolInputs, state.sessionId],
   );
@@ -756,7 +701,6 @@ export function useConversation(workspaceId: string | undefined) {
     });
     dispatch({ type: "clear_pending_tool_inputs" });
     dispatch({ type: "plan_mode_changed", sessionId: state.sessionId ?? "", active: false });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const rejectToolInput = useCallback((message?: string) => {
@@ -771,7 +715,6 @@ export function useConversation(workspaceId: string | undefined) {
       ...sessionIdField(state.sessionId),
     });
     dispatch({ type: "clear_pending_tool_inputs" });
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   const dismissPlan = useCallback((message?: string) => {
@@ -788,11 +731,10 @@ export function useConversation(workspaceId: string | undefined) {
     if (pending) {
       dispatch({ type: "clear_pending_tool_inputs" });
     }
-    historyRequestTokenRef.current += 1;
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
   return {
-    messages: state.messages,
+    messages,
     isStreaming: activeStream?.isStreaming ?? false,
     streamingStartedAt: activeStream?.streamingStartedAt ?? null,
     workspaceStatus: state.workspaceStatus,

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -1,0 +1,86 @@
+import { useQuery, type QueryClient } from "@tanstack/react-query";
+import { api } from "@/hooks/useApi";
+import type { ChatMessage } from "@/types";
+
+/**
+ * Finalized conversation history is owned by React Query (fetched over REST),
+ * not pushed over the WebSocket. The WS carries live state only (status, stream
+ * deltas/snapshot, done/cancelled). This keeps the WS bootstrap light and gives
+ * instant switch-back from the query cache.
+ */
+
+const EMPTY_MESSAGES: ChatMessage[] = [];
+
+export function sessionMessagesKey(
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+): [string, string, string] {
+  return ["session-messages", workspaceId ?? "", sessionId ?? ""];
+}
+
+function fetchSessionMessages(workspaceId: string, sessionId: string): Promise<ChatMessage[]> {
+  return api.get<ChatMessage[]>(`/api/workspaces/${workspaceId}/sessions/${sessionId}/messages`);
+}
+
+/** Subscribe to a session's finalized messages. Returns `[]` until loaded. */
+export function useSessionMessages(
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+): { messages: ChatMessage[]; isLoading: boolean } {
+  const query = useQuery({
+    queryKey: sessionMessagesKey(workspaceId, sessionId),
+    queryFn: () => fetchSessionMessages(workspaceId!, sessionId!),
+    enabled: !!workspaceId && !!sessionId,
+    // Cached data renders instantly on switch-back; a short staleness window
+    // avoids refetch storms while done/cancelled invalidation forces refresh.
+    staleTime: 5_000,
+  });
+  return { messages: query.data ?? EMPTY_MESSAGES, isLoading: query.isLoading };
+}
+
+/** Read the currently-cached messages for a session synchronously (no fetch). */
+export function getCachedSessionMessages(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+): ChatMessage[] | undefined {
+  return queryClient.getQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId));
+}
+
+/** Optimistically append a finalized message to a session's cache (dedup by id). */
+export function appendCachedSessionMessage(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+  message: ChatMessage,
+): void {
+  if (!workspaceId || !sessionId) return;
+  queryClient.setQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId), (prev) => {
+    const list = prev ?? [];
+    if (message.id && list.some((m) => m.id === message.id)) return list;
+    return [...list, message];
+  });
+}
+
+/** Mark a session's messages stale so the authoritative server copy is refetched. */
+export function invalidateSessionMessages(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+): void {
+  if (!workspaceId || !sessionId) return;
+  void queryClient.invalidateQueries({ queryKey: sessionMessagesKey(workspaceId, sessionId) });
+}
+
+/** Drop a session's cached messages entirely (e.g. after deletion). */
+export function removeCachedSessionMessages(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId?: string,
+): void {
+  queryClient.removeQueries({
+    queryKey: sessionId
+      ? sessionMessagesKey(workspaceId, sessionId)
+      : ["session-messages", workspaceId ?? ""],
+  });
+}

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -53,10 +53,9 @@ export function useSessionMessages(
       const cacheAtStart = queryClient.getQueryData<ChatMessage[]>(key);
       const fetched = await fetchSessionMessages(workspaceId!, sessionId!);
       const cacheAtEnd = queryClient.getQueryData<ChatMessage[]>(key);
+      const latestCache = cacheAtEnd ?? cacheAtStart;
 
-      return cacheAtEnd !== cacheAtStart
-        ? mergeFetchedMessagesWithCachedUserEchoes(fetched, cacheAtEnd, sessionId!)
-        : fetched;
+      return mergeFetchedMessagesWithCachedUserEchoes(fetched, latestCache, sessionId!);
     },
     enabled: !!workspaceId && !!sessionId,
     // Cached data renders instantly on switch-back; a short staleness window

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -1,4 +1,4 @@
-import { useQuery, type QueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import type { ChatMessage } from "@/types";
 
@@ -22,14 +22,42 @@ function fetchSessionMessages(workspaceId: string, sessionId: string): Promise<C
   return api.get<ChatMessage[]>(`/api/workspaces/${workspaceId}/sessions/${sessionId}/messages`);
 }
 
+function mergeFetchedMessagesWithCachedUserEchoes(
+  fetched: ChatMessage[],
+  cached: ChatMessage[] | undefined,
+  sessionId: string,
+): ChatMessage[] {
+  if (!cached?.length) return fetched;
+
+  const fetchedIds = new Set(fetched.map((message) => message.id));
+  const missingUserMessages = cached.filter((message) =>
+    message.role === "user" &&
+    message.sessionId === sessionId &&
+    message.id &&
+    !fetchedIds.has(message.id)
+  );
+
+  return missingUserMessages.length > 0 ? [...fetched, ...missingUserMessages] : fetched;
+}
+
 /** Subscribe to a session's finalized messages. Returns `[]` until loaded. */
 export function useSessionMessages(
   workspaceId: string | undefined,
   sessionId: string | undefined,
 ): { messages: ChatMessage[]; isLoading: boolean } {
+  const queryClient = useQueryClient();
+  const key = sessionMessagesKey(workspaceId, sessionId);
   const query = useQuery({
-    queryKey: sessionMessagesKey(workspaceId, sessionId),
-    queryFn: () => fetchSessionMessages(workspaceId!, sessionId!),
+    queryKey: key,
+    queryFn: async () => {
+      const cacheAtStart = queryClient.getQueryData<ChatMessage[]>(key);
+      const fetched = await fetchSessionMessages(workspaceId!, sessionId!);
+      const cacheAtEnd = queryClient.getQueryData<ChatMessage[]>(key);
+
+      return cacheAtEnd !== cacheAtStart
+        ? mergeFetchedMessagesWithCachedUserEchoes(fetched, cacheAtEnd, sessionId!)
+        : fetched;
+    },
     enabled: !!workspaceId && !!sessionId,
     // Cached data renders instantly on switch-back; a short staleness window
     // avoids refetch storms while done/cancelled invalidation forces refresh.
@@ -47,7 +75,7 @@ export function getCachedSessionMessages(
   return queryClient.getQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId));
 }
 
-/** Optimistically append a finalized message to a session's cache (dedup by id). */
+/** Append a WS-echoed user message or finalized assistant UI copy to the cache. */
 export function appendCachedSessionMessage(
   queryClient: QueryClient,
   workspaceId: string | undefined,

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -13,6 +13,19 @@ type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
 const MAX_RECONNECT_DELAY = 30_000;
 const BASE_RECONNECT_DELAY = 1_000;
+// Application-level heartbeat. The browser WebSocket API never surfaces
+// protocol ping/pong to JS, so a frozen-but-OPEN socket (after OS sleep/wake or
+// a network change) is invisible to onclose. We send our own `ping` and watch
+// for the matching `pong` to detect liveness.
+const HEARTBEAT_INTERVAL_MS = 25_000;
+const PONG_TIMEOUT_MS = 10_000;
+// On window focus / tab visibility / network regain, probe the socket and only
+// reconnect if the probe goes unanswered within this window. Active probing (vs.
+// "reconnect any silent socket") is what avoids reconnecting healthy idle sockets.
+const FOCUS_PROBE_TIMEOUT_MS = 3_000;
+
+/** Narrowed hub envelope carrying a workspace event (the non-pong variant). */
+type WorkspaceEnvelope = { workspaceId: string; event: WsOutgoing };
 
 /** Resolve the session a history message belongs to (undefined if session-less). */
 function historySessionKey(msg: HistoryMessage): string | undefined {
@@ -26,6 +39,9 @@ interface HubState {
   status: ConnectionStatus;
   reconnectAttempt: number;
   reconnectTimer: ReturnType<typeof setTimeout> | null;
+  /** Timestamp of the last `pong` received (liveness signal). */
+  lastPongAt: number;
+  heartbeatTimer: ReturnType<typeof setInterval> | null;
 }
 
 // ── Per-workspace subscription data (no socket) ─────────────────────
@@ -50,6 +66,8 @@ class WsTransport {
     status: "disconnected",
     reconnectAttempt: 0,
     reconnectTimer: null,
+    lastPongAt: 0,
+    heartbeatTimer: null,
   };
   private subscriptions = new Map<string, WorkspaceSubscription>();
   private subscribedWorkspaceIds = new Set<string>();
@@ -135,6 +153,32 @@ class WsTransport {
     this.teardownHub();
     this.subscriptions.clear();
     this.subscribedWorkspaceIds.clear();
+  }
+
+  /**
+   * Verify the hub socket is alive and reconnect if it is not. Call on window
+   * focus / tab visibility / network regain — moments when a zombie socket
+   * (frozen OPEN after sleep, never firing onclose) typically surfaces.
+   *
+   * A closed/closing/absent socket reconnects immediately. An OPEN socket is
+   * actively probed with a `ping`; we reconnect only if no `pong` arrives within
+   * FOCUS_PROBE_TIMEOUT_MS. Probing (rather than reconnecting any silent socket)
+   * is what keeps healthy idle conversations from needlessly reconnecting.
+   */
+  probeLiveness(): void {
+    if (this.subscribedWorkspaceIds.size === 0) return;
+    const ws = this.hub.ws;
+    if (!ws || ws.readyState === WebSocket.CLOSING || ws.readyState === WebSocket.CLOSED) {
+      this.forceReconnect();
+      return;
+    }
+    if (ws.readyState === WebSocket.CONNECTING) return; // attempt already in flight
+    const pongBefore = this.hub.lastPongAt;
+    this.sendPing();
+    setTimeout(() => {
+      if (this.hub.ws !== ws) return; // socket already replaced
+      if (this.hub.lastPongAt === pongBefore) this.forceReconnect();
+    }, FOCUS_PROBE_TIMEOUT_MS);
   }
 
   /** Send a message to the backend for a specific workspace. Returns false if the hub isn't open. */
@@ -273,6 +317,8 @@ class WsTransport {
       if (this.hub.ws !== ws) return;
       const isReconnect = this.hub.reconnectAttempt > 0;
       this.hub.reconnectAttempt = 0;
+      this.hub.lastPongAt = Date.now();
+      this.startHeartbeat();
       // Clear per-session status caches on reconnect (will be repopulated by bootstrap)
       for (const sub of this.subscriptions.values()) {
         sub.lastStatusBySession.clear();
@@ -293,7 +339,11 @@ class WsTransport {
       if (this.hub.ws !== ws) return;
       try {
         const envelope = JSON.parse(event.data as string) as HubOutgoing;
-        this.handleIncomingEnvelope(envelope);
+        if ("type" in envelope && envelope.type === "pong") {
+          this.hub.lastPongAt = Date.now();
+          return;
+        }
+        this.handleIncomingEnvelope(envelope as WorkspaceEnvelope);
       } catch (err) {
         if (import.meta.env.DEV) {
           console.warn("[ws] Failed to parse message:", err);
@@ -303,6 +353,7 @@ class WsTransport {
 
     ws.onclose = () => {
       if (this.hub.ws !== ws) return;
+      this.stopHeartbeat();
       this.hub.ws = null;
       this.setHubStatus("disconnected");
       if (this.subscribedWorkspaceIds.size > 0) {
@@ -315,7 +366,7 @@ class WsTransport {
     };
   }
 
-  private handleIncomingEnvelope(envelope: HubOutgoing): void {
+  private handleIncomingEnvelope(envelope: WorkspaceEnvelope): void {
     const { workspaceId, event: msg } = envelope;
 
     // Notify global listeners (toast notifications, etc.) regardless of subscription state
@@ -363,6 +414,46 @@ class WsTransport {
     }));
   }
 
+  private sendPing(): void {
+    if (this.hub.ws?.readyState === WebSocket.OPEN) {
+      this.hub.ws.send(JSON.stringify({ type: "ping" }));
+    }
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    this.hub.heartbeatTimer = setInterval(() => {
+      if (!this.hub.ws || this.hub.ws.readyState !== WebSocket.OPEN) return;
+      // No pong since the previous ping window → the socket is a zombie.
+      if (Date.now() - this.hub.lastPongAt > HEARTBEAT_INTERVAL_MS + PONG_TIMEOUT_MS) {
+        this.forceReconnect();
+        return;
+      }
+      this.sendPing();
+    }, HEARTBEAT_INTERVAL_MS);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.hub.heartbeatTimer) {
+      clearInterval(this.hub.heartbeatTimer);
+      this.hub.heartbeatTimer = null;
+    }
+  }
+
+  /**
+   * Tear down a (possibly zombie) socket and open a fresh one, marking it as a
+   * reconnect so onReconnect listeners fire. The conversation reducer reconciles
+   * non-destructively from the bootstrap (snapshot replace + history), so this
+   * does not blank the visible stream.
+   */
+  private forceReconnect(): void {
+    if (this.subscribedWorkspaceIds.size === 0) return;
+    this.teardownHub();
+    this.hub.reconnectAttempt = 1;
+    this.setHubStatus("connecting");
+    this.openHubSocket();
+  }
+
   private scheduleHubReconnect(): void {
     if (this.hub.reconnectTimer) return;
     const delay = Math.min(
@@ -379,6 +470,7 @@ class WsTransport {
   }
 
   private teardownHub(): void {
+    this.stopHeartbeat();
     if (this.hub.reconnectTimer) {
       clearTimeout(this.hub.reconnectTimer);
       this.hub.reconnectTimer = null;

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -405,8 +405,8 @@ class WsTransport {
   /**
    * Tear down a (possibly zombie) socket and open a fresh one, marking it as a
    * reconnect so onReconnect listeners fire. The conversation reducer reconciles
-   * non-destructively from the bootstrap (snapshot replace + history), so this
-   * does not blank the visible stream.
+   * non-destructively from the bootstrap (snapshot replace + REST history cache),
+   * so this does not blank the visible stream.
    */
   private forceReconnect(): void {
     if (this.subscribedWorkspaceIds.size === 0) return;

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -7,7 +7,6 @@ type MessageHandler = (msg: WsOutgoing) => void;
 type GlobalMessageHandler = (workspaceId: string, msg: WsOutgoing) => void;
 type StatusListener = () => void;
 type StatusMessage = Extract<WsOutgoing, { type: "status" }>;
-export type HistoryMessage = Extract<WsOutgoing, { type: "history" }>;
 type DiffStatsMessage = Extract<WsOutgoing, { type: "diff_stats" }>;
 type BranchInfoMessage = Extract<WsOutgoing, { type: "branch_info" }>;
 
@@ -26,11 +25,6 @@ const FOCUS_PROBE_TIMEOUT_MS = 3_000;
 
 /** Narrowed hub envelope carrying a workspace event (the non-pong variant). */
 type WorkspaceEnvelope = { workspaceId: string; event: WsOutgoing };
-
-/** Resolve the session a history message belongs to (undefined if session-less). */
-function historySessionKey(msg: HistoryMessage): string | undefined {
-  return msg.sessionId ?? msg.messages[0]?.sessionId;
-}
 
 // ── Hub socket state ────────────────────────────────────────────────
 
@@ -52,8 +46,6 @@ interface WorkspaceSubscription {
   statusListeners: Set<StatusListener>;
   lastStatus?: StatusMessage;
   lastStatusBySession: Map<string, StatusMessage>;
-  /** Latest message history per session, so switching between sessions replays instantly. */
-  lastHistoryBySession: Map<string, HistoryMessage>;
   lastDiffStats?: DiffStatsMessage;
   lastBranchInfo?: BranchInfoMessage;
   /** Messages received while no handler was subscribed. Replayed on next onMessage(). */
@@ -104,38 +96,12 @@ class WsTransport {
     this.sendSyncWorkspaces();
   }
 
-  /** Update the cached history for its session so switch-back replays are fresh. */
-  updateCachedHistory(workspaceId: string, historyMsg: HistoryMessage): void {
-    const sub = this.subscriptions.get(workspaceId);
-    if (!sub) return;
-    const sessionId = historySessionKey(historyMsg);
-    if (sessionId) sub.lastHistoryBySession.set(sessionId, historyMsg);
-  }
-
-  /** Return the cached history for a specific session, if any. */
-  getCachedHistory(workspaceId: string, sessionId: string): HistoryMessage | undefined {
-    return this.subscriptions.get(workspaceId)?.lastHistoryBySession.get(sessionId);
-  }
-
-  /**
-   * Check whether cached history exists. With a sessionId, checks that session;
-   * without one, checks whether any session has cached history.
-   */
-  hasCachedHistory(workspaceId: string, sessionId?: string): boolean {
-    const sub = this.subscriptions.get(workspaceId);
-    if (!sub) return false;
-    return sessionId !== undefined
-      ? sub.lastHistoryBySession.has(sessionId)
-      : sub.lastHistoryBySession.size > 0;
-  }
-
-  /** Clear cached status/history for a workspace (e.g. after session deletion). */
+  /** Clear cached live status for a workspace (e.g. after session deletion). */
   clearCachedData(workspaceId: string): void {
     const sub = this.subscriptions.get(workspaceId);
     if (!sub) return;
     sub.lastStatus = undefined;
     sub.lastStatusBySession.clear();
-    sub.lastHistoryBySession.clear();
     sub.lastBranchInfo = undefined;
     sub.messageBuffer = [];
   }
@@ -190,7 +156,7 @@ class WsTransport {
 
   /**
    * Register a handler for incoming messages.
-   * Replays cached status, history, and any buffered messages immediately.
+   * Replays cached live status and any buffered messages immediately.
    * Returns `{ unsubscribe, hadBufferedMessages }`.
    */
   onMessage(workspaceId: string, handler: MessageHandler): { unsubscribe: () => void; hadBufferedMessages: boolean } {
@@ -203,9 +169,6 @@ class WsTransport {
       }
     } else if (sub.lastStatus) {
       handler(sub.lastStatus);
-    }
-    for (const historyMsg of sub.lastHistoryBySession.values()) {
-      handler(historyMsg);
     }
     if (sub.lastDiffStats) {
       handler(sub.lastDiffStats);
@@ -266,7 +229,6 @@ class WsTransport {
       reconnectListeners: new Set<() => void>(),
       statusListeners: new Set<StatusListener>(),
       lastStatusBySession: new Map(),
-      lastHistoryBySession: new Map(),
       messageBuffer: [],
     };
     this.subscriptions.set(workspaceId, created);
@@ -375,7 +337,7 @@ class WsTransport {
     const sub = this.subscriptions.get(workspaceId);
     if (!sub) return;
 
-    // Update per-workspace caches
+    // Update per-workspace live caches (history is owned by React Query / REST).
     if (msg.type === "status") {
       sub.lastStatus = msg;
       if (msg.sessionId) {
@@ -383,9 +345,6 @@ class WsTransport {
       } else if (msg.status === "idle") {
         sub.lastStatusBySession.clear();
       }
-    } else if (msg.type === "history") {
-      const sessionId = historySessionKey(msg);
-      if (sessionId) sub.lastHistoryBySession.set(sessionId, msg);
     } else if (msg.type === "diff_stats") {
       sub.lastDiffStats = msg;
     } else if (msg.type === "branch_info") {
@@ -411,6 +370,9 @@ class WsTransport {
     this.hub.ws.send(JSON.stringify({
       type: "sync_workspaces",
       workspaceIds: [...this.subscribedWorkspaceIds],
+      // Finalized history is loaded over REST (React Query); skip the heavy WS
+      // `history` bootstrap event.
+      historyViaRest: true,
     }));
   }
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,8 +4,22 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { queryClient } from "@/lib/query-client";
 import "./index.css";
 import { copyToClipboard } from "@/lib/clipboard";
+import { wsTransport } from "@/lib/ws-transport";
 import App from "./App";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+// A hub WebSocket can stay readyState OPEN after the OS sleeps/wakes or the
+// network changes, never firing onclose — leaving the UI stuck on stale data.
+// When the user returns (tab visible / window focus / network back), probe the
+// socket; probeLiveness() reconnects only if the probe goes unanswered, so a
+// healthy idle conversation is never needlessly reconnected. Works in both the
+// browser and the Tauri webview (which receives standard focus events).
+const probeHubLiveness = () => wsTransport.probeLiveness();
+document.addEventListener("visibilitychange", () => {
+  if (document.visibilityState === "visible") probeHubLiveness();
+});
+window.addEventListener("focus", probeHubLiveness);
+window.addEventListener("online", probeHubLiveness);
 
 // Fallback for streamdown's code block copy button in non-secure contexts
 // where navigator.clipboard is unavailable (HTTP, remote IP).

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -32,6 +32,7 @@ import { ResizeHandle } from "@/components/ResizeHandle";
 import { Badge } from "@/components/ui/badge";
 import { wsTransport } from "@/lib/ws-transport";
 import { BRAIN_WORKSPACE_ID, brainFileQueryKey } from "@/lib/brain";
+import { removeCachedSessionMessages } from "@/hooks/useSessionMessages";
 import { buildInitialExpanded, countFiles, DEFAULT_EXPANDED } from "@/lib/file-tree";
 import { formatAbsoluteTime, formatRelativeTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
@@ -101,7 +102,8 @@ export default function BrainView() {
 
   const onLastSessionDeleted = useCallback(() => {
     wsTransport.clearCachedData(BRAIN_WORKSPACE_ID);
-  }, []);
+    removeCachedSessionMessages(queryClient, BRAIN_WORKSPACE_ID);
+  }, [queryClient]);
 
   const clearUnread = useClearUnread();
 

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -4,6 +4,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Group, Panel, useDefaultLayout, usePanelRef } from "react-resizable-panels";
 import { api } from "@/hooks/useApi";
 import { useConversationColumn } from "@/hooks/useConversationColumn";
+import { removeCachedSessionMessages } from "@/hooks/useSessionMessages";
 import { useWorkspaceLiveDataContext, useClearUnread } from "@/contexts/WorkspaceLiveDataContext";
 
 import { FileTree, renderFileTreeNodes } from "@/components/ai-elements/file-tree";
@@ -141,7 +142,10 @@ export default function WorkspaceView() {
   }, [wsId, filesQuery.data]);
 
   const onLastSessionDeleted = useCallback(() => {
-    if (wsId) wsTransport.clearCachedData(wsId);
+    if (wsId) {
+      wsTransport.clearCachedData(wsId);
+      removeCachedSessionMessages(queryClient, wsId);
+    }
     void queryClient.invalidateQueries({ queryKey: ["workspace", wsId] });
   }, [wsId, queryClient]);
 

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -710,8 +710,8 @@ export interface UpdateCustomAgentRequest {
 
 // ── Hub WebSocket protocol (multiplexed) ────────────────────────────
 
-/** Server -> Client (hub-level). Every outgoing event is tagged with its workspace. */
-export interface HubOutgoing {
-  workspaceId: string;
-  event: WsOutgoing;
-}
+/** Server -> Client (hub-level). Workspace events are tagged with their workspace. */
+export type HubOutgoing =
+  | { workspaceId: string; event: WsOutgoing }
+  /** Reply to a client `ping` (liveness probe). */
+  | { type: "pong" };

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -385,8 +385,11 @@ describe("ChatConversation hydration on session/workspace switch", () => {
       />,
     );
 
-    expect(conversation.className).toContain("invisible");
-    expect(conversation).toHaveAttribute("data-resize", "instant");
+    // switchCounter is a remount key on <Conversation>, so a switch replaces the
+    // node — re-query to assert on the fresh, re-hydrating instance.
+    const conversationAfterSwitch = screen.getByTestId("conversation");
+    expect(conversationAfterSwitch.className).toContain("invisible");
+    expect(conversationAfterSwitch).toHaveAttribute("data-resize", "instant");
 
     vi.useRealTimers();
     vi.unstubAllGlobals();

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -482,7 +482,6 @@ describe("Sidebar", () => {
   });
 
   it("keeps the latest folder state in react-query cache after saving", async () => {
-    const user = userEvent.setup();
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
     });
@@ -518,9 +517,9 @@ describe("Sidebar", () => {
     );
 
     await screen.findByText(withTextContent("acme/alpha"));
-    await user.click(screen.getByRole("button", { name: "New folder" }));
-    await user.type(screen.getByLabelText("Folder name"), "Client work");
-    await user.click(screen.getByRole("button", { name: "Create folder" }));
+    fireEvent.click(screen.getByRole("button", { name: "New folder" }));
+    fireEvent.change(screen.getByLabelText("Folder name"), { target: { value: "Client work" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create folder" }));
 
     await waitFor(() => {
       expect(api.put).toHaveBeenCalledWith(
@@ -1619,17 +1618,21 @@ describe("Sidebar", () => {
     });
   });
 
-  it("keeps add repository compact in the footer next to settings", async () => {
+  it("keeps repository creation actions compact in the workspaces header", async () => {
     renderSidebar("/workspaces/w1", projects);
 
     await screen.findByText("workspace/tokyo");
 
     const addRepository = screen.getByRole("button", { name: "Add repository" });
+    const newFolder = screen.getByRole("button", { name: "New folder" });
     const settings = screen.getByRole("link", { name: "Settings" });
 
-    expect(addRepository.parentElement).toBe(settings.parentElement);
-    expect(addRepository.parentElement).toHaveClass("justify-between");
-    expect(addRepository).toHaveClass("text-xs");
+    expect(addRepository.parentElement).toBe(newFolder.parentElement);
+    expect(addRepository.parentElement).toHaveClass("gap-0.5");
+    expect(settings.parentElement).toHaveClass("justify-end");
+    expect(settings.parentElement).not.toContainElement(addRepository);
+    expect(addRepository).toHaveClass("p-0.5");
+    expect(addRepository).not.toHaveTextContent("Add repository");
     expect(addRepository).not.toHaveClass("border");
   });
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1063,7 +1063,14 @@ describe("useConversation", () => {
       }),
     );
 
-    const { result } = renderConversation("ws-1");
+    const { result, queryClient } = renderConversation("ws-1");
+
+    await activateSession("ws-1", "sess-1");
+    await waitFor(() => {
+      expect(__apiMock.getMock).toHaveBeenCalledWith(
+        "/api/workspaces/ws-1/sessions/sess-1/messages",
+      );
+    });
 
     act(() => {
       result.current.sendMessage("hello");
@@ -1078,17 +1085,22 @@ describe("useConversation", () => {
         },
       });
     });
-    expect(result.current.messages).toHaveLength(1);
-    expect(result.current.messages[0]?.role).toBe("user");
+    expect(result.current.messages).toEqual([
+      expect.objectContaining({ id: "u1", content: "hello" }),
+    ]);
+    expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([
+      expect.objectContaining({ id: "u1", content: "hello" }),
+    ]);
 
-    act(() => {
+    await act(async () => {
       resolveHistory?.([]);
     });
 
     await waitFor(() => {
-      expect(result.current.messages).toHaveLength(1);
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([
+        expect.objectContaining({ id: "u1", content: "hello" }),
+      ]);
     });
-    expect(result.current.messages[0]?.content).toBe("hello");
   });
 
   it("targets the restored saved session and loads its REST history", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1,6 +1,9 @@
+import type { ReactNode } from "react";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useConversation, _resetSavedSessions } from "@/hooks/useConversation";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useConversation, _resetSavedSessions, setSavedSession } from "@/hooks/useConversation";
+import { sessionMessagesKey, getCachedSessionMessages } from "@/hooks/useSessionMessages";
 import type { ChatMessage, WsOutgoing } from "@/types";
 
 vi.mock("@/hooks/useApi", () => {
@@ -37,13 +40,6 @@ vi.mock("@/lib/ws-transport", () => {
   const statusListeners = new Map<string, Set<() => void>>();
   const replayMessages = new Map<string, WsOutgoing[]>();
   const bufferedFlags = new Map<string, boolean>();
-  const cachedHistories = new Map<string, WsOutgoing>();
-
-  const histKey = (workspaceId: string, sessionId: string) => `${workspaceId}::${sessionId}`;
-  const sessionKeyOf = (msg: WsOutgoing): string | undefined => {
-    if (msg.type !== "history") return undefined;
-    return msg.sessionId ?? msg.messages[0]?.sessionId;
-  };
 
   const getSet = <T,>(source: Map<string, Set<T>>, workspaceId: string) => {
     const existing = source.get(workspaceId);
@@ -93,22 +89,7 @@ vi.mock("@/lib/ws-transport", () => {
       };
     },
     getStatus: (workspaceId: string) => statuses.get(workspaceId) ?? "disconnected",
-    updateCachedHistory: vi.fn((workspaceId: string, historyMsg: WsOutgoing) => {
-      const sessionId = sessionKeyOf(historyMsg);
-      if (sessionId) cachedHistories.set(histKey(workspaceId, sessionId), historyMsg);
-    }),
-    getCachedHistory: vi.fn((workspaceId: string, sessionId: string) =>
-      cachedHistories.get(histKey(workspaceId, sessionId)),
-    ),
-    hasCachedHistory: vi.fn((workspaceId: string, sessionId?: string) => {
-      if (sessionId !== undefined) return cachedHistories.has(histKey(workspaceId, sessionId));
-      const prefix = `${workspaceId}::`;
-      for (const key of cachedHistories.keys()) if (key.startsWith(prefix)) return true;
-      return false;
-    }),
     clearCachedData: vi.fn((workspaceId: string) => {
-      const prefix = `${workspaceId}::`;
-      for (const key of [...cachedHistories.keys()]) if (key.startsWith(prefix)) cachedHistories.delete(key);
       replayMessages.delete(workspaceId);
       bufferedFlags.delete(workspaceId);
     }),
@@ -124,16 +105,12 @@ vi.mock("@/lib/ws-transport", () => {
       statusListeners.clear();
       replayMessages.clear();
       bufferedFlags.clear();
-      cachedHistories.clear();
       wsTransport.connect.mockClear();
       wsTransport.disconnect.mockClear();
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
       wsTransport.onMessage.mockClear();
-      wsTransport.updateCachedHistory.mockClear();
-      wsTransport.getCachedHistory.mockClear();
-      wsTransport.hasCachedHistory.mockClear();
       wsTransport.clearCachedData.mockClear();
     },
     setReplay: (workspaceId: string, messages: WsOutgoing[]) => {
@@ -145,13 +122,6 @@ vi.mock("@/lib/ws-transport", () => {
     sendMock: wsTransport.send,
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
-    updateCachedHistoryMock: wsTransport.updateCachedHistory,
-    getCachedHistoryMock: wsTransport.getCachedHistory,
-    hasCachedHistoryMock: wsTransport.hasCachedHistory,
-    setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => {
-      const sessionId = sessionKeyOf(historyMsg);
-      if (sessionId) cachedHistories.set(histKey(workspaceId, sessionId), historyMsg);
-    },
   };
 
   return { wsTransport, __wsMock };
@@ -167,10 +137,6 @@ const getWsMock = async () =>
       sendMock: ReturnType<typeof vi.fn>;
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
-      updateCachedHistoryMock: ReturnType<typeof vi.fn>;
-      getCachedHistoryMock: ReturnType<typeof vi.fn>;
-      hasCachedHistoryMock: ReturnType<typeof vi.fn>;
-      setCachedHistory: (workspaceId: string, historyMsg: WsOutgoing) => void;
     };
   };
 
@@ -181,6 +147,42 @@ const getApiMock = async () =>
       reset: () => void;
     };
   };
+
+/**
+ * Render useConversation inside a fresh QueryClientProvider. Finalized messages
+ * are owned by React Query now, so the hook calls useQueryClient(); without a
+ * provider it throws. Returns the renderHook result plus the queryClient so
+ * tests can pre-seed / inspect the session-messages cache directly.
+ */
+function renderConversation(
+  initialWsId?: string,
+): ReturnType<typeof renderHook<ReturnType<typeof useConversation>, { wsId?: string }>> & {
+  queryClient: QueryClient;
+} {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  const result = renderHook(({ wsId }: { wsId?: string }) => useConversation(wsId), {
+    wrapper,
+    initialProps: { wsId: initialWsId },
+  });
+  return { ...result, queryClient };
+}
+
+/**
+ * Drive a session active by emitting an (idle) status event. The REST messages
+ * query is `enabled` only once sessionId is set, so tests that load finalized
+ * history over REST must first activate the session this way.
+ */
+async function activateSession(workspaceId: string, sessionId: string): Promise<void> {
+  const { __wsMock } = await getWsMock();
+  act(() => {
+    __wsMock.emit(workspaceId, { type: "status", status: "idle", sessionId, streaming: false });
+  });
+}
 
 describe("useConversation", () => {
   beforeEach(async () => {
@@ -193,7 +195,7 @@ describe("useConversation", () => {
 
   it("connects on mount and keeps connection alive on unmount", async () => {
     const { __wsMock } = await getWsMock();
-    const { unmount } = renderHook(() => useConversation("ws-1"));
+    const { unmount } = renderConversation("ws-1");
 
     expect(__wsMock.connectMock).toHaveBeenCalledWith("ws-1");
 
@@ -204,7 +206,7 @@ describe("useConversation", () => {
 
   it("sends user messages through transport without optimistic local append", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("hello");
@@ -219,7 +221,7 @@ describe("useConversation", () => {
 
   it("forwards per-message options through transport", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("hello", undefined, { planMode: true, thinkingLevel: "low" });
@@ -234,7 +236,7 @@ describe("useConversation", () => {
 
   it("can target an explicit session id when sending a message", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("run in target", undefined, undefined, "sess-target");
@@ -250,7 +252,7 @@ describe("useConversation", () => {
   it("appends user message when backend emits user_message event", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_111);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -276,7 +278,7 @@ describe("useConversation", () => {
 
   it("does not change active session when user_message arrives for another session", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -310,7 +312,7 @@ describe("useConversation", () => {
   it("does not add user message when transport send fails", async () => {
     const { __wsMock } = await getWsMock();
     __wsMock.sendMock.mockReturnValueOnce(false);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       const sent = result.current.sendMessage("hello");
@@ -324,7 +326,7 @@ describe("useConversation", () => {
 
   it("builds assistant message from stream deltas and done event", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("start");
@@ -343,6 +345,10 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "text_delta", text: "Hi " });
       __wsMock.emit("ws-1", { type: "text_delta", text: "there" });
+    });
+    // `done` finalizes from the live stream slot the WS handler reads via stateRef,
+    // which only reflects the deltas after a render flush — emit it separately.
+    act(() => {
       __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
     });
 
@@ -357,8 +363,9 @@ describe("useConversation", () => {
   it("resyncs persisted session history on done to recover missed deltas", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
-    __apiMock.getMock.mockResolvedValueOnce([
+    // The authoritative server copy holds the finalized turns the client never
+    // saw streamed; the done-driven refetch must surface them.
+    __apiMock.getMock.mockResolvedValue([
       {
         id: "u1",
         sessionId: "sess-1",
@@ -375,8 +382,9 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
+    // user_message activates the session and seeds the (optimistic) user bubble.
     act(() => {
       __wsMock.emit("ws-1", {
         type: "user_message",
@@ -388,7 +396,12 @@ describe("useConversation", () => {
           timestamp: "2026-02-12T00:00:00.000Z",
         },
       });
-      // No text_delta received (simulates session unfocused while streaming).
+    });
+
+    // No text_delta received (simulates session unfocused while streaming). On done
+    // the WS handler invalidates the session messages, forcing the authoritative
+    // refetch that recovers the finalized assistant turn from persistence.
+    act(() => {
       __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
     });
 
@@ -396,12 +409,12 @@ describe("useConversation", () => {
       expect(result.current.messages).toHaveLength(2);
       expect(result.current.messages.at(-1)?.content).toBe("final answer from persistence");
     });
-    expect(__apiMock.getMock).toHaveBeenNthCalledWith(2, "/api/workspaces/ws-1/sessions/sess-1/messages");
+    expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-1/messages");
   });
 
   it("preserves parentToolUseId from tool_use events in active and persisted tool calls", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -447,7 +460,7 @@ describe("useConversation", () => {
 
   it("marks assistant output as cancelled when cancelled event is received", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("start");
@@ -465,6 +478,10 @@ describe("useConversation", () => {
 
     act(() => {
       __wsMock.emit("ws-1", { type: "text_delta", text: "partial" });
+    });
+    // `cancelled` finalizes from the stream slot read via stateRef — separate act
+    // so the delta is reflected before finalization.
+    act(() => {
       __wsMock.emit("ws-1", { type: "cancelled" });
     });
 
@@ -477,7 +494,7 @@ describe("useConversation", () => {
   it("clears local chat state", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_222);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -506,7 +523,7 @@ describe("useConversation", () => {
 
   it("formats AskUserQuestion answers and sends a response", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.answerQuestion("tool-1", [
@@ -531,7 +548,7 @@ describe("useConversation", () => {
 
   it("uses pending requestId when answering AskUserQuestion and clears pending state", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -565,7 +582,7 @@ describe("useConversation", () => {
 
   it("batchAnswerQuestions sends one response per tool with original questions and clears pending", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -629,7 +646,23 @@ describe("useConversation", () => {
 
   it("clears pending tool inputs on tool_input_resolved (dismissed on another client)", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result, queryClient } = renderConversation("ws-1");
+
+    // The session's persisted history ends on an open AskUserQuestion, so the
+    // pending question is consistent with REST (reconcile keeps it rather than
+    // dropping it as a stale finished slot).
+    queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:01.000Z",
+        toolCalls: [
+          { id: "tool-1", name: "AskUserQuestion", input: JSON.stringify({ questions: [{ question: "Q1" }] }) },
+        ],
+      },
+    ]);
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1" });
@@ -654,7 +687,20 @@ describe("useConversation", () => {
 
   it("clears pending tool inputs when the session resumes streaming (answered on another client)", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result, queryClient } = renderConversation("ws-1");
+
+    queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "",
+        timestamp: "2026-02-12T00:00:01.000Z",
+        toolCalls: [
+          { id: "tool-1", name: "AskUserQuestion", input: JSON.stringify({ questions: [{ question: "Q1" }] }) },
+        ],
+      },
+    ]);
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1" });
@@ -679,7 +725,7 @@ describe("useConversation", () => {
 
   it("sends approval shortcut message", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.approvePlan();
@@ -695,7 +741,7 @@ describe("useConversation", () => {
 
   it("tracks agentPlanMode from plan_mode_changed events for the active session", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -726,7 +772,7 @@ describe("useConversation", () => {
 
   it("does not change active agentPlanMode when plan_mode_changed is for another session", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -752,7 +798,7 @@ describe("useConversation", () => {
 
   it("tracks live agent activities and persists them into the assistant message on done", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -840,7 +886,8 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-history-activity");
 
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(1);
@@ -856,7 +903,7 @@ describe("useConversation", () => {
 
   it("clears local agentPlanMode after approvePlan", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -898,14 +945,16 @@ describe("useConversation", () => {
 
   it("includes current sessionId in tool input responses when available", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
+      // A live (streaming) session keeps its in-flight pending input authoritative;
+      // reconcile_history leaves it untouched so the live requestId is preserved.
       __wsMock.emit("ws-1", {
         type: "status",
         status: "busy",
         sessionId: "sess-42",
-        streaming: false,
+        streaming: true,
       });
       __wsMock.emit("ws-1", {
         type: "tool_input_required",
@@ -929,12 +978,15 @@ describe("useConversation", () => {
     });
   });
 
-  it("hydrates persisted history after mount even when websocket replays stale history", async () => {
+  it("hydrates persisted history from REST and ignores a stale WS history replay", async () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
 
+    // A stale WS `history` event must no longer feed the conversation — history is
+    // owned by REST. Replaying it should be a no-op.
     __wsMock.setReplay("ws-1", [{
       type: "history",
+      sessionId: "sess-1",
       messages: [
         {
           id: "a1",
@@ -946,7 +998,7 @@ describe("useConversation", () => {
       ],
     }]);
 
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValue([
       {
         id: "u1",
         sessionId: "sess-1",
@@ -963,7 +1015,8 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-1");
 
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(2);
@@ -974,46 +1027,30 @@ describe("useConversation", () => {
     expect(result.current.messages[1]?.content).toBe("world");
   });
 
-  it("does not overwrite replayed buffered state when transport reports buffered messages", async () => {
-    const { __wsMock } = await getWsMock();
+  it("loads finalized history over REST for the active session", async () => {
     const { __apiMock } = await getApiMock();
 
-    __wsMock.setReplay("ws-1", [{
-      type: "history",
-      sessionId: "sess-buffered",
-      messages: [
-        {
-          id: "m-buffered",
-          sessionId: "sess-buffered",
-          role: "assistant",
-          content: "latest from buffered websocket",
-          timestamp: "2026-02-12T00:00:00.000Z",
-        },
-      ],
-    }]);
-    __wsMock.setBuffered("ws-1", true);
-
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValue([
       {
-        id: "m-stale",
+        id: "m-disk",
         sessionId: "sess-buffered",
         role: "assistant",
-        content: "stale from disk",
+        content: "loaded from disk over REST",
         timestamp: "2026-02-12T00:00:00.000Z",
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-buffered");
 
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(1);
     });
-    expect(result.current.messages[0]?.content).toBe("latest from buffered websocket");
+    expect(result.current.messages[0]?.content).toBe("loaded from disk over REST");
 
-    await waitFor(() => {
-      expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/session/messages");
-    });
-    expect(result.current.messages[0]?.content).toBe("latest from buffered websocket");
+    expect(__apiMock.getMock).toHaveBeenCalledWith(
+      "/api/workspaces/ws-1/sessions/sess-buffered/messages",
+    );
   });
 
   it("does not overwrite backend user message with a late history request", async () => {
@@ -1026,7 +1063,7 @@ describe("useConversation", () => {
       }),
     );
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("hello");
@@ -1054,9 +1091,9 @@ describe("useConversation", () => {
     expect(result.current.messages[0]?.content).toBe("hello");
   });
 
-  it("hydrates sessionId from initial history payload", async () => {
+  it("targets the restored saved session and loads its REST history", async () => {
     const { __apiMock } = await getApiMock();
-    __apiMock.getMock.mockResolvedValueOnce([
+    __apiMock.getMock.mockResolvedValue([
       {
         id: "u1",
         sessionId: "sess-hydrated",
@@ -1066,12 +1103,19 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    // The session to restore is established by the saved-session memory (set by a
+    // prior visit), not by a WS history payload — sessionId drives the REST query.
+    setSavedSession("ws-1", "sess-hydrated");
+    const { result } = renderConversation("ws-1");
 
+    expect(result.current.sessionId).toBe("sess-hydrated");
     await waitFor(() => {
       expect(result.current.messages).toHaveLength(1);
     });
-    expect(result.current.sessionId).toBe("sess-hydrated");
+    expect(result.current.messages[0]?.content).toBe("hello");
+    expect(__apiMock.getMock).toHaveBeenCalledWith(
+      "/api/workspaces/ws-1/sessions/sess-hydrated/messages",
+    );
   });
 
   it("rehydrates AskUserQuestion pending input from history when WS request event was missed", async () => {
@@ -1108,7 +1152,8 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-q");
 
     await waitFor(() => {
       expect(result.current.pendingToolInputs).toHaveLength(1);
@@ -1148,7 +1193,8 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-q");
 
     await waitFor(() => {
       expect(result.current.pendingToolInputs).toHaveLength(1);
@@ -1182,7 +1228,8 @@ describe("useConversation", () => {
       },
     ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
+    await activateSession("ws-1", "sess-plan");
 
     await waitFor(() => {
       expect(result.current.pendingToolInputs).toHaveLength(1);
@@ -1196,9 +1243,28 @@ describe("useConversation", () => {
     );
   });
 
-  it("clears stale pending tool inputs when history has no pending prompts", async () => {
+  it("clears stale pending tool inputs when REST history has no pending prompts", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { __apiMock } = await getApiMock();
+    // Authoritative history: the turn finished with no open question.
+    __apiMock.getMock.mockResolvedValue([
+      {
+        id: "u1",
+        sessionId: "sess-1",
+        role: "user",
+        content: "done",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "completed",
+        timestamp: "2026-02-12T00:00:01.000Z",
+      },
+    ]);
+
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -1213,36 +1279,20 @@ describe("useConversation", () => {
     });
     expect(result.current.pendingToolInputs).toHaveLength(1);
 
+    // The turn ends and the REST history (no open prompt) reconciles the slot,
+    // dropping the stale pending question via the reconcile_history effect.
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-1",
-        messages: [
-          {
-            id: "u1",
-            sessionId: "sess-1",
-            role: "user",
-            content: "done",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-          {
-            id: "a1",
-            sessionId: "sess-1",
-            role: "assistant",
-            content: "completed",
-            timestamp: "2026-02-12T00:00:01.000Z",
-          },
-        ],
-      });
     });
 
-    expect(result.current.pendingToolInputs).toEqual([]);
+    await waitFor(() => {
+      expect(result.current.pendingToolInputs).toEqual([]);
+    });
   });
 
   it("keeps active pending tool inputs when a history event arrives during streaming", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -1293,70 +1343,65 @@ describe("useConversation", () => {
     ]);
   });
 
-  it("switches sessions and loads specific session history", async () => {
+  it("switches sessions and loads specific session history over REST", async () => {
     const { __apiMock } = await getApiMock();
     const { __wsMock } = await getWsMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
+    __apiMock.getMock.mockResolvedValue([
+      {
+        id: "m-1",
+        sessionId: "sess-2",
+        role: "assistant",
+        content: "loaded from target session",
+        timestamp: "2026-02-12T00:00:01.000Z",
+      },
+    ]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
-
-    await act(async () => {
-      await result.current.switchSession("sess-2");
-    });
+    const { result } = renderConversation("ws-1");
 
     act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-2",
-        messages: [
-          {
-            id: "m-1",
-            sessionId: "sess-2",
-            role: "assistant",
-            content: "loaded from target session",
-            timestamp: "2026-02-12T00:00:01.000Z",
-          },
-        ],
-      });
+      result.current.switchSession("sess-2");
     });
 
-    expect(__apiMock.getMock).toHaveBeenCalledTimes(1);
-    expect(result.current.messages).toEqual([
-      expect.objectContaining({ id: "m-1", content: "loaded from target session" }),
-    ]);
+    // switchSession re-keys the REST query, which fetches the target session.
+    expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+      type: "switch_session",
+      sessionId: "sess-2",
+    });
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({ id: "m-1", content: "loaded from target session" }),
+      ]);
+    });
+    expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-2/messages");
     expect(result.current.sessionId).toBe("sess-2");
     expect(result.current.isStreaming).toBe(false);
   });
 
   it("restores cached messages synchronously when switching to a previously-viewed session", async () => {
     const { __wsMock } = await getWsMock();
-    __wsMock.setCachedHistory("ws-1", {
-      type: "history",
-      sessionId: "sess-2",
-      messages: [
-        {
-          id: "cached-1",
-          sessionId: "sess-2",
-          role: "assistant",
-          content: "restored instantly",
-          timestamp: "2026-02-12T00:00:01.000Z",
-        },
-      ],
-    });
+    const { result, queryClient } = renderConversation("ws-1");
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    // A previously-viewed session is already in the React Query cache, so its
+    // messages render instantly on switch-back (no WS round-trip / empty flash).
+    queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-2"), [
+      {
+        id: "cached-1",
+        sessionId: "sess-2",
+        role: "assistant",
+        content: "restored instantly",
+        timestamp: "2026-02-12T00:00:01.000Z",
+      },
+    ]);
 
     act(() => {
       result.current.switchSession("sess-2");
     });
 
-    // Messages appear immediately from cache — no WS round-trip / empty flash.
     expect(result.current.sessionId).toBe("sess-2");
     expect(result.current.messages).toEqual([
       expect.objectContaining({ id: "cached-1", content: "restored instantly" }),
     ]);
-    expect(__wsMock.getCachedHistoryMock).toHaveBeenCalledWith("ws-1", "sess-2");
-    // It still asks the backend to reconcile.
+    // It still asks the backend to reconcile the live state.
     expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
       type: "switch_session",
       sessionId: "sess-2",
@@ -1365,34 +1410,34 @@ describe("useConversation", () => {
 
   it("keeps target session visible and sets an error when switch_session send fails", async () => {
     const { __wsMock } = await getWsMock();
-    __wsMock.sendMock.mockReturnValueOnce(false);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result, queryClient } = renderConversation("ws-1");
 
-    act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
+    // Seed an existing session's REST messages, then activate it.
+    queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-old"), [
+      {
+        id: "m-old",
         sessionId: "sess-old",
-        messages: [
-          {
-            id: "m-old",
-            sessionId: "sess-old",
-            role: "assistant",
-            content: "old",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-        ],
-      });
+        role: "assistant",
+        content: "old",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+    ]);
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-old", streaming: false });
     });
     expect(result.current.messages).toHaveLength(1);
 
-    await act(async () => {
-      await result.current.switchSession("sess-fail");
+    __wsMock.sendMock.mockReturnValueOnce(false);
+    act(() => {
+      result.current.switchSession("sess-fail");
     });
 
     expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
       type: "switch_session",
       sessionId: "sess-fail",
     });
+    // The query re-keyed to sess-fail (no cached messages → empty), and the failed
+    // send surfaces an error while keeping the target session selected.
     expect(result.current.messages).toEqual([]);
     expect(result.current.sessionId).toBe("sess-fail");
     expect(result.current.workspaceStatus).toBe("busy");
@@ -1404,7 +1449,7 @@ describe("useConversation", () => {
     __apiMock.getMock.mockResolvedValueOnce([]);
     __apiMock.getMock.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     await act(async () => {
       await result.current.switchSession("sess-empty");
@@ -1414,61 +1459,42 @@ describe("useConversation", () => {
     expect(result.current.sessionId).toBe("sess-empty");
   });
 
-  it("ignores stale session history response when switching rapidly", async () => {
+  it("shows the latest session when switching rapidly (REST query re-keys to it)", async () => {
     const { __apiMock } = await getApiMock();
-    const { __wsMock } = await getWsMock();
-    __apiMock.getMock.mockResolvedValueOnce([]);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    // Each session resolves its own REST history; the active query key follows the
+    // latest switch, so a stale earlier session's payload can never overwrite it.
+    __apiMock.getMock.mockImplementation((url: string) => {
+      if (url.includes("/sessions/sess-new/")) {
+        return Promise.resolve([
+          { id: "m-new", sessionId: "sess-new", role: "assistant", content: "new session payload", timestamp: "2026-02-12T00:00:02.000Z" },
+        ]);
+      }
+      return Promise.resolve([
+        { id: "m-old", sessionId: "sess-old", role: "assistant", content: "stale payload", timestamp: "2026-02-12T00:00:03.000Z" },
+      ]);
+    });
+
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       void result.current.switchSession("sess-old");
     });
-
-    await act(async () => {
-      await result.current.switchSession("sess-new");
-    });
-
     act(() => {
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-old",
-        messages: [
-          {
-            id: "m-old",
-            sessionId: "sess-old",
-            role: "assistant",
-            content: "stale payload",
-            timestamp: "2026-02-12T00:00:03.000Z",
-          },
-        ],
-      });
-      __wsMock.emit("ws-1", {
-        type: "history",
-        sessionId: "sess-new",
-        messages: [
-          {
-            id: "m-new",
-            sessionId: "sess-new",
-            role: "assistant",
-            content: "new session payload",
-            timestamp: "2026-02-12T00:00:02.000Z",
-          },
-        ],
-      });
+      void result.current.switchSession("sess-new");
     });
 
     await waitFor(() => {
       expect(result.current.sessionId).toBe("sess-new");
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({ id: "m-new", content: "new session payload" }),
+      ]);
     });
-    expect(result.current.messages).toEqual([
-      expect.objectContaining({ id: "m-new", content: "new session payload" }),
-    ]);
   });
 
   it("ignores unrecognized WS message types without corrupting state", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-x", streaming: true });
@@ -1490,7 +1516,7 @@ describe("useConversation", () => {
 
   it("does nothing when switchSession is called without workspace id", async () => {
     const { __apiMock } = await getApiMock();
-    const { result } = renderHook(() => useConversation(undefined));
+    const { result } = renderConversation(undefined);
 
     await act(async () => {
       await result.current.switchSession("sess-1");
@@ -1504,7 +1530,7 @@ describe("useConversation", () => {
 
   it("forwards images through transport in sendMessage", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     const images = [
       { name: "screenshot.png", mediaType: "image/png", dataUrl: "data:image/png;base64,abc" },
@@ -1523,7 +1549,7 @@ describe("useConversation", () => {
 
   it("omits images field when images array is empty", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.sendMessage("No images", []);
@@ -1537,7 +1563,7 @@ describe("useConversation", () => {
 
   it("preserves images field from backend user_message event", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     const images = [
       { name: "test.png", mediaType: "image/png", dataUrl: "data:image/png;base64,xyz" },
@@ -1563,7 +1589,7 @@ describe("useConversation", () => {
 
   it("de-duplicates user_message events with images", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     const msg = {
       type: "user_message" as const,
@@ -1589,7 +1615,7 @@ describe("useConversation", () => {
 
   it("accumulates thinking content from multiple thinking events", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1614,7 +1640,7 @@ describe("useConversation", () => {
 
   it("persists thinking content in finalized assistant message on done", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1632,6 +1658,9 @@ describe("useConversation", () => {
     act(() => {
       __wsMock.emit("ws-1", { type: "thinking", text: "Deep thought" });
       __wsMock.emit("ws-1", { type: "text_delta", text: "Answer" });
+    });
+    // Finalization reads the stream slot via stateRef — emit done after a flush.
+    act(() => {
       __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
     });
 
@@ -1642,7 +1671,7 @@ describe("useConversation", () => {
 
   it("updates tool call output via tool_result event", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1674,7 +1703,7 @@ describe("useConversation", () => {
 
   it("creates an explicit cancelled message when no content was produced", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1706,7 +1735,7 @@ describe("useConversation", () => {
 
   it("ignores stale cancelled events when no stream is active", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "cancelled" });
@@ -1718,7 +1747,7 @@ describe("useConversation", () => {
 
   it("preserves durationMs from done event in finalized assistant message", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1744,7 +1773,7 @@ describe("useConversation", () => {
 
   it("sends reject tool input response", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -1774,7 +1803,7 @@ describe("useConversation", () => {
 
   it("does nothing when rejectToolInput is called with no pending inputs", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.rejectToolInput("no pending");
@@ -1786,7 +1815,7 @@ describe("useConversation", () => {
 
   it("sends dismiss plan response using pending ExitPlanMode request id", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -1815,7 +1844,7 @@ describe("useConversation", () => {
 
   it("sends dismiss plan response even without pending inputs (fallback interactive state)", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1840,7 +1869,7 @@ describe("useConversation", () => {
   });
 
   it("sendMessage returns false and sets error when no workspace", () => {
-    const { result } = renderHook(() => useConversation(undefined));
+    const { result } = renderConversation(undefined);
 
     act(() => {
       const sent = result.current.sendMessage("hello");
@@ -1852,7 +1881,7 @@ describe("useConversation", () => {
 
   it("stopStreaming sends stop message through transport", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       result.current.stopStreaming();
@@ -1863,7 +1892,7 @@ describe("useConversation", () => {
 
   it("keeps stop routing on the active session when background user_message events arrive", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1899,10 +1928,7 @@ describe("useConversation", () => {
   it("clears visible state on workspace change", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_333);
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -1930,10 +1956,7 @@ describe("useConversation", () => {
   });
 
   it("increments switchCounter on workspace switch", async () => {
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     const initial = result.current.switchCounter;
 
@@ -1946,10 +1969,7 @@ describe("useConversation", () => {
 
   it("restores last viewed session when switching back to a workspace", async () => {
     const { __wsMock } = await getWsMock();
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     // Establish session sess-A on ws-1 via a status event
     act(() => {
@@ -1981,10 +2001,7 @@ describe("useConversation", () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockResolvedValue([]);
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     // Establish session on ws-1
     act(() => {
@@ -1996,26 +2013,23 @@ describe("useConversation", () => {
       });
     });
 
-    // Switch away and back
-    __apiMock.getMock.mockClear();
-    __apiMock.getMock.mockResolvedValue([]);
+    // Switch away (cleanup saves ws-1 → sess-B) and back.
     rerender({ wsId: "ws-2" });
     __wsMock.setReplay("ws-1", []);
     rerender({ wsId: "ws-1" });
 
+    // The restored saved session re-targets the session-specific REST endpoint.
     await waitFor(() => {
-      expect(__apiMock.getMock).toHaveBeenCalledWith(
-        "/api/workspaces/ws-1/sessions/sess-B/messages",
-      );
+      expect(result.current.sessionId).toBe("sess-B");
     });
+    expect(__apiMock.getMock).toHaveBeenCalledWith(
+      "/api/workspaces/ws-1/sessions/sess-B/messages",
+    );
   });
 
   it("preserves streaming data across workspace switch", async () => {
     const { __wsMock } = await getWsMock();
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     // Start streaming on ws-1
     act(() => {
@@ -2061,10 +2075,7 @@ describe("useConversation", () => {
 
   it("replaces accumulated stream content when a stream snapshot is replayed", async () => {
     const { __wsMock } = await getWsMock();
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2122,10 +2133,7 @@ describe("useConversation", () => {
 
   it("full reset clears sessionStreams when workspaceId becomes undefined", async () => {
     const { __wsMock } = await getWsMock();
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" as string | undefined } },
-    );
+    const { result, rerender } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2160,10 +2168,15 @@ describe("useConversation", () => {
 
   it("finalizes assistant message when done arrives via buffer after workspace switch", async () => {
     const { __wsMock } = await getWsMock();
-    const { result, rerender } = renderHook(
-      ({ wsId }) => useConversation(wsId),
-      { initialProps: { wsId: "ws-1" } },
-    );
+    const { __apiMock } = await getApiMock();
+    // The authoritative finalized turn for sess-1 (recovered on the done-driven
+    // refetch after the buffered replay completes the turn).
+    __apiMock.getMock.mockResolvedValue([
+      { id: "u1", sessionId: "sess-1", role: "user", content: "hello", timestamp: "2026-02-12T00:00:00.000Z" },
+      { id: "a1", sessionId: "sess-1", role: "assistant", content: "Before after", timestamp: "2026-02-12T00:00:01.000Z", durationMs: 1234 },
+    ]);
+
+    const { result, rerender } = renderConversation("ws-1");
 
     // Start streaming on ws-1
     act(() => {
@@ -2185,7 +2198,8 @@ describe("useConversation", () => {
     // Switch to ws-2 while streaming is in progress
     rerender({ wsId: "ws-2" });
 
-    // Switch back — buffer replays remaining deltas + done
+    // Switch back — buffer replays remaining deltas + done. The done invalidates the
+    // session messages, and the authoritative refetch surfaces the finalized turn.
     __wsMock.setReplay("ws-1", [
       { type: "status", status: "busy", sessionId: "sess-1", streaming: true },
       { type: "text_delta", sessionId: "sess-1", text: "after" },
@@ -2193,18 +2207,20 @@ describe("useConversation", () => {
     ]);
     rerender({ wsId: "ws-1" });
 
-    // The done event should have finalized an assistant message with full content
+    // The live stream slot is cleared; the finalized assistant message comes from REST.
     expect(result.current.isStreaming).toBe(false);
     expect(result.current.currentStreamingText).toBe("");
-    const assistantMsg = result.current.messages.find((m) => m.role === "assistant");
-    expect(assistantMsg).toBeDefined();
-    expect(assistantMsg!.content).toBe("Before after");
-    expect(assistantMsg!.durationMs).toBe(1234);
+    await waitFor(() => {
+      const assistantMsg = result.current.messages.find((m) => m.role === "assistant");
+      expect(assistantMsg).toBeDefined();
+      expect(assistantMsg!.content).toBe("Before after");
+      expect(assistantMsg!.durationMs).toBe(1234);
+    });
   });
 
   it("ignores late live stream fragments after done", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2218,6 +2234,9 @@ describe("useConversation", () => {
         },
       });
       __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Done" });
+    });
+    // `done` finalizes from the stream slot read via stateRef — emit after flush.
+    act(() => {
       __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 100 });
     });
 
@@ -2272,7 +2291,7 @@ describe("useConversation", () => {
   it("status event updates workspace status, streaming flag, and streamingStartedAt", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_444);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2325,7 +2344,7 @@ describe("useConversation", () => {
   it("uses Date.now as fallback streamingStartedAt for busy status without backend timestamp", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_555);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", streaming: true, sessionId: "sess-fallback" });
@@ -2338,7 +2357,7 @@ describe("useConversation", () => {
 
   it("normalizes status streamingStartedAt in seconds to milliseconds", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2356,7 +2375,7 @@ describe("useConversation", () => {
   it("preserves streamingStartedAt on same-session history while streaming", async () => {
     const { __wsMock } = await getWsMock();
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1_700_000_001_666);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2392,7 +2411,7 @@ describe("useConversation", () => {
 
   it("error event sets error message and stops streaming", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "error", message: "Connection lost" });
@@ -2414,7 +2433,7 @@ describe("useConversation", () => {
     ]);
     __wsMock.setBuffered("ws-1", true);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     // The session-less error from the synchronous buffer replay should be silently dropped.
     expect(result.current.error).toBeUndefined();
@@ -2431,7 +2450,7 @@ describe("useConversation", () => {
     ]);
     __wsMock.setBuffered("ws-1", true);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     expect(result.current.error).toBe("session error from buffer");
   });
@@ -2445,7 +2464,7 @@ describe("useConversation", () => {
     ]);
     __wsMock.setBuffered("ws-1", true);
 
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
     expect(result.current.error).toBeUndefined();
 
     // A live session-less error arriving after replay should pass through normally.
@@ -2458,7 +2477,7 @@ describe("useConversation", () => {
 
   it("ignores session-scoped error for a background session", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-active", streaming: true });
@@ -2474,7 +2493,7 @@ describe("useConversation", () => {
 
   it("extracts lockedProvider from status event", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     expect(result.current.lockedProvider).toBeUndefined();
 
@@ -2493,7 +2512,7 @@ describe("useConversation", () => {
 
   it("does not clear lockedProvider when status event omits it", async () => {
     const { __wsMock } = await getWsMock();
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2524,7 +2543,7 @@ describe("useConversation", () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockResolvedValueOnce([]);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     act(() => {
       __wsMock.emit("ws-1", {
@@ -2549,7 +2568,7 @@ describe("useConversation", () => {
     const { __wsMock } = await getWsMock();
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockResolvedValueOnce([]);
-    const { result } = renderHook(() => useConversation("ws-1"));
+    const { result } = renderConversation("ws-1");
 
     await act(async () => {
       await result.current.switchSession("sess-2");
@@ -2569,123 +2588,86 @@ describe("useConversation", () => {
     expect(result.current.lockedProvider).toBe("claude");
   });
 
-  describe("transport cache freshness", () => {
-    it("updates transport cache when messages change after done event", async () => {
+  describe("React Query message cache", () => {
+    it("writes the finalized turn into the React Query cache after done", async () => {
       const { __wsMock } = await getWsMock();
 
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { result, queryClient } = renderConversation("ws-1");
 
-      await act(async () => {
+      act(() => {
         __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
         __wsMock.emit("ws-1", {
           type: "user_message",
           message: { id: "u1", sessionId: "sess-1", role: "user", content: "hello", timestamp: "2026-02-20T00:00:00.000Z" },
         });
         __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "hi back" });
+      });
+      // `done` finalizes from the stream slot read via stateRef — emit after flush.
+      act(() => {
         __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1", durationMs: 100 });
       });
 
-      // After done, messages should have both user + assistant messages.
-      // The cache-update effect should have pushed them to the transport.
+      // After done, both the user + finalized assistant message are in the cache.
       expect(result.current.messages).toHaveLength(2);
-      expect(__wsMock.updateCachedHistoryMock).toHaveBeenCalled();
-      const lastCall = __wsMock.updateCachedHistoryMock.mock.calls.at(-1)!;
-      expect(lastCall[0]).toBe("ws-1");
-      expect(lastCall[1].type).toBe("history");
-      expect(lastCall[1].sessionId).toBe("sess-1");
-      expect(lastCall[1].messages).toHaveLength(2);
+      const cached = getCachedSessionMessages(queryClient, "ws-1", "sess-1");
+      expect(cached).toHaveLength(2);
+      expect(cached?.at(-1)).toMatchObject({ role: "assistant", content: "hi back" });
     });
 
-    it("does not update cache with empty messages during workspace switch", async () => {
+    it("keeps a session's cached messages when switching workspaces", async () => {
       const { __wsMock } = await getWsMock();
 
-      const { result, rerender } = renderHook(
-        ({ wsId }) => useConversation(wsId),
-        { initialProps: { wsId: "ws-1" } },
-      );
+      const { result, rerender, queryClient } = renderConversation("ws-1");
 
-      // Populate messages for ws-1
-      await act(async () => {
-        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+      // Populate the cache for ws-1 / sess-1 via a completed turn.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
         __wsMock.emit("ws-1", {
-          type: "history",
-          sessionId: "sess-1",
-          messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" }],
+          type: "user_message",
+          message: { id: "m1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
         });
       });
-
-      expect(result.current.messages).toHaveLength(1);
-      __wsMock.updateCachedHistoryMock.mockClear();
-
-      // Switch to ws-2 — messages clear, cache should NOT be overwritten with empty
-      rerender({ wsId: "ws-2" });
-
-      // Check that no call was made with empty messages for ws-1
-      for (const call of __wsMock.updateCachedHistoryMock.mock.calls) {
-        expect(call[1].messages.length).toBeGreaterThan(0);
-      }
-    });
-
-    it("skips cache write on first effect cycle after workspace switch to prevent cross-workspace pollution", async () => {
-      const { __wsMock } = await getWsMock();
-
-      const { result, rerender } = renderHook(
-        ({ wsId }) => useConversation(wsId),
-        { initialProps: { wsId: "ws-1" } },
-      );
-
-      // Populate ws-1 with messages
-      await act(async () => {
-        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-        __wsMock.emit("ws-1", {
-          type: "history",
-          sessionId: "sess-1",
-          messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "ws-1 msg", timestamp: "2026-02-20T00:00:00.000Z" }],
-        });
+      act(() => {
+        __wsMock.emit("ws-1", { type: "done", sessionId: "sess-1" });
       });
+      expect(result.current.messages.length).toBeGreaterThan(0);
 
-      expect(result.current.messages).toHaveLength(1);
-      __wsMock.updateCachedHistoryMock.mockClear();
-
-      // Switch to ws-2 — React 18 batching may transiently leave state.messages
-      // holding ws-1's messages while workspaceId is already ws-2. The guard
-      // (prevCacheWorkspaceRef) should prevent writing ws-1's messages into ws-2's cache.
+      // Switch to ws-2 — the visible state clears but ws-1's cache is untouched.
       rerender({ wsId: "ws-2" });
 
-      const ws2CacheCalls = __wsMock.updateCachedHistoryMock.mock.calls.filter(
-        ([wsId]: [string]) => wsId === "ws-2",
-      );
-      expect(ws2CacheCalls).toHaveLength(0);
+      const ws1Cached = getCachedSessionMessages(queryClient, "ws-1", "sess-1");
+      expect(ws1Cached?.length).toBeGreaterThan(0);
+      // No bogus cross-workspace entry was created for ws-2.
+      expect(getCachedSessionMessages(queryClient, "ws-2", "sess-1")).toBeUndefined();
     });
 
-    it("skips REST fetch when transport has cached history", async () => {
-      const { __wsMock } = await getWsMock();
+    it("does not refetch when the React Query cache is fresh", async () => {
       const { __apiMock } = await getApiMock();
       __apiMock.getMock.mockResolvedValue([]);
 
-      // Pre-populate the cache so hasCachedHistory returns true
-      __wsMock.setCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "sess-1",
-        messages: [{ id: "m1", sessionId: "sess-1", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" }],
-      });
+      const { result, queryClient } = renderConversation("ws-1");
 
-      renderHook(() => useConversation("ws-1"));
+      // Seed a fresh cache entry for the session, then activate it.
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [
+        { id: "m1", sessionId: "sess-1", role: "user", content: "cached", timestamp: "2026-02-20T00:00:00.000Z" },
+      ]);
+      await activateSession("ws-1", "sess-1");
 
-      // REST should NOT have been called since cache exists
+      // Messages render from the (fresh) cache and no REST fetch is triggered.
+      expect(result.current.messages).toHaveLength(1);
       expect(__apiMock.getMock).not.toHaveBeenCalled();
     });
 
-    it("fires REST fetch on first visit when no cached history exists", async () => {
+    it("fires a REST fetch for the active session when nothing is cached", async () => {
       const { __apiMock } = await getApiMock();
       __apiMock.getMock.mockReturnValue(new Promise<ChatMessage[]>(() => {}));
 
-      renderHook(() => useConversation("ws-1"));
+      renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
 
-      // REST should fire since there's no cached history
       await waitFor(() => {
         expect(__apiMock.getMock).toHaveBeenCalledWith(
-          expect.stringContaining("/api/workspaces/ws-1/"),
+          "/api/workspaces/ws-1/sessions/sess-1/messages",
         );
       });
     });
@@ -2694,7 +2676,7 @@ describe("useConversation", () => {
   describe("token usage in done event", () => {
     it("stores inputTokens/outputTokens from done event in assistant message", async () => {
       const { __wsMock } = await getWsMock();
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { result } = renderConversation("ws-1");
 
       act(() => {
         __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -2730,11 +2712,14 @@ describe("useConversation", () => {
 
     it("stores context usage fields from done event in assistant message", async () => {
       const { __wsMock } = await getWsMock();
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { result } = renderConversation("ws-1");
 
       act(() => {
         __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
         __wsMock.emit("ws-1", { type: "text_delta", text: "Codex reply" });
+      });
+      // `done` finalizes from the stream slot read via stateRef — emit after flush.
+      act(() => {
         __wsMock.emit("ws-1", {
           type: "done",
           sessionId: "sess-1",
@@ -2755,7 +2740,7 @@ describe("useConversation", () => {
 
     it("stores undefined tokens when done event has no token data", async () => {
       const { __wsMock } = await getWsMock();
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { result } = renderConversation("ws-1");
 
       act(() => {
         __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
@@ -2786,7 +2771,15 @@ describe("useConversation", () => {
   describe("non-destructive reconnect resync", () => {
     it("drops a stale stream slot when authoritative history shows the turn finished", async () => {
       const { __wsMock } = await getWsMock();
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { __apiMock } = await getApiMock();
+      // The authoritative REST history holds the finalized turn the zombie socket
+      // missed (it never delivered `done`).
+      __apiMock.getMock.mockResolvedValue([
+        { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+        { id: "a1", sessionId: "sess-1", role: "assistant", content: "Hello", timestamp: "2026-02-12T00:00:01.000Z" },
+      ]);
+
+      const { result, queryClient } = renderConversation("ws-1");
 
       // Active stream accumulates content.
       act(() => {
@@ -2799,30 +2792,28 @@ describe("useConversation", () => {
       expect(result.current.currentStreamingText).toBe("Hello");
       expect(result.current.isStreaming).toBe(true);
 
-      // Reconnect bootstrap: the turn completed while the socket was a zombie.
-      // status (provisional) then authoritative history with the finalized turn.
+      // Reconnect bootstrap: status (provisional, no longer streaming) and the
+      // authoritative REST refetch surface the finalized turn, whose arrival drives
+      // reconcile_history to drop the now-stale live stream slot.
       act(() => {
         __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
-        __wsMock.emit("ws-1", {
-          type: "history",
-          sessionId: "sess-1",
-          messages: [
-            { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
-            { id: "a1", sessionId: "sess-1", role: "assistant", content: "Hello", timestamp: "2026-02-12T00:00:01.000Z" },
-          ],
-        });
+      });
+      await act(async () => {
+        await queryClient.invalidateQueries({ queryKey: sessionMessagesKey("ws-1", "sess-1") });
       });
 
       // No leftover streaming bubble, and the finalized message appears exactly once.
+      await waitFor(() => {
+        expect(result.current.messages).toHaveLength(2);
+      });
       expect(result.current.isStreaming).toBe(false);
       expect(result.current.currentStreamingText).toBe("");
-      expect(result.current.messages).toHaveLength(2);
       expect(result.current.messages.at(-1)?.content).toBe("Hello");
     });
 
     it("keeps an active stream and reconciles it via snapshot replace (no wipe)", async () => {
       const { __wsMock } = await getWsMock();
-      const { result } = renderHook(() => useConversation("ws-1"));
+      const { result } = renderConversation("ws-1");
 
       act(() => {
         __wsMock.emit("ws-1", {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -2782,4 +2782,81 @@ describe("useConversation", () => {
       expect(assistant?.outputTokens).toBeUndefined();
     });
   });
+
+  describe("non-destructive reconnect resync", () => {
+    it("drops a stale stream slot when authoritative history shows the turn finished", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      // Active stream accumulates content.
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Hello" });
+      });
+      expect(result.current.currentStreamingText).toBe("Hello");
+      expect(result.current.isStreaming).toBe(true);
+
+      // Reconnect bootstrap: the turn completed while the socket was a zombie.
+      // status (provisional) then authoritative history with the finalized turn.
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+        __wsMock.emit("ws-1", {
+          type: "history",
+          sessionId: "sess-1",
+          messages: [
+            { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+            { id: "a1", sessionId: "sess-1", role: "assistant", content: "Hello", timestamp: "2026-02-12T00:00:01.000Z" },
+          ],
+        });
+      });
+
+      // No leftover streaming bubble, and the finalized message appears exactly once.
+      expect(result.current.isStreaming).toBe(false);
+      expect(result.current.currentStreamingText).toBe("");
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages.at(-1)?.content).toBe("Hello");
+    });
+
+    it("keeps an active stream and reconciles it via snapshot replace (no wipe)", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderHook(() => useConversation("ws-1"));
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+        });
+        __wsMock.emit("ws-1", { type: "text_delta", sessionId: "sess-1", text: "Hel" });
+      });
+      expect(result.current.currentStreamingText).toBe("Hel");
+
+      // Reconnect bootstrap for a still-streaming session: status (busy) →
+      // history (finalized turns only) → snapshot (authoritative in-flight state).
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "busy", sessionId: "sess-1", streaming: true });
+        __wsMock.emit("ws-1", {
+          type: "history",
+          sessionId: "sess-1",
+          messages: [
+            { id: "u1", sessionId: "sess-1", role: "user", content: "hi", timestamp: "2026-02-12T00:00:00.000Z" },
+          ],
+        });
+        __wsMock.emit("ws-1", {
+          type: "stream_snapshot",
+          sessionId: "sess-1",
+          text: "Hello world",
+          thinking: "",
+          toolCalls: [],
+          agentActivities: [],
+          agentPlanMode: false,
+        });
+      });
+
+      expect(result.current.isStreaming).toBe(true);
+      expect(result.current.currentStreamingText).toBe("Hello world");
+    });
+  });
 });

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
@@ -51,6 +51,16 @@ function message(id: string, content: string): ChatMessage {
   };
 }
 
+function userMessage(id: string, content: string): ChatMessage {
+  return {
+    id,
+    sessionId: "sess-1",
+    role: "user",
+    content,
+    timestamp: "2026-02-20T00:00:00.000Z",
+  };
+}
+
 describe("useSessionMessages", () => {
   beforeEach(async () => {
     const { __apiMock } = await getApiMock();
@@ -96,6 +106,29 @@ describe("useSessionMessages", () => {
   it("sessionMessagesKey normalizes missing ids to empty strings", () => {
     expect(sessionMessagesKey("ws-1", "sess-1")).toEqual(["session-messages", "ws-1", "sess-1"]);
     expect(sessionMessagesKey(undefined, undefined)).toEqual(["session-messages", "", ""]);
+  });
+
+  it("preserves cached user echoes when a stale REST refetch starts after the echo was cached", async () => {
+    const { __apiMock } = await getApiMock();
+    const firstUser = userMessage("u1", "first prompt");
+    const firstAssistant = message("a1", "first answer");
+    const followUp = userMessage("u2", "queued follow-up");
+    __apiMock.getMock.mockResolvedValue([firstUser, firstAssistant]);
+
+    const queryClient = newClient();
+    const key = sessionMessagesKey("ws-1", "sess-1");
+    queryClient.setQueryData(key, [firstUser, firstAssistant, followUp]);
+
+    const { result } = renderHook(() => useSessionMessages("ws-1", "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: key });
+    });
+
+    expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-1/messages");
+    expect(result.current.messages).toEqual([firstUser, firstAssistant, followUp]);
   });
 
   describe("appendCachedSessionMessage", () => {

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -1,0 +1,188 @@
+import type { ReactNode } from "react";
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  useSessionMessages,
+  sessionMessagesKey,
+  getCachedSessionMessages,
+  appendCachedSessionMessage,
+  invalidateSessionMessages,
+  removeCachedSessionMessages,
+} from "@/hooks/useSessionMessages";
+import type { ChatMessage } from "@/types";
+
+vi.mock("@/hooks/useApi", () => {
+  const getMock = vi.fn(() => Promise.resolve<ChatMessage[]>([]));
+  return {
+    api: { get: getMock },
+    __apiMock: {
+      getMock,
+      reset: () => {
+        getMock.mockReset();
+        getMock.mockImplementation(() => Promise.resolve<ChatMessage[]>([]));
+      },
+    },
+  };
+});
+
+const getApiMock = async () =>
+  (await import("@/hooks/useApi")) as unknown as {
+    __apiMock: { getMock: ReturnType<typeof vi.fn>; reset: () => void };
+  };
+
+function newClient(): QueryClient {
+  return new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+}
+
+function wrapperFor(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function message(id: string, content: string): ChatMessage {
+  return {
+    id,
+    sessionId: "sess-1",
+    role: "assistant",
+    content,
+    timestamp: "2026-02-20T00:00:00.000Z",
+  };
+}
+
+describe("useSessionMessages", () => {
+  beforeEach(async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.reset();
+  });
+
+  it("fetches the session messages once a sessionId is provided", async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock.mockResolvedValue([message("a1", "loaded")]);
+
+    const queryClient = newClient();
+    const { result } = renderHook(() => useSessionMessages("ws-1", "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([message("a1", "loaded")]);
+    });
+    expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-1/messages");
+  });
+
+  it("returns an empty list and does not fetch when there is no sessionId", async () => {
+    const { __apiMock } = await getApiMock();
+    const queryClient = newClient();
+    const { result } = renderHook(() => useSessionMessages("ws-1", undefined), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    expect(result.current.messages).toEqual([]);
+    expect(__apiMock.getMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch when there is no workspaceId", async () => {
+    const { __apiMock } = await getApiMock();
+    const queryClient = newClient();
+    renderHook(() => useSessionMessages(undefined, "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    expect(__apiMock.getMock).not.toHaveBeenCalled();
+  });
+
+  it("sessionMessagesKey normalizes missing ids to empty strings", () => {
+    expect(sessionMessagesKey("ws-1", "sess-1")).toEqual(["session-messages", "ws-1", "sess-1"]);
+    expect(sessionMessagesKey(undefined, undefined)).toEqual(["session-messages", "", ""]);
+  });
+
+  describe("appendCachedSessionMessage", () => {
+    it("appends a message to the session cache", () => {
+      const queryClient = newClient();
+      appendCachedSessionMessage(queryClient, "ws-1", "sess-1", message("a1", "first"));
+      appendCachedSessionMessage(queryClient, "ws-1", "sess-1", message("a2", "second"));
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([
+        message("a1", "first"),
+        message("a2", "second"),
+      ]);
+    });
+
+    it("dedups by message id", () => {
+      const queryClient = newClient();
+      appendCachedSessionMessage(queryClient, "ws-1", "sess-1", message("a1", "first"));
+      appendCachedSessionMessage(queryClient, "ws-1", "sess-1", message("a1", "duplicate"));
+
+      const cached = getCachedSessionMessages(queryClient, "ws-1", "sess-1");
+      expect(cached).toHaveLength(1);
+      expect(cached?.[0]?.content).toBe("first");
+    });
+
+    it("is a no-op without a workspaceId or sessionId", () => {
+      const queryClient = newClient();
+      appendCachedSessionMessage(queryClient, undefined, "sess-1", message("a1", "x"));
+      appendCachedSessionMessage(queryClient, "ws-1", undefined, message("a1", "x"));
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toBeUndefined();
+    });
+  });
+
+  describe("getCachedSessionMessages", () => {
+    it("reads the cached messages synchronously without fetching", () => {
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [message("a1", "cached")]);
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([message("a1", "cached")]);
+      expect(getCachedSessionMessages(queryClient, "ws-1", "other")).toBeUndefined();
+    });
+  });
+
+  describe("invalidateSessionMessages", () => {
+    it("marks the session query stale", async () => {
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [message("a1", "cached")]);
+
+      const state = queryClient.getQueryState(sessionMessagesKey("ws-1", "sess-1"));
+      expect(state?.isInvalidated).toBe(false);
+
+      invalidateSessionMessages(queryClient, "ws-1", "sess-1");
+
+      await waitFor(() => {
+        const next = queryClient.getQueryState(sessionMessagesKey("ws-1", "sess-1"));
+        expect(next?.isInvalidated).toBe(true);
+      });
+    });
+
+    it("is a no-op without a workspaceId or sessionId", () => {
+      const queryClient = newClient();
+      const spy = vi.spyOn(queryClient, "invalidateQueries");
+      invalidateSessionMessages(queryClient, undefined, "sess-1");
+      invalidateSessionMessages(queryClient, "ws-1", undefined);
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeCachedSessionMessages", () => {
+    it("clears a specific session's cache", () => {
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [message("a1", "x")]);
+
+      removeCachedSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toBeUndefined();
+    });
+
+    it("clears every session in a workspace when no sessionId is given", () => {
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [message("a1", "x")]);
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-2"), [message("a2", "y")]);
+
+      removeCachedSessionMessages(queryClient, "ws-1");
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toBeUndefined();
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-2")).toBeUndefined();
+    });
+  });
+});

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { wsTransport } from "@/lib/ws-transport";
-import type { HistoryMessage } from "@/lib/ws-transport";
 import type { WsOutgoing, HubOutgoing } from "@/types";
 
 class MockWebSocket {
@@ -170,46 +169,29 @@ describe("wsTransport", () => {
     });
   });
 
-  it("tracks cached history via updateCachedHistory and clears it with clearCachedData", () => {
+  it("does not cache or replay history-shaped messages (history is owned by REST now)", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
 
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
-
-    wsTransport.updateCachedHistory("ws-1", {
+    // A live handler receives the history message as a plain pass-through event,
+    const first: WsOutgoing[] = [];
+    const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
+    socket.hubMessage("ws-1", {
       type: "history",
       sessionId: "sess-1",
       messages: [
-        {
-          id: "m1",
-          sessionId: "sess-1",
-          role: "user",
-          content: "cached",
-          timestamp: "2026-02-20T00:00:00.000Z",
-        },
+        { id: "m1", sessionId: "sess-1", role: "user", content: "live", timestamp: "2026-02-20T00:00:00.000Z" },
       ],
-    });
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
+    } as WsOutgoing);
+    expect(first).toHaveLength(1);
+    unsubscribe();
 
-    wsTransport.clearCachedData("ws-1");
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
-  });
-
-  it("drops cached history after disconnectAll removes subscriptions", () => {
-    wsTransport.connect("ws-1");
-    const socket = MockWebSocket.instances[0]!;
-    socket.open();
-
-    wsTransport.updateCachedHistory("ws-1", {
-      type: "history",
-      sessionId: "sess-1",
-      messages: [],
-    });
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
-
-    wsTransport.disconnectAll();
-    expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
+    // but it is NOT cached, so a fresh handler does not get it replayed.
+    const replayed: WsOutgoing[] = [];
+    const result = wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
+    expect(replayed.find((m) => m.type === "history")).toBeUndefined();
+    expect(result.hadBufferedMessages).toBe(false);
   });
 
   it("dispatches parsed incoming messages to handlers (via hub envelope)", () => {
@@ -416,7 +398,7 @@ describe("wsTransport", () => {
     expect(wsTransport.getStatus("ws-1")).toBe("disconnected");
   });
 
-  it("replays status, history, and buffered messages to newly attached handlers", () => {
+  it("replays cached status and buffered messages to newly attached handlers", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
@@ -427,22 +409,10 @@ describe("wsTransport", () => {
     });
 
     socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
-    socket.hubMessage("ws-1", {
-      type: "history",
-      messages: [
-        {
-          id: "u1",
-          sessionId: "s1",
-          role: "user",
-          content: "hello",
-          timestamp: "2026-02-12T00:00:00.000Z",
-        },
-      ],
-    } as WsOutgoing);
     socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "partial" });
     socket.hubMessage("ws-1", { type: "done", sessionId: "s1" });
 
-    expect(firstHandler).toHaveLength(4);
+    expect(firstHandler).toHaveLength(3);
     unsubscribe();
 
     // Messages arriving while no handler is subscribed should be buffered
@@ -466,20 +436,8 @@ describe("wsTransport", () => {
 
     expect(result.hadBufferedMessages).toBe(true);
     expect(replayed).toEqual([
-      // Cached status + history
+      // Cached status (history is no longer cached/replayed — it comes from REST)
       { type: "status", status: "busy", streaming: true },
-      {
-        type: "history",
-        messages: [
-          {
-            id: "u1",
-            sessionId: "s1",
-            role: "user",
-            content: "hello",
-            timestamp: "2026-02-12T00:00:00.000Z",
-          },
-        ],
-      },
       // Buffered messages
       {
         type: "user_message",
@@ -512,11 +470,6 @@ describe("wsTransport", () => {
       streaming: true,
       sessionId: "s-new",
     });
-    socket.hubMessage("ws-1", {
-      type: "history",
-      sessionId: "s-new",
-      messages: [],
-    } as WsOutgoing);
     unsubscribe();
 
     // Buffer events from multiple sessions while no message handlers are attached.
@@ -531,7 +484,6 @@ describe("wsTransport", () => {
     expect(result.hadBufferedMessages).toBe(true);
     expect(replayed).toEqual([
       { type: "status", status: "busy", streaming: true, sessionId: "s-new" },
-      { type: "history", sessionId: "s-new", messages: [] },
       { type: "text_delta", sessionId: "s-old", text: "stale" },
       { type: "done", sessionId: "s-old" },
       { type: "text_delta", sessionId: "s-new", text: "fresh" },
@@ -631,7 +583,7 @@ describe("wsTransport", () => {
       });
     });
 
-    it("replays branch_info together with status and history", () => {
+    it("replays branch_info together with status and diff_stats", () => {
       wsTransport.connect("ws-1");
       const socket = MockWebSocket.instances[0]!;
       socket.open();
@@ -640,7 +592,6 @@ describe("wsTransport", () => {
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
 
       socket.hubMessage("ws-1", { type: "status", status: "idle", streaming: false });
-      socket.hubMessage("ws-1", { type: "history", sessionId: "s1", messages: [] } as WsOutgoing);
       socket.hubMessage("ws-1", {
         type: "diff_stats",
         stats: { committed: [], uncommitted: [] },
@@ -656,9 +607,10 @@ describe("wsTransport", () => {
 
       const types = replayed.map((m) => m.type);
       expect(types).toContain("status");
-      expect(types).toContain("history");
       expect(types).toContain("diff_stats");
       expect(types).toContain("branch_info");
+      // History is no longer cached/replayed (owned by REST).
+      expect(types).not.toContain("history");
     });
 
     it("updates cached branch_info when a newer one arrives", () => {
@@ -689,7 +641,7 @@ describe("wsTransport", () => {
   });
 
   describe("clearCachedData", () => {
-    it("clears cached status, history, and message buffer", () => {
+    it("clears cached status and message buffer", () => {
       wsTransport.connect("ws-1");
       const socket = MockWebSocket.instances[0]!;
       socket.open();
@@ -697,7 +649,6 @@ describe("wsTransport", () => {
       const first: WsOutgoing[] = [];
       const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
       socket.hubMessage("ws-1", { type: "status", status: "busy", streaming: true });
-      socket.hubMessage("ws-1", { type: "history", sessionId: "s1", messages: [] } as WsOutgoing);
       unsubscribe();
 
       socket.hubMessage("ws-1", { type: "text_delta", sessionId: "s1", text: "buffered" });
@@ -764,165 +715,6 @@ describe("wsTransport", () => {
       const replayed: WsOutgoing[] = [];
       wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
       expect(replayed).toEqual([{ type: "status", status: "idle", streaming: false }]);
-    });
-  });
-
-  describe("updateCachedHistory / hasCachedHistory", () => {
-    it("replays updated history to next handler", () => {
-      wsTransport.connect("ws-1");
-      const socket = MockWebSocket.instances[0]!;
-      socket.open();
-
-      const first: WsOutgoing[] = [];
-      const { unsubscribe } = wsTransport.onMessage("ws-1", (msg) => first.push(msg));
-      socket.hubMessage("ws-1", { type: "history", messages: [{ id: "old" }] } as WsOutgoing);
-      unsubscribe();
-
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "s1",
-        messages: [{ id: "old" }, { id: "new" }] as never[],
-      });
-
-      const replayed: WsOutgoing[] = [];
-      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
-      const history = replayed.find((m) => m.type === "history");
-      expect(history).toBeDefined();
-      expect((history as { messages: { id: string }[] }).messages).toEqual([
-        { id: "old" },
-        { id: "new" },
-      ]);
-    });
-
-    it("hasCachedHistory returns false when no history was received", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
-    });
-
-    it("hasCachedHistory returns true after updateCachedHistory", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "s1",
-        messages: [],
-      });
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
-    });
-
-    it("hasCachedHistory returns false after clearCachedData", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-      wsTransport.updateCachedHistory("ws-1", {
-        type: "history",
-        sessionId: "s1",
-        messages: [],
-      });
-      wsTransport.clearCachedData("ws-1");
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
-    });
-
-    it("is a no-op for unknown workspace", () => {
-      wsTransport.updateCachedHistory("unknown", {
-        type: "history",
-        messages: [],
-      });
-      expect(wsTransport.hasCachedHistory("unknown")).toBe(false);
-    });
-  });
-
-  describe("per-session history cache", () => {
-    const historyFor = (sessionId: string, text: string): HistoryMessage => ({
-      type: "history",
-      sessionId,
-      messages: [
-        {
-          id: `${sessionId}-m`,
-          sessionId,
-          role: "user",
-          content: text,
-          timestamp: "2026-02-20T00:00:00.000Z",
-        },
-      ],
-    });
-
-    it("caches history per session and replays every session on resubscribe", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-
-      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
-      wsTransport.updateCachedHistory("ws-1", historyFor("sess-2", "two"));
-
-      const replayed: WsOutgoing[] = [];
-      wsTransport.onMessage("ws-1", (msg) => replayed.push(msg));
-
-      const histories = replayed.filter((m) => m.type === "history");
-      expect(histories).toEqual(expect.arrayContaining([
-        historyFor("sess-1", "one"),
-        historyFor("sess-2", "two"),
-      ]));
-      expect(histories).toHaveLength(2);
-    });
-
-    it("getCachedHistory returns the cached history for a specific session", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-
-      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
-      wsTransport.updateCachedHistory("ws-1", historyFor("sess-2", "two"));
-
-      expect(wsTransport.getCachedHistory("ws-1", "sess-2")).toEqual(historyFor("sess-2", "two"));
-      expect(wsTransport.getCachedHistory("ws-1", "unknown")).toBeUndefined();
-      expect(wsTransport.getCachedHistory("unknown-ws", "sess-1")).toBeUndefined();
-    });
-
-    it("hasCachedHistory is session-specific when a sessionId is given", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-
-      wsTransport.updateCachedHistory("ws-1", historyFor("sess-1", "one"));
-
-      expect(wsTransport.hasCachedHistory("ws-1", "sess-1")).toBe(true);
-      expect(wsTransport.hasCachedHistory("ws-1", "sess-2")).toBe(false);
-      // Without a sessionId it reports whether any session is cached.
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(true);
-    });
-
-    it("does not overwrite another session's cache when a new session history arrives", () => {
-      wsTransport.connect("ws-1");
-      const socket = MockWebSocket.instances[0]!;
-      socket.open();
-
-      socket.hubMessage("ws-1", historyFor("sess-1", "one") as WsOutgoing);
-      socket.hubMessage("ws-1", historyFor("sess-2", "two") as WsOutgoing);
-
-      expect(wsTransport.getCachedHistory("ws-1", "sess-1")).toEqual(historyFor("sess-1", "one"));
-      expect(wsTransport.getCachedHistory("ws-1", "sess-2")).toEqual(historyFor("sess-2", "two"));
-    });
-
-    it("keys incoming history by its first message when no top-level sessionId is present", () => {
-      wsTransport.connect("ws-1");
-      const socket = MockWebSocket.instances[0]!;
-      socket.open();
-
-      socket.hubMessage("ws-1", {
-        type: "history",
-        messages: [
-          { id: "m1", sessionId: "sess-9", role: "user", content: "hi", timestamp: "2026-02-20T00:00:00.000Z" },
-        ],
-      } as WsOutgoing);
-
-      expect(wsTransport.hasCachedHistory("ws-1", "sess-9")).toBe(true);
-    });
-
-    it("ignores session-less history (no sessionId and empty messages)", () => {
-      wsTransport.connect("ws-1");
-      MockWebSocket.instances[0]!.open();
-
-      wsTransport.updateCachedHistory("ws-1", { type: "history", messages: [] });
-
-      expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
     });
   });
 

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -925,4 +925,115 @@ describe("wsTransport", () => {
       expect(wsTransport.hasCachedHistory("ws-1")).toBe(false);
     });
   });
+
+  describe("heartbeat + liveness", () => {
+    const getPings = (socket: MockWebSocket): unknown[] =>
+      socket.sent
+        .map((s) => { try { return JSON.parse(s); } catch { return null; } })
+        .filter((m) => m?.type === "ping");
+    const sendPong = (socket: MockWebSocket): void =>
+      socket.message(JSON.stringify({ type: "pong" }));
+
+    it("sends an app-level ping on the heartbeat interval", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      expect(getPings(socket)).toHaveLength(0);
+      vi.advanceTimersByTime(25_000);
+      expect(getPings(socket).length).toBeGreaterThanOrEqual(1);
+    });
+
+    it("keeps a socket that answers pongs (no reconnect)", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      for (let i = 0; i < 4; i++) {
+        vi.advanceTimersByTime(25_000);
+        sendPong(socket);
+      }
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(socket.readyState).toBe(MockWebSocket.OPEN);
+    });
+
+    it("reconnects a zombie socket that never answers pongs", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      // Silent past HEARTBEAT_INTERVAL_MS + PONG_TIMEOUT_MS (25s + 10s).
+      vi.advanceTimersByTime(60_000);
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("ignores pong frames (does not forward them as workspace events)", () => {
+      const received: WsOutgoing[] = [];
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+      wsTransport.onMessage("ws-1", (msg) => received.push(msg));
+
+      sendPong(socket);
+
+      expect(received).toHaveLength(0);
+    });
+  });
+
+  describe("probeLiveness", () => {
+    const sendPong = (socket: MockWebSocket): void =>
+      socket.message(JSON.stringify({ type: "pong" }));
+
+    it("is a no-op when nothing is subscribed", () => {
+      wsTransport.probeLiveness();
+      expect(MockWebSocket.instances).toHaveLength(0);
+    });
+
+    it("does not reconnect a healthy OPEN socket that answers the probe", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      wsTransport.probeLiveness();
+      vi.advanceTimersByTime(100); // pong round-trips before the probe deadline
+      sendPong(socket);
+      vi.advanceTimersByTime(3_000);
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(socket.readyState).toBe(MockWebSocket.OPEN);
+    });
+
+    it("reconnects an OPEN-but-frozen socket that ignores the probe", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+
+      wsTransport.probeLiveness();
+      vi.advanceTimersByTime(3_000); // no pong arrives within the probe window
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("reconnects immediately when the socket is closed", () => {
+      wsTransport.connect("ws-1");
+      const socket = MockWebSocket.instances[0]!;
+      socket.open();
+      socket.readyState = MockWebSocket.CLOSED;
+
+      wsTransport.probeLiveness();
+
+      expect(MockWebSocket.instances).toHaveLength(2);
+    });
+
+    it("is a no-op while a connection attempt is already in flight", () => {
+      wsTransport.connect("ws-1");
+      expect(MockWebSocket.instances[0]!.readyState).toBe(MockWebSocket.CONNECTING);
+
+      wsTransport.probeLiveness();
+
+      expect(MockWebSocket.instances).toHaveLength(1);
+    });
+  });
 });

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -19,6 +19,9 @@ enum HubIncoming: Encodable {
             var container = encoder.container(keyedBy: SyncCodingKeys.self)
             try container.encode("sync_workspaces", forKey: .type)
             try container.encode(workspaceIds, forKey: .workspaceIds)
+            // iOS is fully migrated to REST-owned history: always opt in so the
+            // backend skips the WS `history` bootstrap event for this client.
+            try container.encode(true, forKey: .historyViaRest)
         case .workspaceEvent(let workspaceId, let event):
             var container = encoder.container(keyedBy: EventCodingKeys.self)
             try container.encode(workspaceId, forKey: .workspaceId)
@@ -27,7 +30,7 @@ enum HubIncoming: Encodable {
     }
 
     private enum SyncCodingKeys: String, CodingKey {
-        case type, workspaceIds
+        case type, workspaceIds, historyViaRest
     }
 
     private enum EventCodingKeys: String, CodingKey {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -258,16 +258,22 @@ final class ConversationStore {
             bumpHistoryToken(for: historySessionId)
             sessionId = historySessionId ?? sessionId
 
-            // Derive pending tool inputs from history only when not actively
-            // streaming (during streaming, live WS tool inputs take precedence).
-            let activeStream = historySessionId.flatMap { sessionStreams[$0] }
-            if activeStream?.isStreaming != true {
+            // Reconcile any stale in-progress stream slot for a non-streaming session.
+            // History only carries finalized turns, so when it arrives for a session that
+            // is NOT actively streaming, any leftover stream slot has already been
+            // persisted into `messages` (e.g. the turn finished while the socket was a
+            // backgrounded zombie). Rebuild a CLEAN slot containing only pending tool
+            // inputs (an unanswered question/plan), or drop the stale slot entirely.
+            // During streaming, live WS state takes precedence, so we leave it untouched.
+            let existingStream = historySessionId.flatMap { sessionStreams[$0] }
+            if existingStream?.isStreaming != true, let sid = historySessionId {
                 let derived = derivePendingToolInputsFromHistory(msgs)
-                if let sid = historySessionId {
-                    if activeStream != nil || !derived.isEmpty {
-                        ensureStream(for: sid, streaming: false)
-                        sessionStreams[sid]?.pendingToolInputs = derived
-                    }
+                if !derived.isEmpty {
+                    var rebuilt = SessionStreamState()
+                    rebuilt.pendingToolInputs = derived
+                    sessionStreams[sid] = rebuilt
+                } else if existingStream != nil {
+                    sessionStreams.removeValue(forKey: sid)
                 }
             }
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -36,6 +36,11 @@ final class ConversationStore {
 
     var messages: [ChatMessage] = []
 
+    /// Per-session finalized-history cache. Mirrors web's React Query cache so
+    /// switching back to a previously-viewed session restores its messages
+    /// instantly (no empty flash) while the authoritative REST refetch runs.
+    private var messagesBySession: [String: [ChatMessage]] = [:]
+
     /// Session currently displayed in chat.
     var sessionId: String?
 
@@ -237,6 +242,8 @@ final class ConversationStore {
             let alreadyExists = messages.contains { $0.id == msg.id }
             if isActive && !alreadyExists {
                 messages.append(msg)
+                // Keep the cache in sync so switch-away/back shows this turn.
+                messagesBySession[sid] = messages
             }
             sessionId = sessionId ?? sid
             ensureStream(for: sid)
@@ -247,35 +254,18 @@ final class ConversationStore {
             sessionStreams[sid]?.pendingToolInputs = []
 
         case .history(let msgs, let incomingSessionId):
+            // iOS opts into `historyViaRest`, so the backend no longer sends a
+            // `history` bootstrap event. This case remains only as a defensive
+            // fallback (e.g. an older backend) and routes through the same path
+            // the REST fetch uses, so reconciliation logic lives in one place.
             let historySessionId = incomingSessionId ?? msgs.first?.sessionId ?? sessionId
-            // Only update messages for the active session
-            guard historySessionId == nil || sessionId == nil || historySessionId == sessionId else { return }
-
-            // Always apply history — it contains finalized turns only.
-            // Streaming content lives in sessionStreams and is rendered as a
-            // separate in-progress bubble by the chat view.
-            messages = msgs
-            bumpHistoryToken(for: historySessionId)
-            sessionId = historySessionId ?? sessionId
-
-            // Reconcile any stale in-progress stream slot for a non-streaming session.
-            // History only carries finalized turns, so when it arrives for a session that
-            // is NOT actively streaming, any leftover stream slot has already been
-            // persisted into `messages` (e.g. the turn finished while the socket was a
-            // backgrounded zombie). Rebuild a CLEAN slot containing only pending tool
-            // inputs (an unanswered question/plan), or drop the stale slot entirely.
-            // During streaming, live WS state takes precedence, so we leave it untouched.
-            let existingStream = historySessionId.flatMap { sessionStreams[$0] }
-            if existingStream?.isStreaming != true, let sid = historySessionId {
-                let derived = derivePendingToolInputsFromHistory(msgs)
-                if !derived.isEmpty {
-                    var rebuilt = SessionStreamState()
-                    rebuilt.pendingToolInputs = derived
-                    sessionStreams[sid] = rebuilt
-                } else if existingStream != nil {
-                    sessionStreams.removeValue(forKey: sid)
-                }
+            guard let sid = historySessionId else { return }
+            // Adopt the session when none is focused yet so the messages land on
+            // the active conversation (matches the pre-REST history behaviour).
+            if sessionId == nil {
+                sessionId = sid
             }
+            applyFetchedHistory(msgs, for: sid)
 
         case .branchInfo(let info):
             branchInfo = info
@@ -292,6 +282,47 @@ final class ConversationStore {
 
         case .unknown:
             break
+        }
+    }
+
+    /// Cached finalized messages for a session, if any have been fetched before.
+    /// Used by ChatView to render instantly on switch-back while the authoritative
+    /// REST refetch runs in the background.
+    func cachedMessages(for sessionId: String) -> [ChatMessage]? {
+        messagesBySession[sessionId]
+    }
+
+    /// Apply finalized history fetched from REST (or, defensively, a WS `history`
+    /// event) for a session. Caches it for instant switch-back, and — if the
+    /// session is currently active — applies it to `messages` and reconciles any
+    /// stale in-progress stream slot.
+    ///
+    /// History contains only finalized turns. Streaming content lives in
+    /// `sessionStreams` and is rendered as a separate in-progress bubble.
+    func applyFetchedHistory(_ msgs: [ChatMessage], for sessionId: String) {
+        messagesBySession[sessionId] = msgs
+
+        guard sessionId == self.sessionId else { return }
+
+        messages = msgs
+
+        // Reconcile any stale in-progress stream slot for a non-streaming session.
+        // History only carries finalized turns, so when it arrives for a session
+        // that is NOT actively streaming, any leftover stream slot has already been
+        // persisted into `messages` (e.g. the turn finished while the socket was a
+        // backgrounded zombie). Rebuild a CLEAN slot containing only pending tool
+        // inputs (an unanswered question/plan), or drop the stale slot entirely.
+        // During streaming, live WS state takes precedence, so we leave it untouched.
+        let existingStream = sessionStreams[sessionId]
+        if existingStream?.isStreaming != true {
+            let derived = derivePendingToolInputsFromHistory(msgs)
+            if !derived.isEmpty {
+                var rebuilt = SessionStreamState()
+                rebuilt.pendingToolInputs = derived
+                sessionStreams[sessionId] = rebuilt
+            } else if existingStream != nil {
+                sessionStreams.removeValue(forKey: sessionId)
+            }
         }
     }
 
@@ -335,7 +366,10 @@ final class ConversationStore {
     func prepareSessionSwitch(_ newSessionId: String) {
         let previousSessionId = sessionId
         sessionId = newSessionId
-        messages = []
+        // Restore from the per-session cache for instant switch-back (no empty
+        // flash). The REST refetch in ChatView replaces this with the
+        // authoritative copy. Empty array when this session was never viewed.
+        messages = messagesBySession[newSessionId] ?? []
         lockedProvider = nil
         bumpHistoryToken(for: previousSessionId)
         bumpHistoryToken(for: newSessionId)
@@ -345,17 +379,20 @@ final class ConversationStore {
     func removeSessionState(_ removedSessionId: String, fallbackSessionId: String?) {
         sessionStreams.removeValue(forKey: removedSessionId)
         historyTokenBySession.removeValue(forKey: removedSessionId)
+        messagesBySession.removeValue(forKey: removedSessionId)
 
         guard sessionId == removedSessionId else { return }
 
-        messages = []
-        lockedProvider = nil
-
+        // Restore the fallback's cached messages (if any) for instant display.
         if let fallbackSessionId, fallbackSessionId != removedSessionId {
             sessionId = fallbackSessionId
+            messages = messagesBySession[fallbackSessionId] ?? []
+            lockedProvider = nil
             bumpHistoryToken(for: fallbackSessionId)
         } else {
             sessionId = nil
+            messages = []
+            lockedProvider = nil
         }
     }
 
@@ -448,6 +485,10 @@ final class ConversationStore {
                 )
                 messages.append(msg)
             }
+            // Keep the cache in sync so switch-away/back shows the finalized turn.
+            // The onTurnCompleted REST refetch later replaces it with the
+            // authoritative (backend-ID'd) copy.
+            messagesBySession[sid] = messages
         }
     }
 

--- a/ios/HiveMobile/Stores/ConversationStoreCache.swift
+++ b/ios/HiveMobile/Stores/ConversationStoreCache.swift
@@ -28,12 +28,4 @@ final class ConversationStoreCache {
     func evict(_ workspaceId: String) {
         stores.removeValue(forKey: workspaceId)
     }
-
-    /// Clear all streaming state from every cached store.
-    /// Called before force-reconnect so bootstrap data writes into a clean slate.
-    func clearAllStreamingState() {
-        for store in stores.values {
-            store.sessionStreams.removeAll()
-        }
-    }
 }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -342,8 +342,9 @@ final class HubStatusMonitor {
     }
 
     /// Called when the app returns to foreground after a non-trivial background period.
-    /// Clears stale streaming state and forces an immediate hub reconnect so the
-    /// backend bootstrap (status + history) writes into a clean slate.
+    /// Forces an immediate hub reconnect so the backend bootstrap (status + history)
+    /// re-syncs every workspace. The reconnect is non-destructive: streaming state is
+    /// reconciled silently from bootstrap events rather than wiped (issue #259).
     func appDidBecomeActive() {
         // Snapshot workspace IDs that had any streaming session
         streamingBeforeBackground = Set(streamingSessions.keys)
@@ -432,10 +433,11 @@ private final class HubConnection {
         task.resume()
         backoff = 1
 
-        // Clear stale streaming state and re-wire send closures on all existing stores.
-        // Without clearing, the bootstrap snapshot would be appended to pre-disconnect
-        // accumulated data, causing duplicate tool calls and garbled text.
-        monitor?.storeCache.clearAllStreamingState()
+        // Re-wire send closures on all existing stores so they target the fresh socket.
+        // We deliberately do NOT wipe streaming state here: the reconnect is
+        // non-destructive (issue #259). The visible conversation stays as-is and is
+        // reconciled silently from authoritative bootstrap events (stream_snapshot
+        // replaces active streams; history drops stale finalized stream slots).
         monitor?.rewireAllSendClosures()
 
         startReceiving()

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -335,15 +335,15 @@ final class HubStatusMonitor {
     // MARK: - App lifecycle
 
     /// Force a full WS reconnect to get fresh bootstrap data for all workspaces.
-    /// Used by pull-to-refresh so the backend re-sends status, history, branch_info,
-    /// diff_stats, and script_status for every subscribed workspace.
+    /// Used by pull-to-refresh so the backend re-sends status, live stream snapshots,
+    /// branch_info, diff_stats, and script_status for every subscribed workspace.
     func forceRefresh() {
         hubConnection?.forceReconnect()
     }
 
     /// Called when the app returns to foreground after a non-trivial background period.
-    /// Forces an immediate hub reconnect so the backend bootstrap (status + history)
-    /// re-syncs every workspace. The reconnect is non-destructive: streaming state is
+    /// Forces an immediate hub reconnect so the backend bootstrap re-syncs live
+    /// workspace state. The reconnect is non-destructive: streaming state is
     /// reconciled silently from bootstrap events rather than wiped (issue #259).
     func appDidBecomeActive() {
         // Snapshot workspace IDs that had any streaming session
@@ -436,8 +436,9 @@ private final class HubConnection {
         // Re-wire send closures on all existing stores so they target the fresh socket.
         // We deliberately do NOT wipe streaming state here: the reconnect is
         // non-destructive (issue #259). The visible conversation stays as-is and is
-        // reconciled silently from authoritative bootstrap events (stream_snapshot
-        // replaces active streams; history drops stale finalized stream slots).
+        // reconciled silently from authoritative bootstrap events plus REST history
+        // refreshes (stream_snapshot replaces active streams; REST history drops
+        // stale finalized stream slots).
         monitor?.rewireAllSendClosures()
 
         startReceiving()

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -404,7 +404,7 @@ struct ChatView: View {
                     )
                     guard store.sessionId == sessionId else { return }
                     guard store.historyToken(for: sessionId) == requestToken else { return }
-                    store.messages = msgs
+                    store.applyFetchedHistory(msgs, for: sessionId)
                 } catch {
                     // Best-effort — streamed messages remain as fallback
                 }
@@ -434,6 +434,12 @@ struct ChatView: View {
     private func loadMessages() async {
         let sessionId = session.sessionId
         store.setFocusedSessionId(sessionId)
+        // Instant-load: show cached messages immediately (if any) so the bubble
+        // isn't empty while the authoritative REST refetch runs.
+        if store.messages.isEmpty, let cached = store.cachedMessages(for: sessionId), !cached.isEmpty {
+            store.messages = cached
+            isLoading = false
+        }
         let requestToken = store.beginHistoryRequest(for: sessionId)
         do {
             let msgs = try await api.fetchMessages(
@@ -453,7 +459,7 @@ struct ChatView: View {
             }
             // History contains only finalized turns; streaming content lives
             // in sessionStreams and is rendered as a separate in-progress bubble.
-            store.messages = msgs
+            store.applyFetchedHistory(msgs, for: sessionId)
         } catch is CancellationError {
             // View disappeared
         } catch {

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -54,7 +54,7 @@ struct HubView: View {
             // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
             await Task { @MainActor in
                 // Force WS reconnect so the backend re-sends full bootstrap
-                // (status, history, branch_info, diff_stats) for all workspaces.
+                // (status, live snapshots, branch_info, diff_stats) for all workspaces.
                 store.statusMonitor.forceRefresh()
                 await store.refresh()
             }.value

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -364,6 +364,204 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func reconnectBootstrapKeepsActiveStreamAlive() {
+        // Models the non-destructive reconnect (issue #259): the hub no longer wipes
+        // sessionStreams on (re)connect, so an in-progress stream must survive a fresh
+        // bootstrap and be reconciled in place by the authoritative stream_snapshot.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "In progress before reconnect"))
+        store.handle(.toolUse(
+            sessionId: "session-1",
+            id: "tool-1",
+            name: "Read",
+            input: "{}",
+            parentToolUseId: nil
+        ))
+        #expect(store.currentText == "In progress before reconnect")
+        #expect(store.activeToolCalls.count == 1)
+
+        // Reconnect re-bootstraps: a status event reasserts streaming, then the snapshot
+        // replaces the accumulated state. No clear happens in between.
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        // Stream slot is intact immediately after the status re-bootstrap.
+        #expect(store.sessionStreams["session-1"]?.isStreaming == true)
+        #expect(store.sessionStreams["session-1"]?.currentText == "In progress before reconnect")
+        #expect(store.sessionStreams["session-1"]?.activeToolCalls.count == 1)
+
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "In progress before reconnect, now continued",
+            thinking: "",
+            toolCalls: [
+                ToolCall(id: "tool-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+            ],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: 1_700_000_002_000.0
+        ))
+
+        // Snapshot REPLACED rather than appended — no duplicate tool calls.
+        #expect(store.isStreaming == true)
+        #expect(store.currentText == "In progress before reconnect, now continued")
+        #expect(store.activeToolCalls.count == 1)
+        #expect(store.activeToolCalls.first?.output == "ok")
+    }
+
+    @Test @MainActor
+    func historyDropsStaleNonStreamingStreamSlot() {
+        // A turn finished while the socket was a backgrounded zombie. On reconnect the
+        // status arrives as idle (not streaming) and history carries the finalized turn.
+        // The stale in-progress stream slot must be dropped so it is not rendered as a
+        // duplicate bubble alongside the persisted message (issue #259).
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "Half-finished answer"))
+        #expect(store.sessionStreams["session-1"]?.currentText == "Half-finished answer")
+
+        // The turn is no longer streaming (e.g. idle status from bootstrap).
+        store.handle(.status(
+            status: .idle,
+            sessionId: "session-1",
+            streaming: false,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        #expect(store.sessionStreams["session-1"] != nil)
+
+        // History arrives with the finalized assistant turn (no unanswered question).
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Question",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            ),
+            ChatMessage(
+                id: "message-2",
+                sessionId: "session-1",
+                role: .assistant,
+                content: "Half-finished answer, now complete",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        #expect(store.messages.count == 2)
+        #expect(store.sessionStreams["session-1"] == nil)
+    }
+
+    @Test @MainActor
+    func historyRebuildsCleanSlotWithPendingToolInputs() {
+        // The last finalized assistant turn ends on an unanswered AskUserQuestion. History
+        // must rebuild a CLEAN slot carrying only those pending inputs (no stale streaming
+        // text/tool calls), so the question prompt survives reconnect.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "stale streaming text"))
+        store.handle(.status(
+            status: .idle,
+            sessionId: "session-1",
+            streaming: false,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .assistant,
+                content: "Which option?",
+                images: nil,
+                toolCalls: [
+                    ToolCall(id: "ask-1", name: "AskUserQuestion", input: "{}", output: nil, parentToolUseId: nil)
+                ],
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:01.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        let stream = store.sessionStreams["session-1"]
+        #expect(stream != nil)
+        #expect(stream?.currentText == "")
+        #expect(stream?.activeToolCalls.isEmpty == true)
+        #expect(stream?.isStreaming == false)
+        #expect(stream?.pendingToolInputs.count == 1)
+        #expect(stream?.pendingToolInputs.first?.toolName == "AskUserQuestion")
+    }
+
+    @Test @MainActor
+    func historyLeavesActiveStreamingSessionUntouched() {
+        // While a session is actively streaming, history (finalized turns) must not
+        // disturb the live stream slot — live WS state wins.
+        let store = ConversationStore()
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-1", text: "Live streaming content"))
+
+        store.handle(.history(messages: [
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Earlier turn",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], sessionId: "session-1"))
+
+        #expect(store.sessionStreams["session-1"]?.isStreaming == true)
+        #expect(store.sessionStreams["session-1"]?.currentText == "Live streaming content")
+        #expect(store.messages.count == 1)
+    }
+
+    @Test @MainActor
     func toolInputResolvedClearsPendingToolInputs() throws {
         let store = ConversationStore()
         store.handle(.status(

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -447,8 +447,8 @@ struct ConversationStoreSessionTests {
         ))
         #expect(store.sessionStreams["session-1"] != nil)
 
-        // History arrives with the finalized assistant turn (no unanswered question).
-        store.handle(.history(messages: [
+        // REST history arrives with the finalized assistant turn (no unanswered question).
+        store.applyFetchedHistory([
             ChatMessage(
                 id: "message-1",
                 sessionId: "session-1",
@@ -473,7 +473,7 @@ struct ConversationStoreSessionTests {
                 cancelled: nil,
                 durationMs: nil
             )
-        ], sessionId: "session-1"))
+        ], for: "session-1")
 
         #expect(store.messages.count == 2)
         #expect(store.sessionStreams["session-1"] == nil)
@@ -501,7 +501,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: nil
         ))
 
-        store.handle(.history(messages: [
+        store.applyFetchedHistory([
             ChatMessage(
                 id: "message-1",
                 sessionId: "session-1",
@@ -516,7 +516,7 @@ struct ConversationStoreSessionTests {
                 cancelled: nil,
                 durationMs: nil
             )
-        ], sessionId: "session-1"))
+        ], for: "session-1")
 
         let stream = store.sessionStreams["session-1"]
         #expect(stream != nil)
@@ -541,7 +541,7 @@ struct ConversationStoreSessionTests {
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "Live streaming content"))
 
-        store.handle(.history(messages: [
+        store.applyFetchedHistory([
             ChatMessage(
                 id: "message-1",
                 sessionId: "session-1",
@@ -554,11 +554,120 @@ struct ConversationStoreSessionTests {
                 cancelled: nil,
                 durationMs: nil
             )
-        ], sessionId: "session-1"))
+        ], for: "session-1")
 
         #expect(store.sessionStreams["session-1"]?.isStreaming == true)
         #expect(store.sessionStreams["session-1"]?.currentText == "Live streaming content")
         #expect(store.messages.count == 1)
+    }
+
+    @Test @MainActor
+    func switchBackRestoresCachedMessagesInstantly() {
+        // View session A (REST history applied), switch to B, switch back to A.
+        // A's messages must reappear instantly from the per-session cache — no
+        // empty flash, no refetch required. Mirrors web's React Query cache.
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-A")
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "a-1",
+                sessionId: "session-A",
+                role: .user,
+                content: "Hello from A",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], for: "session-A")
+        #expect(store.messages.count == 1)
+
+        // Switch to B (never viewed) — empty.
+        store.prepareSessionSwitch("session-B")
+        #expect(store.sessionId == "session-B")
+        #expect(store.messages.isEmpty)
+
+        // Switch back to A — restored instantly from cache without a refetch.
+        store.prepareSessionSwitch("session-A")
+        #expect(store.sessionId == "session-A")
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.content == "Hello from A")
+    }
+
+    @Test @MainActor
+    func userMessageKeepsCacheInSyncForSwitchBack() {
+        // A user message appended over WS must land in the cache so switching
+        // away and back shows the turn without a refetch.
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-A")
+        store.applyFetchedHistory([], for: "session-A")
+
+        store.handle(.userMessage(message: ChatMessage(
+            id: "u-1",
+            sessionId: "session-A",
+            role: .user,
+            content: "New question",
+            images: nil,
+            toolCalls: nil,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )))
+        #expect(store.messages.count == 1)
+
+        store.prepareSessionSwitch("session-B")
+        #expect(store.messages.isEmpty)
+
+        store.prepareSessionSwitch("session-A")
+        #expect(store.messages.count == 1)
+        #expect(store.messages.first?.content == "New question")
+    }
+
+    @Test @MainActor
+    func doneKeepsCacheInSyncForSwitchBack() {
+        // A finalized assistant turn (done) must land in the cache so switching
+        // away and back shows the finalized turn from cache.
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-A")
+        store.applyFetchedHistory([], for: "session-A")
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-A",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-A", text: "Finalized answer"))
+        store.handle(.done(
+            sessionId: "session-A",
+            durationMs: 100,
+            inputTokens: nil,
+            outputTokens: nil,
+            contextUsedTokens: nil,
+            contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+        #expect(store.messages.contains { $0.content == "Finalized answer" })
+
+        store.prepareSessionSwitch("session-B")
+        #expect(store.messages.isEmpty)
+
+        store.prepareSessionSwitch("session-A")
+        #expect(store.messages.contains { $0.content == "Finalized answer" })
+    }
+
+    @Test @MainActor
+    func syncWorkspacesEncodesHistoryViaRest() throws {
+        let message = HubIncoming.syncWorkspaces(workspaceIds: ["ws-1"])
+        let data = try JSONEncoder().encode(message)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(object?["type"] as? String == "sync_workspaces")
+        #expect(object?["historyViaRest"] as? Bool == true)
+        #expect((object?["workspaceIds"] as? [String]) == ["ws-1"])
     }
 
     @Test @MainActor


### PR DESCRIPTION
Single PR for the whole chat streaming rework (backend + web + iOS). Two commits:
1. **Recover zombie hub sockets and make reconnect non-destructive**
2. **Move conversation history to REST/React Query (light WS bootstrap)**

Closes the symptoms: "I have to reload the whole page when I come back" and "the snapshot takes a while to load". Supersedes the earlier split PRs.

---

## 1. Zombie-socket recovery + non-destructive resync

**Problem.** After a Mac sleep/wake or network change the hub WebSocket can freeze (`readyState` stays OPEN, `onclose` never fires) — the web client had no liveness detection and stayed stuck on stale data until a full reload. The previous focus-reconnect attempt was reverted because it wiped in-progress streams on reconnect, making the UI look like it deleted and recreated the response (issue #259).

**Change.**
- **Backend**: application-level hub `ping` → `pong` (the browser WebSocket API never surfaces protocol ping/pong to JS).
- **Web transport**: 25s heartbeat + watchdog reconnect of a silent socket; `probeLiveness()` on window focus / tab visibility / network regain that actively pings and reconnects **only if the probe is unanswered** — so a healthy idle conversation is never needlessly reconnected (the false positive that sank the earlier attempt).
- **Non-destructive resync (#259)**: dropped the `sessionStreams` wipe on reconnect. Active streams reconcile via the `stream_snapshot` REPLACE; a finished-during-freeze turn reconciles via authoritative history without a flash.
- **iOS**: same non-destructive resync (removed `clearAllStreamingState` on reconnect); iOS keeps its existing ping + foreground reconnect.

## 2. REST owns history (React Query) — the "slow snapshot"

**Problem.** The WS bootstrap re-sent the full history with complete tool outputs (2-10 MB, synchronous) on every switch and reconnect, handled three ways at once (WS replay + manual transport cache + REST fallback) with token juggling.

**Change.**
- **Backend**: `sync_workspaces` accepts `historyViaRest`; when set, the hub skips the `history` bootstrap event. Web opts in; **iOS keeps the legacy WS history until it migrates** (no breakage).
- **Web**: new `useSessionMessages` (`useQuery(["session-messages", wsId, sessionId])`) — instant switch-back from the query cache, no manual cache. `useConversation` reducer holds live state only; the WS handler appends finalized turns to the RQ cache + invalidates for the authoritative refetch (safe: backend persists before emitting `done`). Pending-input derivation + stale-slot reconcile moved to a `reconcile_history` action keyed on the RQ messages reference (an answered question can't flicker back). Removed the transport history cache and token juggling — two fewer effects, no double-fetch, no new fetch `useEffect` (React Query owns fetching).

## iOS status
- **Phase 1 (non-destructive reconnect)**: included.
- **Phase 2 (REST-owned history)**: follow-up — iOS must send `historyViaRest` and read history over REST. Owner: app. Until then iOS transparently uses the legacy WS history, so this PR does not break it. Add those commits to this branch to test web + backend + iOS together.

## Testing
- `lint` + `typecheck` clean (backend + frontend).
- Backend: **1542 pass** (hub ping/pong + `historyViaRest` opt-in tests).
- Frontend: transport + hook suites reconciled to the heartbeat/RQ model; new `useSessionMessages` suite. Full suite green except the pre-existing unrelated `Sidebar.test.tsx > keeps add repository compact` (fails on baseline too).
- iOS: Swift tests added; **not compiled here** (no Swift/Xcode toolchain) — needs CI.

## Backlog (not in this PR)
- Backend dead-peer termination (server `terminate()` of a client that stops answering pongs).
- Optional: truncate tool outputs in REST history + lazy full-output endpoint for pathologically large sessions.