### PR TITLE
Find-in-conversation (Cmd/Ctrl+F)

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -8,6 +8,7 @@ import {
   ConversationScrollTrigger,
 } from "@/components/ai-elements/conversation";
 import ChatMessage from "@/components/ChatMessage";
+import { ConversationFind } from "@/components/chat/ConversationFind";
 import AgentActivityPreview from "@/components/chat/AgentActivityPreview";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
@@ -258,7 +259,7 @@ export default function ChatConversation({
                 <ThinkingBlock content={currentThinking} defaultOpen streaming />
               )}
               {currentStreamingText && (
-                <div className="prose-sm">
+                <div className="prose-sm" data-find-content="">
                   <MessageResponse isAnimating>{currentStreamingText}</MessageResponse>
                 </div>
               )}
@@ -302,6 +303,7 @@ export default function ChatConversation({
       <ConversationScrollButton />
       <ConversationScrollLockReEngager />
       <ConversationScrollTrigger trigger={scrollToBottomTrigger} />
+      <ConversationFind switchCounter={switchCounter} />
     </Conversation>
   );
 }

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -21,7 +21,7 @@ function renderContentWithMentions(
   const atMentions = atMatches ? [...new Set(atMatches)] : [];
 
   if (!mentions?.length && atMentions.length === 0)
-    return <p className="whitespace-pre-wrap wrap-anywhere">{content}</p>;
+    return <p className="whitespace-pre-wrap wrap-anywhere" data-find-content="">{content}</p>;
 
   const segments = splitByAllMentions(content, mentions, atMentions).map((segment, i) => {
     if (segment.mention) {
@@ -50,7 +50,7 @@ function renderContentWithMentions(
     return <span key={i}>{segment.text}</span>;
   });
 
-  return <p className="whitespace-pre-wrap wrap-anywhere">{segments}</p>;
+  return <p className="whitespace-pre-wrap wrap-anywhere" data-find-content="">{segments}</p>;
 }
 
 interface ChatMessageProps {
@@ -142,7 +142,7 @@ const ChatMessage = memo(function ChatMessage({
             <ThinkingBlock content={message.thinkingContent} />
           )}
           {message.content && (
-            <div className="prose-sm">
+            <div className="prose-sm" data-find-content="">
               <MessageResponse>{message.content}</MessageResponse>
             </div>
           )}

--- a/frontend/src/components/chat/ConversationFind.tsx
+++ b/frontend/src/components/chat/ConversationFind.tsx
@@ -13,7 +13,7 @@ import { cn } from "@/lib/utils";
  */
 export function ConversationFind({ switchCounter }: { switchCounter: number }) {
   const { scrollRef } = useStickToBottomContext();
-  const { open, query, matchCount, activeIndex, inputRef, setQuery, next, prev, close } =
+  const { open, query, matchCount, activeIndex, noResults, inputRef, setQuery, next, prev, close } =
     useConversationFind({
       scrollRef: scrollRef as RefObject<HTMLElement | null>,
       switchCounter,
@@ -21,7 +21,6 @@ export function ConversationFind({ switchCounter }: { switchCounter: number }) {
 
   if (!open) return null;
 
-  const noResults = matchCount === 0 && query !== "";
   const counter = matchCount === 0 ? "0/0" : `${activeIndex + 1}/${matchCount}`;
 
   const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/chat/ConversationFind.tsx
+++ b/frontend/src/components/chat/ConversationFind.tsx
@@ -1,0 +1,94 @@
+import type { KeyboardEvent, RefObject } from "react";
+import { ChevronDownIcon, ChevronUpIcon, XIcon } from "lucide-react";
+import { useStickToBottomContext } from "use-stick-to-bottom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useConversationFind } from "@/hooks/useConversationFind";
+import { cn } from "@/lib/utils";
+
+/**
+ * Floating "find in conversation" (Cmd/Ctrl+F) bar. All matching, navigation,
+ * and highlight painting lives in `useConversationFind`; this component is the
+ * presentational shell wired to that hook.
+ */
+export function ConversationFind({ switchCounter }: { switchCounter: number }) {
+  const { scrollRef } = useStickToBottomContext();
+  const { open, query, matchCount, activeIndex, inputRef, setQuery, next, prev, close } =
+    useConversationFind({
+      scrollRef: scrollRef as RefObject<HTMLElement | null>,
+      switchCounter,
+    });
+
+  if (!open) return null;
+
+  const noResults = matchCount === 0 && query !== "";
+  const counter = matchCount === 0 ? "0/0" : `${activeIndex + 1}/${matchCount}`;
+
+  const onKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (e.shiftKey) prev();
+      else next();
+    } else if (e.key === "Escape") {
+      e.preventDefault();
+      close();
+    }
+  };
+
+  return (
+    <div
+      role="search"
+      className="absolute right-3 top-3 z-20 flex items-center gap-1 rounded-md border bg-popover p-1 shadow-md"
+    >
+      <Input
+        ref={inputRef}
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        onKeyDown={onKeyDown}
+        placeholder="Find in conversation"
+        aria-invalid={noResults}
+        className="h-7 w-48 text-sm"
+      />
+      <span
+        className={cn(
+          "min-w-10 shrink-0 text-center text-xs tabular-nums",
+          noResults ? "text-destructive" : "text-muted-foreground",
+        )}
+      >
+        {counter}
+      </span>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        title="Previous match"
+        aria-label="Previous match"
+        disabled={matchCount === 0}
+        onClick={prev}
+      >
+        <ChevronUpIcon className="size-3" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        title="Next match"
+        aria-label="Next match"
+        disabled={matchCount === 0}
+        onClick={next}
+      >
+        <ChevronDownIcon className="size-3" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-xs"
+        title="Close find"
+        aria-label="Close find"
+        onClick={close}
+      >
+        <XIcon className="size-3" />
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useConversationFind.ts
+++ b/frontend/src/hooks/useConversationFind.ts
@@ -1,0 +1,256 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from "react";
+import { collectMatches, stepIndex, clampIndex } from "@/lib/conversation-find";
+
+const FIND_HIGHLIGHT = "conversation-find";
+const FIND_ACTIVE_HIGHLIGHT = "conversation-find-active";
+const FIND_CONTENT_SELECTOR = "[data-find-content]";
+const REINDEX_DEBOUNCE_MS = 150;
+const MAX_PREFILL_LENGTH = 200;
+
+/**
+ * The CSS Custom Highlight API paints matches without mutating the DOM, which is
+ * why we can highlight Streamdown-rendered content safely. Older engines without
+ * it simply skip painting (the counter and navigation still work); per product
+ * decision we do not ship a `<mark>`-wrapping fallback.
+ */
+const highlightsSupported =
+  typeof CSS !== "undefined" && "highlights" in CSS && typeof Highlight !== "undefined";
+
+/** A text node and where its text sits within its parent segment string. */
+interface SegmentNode {
+  node: Text;
+  start: number;
+  length: number;
+}
+
+/** Map an absolute offset within a segment back to a (text node, node offset). */
+function locate(nodes: SegmentNode[], offset: number): { node: Text; offset: number } | null {
+  for (const entry of nodes) {
+    if (offset >= entry.start && offset <= entry.start + entry.length) {
+      return { node: entry.node, offset: offset - entry.start };
+    }
+  }
+  return null;
+}
+
+export interface UseConversationFindOptions {
+  /** The conversation scroll container; matches are searched and scrolled within it. */
+  scrollRef: RefObject<HTMLElement | null>;
+  /** Changing this (conversation/session switch) closes the bar and clears highlights. */
+  switchCounter: number;
+}
+
+export interface UseConversationFindResult {
+  open: boolean;
+  query: string;
+  matchCount: number;
+  /** 0-based index of the active match, or -1 when there are no matches. */
+  activeIndex: number;
+  inputRef: RefObject<HTMLInputElement | null>;
+  setQuery: (value: string) => void;
+  next: () => void;
+  prev: () => void;
+  close: () => void;
+}
+
+/**
+ * Find-in-conversation behaviour: owns the Cmd/Ctrl+F shortcut, the match index,
+ * and the CSS Custom Highlight API painting. Pure matching/navigation arithmetic
+ * lives in `lib/conversation-find`; this hook is the thin DOM glue around it.
+ */
+export function useConversationFind({
+  scrollRef,
+  switchCounter,
+}: UseConversationFindOptions): UseConversationFindResult {
+  const [open, setOpen] = useState(false);
+  const [query, setQueryState] = useState("");
+  const [matchCount, setMatchCount] = useState(0);
+  const [activeIndex, setActiveIndex] = useState(-1);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const rangesRef = useRef<Range[]>([]);
+  const queryRef = useRef(query);
+  const openRef = useRef(open);
+  const activeIndexRef = useRef(activeIndex);
+  const debounceRef = useRef<number | null>(null);
+  openRef.current = open;
+  activeIndexRef.current = activeIndex;
+
+  const clearHighlights = useCallback(() => {
+    if (!highlightsSupported) return;
+    CSS.highlights.delete(FIND_HIGHLIGHT);
+    CSS.highlights.delete(FIND_ACTIVE_HIGHLIGHT);
+  }, []);
+
+  // Build a fresh Range for every match by walking the tagged content regions.
+  const buildRanges = useCallback(
+    (q: string): Range[] => {
+      const el = scrollRef.current;
+      if (!el || !q) return [];
+
+      const segmentEls = Array.from(el.querySelectorAll<HTMLElement>(FIND_CONTENT_SELECTOR));
+      const segmentTexts: string[] = [];
+      const segmentNodes: SegmentNode[][] = [];
+
+      for (const segmentEl of segmentEls) {
+        const walker = document.createTreeWalker(segmentEl, NodeFilter.SHOW_TEXT);
+        let text = "";
+        const nodes: SegmentNode[] = [];
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+          const value = node.nodeValue ?? "";
+          if (value.length === 0) continue;
+          nodes.push({ node: node as Text, start: text.length, length: value.length });
+          text += value;
+        }
+        segmentTexts.push(text);
+        segmentNodes.push(nodes);
+      }
+
+      const ranges: Range[] = [];
+      for (const match of collectMatches(segmentTexts, q)) {
+        const nodes = segmentNodes[match.segmentIndex];
+        const startPos = locate(nodes, match.start);
+        const endPos = locate(nodes, match.end);
+        if (!startPos || !endPos) continue;
+        const range = document.createRange();
+        range.setStart(startPos.node, startPos.offset);
+        range.setEnd(endPos.node, endPos.offset);
+        ranges.push(range);
+      }
+      return ranges;
+    },
+    [scrollRef],
+  );
+
+  // Paint the active match distinctly and scroll it into view (centered).
+  const paintActive = useCallback(() => {
+    const ranges = rangesRef.current;
+    const index = activeIndexRef.current;
+    const active = index >= 0 && index < ranges.length ? ranges[index] : null;
+
+    if (highlightsSupported) {
+      if (active) CSS.highlights.set(FIND_ACTIVE_HIGHLIGHT, new Highlight(active));
+      else CSS.highlights.delete(FIND_ACTIVE_HIGHLIGHT);
+    }
+
+    const el = scrollRef.current;
+    if (!el || !active) return;
+    const rect = active.getBoundingClientRect();
+    // jsdom and pre-layout states return zero-sized rects; skip scrolling then.
+    if (rect.height === 0 && rect.width === 0) return;
+    const containerRect = el.getBoundingClientRect();
+    const target = el.scrollTop + (rect.top - containerRect.top) - el.clientHeight / 2 + rect.height / 2;
+    el.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+  }, [scrollRef]);
+
+  const reindex = useCallback(
+    (reason: "query" | "content") => {
+      const ranges = buildRanges(queryRef.current);
+      rangesRef.current = ranges;
+      setMatchCount(ranges.length);
+
+      if (highlightsSupported) {
+        if (ranges.length > 0) CSS.highlights.set(FIND_HIGHLIGHT, new Highlight(...ranges));
+        else CSS.highlights.delete(FIND_HIGHLIGHT);
+      }
+
+      setActiveIndex((prev) => {
+        if (ranges.length === 0) return -1;
+        // A new query jumps to the first match; a content change keeps position.
+        return reason === "query" ? 0 : clampIndex(prev < 0 ? 0 : prev, ranges.length);
+      });
+    },
+    [buildRanges],
+  );
+
+  const scheduleReindex = useCallback(
+    (reason: "query" | "content") => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+      debounceRef.current = window.setTimeout(() => reindex(reason), REINDEX_DEBOUNCE_MS);
+    },
+    [reindex],
+  );
+
+  const setQuery = useCallback((value: string) => setQueryState(value), []);
+
+  const next = useCallback(() => {
+    setActiveIndex((prev) => stepIndex(prev, rangesRef.current.length, 1));
+  }, []);
+
+  const prev = useCallback(() => {
+    setActiveIndex((p) => stepIndex(p, rangesRef.current.length, -1));
+  }, []);
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setMatchCount(0);
+    setActiveIndex(-1);
+    rangesRef.current = [];
+    clearHighlights();
+  }, [clearHighlights]);
+
+  // Re-index (debounced) whenever the query changes while the bar is open.
+  useEffect(() => {
+    queryRef.current = query;
+    if (!open) return;
+    scheduleReindex("query");
+  }, [query, open, scheduleReindex]);
+
+  // Re-index (debounced) when the conversation content mutates (streaming, new
+  // messages) so counts and highlights stay accurate.
+  useEffect(() => {
+    if (!open) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    const observer = new MutationObserver(() => scheduleReindex("content"));
+    observer.observe(el, { childList: true, subtree: true, characterData: true });
+    return () => observer.disconnect();
+  }, [open, scrollRef, scheduleReindex]);
+
+  // Repaint the active match whenever the index or the match set changes.
+  useEffect(() => {
+    if (!open) return;
+    paintActive();
+  }, [open, activeIndex, matchCount, paintActive]);
+
+  // Global Cmd/Ctrl+F: open (or refocus) the bar and suppress native find.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey) || e.altKey) return;
+      if (e.key !== "f" && e.key !== "F") return;
+      if (!scrollRef.current) return;
+      e.preventDefault();
+
+      const wasOpen = openRef.current;
+      setOpen(true);
+      if (!wasOpen) {
+        const selection = window.getSelection()?.toString() ?? "";
+        if (selection && selection.length <= MAX_PREFILL_LENGTH && !selection.includes("\n")) {
+          setQueryState(selection);
+        }
+      }
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+        inputRef.current?.select();
+      });
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [scrollRef]);
+
+  // Conversation/session switch: reset everything.
+  useEffect(() => {
+    close();
+    setQueryState("");
+  }, [switchCounter, close]);
+
+  // Clear highlights and any pending work on unmount.
+  useEffect(() => {
+    return () => {
+      clearHighlights();
+      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+    };
+  }, [clearHighlights]);
+
+  return { open, query, matchCount, activeIndex, inputRef, setQuery, next, prev, close };
+}

--- a/frontend/src/hooks/useConversationFind.ts
+++ b/frontend/src/hooks/useConversationFind.ts
@@ -46,6 +46,8 @@ export interface UseConversationFindResult {
   matchCount: number;
   /** 0-based index of the active match, or -1 when there are no matches. */
   activeIndex: number;
+  /** True only after a completed search for the current query found nothing. */
+  noResults: boolean;
   inputRef: RefObject<HTMLInputElement | null>;
   setQuery: (value: string) => void;
   next: () => void;
@@ -66,6 +68,10 @@ export function useConversationFind({
   const [query, setQueryState] = useState("");
   const [matchCount, setMatchCount] = useState(0);
   const [activeIndex, setActiveIndex] = useState(-1);
+  // The query whose results are currently reflected in matchCount. Kept distinct
+  // from `query` so the "no results" state only shows after a search has actually
+  // run — not during the debounce window, which would flash red prematurely.
+  const [indexedQuery, setIndexedQuery] = useState("");
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const rangesRef = useRef<Range[]>([]);
@@ -148,6 +154,7 @@ export function useConversationFind({
       const ranges = buildRanges(queryRef.current);
       rangesRef.current = ranges;
       setMatchCount(ranges.length);
+      setIndexedQuery(queryRef.current);
 
       if (highlightsSupported) {
         if (ranges.length > 0) CSS.highlights.set(FIND_HIGHLIGHT, new Highlight(...ranges));
@@ -185,6 +192,7 @@ export function useConversationFind({
     setOpen(false);
     setMatchCount(0);
     setActiveIndex(-1);
+    setIndexedQuery("");
     rangesRef.current = [];
     clearHighlights();
   }, [clearHighlights]);
@@ -252,5 +260,7 @@ export function useConversationFind({
     };
   }, [clearHighlights]);
 
-  return { open, query, matchCount, activeIndex, inputRef, setQuery, next, prev, close };
+  const noResults = matchCount === 0 && indexedQuery !== "";
+
+  return { open, query, matchCount, activeIndex, noResults, inputRef, setQuery, next, prev, close };
 }

--- a/frontend/src/hooks/useConversationFind.ts
+++ b/frontend/src/hooks/useConversationFind.ts
@@ -173,7 +173,10 @@ export function useConversationFind({
   const scheduleReindex = useCallback(
     (reason: "query" | "content") => {
       if (debounceRef.current) window.clearTimeout(debounceRef.current);
-      debounceRef.current = window.setTimeout(() => reindex(reason), REINDEX_DEBOUNCE_MS);
+      debounceRef.current = window.setTimeout(() => {
+        debounceRef.current = null;
+        reindex(reason);
+      }, REINDEX_DEBOUNCE_MS);
     },
     [reindex],
   );
@@ -189,6 +192,10 @@ export function useConversationFind({
   }, []);
 
   const close = useCallback(() => {
+    if (debounceRef.current) {
+      window.clearTimeout(debounceRef.current);
+      debounceRef.current = null;
+    }
     setOpen(false);
     setMatchCount(0);
     setActiveIndex(-1);
@@ -256,11 +263,14 @@ export function useConversationFind({
   useEffect(() => {
     return () => {
       clearHighlights();
-      if (debounceRef.current) window.clearTimeout(debounceRef.current);
+      if (debounceRef.current) {
+        window.clearTimeout(debounceRef.current);
+        debounceRef.current = null;
+      }
     };
   }, [clearHighlights]);
 
-  const noResults = matchCount === 0 && indexedQuery !== "";
+  const noResults = query !== "" && indexedQuery === query && matchCount === 0;
 
   return { open, query, matchCount, activeIndex, noResults, inputRef, setQuery, next, prev, close };
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -116,6 +116,8 @@
   --muted-foreground: oklch(0.45 0.006 255);
   --terminal-selection: rgba(99, 91, 255, 0.3);
   --terminal-selection-inactive: rgba(99, 91, 255, 0.18);
+  --find-match: rgba(253, 224, 71, 0.55);
+  --find-match-active: rgba(251, 146, 60, 0.85);
   --accent: oklch(0.97 0.003 255);
   --accent-foreground: oklch(0.205 0 0);
   --field: var(--background);
@@ -199,6 +201,8 @@
   --muted-foreground: oklch(0.707 0.022 261.325);
   --terminal-selection: rgba(99, 91, 255, 0.45);
   --terminal-selection-inactive: rgba(99, 91, 255, 0.28);
+  --find-match: rgba(250, 204, 21, 0.32);
+  --find-match-active: rgba(251, 146, 60, 0.6);
   --accent: oklch(0.2 0.015 270);
   --accent-foreground: oklch(0.93 0.005 260);
   --field: #1e1e28;
@@ -263,6 +267,15 @@
   /* Accent glow for focus rings & highlights */
   --hive-accent-glow: color-mix(in oklch, var(--hive-accent, #635BFF) 15%, transparent);
   --center-card-shadow: inset 0 1px 0 oklch(1 0 0 / 3%), 0 16px 36px oklch(0 0 0 / 22%);
+}
+
+/* Find-in-conversation match highlights (CSS Custom Highlight API). Only a small
+   set of properties is allowed on ::highlight(); background-color is enough. */
+::highlight(conversation-find) {
+  background-color: var(--find-match);
+}
+::highlight(conversation-find-active) {
+  background-color: var(--find-match-active);
 }
 
 /* Streamdown ships its own render chrome. Keep it mapped to the app theme:

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -116,8 +116,11 @@
   --muted-foreground: oklch(0.45 0.006 255);
   --terminal-selection: rgba(99, 91, 255, 0.3);
   --terminal-selection-inactive: rgba(99, 91, 255, 0.18);
+  /* Find-in-conversation highlights (light). Text keeps its own color. */
   --find-match: rgba(253, 224, 71, 0.55);
   --find-match-active: rgba(251, 146, 60, 0.85);
+  --find-match-foreground: inherit;
+  --find-match-active-foreground: inherit;
   --accent: oklch(0.97 0.003 255);
   --accent-foreground: oklch(0.205 0 0);
   --field: var(--background);
@@ -201,8 +204,12 @@
   --muted-foreground: oklch(0.707 0.022 261.325);
   --terminal-selection: rgba(99, 91, 255, 0.45);
   --terminal-selection-inactive: rgba(99, 91, 255, 0.28);
-  --find-match: rgba(250, 204, 21, 0.32);
-  --find-match-active: rgba(251, 146, 60, 0.6);
+  /* Find-in-conversation highlights (dark). Bright fills need dark text to stay
+     readable, the way browser find bars render on dark pages. */
+  --find-match: #ffe066;
+  --find-match-active: #ff9838;
+  --find-match-foreground: #18181b;
+  --find-match-active-foreground: #18181b;
   --accent: oklch(0.2 0.015 270);
   --accent-foreground: oklch(0.93 0.005 260);
   --field: #1e1e28;
@@ -273,9 +280,11 @@
    set of properties is allowed on ::highlight(); background-color is enough. */
 ::highlight(conversation-find) {
   background-color: var(--find-match);
+  color: var(--find-match-foreground);
 }
 ::highlight(conversation-find-active) {
   background-color: var(--find-match-active);
+  color: var(--find-match-active-foreground);
 }
 
 /* Streamdown ships its own render chrome. Keep it mapped to the app theme:

--- a/frontend/src/lib/conversation-find.ts
+++ b/frontend/src/lib/conversation-find.ts
@@ -1,0 +1,76 @@
+export interface TextMatch {
+  start: number; // match start offset within the text (UTF-16 code units), inclusive
+  end: number; // match end offset, exclusive
+}
+
+export interface FlatMatch {
+  segmentIndex: number; // index into the segmentTexts array passed to collectMatches
+  start: number;
+  end: number;
+}
+
+/**
+ * All case-insensitive, accent-sensitive, literal substring matches within one text.
+ * Non-overlapping and left-to-right, like a browser find.
+ *
+ * Case-insensitivity lowercases both text and query. This assumes `toLowerCase()`
+ * preserves string length so the lowercased offsets map back to the original text
+ * (true for ASCII and accented Latin like "É" -> "é"). Rare length-changing cases
+ * (e.g. "İ", ligatures) are out of scope for v1 and intentionally not handled.
+ */
+export function findMatchesInText(text: string, query: string): TextMatch[] {
+  if (!query) return [];
+
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const matches: TextMatch[] = [];
+
+  let from = 0;
+  for (;;) {
+    const start = haystack.indexOf(needle, from);
+    if (start === -1) break;
+    const end = start + needle.length;
+    matches.push({ start, end });
+    from = end; // resume after the match so results never overlap
+  }
+
+  return matches;
+}
+
+/**
+ * Run {@link findMatchesInText} over an ordered list of segment texts and flatten the
+ * results into one array in document order (segment 0 first, then segment 1, ...).
+ */
+export function collectMatches(segmentTexts: string[], query: string): FlatMatch[] {
+  if (!query) return [];
+
+  const flat: FlatMatch[] = [];
+  for (let segmentIndex = 0; segmentIndex < segmentTexts.length; segmentIndex++) {
+    for (const match of findMatchesInText(segmentTexts[segmentIndex], query)) {
+      flat.push({ segmentIndex, start: match.start, end: match.end });
+    }
+  }
+
+  return flat;
+}
+
+/**
+ * Next/previous active-match index with wrap-around.
+ * `direction` is 1 for next and -1 for previous. Returns -1 when there are no matches.
+ */
+export function stepIndex(current: number, total: number, direction: 1 | -1): number {
+  if (total === 0) return -1;
+  if (current < 0 || current >= total) {
+    // No active match (or out of range): start at the appropriate end.
+    return direction === 1 ? 0 : total - 1;
+  }
+  return (current + direction + total) % total;
+}
+
+/** Clamp an active index into `[0, total-1]`, or -1 when there are no matches. */
+export function clampIndex(index: number, total: number): number {
+  if (total === 0) return -1;
+  if (index < 0) return 0;
+  if (index > total - 1) return total - 1;
+  return index;
+}

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -34,6 +34,13 @@ vi.mock("@/components/ai-elements/conversation", () => ({
   ConversationScrollTrigger: () => null,
 }));
 
+// ConversationFind reads the stick-to-bottom context, which the mocked
+// Conversation above does not provide; stub it out since these tests exercise
+// ChatConversation, not the find bar (which has its own tests).
+vi.mock("@/components/chat/ConversationFind", () => ({
+  ConversationFind: () => null,
+}));
+
 vi.mock("@/components/ChatMessage", () => ({
   default: ({
     message,

--- a/frontend/tests/components/ConversationFind.test.tsx
+++ b/frontend/tests/components/ConversationFind.test.tsx
@@ -1,0 +1,109 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StickToBottom } from "use-stick-to-bottom";
+import { ConversationFind } from "@/components/chat/ConversationFind";
+
+/**
+ * ConversationFind reads its scroll container from useStickToBottomContext, so it
+ * must render inside <StickToBottom>. The searchable content lives in
+ * <StickToBottom.Content> so it sits within scrollRef.current.
+ *
+ * We drive the input with fireEvent (synchronous) rather than userEvent: under
+ * jsdom + fake timers, userEvent's internal timer pumping deadlocks against the
+ * hook's debounce and StickToBottom's effects.
+ */
+function renderFind(switchCounter = 0) {
+  return render(
+    <StickToBottom>
+      <StickToBottom.Content>
+        <p data-find-content="">foo bar Foo</p>
+        <div data-find-content="">
+          <span>foo</span>
+        </div>
+      </StickToBottom.Content>
+      <ConversationFind switchCounter={switchCounter} />
+    </StickToBottom>,
+  );
+}
+
+function pressFindShortcut() {
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+}
+
+function typeQuery(input: HTMLElement, value: string) {
+  fireEvent.change(input, { target: { value } });
+  act(() => {
+    vi.advanceTimersByTime(150);
+  });
+}
+
+describe("ConversationFind", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing until opened", () => {
+    renderFind();
+    expect(screen.queryByPlaceholderText("Find in conversation")).toBeNull();
+  });
+
+  it("opens on Ctrl+F and shows a correct counter for a matching query", () => {
+    renderFind();
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    const input = screen.getByPlaceholderText("Find in conversation");
+    expect(input).toBeInTheDocument();
+
+    typeQuery(input, "bar");
+
+    // "bar" matches once: 1/1.
+    expect(screen.getByText("1/1")).toBeInTheDocument();
+    expect(input).not.toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("shows 0/0 and marks the input invalid when there are no matches", () => {
+    renderFind();
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    const input = screen.getByPlaceholderText("Find in conversation");
+    typeQuery(input, "zzz");
+
+    expect(screen.getByText("0/0")).toBeInTheDocument();
+    expect(input).toHaveAttribute("aria-invalid", "true");
+  });
+
+  it("disables Previous/Next buttons when there are no matches", () => {
+    renderFind();
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    expect(screen.getByLabelText("Previous match")).toBeDisabled();
+    expect(screen.getByLabelText("Next match")).toBeDisabled();
+  });
+
+  it("closes the bar when Escape is pressed in the input", () => {
+    renderFind();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    const input = screen.getByPlaceholderText("Find in conversation");
+    expect(input).toBeInTheDocument();
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.queryByPlaceholderText("Find in conversation")).toBeNull();
+  });
+});

--- a/frontend/tests/hooks/useConversationFind.test.tsx
+++ b/frontend/tests/hooks/useConversationFind.test.tsx
@@ -193,6 +193,58 @@ describe("useConversationFind", () => {
     expect(result.current.noResults).toBe(true);
   });
 
+  it("clears stale noResults while a replacement query waits for debounce", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("zzz");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.noResults).toBe(true);
+
+    act(() => {
+      result.current.setQuery("foo");
+    });
+
+    expect(result.current.noResults).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.matchCount).toBe(3);
+    expect(result.current.noResults).toBe(false);
+  });
+
+  it("clears stale noResults immediately when the query is emptied", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("zzz");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.noResults).toBe(true);
+
+    act(() => {
+      result.current.setQuery("");
+    });
+
+    expect(result.current.noResults).toBe(false);
+  });
+
   it("never flags noResults for a query that has matches", () => {
     const { result } = setup();
 
@@ -231,6 +283,28 @@ describe("useConversationFind", () => {
     expect(result.current.open).toBe(false);
     expect(result.current.matchCount).toBe(0);
     expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("cancels a pending debounced search when closed", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+    act(() => {
+      result.current.close();
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.open).toBe(false);
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeIndex).toBe(-1);
+    expect(result.current.noResults).toBe(false);
   });
 
   it("resets query and closes when switchCounter changes", () => {

--- a/frontend/tests/hooks/useConversationFind.test.tsx
+++ b/frontend/tests/hooks/useConversationFind.test.tsx
@@ -170,6 +170,46 @@ describe("useConversationFind", () => {
     expect(result.current.activeIndex).toBe(-1);
   });
 
+  it("does not flag noResults during the debounce window, only after the search runs", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("zzz"); // no matches
+    });
+
+    // During the debounce the search hasn't run yet, so we must NOT claim
+    // "no results" — that is the premature red flash we are guarding against.
+    expect(result.current.noResults).toBe(false);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    // Now the search has completed and genuinely found nothing.
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.noResults).toBe(true);
+  });
+
+  it("never flags noResults for a query that has matches", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+    expect(result.current.noResults).toBe(false); // during debounce
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.matchCount).toBe(3);
+    expect(result.current.noResults).toBe(false); // after search
+  });
+
   it("resets open/matchCount/activeIndex on close()", () => {
     const { result } = setup();
 

--- a/frontend/tests/hooks/useConversationFind.test.tsx
+++ b/frontend/tests/hooks/useConversationFind.test.tsx
@@ -1,0 +1,254 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { RefObject } from "react";
+import { useConversationFind } from "@/hooks/useConversationFind";
+
+/**
+ * Build a detached-but-attached container holding `[data-find-content]` segments
+ * and return a ref pointing at it. The hook walks text nodes inside these
+ * segments, so the markup determines the match counts the assertions expect.
+ */
+function mountContent(html: string): {
+  container: HTMLDivElement;
+  scrollRef: RefObject<HTMLElement | null>;
+} {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  document.body.appendChild(container);
+  const scrollRef = { current: container } as RefObject<HTMLElement | null>;
+  return { container, scrollRef };
+}
+
+function pressFindShortcut() {
+  // Cmd/Ctrl+F is registered on `window`; dispatch a real KeyboardEvent there.
+  window.dispatchEvent(new KeyboardEvent("keydown", { key: "f", ctrlKey: true }));
+}
+
+const DEFAULT_HTML = `<p data-find-content="">foo bar Foo</p><div data-find-content=""><span>foo</span></div>`;
+
+describe("useConversationFind", () => {
+  let appended: HTMLElement[];
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    appended = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    for (const el of appended) el.remove();
+    vi.restoreAllMocks();
+  });
+
+  function setup(html: string = DEFAULT_HTML, switchCounter = 0) {
+    const { container, scrollRef } = mountContent(html);
+    appended.push(container);
+    const view = renderHook(
+      (props: { switchCounter: number }) =>
+        useConversationFind({ scrollRef, switchCounter: props.switchCounter }),
+      { initialProps: { switchCounter } },
+    );
+    return { ...view, scrollRef, container };
+  }
+
+  it("opens the find bar on Ctrl+F when scrollRef is populated", () => {
+    const { result } = setup();
+    expect(result.current.open).toBe(false);
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    expect(result.current.open).toBe(true);
+  });
+
+  it("does not open when scrollRef.current is null", () => {
+    const scrollRef = { current: null } as RefObject<HTMLElement | null>;
+    const { result } = renderHook(() =>
+      useConversationFind({ scrollRef, switchCounter: 0 }),
+    );
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    expect(result.current.open).toBe(false);
+  });
+
+  it("counts case-insensitive matches across all segments after the 150ms debounce", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+
+    // Before the debounce elapses nothing is indexed yet.
+    expect(result.current.matchCount).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    // "foo", "Foo" in the first segment and "foo" in the span => 3 matches.
+    expect(result.current.matchCount).toBe(3);
+    expect(result.current.activeIndex).toBe(0);
+  });
+
+  it("wraps activeIndex with next() and prev()", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.matchCount).toBe(3);
+    expect(result.current.activeIndex).toBe(0);
+
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(1);
+
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(2);
+
+    // Wrap from the last match back to the first.
+    act(() => {
+      result.current.next();
+    });
+    expect(result.current.activeIndex).toBe(0);
+
+    // Wrap from the first match back to the last.
+    act(() => {
+      result.current.prev();
+    });
+    expect(result.current.activeIndex).toBe(2);
+  });
+
+  it("reports no matches for a query with zero hits", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("zzz");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("keeps matchCount at 0 for an empty query", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("resets open/matchCount/activeIndex on close()", () => {
+    const { result } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.matchCount).toBe(3);
+
+    act(() => {
+      result.current.close();
+    });
+
+    expect(result.current.open).toBe(false);
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("resets query and closes when switchCounter changes", () => {
+    const { result, rerender } = setup();
+
+    act(() => {
+      pressFindShortcut();
+    });
+    act(() => {
+      result.current.setQuery("foo");
+    });
+    act(() => {
+      vi.advanceTimersByTime(150);
+    });
+    expect(result.current.open).toBe(true);
+    expect(result.current.query).toBe("foo");
+
+    act(() => {
+      rerender({ switchCounter: 1 });
+    });
+
+    expect(result.current.open).toBe(false);
+    expect(result.current.query).toBe("");
+    expect(result.current.matchCount).toBe(0);
+    expect(result.current.activeIndex).toBe(-1);
+  });
+
+  it("prefills the query from a single-line window selection on open", () => {
+    const { result } = setup();
+
+    // jsdom does not produce a usable Selection from layout, so stub
+    // window.getSelection to return a deterministic single-line string.
+    const getSelectionSpy = vi
+      .spyOn(window, "getSelection")
+      .mockReturnValue({ toString: () => "bar" } as unknown as Selection);
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    expect(result.current.open).toBe(true);
+    expect(result.current.query).toBe("bar");
+    getSelectionSpy.mockRestore();
+  });
+
+  it("does not prefill when the selection spans multiple lines", () => {
+    const { result } = setup();
+
+    const getSelectionSpy = vi
+      .spyOn(window, "getSelection")
+      .mockReturnValue({ toString: () => "line one\nline two" } as unknown as Selection);
+
+    act(() => {
+      pressFindShortcut();
+    });
+
+    expect(result.current.open).toBe(true);
+    expect(result.current.query).toBe("");
+    getSelectionSpy.mockRestore();
+  });
+});

--- a/frontend/tests/lib/conversation-find.test.ts
+++ b/frontend/tests/lib/conversation-find.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  findMatchesInText,
+  collectMatches,
+  stepIndex,
+  clampIndex,
+} from "@/lib/conversation-find";
+
+describe("findMatchesInText", () => {
+  it("finds a single match", () => {
+    expect(findMatchesInText("hello world", "world")).toEqual([{ start: 6, end: 11 }]);
+  });
+
+  it("finds multiple matches", () => {
+    expect(findMatchesInText("ab ab ab", "ab")).toEqual([
+      { start: 0, end: 2 },
+      { start: 3, end: 5 },
+      { start: 6, end: 8 },
+    ]);
+  });
+
+  it("returns [] when there is no match", () => {
+    expect(findMatchesInText("hello", "xyz")).toEqual([]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(findMatchesInText("Dev dev DEV", "dev")).toEqual([
+      { start: 0, end: 3 },
+      { start: 4, end: 7 },
+      { start: 8, end: 11 },
+    ]);
+  });
+
+  it("is accent-sensitive: 'resume' does not match 'résumé'", () => {
+    expect(findMatchesInText("résumé", "resume")).toEqual([]);
+  });
+
+  it("is accent-sensitive: 'résumé' does not match 'resume'", () => {
+    expect(findMatchesInText("resume", "résumé")).toEqual([]);
+  });
+
+  it("matches accented text case-insensitively without shifting offsets", () => {
+    expect(findMatchesInText("RÉSUMÉ", "résumé")).toEqual([{ start: 0, end: 6 }]);
+  });
+
+  it("does not overlap matches", () => {
+    expect(findMatchesInText("aaaa", "aa")).toEqual([
+      { start: 0, end: 2 },
+      { start: 2, end: 4 },
+    ]);
+  });
+
+  it("returns [] for an empty query", () => {
+    expect(findMatchesInText("anything", "")).toEqual([]);
+  });
+
+  it("treats a space query literally", () => {
+    expect(findMatchesInText("a b c", " ")).toEqual([
+      { start: 1, end: 2 },
+      { start: 3, end: 4 },
+    ]);
+  });
+
+  it("matches at the very start of the text", () => {
+    expect(findMatchesInText("start here", "start")).toEqual([{ start: 0, end: 5 }]);
+  });
+
+  it("matches at the very end of the text", () => {
+    expect(findMatchesInText("the end", "end")).toEqual([{ start: 4, end: 7 }]);
+  });
+});
+
+describe("collectMatches", () => {
+  it("flattens matches in document order across segments", () => {
+    expect(collectMatches(["foo bar", "bar foo"], "foo")).toEqual([
+      { segmentIndex: 0, start: 0, end: 3 },
+      { segmentIndex: 1, start: 4, end: 7 },
+    ]);
+  });
+
+  it("carries the correct segmentIndex", () => {
+    expect(collectMatches(["xx", "x", "xxx"], "x")).toEqual([
+      { segmentIndex: 0, start: 0, end: 1 },
+      { segmentIndex: 0, start: 1, end: 2 },
+      { segmentIndex: 1, start: 0, end: 1 },
+      { segmentIndex: 2, start: 0, end: 1 },
+      { segmentIndex: 2, start: 1, end: 2 },
+      { segmentIndex: 2, start: 2, end: 3 },
+    ]);
+  });
+
+  it("skips segments with zero matches but keeps order", () => {
+    expect(collectMatches(["hit", "miss", "hit"], "hit")).toEqual([
+      { segmentIndex: 0, start: 0, end: 3 },
+      { segmentIndex: 2, start: 0, end: 3 },
+    ]);
+  });
+
+  it("returns [] for an empty query", () => {
+    expect(collectMatches(["a", "b"], "")).toEqual([]);
+  });
+
+  it("returns [] when no segment matches", () => {
+    expect(collectMatches(["a", "b"], "z")).toEqual([]);
+  });
+});
+
+describe("stepIndex", () => {
+  it("steps forward", () => {
+    expect(stepIndex(0, 3, 1)).toBe(1);
+  });
+
+  it("wraps forward from the last index to 0", () => {
+    expect(stepIndex(2, 3, 1)).toBe(0);
+  });
+
+  it("steps backward", () => {
+    expect(stepIndex(2, 3, -1)).toBe(1);
+  });
+
+  it("wraps backward from 0 to the last index", () => {
+    expect(stepIndex(0, 3, -1)).toBe(2);
+  });
+
+  it("from -1 forward goes to 0", () => {
+    expect(stepIndex(-1, 3, 1)).toBe(0);
+  });
+
+  it("from -1 backward goes to the last index", () => {
+    expect(stepIndex(-1, 3, -1)).toBe(2);
+  });
+
+  it("returns -1 when total is 0", () => {
+    expect(stepIndex(0, 0, 1)).toBe(-1);
+    expect(stepIndex(-1, 0, -1)).toBe(-1);
+  });
+
+  it("handles a single-element total", () => {
+    expect(stepIndex(0, 1, 1)).toBe(0);
+    expect(stepIndex(0, 1, -1)).toBe(0);
+  });
+
+  it("treats an out-of-range current defensively", () => {
+    expect(stepIndex(99, 3, 1)).toBe(0);
+    expect(stepIndex(99, 3, -1)).toBe(2);
+  });
+});
+
+describe("clampIndex", () => {
+  it("leaves an in-range index unchanged", () => {
+    expect(clampIndex(1, 3)).toBe(1);
+  });
+
+  it("clamps an above-range index to total-1", () => {
+    expect(clampIndex(5, 3)).toBe(2);
+  });
+
+  it("returns -1 when total is 0", () => {
+    expect(clampIndex(0, 0)).toBe(-1);
+  });
+
+  it("clamps a negative index to 0", () => {
+    expect(clampIndex(-4, 3)).toBe(0);
+  });
+});


### PR DESCRIPTION
Implements #275.

## What
A custom in-app find bar, opened with **Cmd/Ctrl+F**, scoped to the **active conversation**. It searches the base text of user and assistant messages, highlights every match in place (exact word), and lets you cycle matches with a counter.

## How it works
- **Highlighting** uses the native **CSS Custom Highlight API** — matches are painted via a separate `Range` registry, never by mutating the DOM. This is why it works over Streamdown-rendered markdown and why a match that **crosses an element boundary** (e.g. `cross<strong>ing</strong>`) highlights as one continuous span, which naive `<mark>`-wrapping breaks.
- **Scope** is enforced by tagging only the user text and assistant rendered-markdown containers with `data-find-content`; a `TreeWalker` over those regions excludes collapsed content (thinking, tool output, activities) by construction.
- **Pure core** (`lib/conversation-find`) owns all matching/navigation arithmetic, DOM-free and heavily unit-tested; the hook is thin glue.

## Behaviour
- Case-insensitive, accent-sensitive, literal substring (no regex).
- `Enter`/`Shift+Enter` next/prev with wrap-around; ↑/↓ buttons; counter `3/12`; `0/0` + red input on no match.
- `Esc` closes and clears highlights. Re-`Cmd+F` refocuses+selects. Prefills from the current selection. Works even while focused in the composer. Native find is suppressed via `preventDefault`.
- Debounced re-index on query change and on streaming/content mutation. Closes + clears on conversation switch.

## Tests
- `tests/lib/conversation-find` — 30 unit tests (matching, accents, non-overlap, wrap, clamp).
- `tests/hooks/useConversationFind` — 10 tests (shortcut open, debounced counts, wrap nav, reset on switch, selection prefill).
- `tests/components/ConversationFind` — 5 RTL tests (counter, no-result state, disabled nav, Escape).
- Full frontend suite green except one **pre-existing, unrelated** failure in `Sidebar.test.tsx` ("add repository compact in the footer") that also fails on `main` (Sidebar files untouched here).

## Verification beyond unit tests
The Highlight-API painting and scroll glue can't run under jsdom, so it was verified with a pixel-faithful repro (same TreeWalker/Range algorithm, same `::highlight()` CSS and tokens): confirmed correct painting in light + dark, readable text, scoping across segments, and a match cleanly crossing a `<strong>` boundary.

## Not yet verified in the running app
End-to-end in the real desktop/web shell (actual Cmd+F native-find suppression on WebKitGTK, and the bar's live placement) — worth a manual pass before merge.

## Out of scope (v1, per PRD)
Collapsed-content search, cross-session/global search, regex/whole-word/case toggles, accent-insensitive matching, a `<mark>` fallback for engines without the Highlight API.