### PR TITLE
Derive subagent tool nesting from native parent_tool_use_id

### DIFF
--- a/backend/src/agents/agent-event-normalizer.test.ts
+++ b/backend/src/agents/agent-event-normalizer.test.ts
@@ -2,9 +2,14 @@ import { describe, expect, it } from "vitest";
 import { AgentEventNormalizer } from "./agent-event-normalizer.js";
 import type { CliJsonLine } from "../types.js";
 
-function assistant(content: Extract<CliJsonLine, { type: "assistant" }>["message"]["content"], usage?: Extract<CliJsonLine, { type: "assistant" }>["message"]["usage"]): Extract<CliJsonLine, { type: "assistant" }> {
+function assistant(
+  content: Extract<CliJsonLine, { type: "assistant" }>["message"]["content"],
+  usage?: Extract<CliJsonLine, { type: "assistant" }>["message"]["usage"],
+  envelope?: { parent_tool_use_id?: string | null },
+): Extract<CliJsonLine, { type: "assistant" }> {
   return {
     type: "assistant",
+    ...(envelope ?? {}),
     message: {
       id: "msg-1",
       role: "assistant",
@@ -66,24 +71,66 @@ describe("AgentEventNormalizer", () => {
     ]);
   });
 
-  it("tracks task parentage until the task result arrives", () => {
+  it("nests a subagent's tool under its parent via the native parent_tool_use_id", () => {
     const normalizer = new AgentEventNormalizer();
 
-    normalizer.handleAssistant(assistant([
-      { type: "tool_use", id: "task-1", name: "Task", input: { prompt: "inspect" } },
-    ]));
-    const childEvents = normalizer.handleAssistant(assistant([
+    // The Agent spawn is top-level (parent null); the tool it runs arrives in a
+    // sidechain message stamped with the Agent's id.
+    const spawn = normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "agent-1", name: "Agent", input: { prompt: "inspect" } }],
+      undefined,
+      { parent_tool_use_id: null },
+    ));
+    const child = normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "bash-1", name: "Bash", input: { command: "ls" } }],
+      undefined,
+      { parent_tool_use_id: "agent-1" },
+    ));
+
+    expect(spawn[0]).toMatchObject({ type: "tool_started", id: "agent-1", parentToolUseId: undefined });
+    expect(child[0]).toMatchObject({ type: "tool_started", id: "bash-1", parentToolUseId: "agent-1" });
+  });
+
+  it("assigns parallel subagents' children to their own parents (no cross-contamination)", () => {
+    const normalizer = new AgentEventNormalizer();
+
+    // Two Agents spawn top-level, then their children interleave — the exact case
+    // the old heuristic stack mis-attributed. Each child carries its true parent.
+    normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "agent-A", name: "Agent", input: {} }],
+      undefined,
+      { parent_tool_use_id: null },
+    ));
+    normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "agent-B", name: "Agent", input: {} }],
+      undefined,
+      { parent_tool_use_id: null },
+    ));
+    const childA = normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "bash-A", name: "Bash", input: { command: "a" } }],
+      undefined,
+      { parent_tool_use_id: "agent-A" },
+    ));
+    const childB = normalizer.handleAssistant(assistant(
+      [{ type: "tool_use", id: "bash-B", name: "Bash", input: { command: "b" } }],
+      undefined,
+      { parent_tool_use_id: "agent-B" },
+    ));
+
+    expect(childA[0]).toMatchObject({ type: "tool_started", parentToolUseId: "agent-A" });
+    expect(childB[0]).toMatchObject({ type: "tool_started", parentToolUseId: "agent-B" });
+  });
+
+  it("falls back to top-level when a message carries no native parent field", () => {
+    const normalizer = new AgentEventNormalizer();
+
+    // Shapes that omit the envelope field (e.g. non-Claude streams) degrade to a
+    // flat tree rather than crashing — there is no heuristic stack to consult.
+    const events = normalizer.handleAssistant(assistant([
       { type: "tool_use", id: "read-1", name: "Read", input: { file_path: "a.ts" } },
     ]));
-    normalizer.handleUser(user([
-      { type: "tool_result", tool_use_id: "task-1", content: "done" },
-    ]));
-    const nextEvents = normalizer.handleAssistant(assistant([
-      { type: "tool_use", id: "read-2", name: "Read", input: { file_path: "b.ts" } },
-    ]));
 
-    expect(childEvents[0]).toMatchObject({ type: "tool_started", parentToolUseId: "task-1" });
-    expect(nextEvents[0]).toMatchObject({ type: "tool_started", parentToolUseId: undefined });
+    expect(events[0]).toMatchObject({ type: "tool_started", parentToolUseId: undefined });
   });
 
   it("preserves explicit tool parentage from provider adapters", () => {
@@ -100,6 +147,18 @@ describe("AgentEventNormalizer", () => {
         name: "Bash",
         parentToolUseId: "agent-1",
       }),
+    ]);
+  });
+
+  it("normalizes user tool_result blocks into tool completions", () => {
+    const normalizer = new AgentEventNormalizer();
+
+    const events = normalizer.handleUser(user([
+      { type: "tool_result", tool_use_id: "task-1", content: "done" },
+    ]));
+
+    expect(events).toEqual([
+      { type: "tool_completed", id: "task-1", output: "done" },
     ]);
   });
 

