### PR TITLE
Recover conversation history after missed stream completion

### DIFF
--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -50,6 +50,7 @@ interface ConversationState {
 }
 
 const CANCELLED_NO_OUTPUT_MESSAGE = "Generation interrupted before any output.";
+const TERMINAL_STATUS_RESYNC_DELAY_MS = 300;
 
 type LocalAction =
   | { type: "reset" }
@@ -123,6 +124,23 @@ function lastMessageIsTerminalAssistant(messages: ChatMessage[], sid: string): b
     return message.role === "assistant";
   }
   return false;
+}
+
+function streamHasRecoverableState(stream: SessionStreamState): boolean {
+  return stream.isStreaming ||
+    stream.currentText.length > 0 ||
+    stream.currentThinking.length > 0 ||
+    stream.activeToolCalls.length > 0 ||
+    stream.activeAgentActivities.length > 0 ||
+    stream.pendingToolInputs.length > 0;
+}
+
+function streamHasVisibleState(stream: SessionStreamState): boolean {
+  return stream.currentText.length > 0 ||
+    stream.currentThinking.length > 0 ||
+    stream.activeToolCalls.length > 0 ||
+    stream.activeAgentActivities.length > 0 ||
+    stream.pendingToolInputs.length > 0;
 }
 
 /** Build the finalized assistant message from a stream slot on done/cancelled. */
@@ -404,6 +422,9 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       // No pending question and a stale finished slot lingers → drop it so it is
       // not rendered as a duplicate bubble alongside the now-persisted message.
       if (activeStream) {
+        if (!lastMessageIsTerminalAssistant(action.messages, sid) && streamHasVisibleState(activeStream)) {
+          return state;
+        }
         return { ...state, sessionStreams: deleteStream(state, sid) };
       }
       return state;
@@ -509,6 +530,7 @@ function sessionIdField(id: string | undefined): { sessionId: string } | Record<
 export function useConversation(workspaceId: string | undefined) {
   const [state, dispatch] = useReducer(reducer, initialState);
   const queryClient = useQueryClient();
+  const terminalStatusResyncTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   // Finalized messages for the active session — owned by React Query (REST).
   const { messages } = useSessionMessages(workspaceId, state.sessionId);
@@ -571,6 +593,24 @@ export function useConversation(workspaceId: string | undefined) {
         if (sid) invalidateSessionMessages(queryClient, workspaceId, sid);
       }
 
+      // A client can miss the terminal done/cancelled event while the app is
+      // backgrounded or while a zombie socket is being recovered. Reconnect
+      // bootstrap still sends idle status, so use it to resync the REST-owned
+      // finalized history and let reconcile_history clear stale live state.
+      if (msg.type === "status" && msg.status === "idle") {
+        const sid = msg.sessionId ?? stateRef.current.sessionId;
+        const stream = sid ? stateRef.current.sessionStreams[sid] : undefined;
+        if (sid && stream && streamHasRecoverableState(stream)) {
+          invalidateSessionMessages(queryClient, workspaceId, sid);
+          const existingTimer = terminalStatusResyncTimersRef.current[sid];
+          if (existingTimer) clearTimeout(existingTimer);
+          terminalStatusResyncTimersRef.current[sid] = setTimeout(() => {
+            delete terminalStatusResyncTimersRef.current[sid];
+            invalidateSessionMessages(queryClient, workspaceId, sid);
+          }, TERMINAL_STATUS_RESYNC_DELAY_MS);
+        }
+      }
+
       if (msg.type === "user_message") {
         const sid = msg.message.sessionId ?? stateRef.current.sessionId;
         appendCachedSessionMessage(queryClient, workspaceId, sid, msg.message);
@@ -589,6 +629,10 @@ export function useConversation(workspaceId: string | undefined) {
       if (workspaceId && sessionIdRef.current) {
         savedSessionByWorkspace.set(workspaceId, sessionIdRef.current);
       }
+      for (const timer of Object.values(terminalStatusResyncTimersRef.current)) {
+        clearTimeout(timer);
+      }
+      terminalStatusResyncTimersRef.current = {};
       unsubscribe();
     };
   }, [workspaceId, queryClient]);

