### PR TITLE
UI/UX fixes: script sidebar alignment & terminal selection contrast

### DIFF
--- a/frontend/src/components/XtermSurface.tsx
+++ b/frontend/src/components/XtermSurface.tsx
@@ -15,7 +15,16 @@ export function buildXtermTheme(theme: "dark" | "light", backgroundVar = "--side
     background: readThemeColor(backgroundVar, theme === "dark" ? "#0c0c14" : "#f8f8fb"),
     foreground,
     cursor: foreground,
-    selectionBackground: readThemeColor("--muted", theme === "dark" ? "#262636" : "#f0f1f4"),
+    // Translucent accent so the selection stands out from the panel background
+    // while keeping the underlying text readable (--muted was too close to it).
+    selectionBackground: readThemeColor(
+      "--terminal-selection",
+      theme === "dark" ? "rgba(99, 91, 255, 0.45)" : "rgba(99, 91, 255, 0.3)",
+    ),
+    selectionInactiveBackground: readThemeColor(
+      "--terminal-selection-inactive",
+      theme === "dark" ? "rgba(99, 91, 255, 0.28)" : "rgba(99, 91, 255, 0.18)",
+    ),
   };
 }
 

--- a/frontend/src/components/ui/activity-wave.tsx
+++ b/frontend/src/components/ui/activity-wave.tsx
@@ -7,10 +7,12 @@ const SIZE_CLASS: Record<ActivityWaveSize, string> = {
   large: "size-4",
 };
 
+// Bars share a common bottom (equalizer look) but the whole group is centered
+// vertically in the 12x12 viewBox so the glyph aligns with adjacent text/icons.
 const BARS = [
-  { x: 1, y: 7, height: 4, delay: 0 },
-  { x: 5, y: 4, height: 7, delay: 0.15 },
-  { x: 9, y: 6, height: 5, delay: 0.3 },
+  { x: 1, y: 5.5, height: 4, delay: 0 },
+  { x: 5, y: 2.5, height: 7, delay: 0.15 },
+  { x: 9, y: 4.5, height: 5, delay: 0.3 },
 ] as const;
 
 interface ActivityWaveProps {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -114,6 +114,8 @@
   --secondary-foreground: oklch(0.205 0 0);
   --muted: oklch(0.97 0.003 255);
   --muted-foreground: oklch(0.45 0.006 255);
+  --terminal-selection: rgba(99, 91, 255, 0.3);
+  --terminal-selection-inactive: rgba(99, 91, 255, 0.18);
   --accent: oklch(0.97 0.003 255);
   --accent-foreground: oklch(0.205 0 0);
   --field: var(--background);
@@ -195,6 +197,8 @@
   --secondary-foreground: oklch(0.93 0.005 260);
   --muted: #262636;
   --muted-foreground: oklch(0.707 0.022 261.325);
+  --terminal-selection: rgba(99, 91, 255, 0.45);
+  --terminal-selection-inactive: rgba(99, 91, 255, 0.28);
   --accent: oklch(0.2 0.015 270);
   --accent-foreground: oklch(0.93 0.005 260);
   --field: #1e1e28;


### PR DESCRIPTION
Dedicated PR for small UI/UX fixes in the workspace right-sidebar **Scripts** area.

## 1. Center ActivityWave bars for inline alignment

The `ActivityWave` indicator (the "running" wave in the Scripts tab bar, also the "Agent thinking" indicator in chat) rendered slightly **below** the optical center of its box.

The three SVG bars shared a common bottom at `y=11` in a `12×12` viewBox (equalizer look), so the drawn content spanned `[4, 11]` — center `7.5` vs box center `6`. At `size-3` (12px) the glyph sat ~1.5px low, misaligned next to the status check icon, the tab labels, and the stop/start button.

**Fix:** shift the bar group up so content spans `[2.5, 9.5]`, centered on `6`. Equalizer aesthetic preserved (bars stay bottom-aligned with each other). Benefits every `ActivityWave` usage.

## 2. Increase terminal selection contrast

The xterm selection used `--muted`, which is nearly identical to the panel background (`--sidebar`) in both light and dark themes — selected text was almost invisible.

**Fix:** add dedicated `--terminal-selection` / `--terminal-selection-inactive` tokens (translucent brand accent) and wire `selectionBackground` + `selectionInactiveBackground` to them. Strong contrast against the background while keeping the underlying text readable.

---

Both changes verified with pixel-faithful repros (real xterm.js for the selection compositing). Typecheck + lint clean.