--- a/backend/src/agents/agent-event-normalizer.ts
+++ b/backend/src/agents/agent-event-normalizer.ts
@@ -79,11 +79,15 @@ const serverToolNameMap: Record<string, string> = {
 };
 
 export class AgentEventNormalizer {
-  private readonly pendingTaskStack: string[] = [];
   private readonly emittedToolIds = new Set<string>();
 
   handleAssistant(data: AssistantEvent): NormalizedAgentEvent[] {
     const events: NormalizedAgentEvent[] = [];
+    // Subagent nesting comes straight from the Claude CLI, which stamps every
+    // message with parent_tool_use_id (null at top level, the parent Task/Agent
+    // id inside a subagent sidechain). It is the ground truth even when subagents
+    // run in parallel, so we read it directly — no heuristic stack to mis-attribute.
+    const messageParentToolUseId = data.parent_tool_use_id ?? undefined;
 
     for (const block of data.message.content) {
       switch (block.type) {
@@ -104,19 +108,15 @@ export class AgentEventNormalizer {
             ? block.input
             : JSON.stringify(block.input, null, 2);
           const explicitParentToolUseId = "parentToolUseId" in block ? block.parentToolUseId : undefined;
-          const parentToolUseId = explicitParentToolUseId ?? (this.pendingTaskStack.length > 0
-            ? this.pendingTaskStack[this.pendingTaskStack.length - 1]
-            : undefined);
+          // Explicit per-block parent (Codex adapter) wins; otherwise the native
+          // message-level parent. Absent or null both mean "top level".
+          const parentToolUseId = explicitParentToolUseId ?? messageParentToolUseId;
 
           if (this.emittedToolIds.has(block.id)) {
             events.push({ type: "tool_updated", id: block.id, input });
           } else {
             this.emittedToolIds.add(block.id);
             events.push({ type: "tool_started", id: block.id, name, rawName, input, parentToolUseId });
-          }
-
-          if (rawName === "Task" || rawName === "Agent") {
-            this.pendingTaskStack.push(block.id);
           }
 
           if (rawName === "EnterPlanMode" || rawName === "ExitPlanMode") {
@@ -161,10 +161,6 @@ export class AgentEventNormalizer {
 
     for (const block of data.message.content) {
       if (block.type !== "tool_result") continue;
-      const stackTop = this.pendingTaskStack[this.pendingTaskStack.length - 1];
-      if (stackTop && stackTop === block.tool_use_id) {
-        this.pendingTaskStack.pop();
-      }
       events.push({
         type: "tool_completed",
         id: block.tool_use_id,

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -66,9 +66,15 @@ function assistantLine(text: string, toolUse?: { id: string; name: string; input
   return JSON.stringify({ type: "assistant", message: { id: "msg-1", role: "assistant", content } }) + "\n";
 }
 
-function assistantToolUseLine(toolUse: { id: string; name: string; input: unknown }): string {
+function assistantToolUseLine(
+  toolUse: { id: string; name: string; input: unknown },
+  parentToolUseId?: string | null,
+): string {
   return JSON.stringify({
     type: "assistant",
+    // The Claude CLI stamps sidechain messages with the parent Task/Agent id;
+    // omit at top level (the normalizer reads this directly for tool nesting).
+    ...(parentToolUseId !== undefined ? { parent_tool_use_id: parentToolUseId } : {}),
     message: {
       id: "msg-1",
       role: "assistant",
@@ -2648,26 +2654,29 @@ describe("ConversationSession", () => {
     });
   });
 
-  it("assigns parentToolUseId for nested Task sub-tools and clears it when tasks complete", () => {
+  it("assigns parentToolUseId for nested sub-tools from the native parent_tool_use_id", () => {
     const session = createSession();
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
     session.sendMessage("Run nested tools");
 
+    // Mirror the real CLI stream: each sidechain message carries its parent
+    // Task/Agent id; top-level tools carry none. (read-child nests under
+    // task-child, which nests under task-root; grep-root is back at task-root.)
     mockProc._stdout.push(
       assistantToolUseLine({ id: "task-root", name: "Task", input: { prompt: "Root task" } }),
     );
     mockProc._stdout.push(
-      assistantToolUseLine({ id: "task-child", name: "Task", input: { prompt: "Child task" } }),
+      assistantToolUseLine({ id: "task-child", name: "Task", input: { prompt: "Child task" } }, "task-root"),
     );
     mockProc._stdout.push(
-      assistantToolUseLine({ id: "read-child", name: "Read", input: { file_path: "/tmp/a.ts" } }),
+      assistantToolUseLine({ id: "read-child", name: "Read", input: { file_path: "/tmp/a.ts" } }, "task-child"),
     );
     mockProc._stdout.push(userLine([{ tool_use_id: "read-child", content: "read done" }]));
     mockProc._stdout.push(userLine([{ tool_use_id: "task-child", content: "child done" }]));
     mockProc._stdout.push(
-      assistantToolUseLine({ id: "grep-root", name: "Grep", input: { pattern: "TODO" } }),
+      assistantToolUseLine({ id: "grep-root", name: "Grep", input: { pattern: "TODO" } }, "task-root"),
     );
     mockProc._stdout.push(userLine([{ tool_use_id: "grep-root", content: "grep done" }]));
     mockProc._stdout.push(userLine([{ tool_use_id: "task-root", content: "root done" }]));

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -270,6 +270,12 @@ export interface ToolResultBlock {
 export type CliJsonLine =
   | {
       type: "assistant";
+      /**
+       * Set by the Claude CLI on every message: null at top level, or the id of
+       * the parent Task/Agent tool_use for messages emitted inside a subagent
+       * sidechain. The ground-truth source for tool nesting.
+       */
+      parent_tool_use_id?: string | null;
       message: {
         id: string;
         role: "assistant";
@@ -286,6 +292,8 @@ export type CliJsonLine =
     }
   | {
       type: "user";
+      /** See the assistant variant: parent Task/Agent tool_use id for sidechain messages. */
+      parent_tool_use_id?: string | null;
       message: {
         role: "user";
         content: ToolResultBlock[];


### PR DESCRIPTION
## Problem

The agent event normalizer inferred subagent (`Task`/`Agent`) tool nesting with a **heuristic stack**: push on each Task/Agent `tool_use`, attribute following tools to the stack top, pop on the matching `tool_result`. That's correct for a single sequential foreground subagent, but **mis-attributes parentage when subagents run in parallel** — interleaved child tools all get pinned to the last-spawned task, and out-of-order results desync the stack.

## Insight

The Claude CLI already stamps **every** assistant/user message with `parent_tool_use_id` (null at top level, the parent Task/Agent id inside a subagent sidechain). It's the ground truth regardless of stream ordering. Hive was ignoring it and guessing.

## Change

- **`types.ts`** — add `parent_tool_use_id` to the `assistant`/`user` `CliJsonLine` variants. (`isSidechain` is not emitted by the CLI and is redundant with `parent_tool_use_id`, so it is not modelled.)
- **`agent-event-normalizer.ts`** — `parentToolUseId = explicit per-block parent (Codex adapter) ?? native message-level parent`. Absent or null both mean top level. **Remove `pendingTaskStack`, its push, and the `handleUser` pop** — the normalizer is now stateless w.r.t. nesting.
- Messages without the field **degrade to a flat tree** instead of guessing wrong. Codex is unaffected (separate `agent_event` channel with explicit per-block parentage).

No protocol/frontend/iOS change: the output field `parentToolUseId` is unchanged; only its derivation improves. The existing frontend hierarchy rendering (`sub-agent.ts`, `ToolCallList.tsx`) now receives ground truth, so parallel subagents render correctly nested instead of mixed.

## Verification

- Backend: **468 tests pass**, typecheck + lint clean. Normalizer tests refactored to the native shape, incl. a parallel-subagents regression test and a graceful no-field fallback. `conversation-session.test.ts` nesting test now feeds the real envelope field.
- **Live, twice, against `claude` 2.1.185 with three parallel subagents**: ran the real `--print --output-format stream-json` output through the actual normalizer and compared to the native ground truth.

| | normalizer | old pure-stack |
|---|---|---|
| mismatches vs native ground truth (6 tools) | **0** | **4** |

The old stack pinned ALPHA's and BETA's interleaved `Bash` calls to GAMMA and chained the `Agent` spawns; the native field gets every one right.

## Tradeoff

A stream that doesn't emit `parent_tool_use_id` (ancient CLI, exotic provider routed through this normalizer) now renders a flat tree rather than a mis-guessed one. Acceptable: the heuristic was already unreliable for that case.