--- a/frontend/src/hooks/useWsCacheInvalidation.ts
+++ b/frontend/src/hooks/useWsCacheInvalidation.ts
@@ -1,6 +1,7 @@
 import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { wsTransport } from "@/lib/ws-transport";
+import { invalidateSessionMessages } from "@/hooks/useSessionMessages";
 
 /**
  * Subscribe to WS messages for the given workspace IDs and invalidate
@@ -22,6 +23,9 @@ export function useWsCacheInvalidation(workspaceIds: string[]): void {
           case "cancelled":
             // Session titles update after a turn completes (naming.ts).
             void queryClient.invalidateQueries({ queryKey: ["sessions", wsId] });
+            if (msg.sessionId) {
+              invalidateSessionMessages(queryClient, wsId, msg.sessionId);
+            }
             break;
 
           case "diff_stats":

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -474,6 +474,93 @@ describe("useConversation", () => {
     expect(__apiMock.getMock).toHaveBeenCalledTimes(2);
   });
 
+  it("retries idle-status history resync when the first REST response is still stale", async () => {
+    const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
+    const userMessage: ChatMessage = {
+      id: "u1",
+      sessionId: "sess-1",
+      role: "user",
+      content: "start",
+      timestamp: "2026-02-12T00:00:00.000Z",
+    };
+    const assistantMessage: ChatMessage = {
+      id: "a1",
+      sessionId: "sess-1",
+      role: "assistant",
+      content: "final answer from persistence",
+      timestamp: "2026-02-12T00:00:01.000Z",
+      toolCalls: [
+        { id: "task-1", name: "Task", input: JSON.stringify({ prompt: "Review" }), output: "done" },
+      ],
+    };
+    __apiMock.getMock
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValueOnce([userMessage, assistantMessage]);
+
+    const { result, queryClient } = renderConversation("ws-1");
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+    });
+
+    await waitFor(() => {
+      expect(__apiMock.getMock).toHaveBeenCalledTimes(1);
+      expect(queryClient.isFetching({ queryKey: sessionMessagesKey("ws-1", "sess-1") })).toBe(0);
+    });
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "user_message", message: userMessage });
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([expect.objectContaining({ id: "u1" })]);
+    });
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "tool_use",
+        sessionId: "sess-1",
+        id: "task-1",
+        name: "Task",
+        input: JSON.stringify({ prompt: "Review" }),
+      });
+    });
+    expect(result.current.activeToolCalls).toHaveLength(1);
+
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      act(() => {
+        __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+      });
+
+      await waitFor(() => {
+        expect(__apiMock.getMock).toHaveBeenCalledTimes(2);
+        expect(queryClient.isFetching({ queryKey: sessionMessagesKey("ws-1", "sess-1") })).toBe(0);
+      });
+      expect(result.current.messages).toEqual([expect.objectContaining({ id: "u1" })]);
+      expect(result.current.messages.some((message) => message.id === "a1")).toBe(false);
+      expect(result.current.activeToolCalls).toEqual([expect.objectContaining({ id: "task-1", name: "Task" })]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      await waitFor(() => {
+        expect(result.current.messages).toEqual([
+          expect.objectContaining({ id: "u1" }),
+          expect.objectContaining({ id: "a1", content: "final answer from persistence" }),
+        ]);
+        expect(result.current.activeToolCalls).toEqual([]);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+    expect(__apiMock.getMock).toHaveBeenCalledTimes(3);
+    expect(result.current.activeToolCalls).toEqual([]);
+  });
+
   it("preserves parentToolUseId from tool_use events in active and persisted tool calls", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderConversation("ws-1");

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -412,6 +412,68 @@ describe("useConversation", () => {
     expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-1/messages");
   });
 
+  it("resyncs persisted history when only idle status is observed after a stream", async () => {
+    const { __wsMock } = await getWsMock();
+    const { __apiMock } = await getApiMock();
+    const userMessage: ChatMessage = {
+      id: "u1",
+      sessionId: "sess-1",
+      role: "user",
+      content: "start",
+      timestamp: "2026-02-12T00:00:00.000Z",
+    };
+    const assistantMessage: ChatMessage = {
+      id: "a1",
+      sessionId: "sess-1",
+      role: "assistant",
+      content: "final answer from persistence",
+      timestamp: "2026-02-12T00:00:01.000Z",
+      toolCalls: [
+        { id: "task-1", name: "Task", input: JSON.stringify({ prompt: "Review" }), output: "done" },
+      ],
+    };
+    __apiMock.getMock
+      .mockResolvedValueOnce([userMessage])
+      .mockResolvedValueOnce([userMessage, assistantMessage]);
+
+    const { result } = renderConversation("ws-1");
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "user_message", message: userMessage });
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([expect.objectContaining({ id: "u1" })]);
+    });
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "tool_use",
+        sessionId: "sess-1",
+        id: "task-1",
+        name: "Task",
+        input: JSON.stringify({ prompt: "Review" }),
+      });
+    });
+    expect(result.current.activeToolCalls).toHaveLength(1);
+
+    // Simulates a hidden/zombie client that misses the terminal `done` event and
+    // later receives only the idle status from reconnect/bootstrap.
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
+    });
+
+    await waitFor(() => {
+      expect(result.current.messages).toEqual([
+        expect.objectContaining({ id: "u1" }),
+        expect.objectContaining({ id: "a1", content: "final answer from persistence" }),
+      ]);
+    });
+    expect(result.current.activeToolCalls).toEqual([]);
+    expect(result.current.isStreaming).toBe(false);
+    expect(__apiMock.getMock).toHaveBeenCalledTimes(2);
+  });
+
   it("preserves parentToolUseId from tool_use events in active and persisted tool calls", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderConversation("ws-1");

--- a/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
+++ b/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
+import { sessionMessagesKey } from "@/hooks/useSessionMessages";
 import { createWrapper } from "../test-utils";
 
 interface Message {
@@ -54,16 +55,18 @@ describe("useWsCacheInvalidation", () => {
     expect(mocks.onMessage).toHaveBeenNthCalledWith(2, "ws-2", expect.any(Function));
   });
 
-  it("invalidates sessions on done and cancelled messages", () => {
+  it("invalidates sessions and finalized messages on done and cancelled messages", () => {
     const { wrapper, queryClient } = createWrapper();
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries").mockResolvedValue(undefined);
     renderHook(() => useWsCacheInvalidation(["ws-1"]), { wrapper });
 
-    emit("ws-1", { type: "done" });
-    emit("ws-1", { type: "cancelled" });
+    emit("ws-1", { type: "done", sessionId: "sess-1" });
+    emit("ws-1", { type: "cancelled", sessionId: "sess-1" });
 
     expect(invalidateSpy).toHaveBeenNthCalledWith(1, { queryKey: ["sessions", "ws-1"] });
-    expect(invalidateSpy).toHaveBeenNthCalledWith(2, { queryKey: ["sessions", "ws-1"] });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(2, { queryKey: sessionMessagesKey("ws-1", "sess-1") });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(3, { queryKey: ["sessions", "ws-1"] });
+    expect(invalidateSpy).toHaveBeenNthCalledWith(4, { queryKey: sessionMessagesKey("ws-1", "sess-1") });
   });
 
   it("invalidates files and diff-stat caches on diff_stats messages", () => {


### PR DESCRIPTION
## Summary
- resync REST-owned session history when a reconnect/bootstrap only reports idle after a stream
- keep visible live stream state until authoritative history includes a terminal assistant turn
- invalidate session message queries from global done/cancelled WS cache invalidation

## Tests
- npm test -- useConversation.test.tsx
- npm test -- useWsCacheInvalidation.test.tsx useSessionMessages.test.tsx
- npm run typecheck
- npm run lint