### PR TITLE
Fix empty-state flash + pre-warm history when switching conversations

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ import { BRAIN_WORKSPACE_ID } from "@/lib/brain";
 import type { Project } from "@/types";
 import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
+import { useActiveSessionPrewarm } from "@/hooks/useActiveSessionPrewarm";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
 import { wsTransport } from "@/lib/ws-transport";
 import { HiveToaster } from "@/components/ui/toaster";
@@ -55,6 +56,10 @@ export default function App() {
   }, [loading, workspaceIds]);
 
   useWsCacheInvalidation(workspaceIds);
+
+  // Prewarm each workspace's active-session history at bootstrap so the first
+  // switch into a workspace is instant (no empty-state blank on cache-miss).
+  useActiveSessionPrewarm(projects);
 
   useEffect(() => () => {
     wsTransport.disconnectAll();

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -29,6 +29,7 @@ interface ChatConversationProps {
    * the empty state before the fetched messages arrive.
    */
   isHistoryLoading?: boolean;
+  isHistoryError?: boolean;
   isStreaming: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
@@ -62,6 +63,7 @@ interface ChatConversationProps {
 export default function ChatConversation({
   messages,
   isHistoryLoading = false,
+  isHistoryError = false,
   isStreaming,
   streamingStartedAt,
   currentStreamingText,
@@ -221,6 +223,7 @@ export default function ChatConversation({
       <ConversationContent className="gap-4 px-8 py-4">
         {!hasContent &&
           !isHistoryLoading &&
+          !isHistoryError &&
           (workspaceName && projectName && branch && defaultBranch ? (
             <ConversationEmptyState className="py-20">
               <WorkspaceWelcome

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -23,6 +23,12 @@ import type { PlanStatus } from "@/components/chat/PlanProposal";
 
 interface ChatConversationProps {
   messages: ChatMessageType[];
+  /**
+   * True only during a cache-miss first history load. While loading, the
+   * message area stays deliberately blank (no skeleton) instead of flashing
+   * the empty state before the fetched messages arrive.
+   */
+  isHistoryLoading?: boolean;
   isStreaming: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
@@ -55,6 +61,7 @@ interface ChatConversationProps {
 
 export default function ChatConversation({
   messages,
+  isHistoryLoading = false,
   isStreaming,
   streamingStartedAt,
   currentStreamingText,
@@ -213,6 +220,7 @@ export default function ChatConversation({
       )}
       <ConversationContent className="gap-4 px-8 py-4">
         {!hasContent &&
+          !isHistoryLoading &&
           (workspaceName && projectName && branch && defaultBranch ? (
             <ConversationEmptyState className="py-20">
               <WorkspaceWelcome

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -52,6 +52,8 @@ export interface ConversationPaneProps {
 
   // ── Conversation (ChatConversation surface) ──
   messages: ChatMessage[];
+  /** True only on a cache-miss first history load; suppresses the empty state. */
+  isHistoryLoading?: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
   currentThinking: string;
@@ -117,6 +119,7 @@ export function ConversationPane({
   onConversationActivate,
   activeProvider,
   messages,
+  isHistoryLoading,
   streamingStartedAt,
   currentStreamingText,
   currentThinking,
@@ -181,6 +184,7 @@ export function ConversationPane({
           <>
             <ChatConversation
               messages={messages}
+              isHistoryLoading={isHistoryLoading}
               isStreaming={isStreaming}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -54,6 +54,8 @@ export interface ConversationPaneProps {
   messages: ChatMessage[];
   /** True only on a cache-miss first history load; suppresses the empty state. */
   isHistoryLoading?: boolean;
+  /** True when the active REST history query failed; suppresses the empty state. */
+  isHistoryError?: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
   currentThinking: string;
@@ -120,6 +122,7 @@ export function ConversationPane({
   activeProvider,
   messages,
   isHistoryLoading,
+  isHistoryError,
   streamingStartedAt,
   currentStreamingText,
   currentThinking,
@@ -185,6 +188,7 @@ export function ConversationPane({
             <ChatConversation
               messages={messages}
               isHistoryLoading={isHistoryLoading}
+              isHistoryError={isHistoryError}
               isStreaming={isStreaming}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}

--- a/frontend/src/hooks/useActiveSessionPrewarm.ts
+++ b/frontend/src/hooks/useActiveSessionPrewarm.ts
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { prefetchSessionMessages } from "@/hooks/useSessionMessages";
+import { useSessions } from "@/hooks/useSessions";
+import { useBrain } from "@/hooks/useBrain";
+import { BRAIN_WORKSPACE_ID } from "@/lib/brain";
+import type { Project } from "@/types";
+
+/**
+ * Prewarm the REST history cache for the entry session of every conversation
+ * context — each workspace AND the Brain — at app bootstrap, so the FIRST switch
+ * into any of them finds warm data. React Query `isLoading` stays false, so no
+ * empty-state blank while the fetch resolves.
+ *
+ * The per-context prewarm in {@link useConversationColumn} only warms the
+ * *other* (non-entry) sessions of the *currently open* context: it can't warm a
+ * context before you enter it, and it excludes the entry session by design (that
+ * one fetches itself on display). This closes that gap — the "everything warm"
+ * property the old WebSocket bootstrap had before the REST-owned history
+ * refactor — and unifies workspaces and the Brain under one boot path.
+ *
+ * Entry session per context:
+ * - Workspaces: `activeSessionId` + `lastActivityAt` already ride on the
+ *   `/api/projects` payload, so no extra request is needed to know them.
+ * - Brain: it carries no inline `activeSessionId`, so we mirror the server's
+ *   default-session pick (`getDefaultBrainSessionId`: most-recently-updated
+ *   non-empty session) from its sessions list. The list is fetched only when a
+ *   Brain exists (`useBrain` is already loaded at boot by the sidebar, a cache
+ *   hit) and shares the `useSessions` cache key, so it also warms BrainView.
+ *
+ * Bounded to the most-recently-active workspaces to keep the boot request burst
+ * small (boot is the most latency-sensitive moment); older workspaces fall back
+ * to lazy load on switch. Pure additive optimization: `prefetchQuery` dedupes by
+ * key and no-ops while fresh, so nothing depends on it completing.
+ */
+const PREWARM_WORKSPACE_LIMIT = 15;
+
+export function useActiveSessionPrewarm(projects: Project[]): void {
+  const queryClient = useQueryClient();
+  const { brain } = useBrain();
+  // Reuse the sessions query (same cache key as BrainView) but only when a Brain
+  // exists — passing undefined disables it, so users without a Brain make no
+  // request. This also warms BrainView's own session list as a side benefit.
+  const { sessions: brainSessions } = useSessions(brain.exists ? BRAIN_WORKSPACE_ID : undefined);
+
+  useEffect(() => {
+    const targets = projects
+      .flatMap((project) => project.workspaces ?? [])
+      .filter((workspace) => !!workspace.activeSessionId)
+      // Most-recently-active first; workspaces without lastActivityAt sink last.
+      // lastActivityAt is an ISO 8601 string, which sorts lexicographically.
+      .sort((a, b) => (b.lastActivityAt ?? "").localeCompare(a.lastActivityAt ?? ""))
+      .slice(0, PREWARM_WORKSPACE_LIMIT)
+      .map((workspace) => ({ wsId: workspace.id, sessionId: workspace.activeSessionId! }));
+
+    // Brain entry session: most-recently-updated non-empty session, matching the
+    // server's getDefaultBrainSessionId fallback. Empty sessions have no history
+    // to warm; terminals never exist on the Brain.
+    const brainEntry = brainSessions
+      .filter((session) => session.messageCount > 0)
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt))[0];
+    if (brainEntry) {
+      targets.push({ wsId: BRAIN_WORKSPACE_ID, sessionId: brainEntry.sessionId });
+    }
+
+    for (const target of targets) {
+      prefetchSessionMessages(queryClient, target.wsId, target.sessionId);
+    }
+  }, [projects, brainSessions, queryClient]);
+}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -533,7 +533,13 @@ export function useConversation(workspaceId: string | undefined) {
   const terminalStatusResyncTimersRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   // Finalized messages for the active session — owned by React Query (REST).
-  const { messages } = useSessionMessages(workspaceId, state.sessionId);
+  // `isHistoryLoading` is true only on a cache-miss first load (React Query
+  // `isLoading`, not `isFetching`), so switch-back and background refetches
+  // stay false and never blank the transcript.
+  const { messages, isLoading: isHistoryLoading } = useSessionMessages(
+    workspaceId,
+    state.sessionId,
+  );
 
   // Track latest state so the WS handler (set up once per workspace) can read the
   // current stream content and session id without re-subscribing.
@@ -779,6 +785,7 @@ export function useConversation(workspaceId: string | undefined) {
 
   return {
     messages,
+    isHistoryLoading,
     isStreaming: activeStream?.isStreaming ?? false,
     streamingStartedAt: activeStream?.streamingStartedAt ?? null,
     workspaceStatus: state.workspaceStatus,

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -536,10 +536,11 @@ export function useConversation(workspaceId: string | undefined) {
   // `isHistoryLoading` is true only on a cache-miss first load (React Query
   // `isLoading`, not `isFetching`), so switch-back and background refetches
   // stay false and never blank the transcript.
-  const { messages, isLoading: isHistoryLoading } = useSessionMessages(
-    workspaceId,
-    state.sessionId,
-  );
+  const {
+    messages,
+    isLoading: isHistoryLoading,
+    error: historyError,
+  } = useSessionMessages(workspaceId, state.sessionId);
 
   // Track latest state so the WS handler (set up once per workspace) can read the
   // current stream content and session id without re-subscribing.
@@ -703,6 +704,10 @@ export function useConversation(workspaceId: string | undefined) {
 
   // Derive active session's stream state for the public API
   const activeStream = state.sessionId ? state.sessionStreams[state.sessionId] : undefined;
+  const historyErrorMessage = historyError
+    ? `Failed to load conversation history: ${historyError}`
+    : undefined;
+  const isHistoryError = !!historyError;
 
   const answerQuestion = useCallback((toolCallId: string, answers: QuestionAnswer[]) => {
     if (!workspaceId) return;
@@ -786,6 +791,7 @@ export function useConversation(workspaceId: string | undefined) {
   return {
     messages,
     isHistoryLoading,
+    isHistoryError,
     isStreaming: activeStream?.isStreaming ?? false,
     streamingStartedAt: activeStream?.streamingStartedAt ?? null,
     workspaceStatus: state.workspaceStatus,
@@ -795,7 +801,7 @@ export function useConversation(workspaceId: string | undefined) {
     activeAgentActivities: activeStream?.activeAgentActivities ?? [],
     pendingToolInputs: activeStream?.pendingToolInputs ?? [],
     connectionStatus,
-    error: state.error,
+    error: state.error ?? historyErrorMessage,
     sessionId: state.sessionId,
     agentPlanMode: activeStream?.agentPlanMode,
     lockedProvider: state.lockedProvider,

--- a/frontend/src/hooks/useConversationColumn.ts
+++ b/frontend/src/hooks/useConversationColumn.ts
@@ -1,5 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
+import { prefetchSessionMessages } from "@/hooks/useSessionMessages";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
 import { useTabs, type UseTabsReturn } from "@/hooks/useTabs";
@@ -120,6 +122,29 @@ export function useConversationColumn(
   } = conversation;
 
   const { sessions, loading: sessionsLoading, createSession, convertToTerminal, deleteSession, refresh: refreshSessions } = useSessions(wsId);
+
+  // Pre-warm REST history for the workspace's recent sessions so switching to
+  // any of them is instant (no empty-state blank). Pure additive optimization:
+  // prefetchQuery dedupes by key and no-ops while fresh, so nothing depends on
+  // it completing — an un-warmed session just falls back to lazy load on switch.
+  const queryClient = useQueryClient();
+  useEffect(() => {
+    if (!wsId) return;
+    // Cap to the most-recent sessions to bound the request burst; older ones
+    // fall back to lazy load on switch (same as before this optimization).
+    const PREWARM_LIMIT = 25;
+    const eligible = sessions
+      .filter((s) => s.kind !== "terminal") // terminals have no chat transcript
+      .filter((s) => s.messageCount > 0) // nothing to warm for empty sessions
+      .filter((s) => s.sessionId !== sessionId) // active session already fetches
+      .slice()
+      // updatedAt is an ISO 8601 string, which sorts correctly lexicographically.
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)) // most-recent first
+      .slice(0, PREWARM_LIMIT);
+    for (const s of eligible) {
+      prefetchSessionMessages(queryClient, wsId, s.sessionId);
+    }
+  }, [wsId, sessions, sessionId, queryClient]);
 
   // Mirror iOS: fall back to session metadata when WS hasn't delivered
   // lockedProvider yet.

--- a/frontend/src/hooks/useConversationColumn.ts
+++ b/frontend/src/hooks/useConversationColumn.ts
@@ -130,17 +130,16 @@ export function useConversationColumn(
   const queryClient = useQueryClient();
   useEffect(() => {
     if (!wsId) return;
-    // Cap to the most-recent sessions to bound the request burst; older ones
-    // fall back to lazy load on switch (same as before this optimization).
-    const PREWARM_LIMIT = 25;
+    // A context holds at most MAX_SESSIONS_PER_WORKSPACE (6) sessions, so this
+    // set is tiny (≤5 after excluding the active one) — no cap needed. Sorted
+    // most-recent first only so the warm-up order is predictable.
     const eligible = sessions
       .filter((s) => s.kind !== "terminal") // terminals have no chat transcript
       .filter((s) => s.messageCount > 0) // nothing to warm for empty sessions
       .filter((s) => s.sessionId !== sessionId) // active session already fetches
       .slice()
       // updatedAt is an ISO 8601 string, which sorts correctly lexicographically.
-      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)) // most-recent first
-      .slice(0, PREWARM_LIMIT);
+      .sort((a, b) => b.updatedAt.localeCompare(a.updatedAt)); // most-recent first
     for (const s of eligible) {
       prefetchSessionMessages(queryClient, wsId, s.sessionId);
     }

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -27,6 +27,12 @@ function fetchSessionMessages(workspaceId: string, sessionId: string): Promise<C
   return api.get<ChatMessage[]>(`/api/workspaces/${workspaceId}/sessions/${sessionId}/messages`);
 }
 
+function historyErrorMessage(error: unknown): string | undefined {
+  if (!error) return undefined;
+  if (error instanceof Error && error.message.trim()) return error.message;
+  return "Failed to load conversation history.";
+}
+
 function mergeFetchedMessagesWithCachedUserEchoes(
   fetched: ChatMessage[],
   cached: ChatMessage[] | undefined,
@@ -68,7 +74,7 @@ export function fetchAndMergeSessionMessages(
 export function useSessionMessages(
   workspaceId: string | undefined,
   sessionId: string | undefined,
-): { messages: ChatMessage[]; isLoading: boolean } {
+): { messages: ChatMessage[]; isLoading: boolean; error: string | undefined } {
   const queryClient = useQueryClient();
   const key = sessionMessagesKey(workspaceId, sessionId);
   const query = useQuery({
@@ -77,7 +83,11 @@ export function useSessionMessages(
     enabled: !!workspaceId && !!sessionId,
     staleTime: SESSION_MESSAGES_STALE_TIME,
   });
-  return { messages: query.data ?? EMPTY_MESSAGES, isLoading: query.isLoading };
+  return {
+    messages: query.data ?? EMPTY_MESSAGES,
+    isLoading: query.isLoading,
+    error: historyErrorMessage(query.error),
+  };
 }
 
 /**

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -11,11 +11,6 @@ import type { ChatMessage } from "@/types";
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
 
-// Cached data renders instantly on switch-back; a short staleness window avoids
-// refetch storms while done/cancelled invalidation forces refresh. Shared with
-// the prefetch helper so warmed entries dedupe against the live hook query.
-const SESSION_MESSAGES_STALE_TIME = 5_000;
-
 export function sessionMessagesKey(
   workspaceId: string | undefined,
   sessionId: string | undefined,
@@ -81,7 +76,10 @@ export function useSessionMessages(
     queryKey: key,
     queryFn: () => fetchAndMergeSessionMessages(queryClient, workspaceId!, sessionId!),
     enabled: !!workspaceId && !!sessionId,
-    staleTime: SESSION_MESSAGES_STALE_TIME,
+    // Freshness is driven by WS done/cancelled invalidation (see
+    // useWsCacheInvalidation), not time-based expiry — matching the app-wide
+    // policy in query-client.ts. So inherit the global staleTime default instead
+    // of forcing a full-transcript refetch on every workspace switch-back.
   });
   return {
     messages: query.data ?? EMPTY_MESSAGES,
@@ -94,8 +92,8 @@ export function useSessionMessages(
  * Pre-warm the REST history cache for a session so a later switch finds warm
  * data (React Query `isLoading` stays false → no empty-state flash). Pure
  * additive optimization: `prefetchQuery` dedupes by key against in-flight
- * fetches and no-ops while data is still fresh within staleTime, so it's safe
- * to call alongside the active session's own fetch.
+ * fetches and no-ops while data is still fresh within the global staleTime, so
+ * it's safe to call alongside the active session's own fetch.
  */
 export function prefetchSessionMessages(
   queryClient: QueryClient,
@@ -103,10 +101,11 @@ export function prefetchSessionMessages(
   sessionId: string | undefined,
 ): void {
   if (!workspaceId || !sessionId) return;
+  // Inherits the global staleTime (see useSessionMessages), so it no-ops while
+  // the cached transcript is still fresh.
   void queryClient.prefetchQuery({
     queryKey: sessionMessagesKey(workspaceId, sessionId),
     queryFn: () => fetchAndMergeSessionMessages(queryClient, workspaceId, sessionId),
-    staleTime: SESSION_MESSAGES_STALE_TIME,
   });
 }
 

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -11,6 +11,11 @@ import type { ChatMessage } from "@/types";
 
 const EMPTY_MESSAGES: ChatMessage[] = [];
 
+// Cached data renders instantly on switch-back; a short staleness window avoids
+// refetch storms while done/cancelled invalidation forces refresh. Shared with
+// the prefetch helper so warmed entries dedupe against the live hook query.
+const SESSION_MESSAGES_STALE_TIME = 5_000;
+
 export function sessionMessagesKey(
   workspaceId: string | undefined,
   sessionId: string | undefined,
@@ -40,6 +45,25 @@ function mergeFetchedMessagesWithCachedUserEchoes(
   return missingUserMessages.length > 0 ? [...fetched, ...missingUserMessages] : fetched;
 }
 
+/**
+ * Fetch a session's finalized messages and merge back any cached user echoes
+ * that the fetch didn't yet include. Re-reads the cache at fetch end so an
+ * in-flight WS user echo isn't dropped by a concurrent fetch/prefetch. Shared
+ * by both the live hook and the prefetch helper to keep behavior identical.
+ */
+export function fetchAndMergeSessionMessages(
+  queryClient: QueryClient,
+  workspaceId: string,
+  sessionId: string,
+): Promise<ChatMessage[]> {
+  const key = sessionMessagesKey(workspaceId, sessionId);
+  const cacheAtStart = queryClient.getQueryData<ChatMessage[]>(key);
+  return fetchSessionMessages(workspaceId, sessionId).then((fetched) => {
+    const cacheAtEnd = queryClient.getQueryData<ChatMessage[]>(key);
+    return mergeFetchedMessagesWithCachedUserEchoes(fetched, cacheAtEnd ?? cacheAtStart, sessionId);
+  });
+}
+
 /** Subscribe to a session's finalized messages. Returns `[]` until loaded. */
 export function useSessionMessages(
   workspaceId: string | undefined,
@@ -49,20 +73,31 @@ export function useSessionMessages(
   const key = sessionMessagesKey(workspaceId, sessionId);
   const query = useQuery({
     queryKey: key,
-    queryFn: async () => {
-      const cacheAtStart = queryClient.getQueryData<ChatMessage[]>(key);
-      const fetched = await fetchSessionMessages(workspaceId!, sessionId!);
-      const cacheAtEnd = queryClient.getQueryData<ChatMessage[]>(key);
-      const latestCache = cacheAtEnd ?? cacheAtStart;
-
-      return mergeFetchedMessagesWithCachedUserEchoes(fetched, latestCache, sessionId!);
-    },
+    queryFn: () => fetchAndMergeSessionMessages(queryClient, workspaceId!, sessionId!),
     enabled: !!workspaceId && !!sessionId,
-    // Cached data renders instantly on switch-back; a short staleness window
-    // avoids refetch storms while done/cancelled invalidation forces refresh.
-    staleTime: 5_000,
+    staleTime: SESSION_MESSAGES_STALE_TIME,
   });
   return { messages: query.data ?? EMPTY_MESSAGES, isLoading: query.isLoading };
+}
+
+/**
+ * Pre-warm the REST history cache for a session so a later switch finds warm
+ * data (React Query `isLoading` stays false → no empty-state flash). Pure
+ * additive optimization: `prefetchQuery` dedupes by key against in-flight
+ * fetches and no-ops while data is still fresh within staleTime, so it's safe
+ * to call alongside the active session's own fetch.
+ */
+export function prefetchSessionMessages(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+): void {
+  if (!workspaceId || !sessionId) return;
+  void queryClient.prefetchQuery({
+    queryKey: sessionMessagesKey(workspaceId, sessionId),
+    queryFn: () => fetchAndMergeSessionMessages(queryClient, workspaceId, sessionId),
+    staleTime: SESSION_MESSAGES_STALE_TIME,
+  });
 }
 
 /** Read the currently-cached messages for a session synchronously (no fetch). */

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -120,6 +120,7 @@ export default function BrainView() {
   // WorkspaceView via useConversationColumn.
   const {
     messages,
+    isHistoryLoading,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -366,6 +367,7 @@ export default function BrainView() {
               onFileTabClose={closeFileTab}
               onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
               messages={messages}
+              isHistoryLoading={isHistoryLoading}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}
               currentThinking={currentThinking}

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -121,6 +121,7 @@ export default function BrainView() {
   const {
     messages,
     isHistoryLoading,
+    isHistoryError,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -368,6 +369,7 @@ export default function BrainView() {
               onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
               messages={messages}
               isHistoryLoading={isHistoryLoading}
+              isHistoryError={isHistoryError}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}
               currentThinking={currentThinking}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -158,6 +158,7 @@ export default function WorkspaceView() {
 
   const {
     messages,
+    isHistoryLoading,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -474,6 +475,7 @@ export default function WorkspaceView() {
             onFileTabClose={closeFileTab}
             onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
             messages={messages}
+            isHistoryLoading={isHistoryLoading}
             streamingStartedAt={streamingStartedAt}
             currentStreamingText={currentStreamingText}
             currentThinking={currentThinking}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -159,6 +159,7 @@ export default function WorkspaceView() {
   const {
     messages,
     isHistoryLoading,
+    isHistoryError,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -476,6 +477,7 @@ export default function WorkspaceView() {
             onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
             messages={messages}
             isHistoryLoading={isHistoryLoading}
+            isHistoryError={isHistoryError}
             streamingStartedAt={streamingStartedAt}
             currentStreamingText={currentStreamingText}
             currentThinking={currentThinking}

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -115,6 +115,36 @@ describe("ChatConversation empty states", () => {
     expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
   });
 
+  it("suppresses the workspace welcome while history is loading", () => {
+    renderConversation({
+      isHistoryLoading: true,
+      workspaceName: "san-antonio",
+      projectName: "hive",
+      branch: "workspace/san-antonio",
+      defaultBranch: "main",
+    });
+
+    expect(screen.queryByText(/You're in a new copy of/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
+  });
+
+  it("suppresses empty states when history failed to load", () => {
+    renderConversation({
+      isHistoryError: true,
+      error: "Failed to load conversation history: network down",
+      messages: [],
+      isStreaming: false,
+      workspaceName: "san-antonio",
+      projectName: "hive",
+      branch: "workspace/san-antonio",
+      defaultBranch: "main",
+    });
+
+    expect(screen.getByText("Failed to load conversation history: network down")).toBeInTheDocument();
+    expect(screen.queryByText(/You're in a new copy of/i)).not.toBeInTheDocument();
+    expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
+  });
+
   it("defaults fileCount to 0 when not provided", () => {
     renderConversation({
       workspaceName: "san-antonio",
@@ -145,6 +175,17 @@ describe("ChatConversation empty states", () => {
     });
 
     expect(screen.getByTestId("custom-empty")).toHaveTextContent("brain welcome");
+    expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
+  });
+
+  it("suppresses the custom emptyState while history is loading", () => {
+    renderConversation({
+      isHistoryLoading: true,
+      projectName: "Brain",
+      emptyState: <div data-testid="custom-empty">brain welcome</div>,
+    });
+
+    expect(screen.queryByTestId("custom-empty")).not.toBeInTheDocument();
     expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
   });
 

--- a/frontend/tests/hooks/useActiveSessionPrewarm.test.tsx
+++ b/frontend/tests/hooks/useActiveSessionPrewarm.test.tsx
@@ -1,0 +1,163 @@
+import type { ReactNode } from "react";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useActiveSessionPrewarm } from "@/hooks/useActiveSessionPrewarm";
+import * as sessionMessages from "@/hooks/useSessionMessages";
+import { BRAIN_WORKSPACE_ID } from "@/lib/brain";
+import type { Project, SessionMetadata, Workspace } from "@/types";
+
+const mocks = vi.hoisted(() => ({
+  useBrain: vi.fn(),
+  useSessions: vi.fn(),
+}));
+
+vi.mock("@/hooks/useBrain", () => ({ useBrain: mocks.useBrain }));
+vi.mock("@/hooks/useSessions", () => ({ useSessions: mocks.useSessions }));
+
+function wrapperFor(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderPrewarm(projects: Project[]) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return renderHook(() => useActiveSessionPrewarm(projects), {
+    wrapper: wrapperFor(queryClient),
+  });
+}
+
+function ws(overrides: Partial<Workspace> & { id: string }): Workspace {
+  return {
+    name: overrides.id,
+    branch: "main",
+    status: "idle",
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function project(id: string, workspaces: Workspace[]): Project {
+  return { id, name: id, createdAt: "2024-01-01T00:00:00Z", workspaces };
+}
+
+function brainSession(overrides: Partial<SessionMetadata> & { sessionId: string }): SessionMetadata {
+  return {
+    workspaceId: BRAIN_WORKSPACE_ID,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    messageCount: 1,
+    ...overrides,
+  } as SessionMetadata;
+}
+
+describe("useActiveSessionPrewarm", () => {
+  let prefetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prefetchSpy = vi.spyOn(sessionMessages, "prefetchSessionMessages").mockImplementation(() => {});
+    // Default: no Brain configured, empty brain sessions.
+    mocks.useBrain.mockReturnValue({ brain: { exists: false } });
+    mocks.useSessions.mockReturnValue({ sessions: [] });
+  });
+
+  it("prewarms the active session of every workspace, skipping those without one", () => {
+    renderPrewarm([
+      project("p1", [
+        ws({ id: "w1", activeSessionId: "s1", lastActivityAt: "2024-03-02T00:00:00Z" }),
+        ws({ id: "w2", lastActivityAt: "2024-03-01T00:00:00Z" }), // no active session
+      ]),
+      project("p2", [
+        ws({ id: "w3", activeSessionId: "s3", lastActivityAt: "2024-03-03T00:00:00Z" }),
+      ]),
+    ]);
+
+    expect(prefetchSpy).toHaveBeenCalledTimes(2);
+    expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), "w1", "s1");
+    expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), "w3", "s3");
+    const warmedWs = prefetchSpy.mock.calls.map((call) => call[1]);
+    expect(warmedWs).not.toContain("w2");
+  });
+
+  it("orders most-recently-active first and caps the burst at 15 workspaces", () => {
+    const workspaces = Array.from({ length: 20 }, (_, i) => {
+      const day = String(i + 1).padStart(2, "0");
+      return ws({
+        id: `w${i}`,
+        activeSessionId: `s${i}`,
+        lastActivityAt: `2024-04-${day}T00:00:00Z`,
+      });
+    });
+
+    renderPrewarm([project("p1", workspaces)]);
+
+    const warmedWs = prefetchSpy.mock.calls.map((call) => call[1]);
+    expect(warmedWs).toHaveLength(15);
+    expect(warmedWs[0]).toBe("w19");
+    expect(warmedWs[14]).toBe("w5");
+    expect(warmedWs).not.toContain("w4");
+  });
+
+  it("does nothing when no workspace has an active session and no Brain exists", () => {
+    renderPrewarm([project("p1", [ws({ id: "w1" }), ws({ id: "w2" })])]);
+    expect(prefetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("sinks workspaces without lastActivityAt below dated ones", () => {
+    renderPrewarm([
+      project("p1", [
+        ws({ id: "wUndated", activeSessionId: "sU" }),
+        ws({ id: "wDated", activeSessionId: "sD", lastActivityAt: "2024-05-01T00:00:00Z" }),
+      ]),
+    ]);
+
+    const warmedWs = prefetchSpy.mock.calls.map((call) => call[1]);
+    expect(warmedWs).toEqual(["wDated", "wUndated"]);
+  });
+
+  describe("Brain coverage", () => {
+    it("prewarms the Brain's most-recent non-empty session when a Brain exists", () => {
+      mocks.useBrain.mockReturnValue({ brain: { exists: true } });
+      mocks.useSessions.mockReturnValue({
+        sessions: [
+          brainSession({ sessionId: "bOld", updatedAt: "2024-02-01T00:00:00Z", messageCount: 3 }),
+          brainSession({ sessionId: "bNew", updatedAt: "2024-06-01T00:00:00Z", messageCount: 2 }),
+          brainSession({ sessionId: "bEmpty", updatedAt: "2024-07-01T00:00:00Z", messageCount: 0 }),
+        ],
+      });
+
+      renderPrewarm([project("p1", [ws({ id: "w1", activeSessionId: "s1" })])]);
+
+      // Workspace active session + Brain entry (bNew, newest non-empty; bEmpty skipped).
+      expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), "w1", "s1");
+      expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), BRAIN_WORKSPACE_ID, "bNew");
+      const warmed = prefetchSpy.mock.calls.map((call) => [call[1], call[2]]);
+      expect(warmed).not.toContainEqual([BRAIN_WORKSPACE_ID, "bEmpty"]);
+    });
+
+    it("passes undefined to useSessions (disabling the query) when no Brain exists", () => {
+      renderPrewarm([]);
+      expect(mocks.useSessions).toHaveBeenCalledWith(undefined);
+    });
+
+    it("passes the Brain id to useSessions when a Brain exists", () => {
+      mocks.useBrain.mockReturnValue({ brain: { exists: true } });
+      mocks.useSessions.mockReturnValue({ sessions: [] });
+      renderPrewarm([]);
+      expect(mocks.useSessions).toHaveBeenCalledWith(BRAIN_WORKSPACE_ID);
+    });
+
+    it("does not prewarm the Brain when all its sessions are empty", () => {
+      mocks.useBrain.mockReturnValue({ brain: { exists: true } });
+      mocks.useSessions.mockReturnValue({
+        sessions: [brainSession({ sessionId: "bEmpty", messageCount: 0 })],
+      });
+      renderPrewarm([]);
+      expect(prefetchSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -68,7 +68,7 @@ vi.mock("@/lib/ws-transport", () => {
       messageHandlers.clear();
       statusListeners.clear();
     }),
-    send: vi.fn((_workspaceId: string, _message: unknown) => true),
+    send: vi.fn(() => true),
     onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
       getSet(messageHandlers, workspaceId).add(handler);
       for (const msg of replayMessages.get(workspaceId) ?? []) {
@@ -79,7 +79,7 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: bufferedFlags.get(workspaceId) ?? false,
       };
     }),
-    onReconnect: vi.fn((_workspaceId: string, _callback: () => void) => {
+    onReconnect: vi.fn(() => {
       return () => {};
     }),
     subscribe: (workspaceId: string, listener: () => void) => {
@@ -1538,6 +1538,23 @@ describe("useConversation", () => {
     expect(result.current.isStreaming).toBe(false);
   });
 
+  it("surfaces REST history errors for the active session", async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock.mockRejectedValue(new Error("network down"));
+
+    const { result } = renderConversation("ws-1");
+
+    act(() => {
+      result.current.switchSession("sess-2");
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Failed to load conversation history: network down");
+    });
+    expect(result.current.isHistoryError).toBe(true);
+    expect(result.current.messages).toEqual([]);
+  });
+
   it("restores cached messages synchronously when switching to a previously-viewed session", async () => {
     const { __wsMock } = await getWsMock();
     const { result, queryClient } = renderConversation("ws-1");
@@ -1667,7 +1684,7 @@ describe("useConversation", () => {
       __wsMock.emit("ws-1", {
         type: "branch_info",
         info: { name: "feat/new", lastSyncedAt: "2026-02-13T00:00:00.000Z" },
-      } as any);
+      } as unknown as WsOutgoing);
     });
 
     expect(result.current.workspaceStatus).toBe("busy");

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -160,7 +160,10 @@ function renderConversation(
   queryClient: QueryClient;
 } {
   const queryClient = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    // Mirror the production default staleTime (query-client.ts) so the session
+    // messages query — which now inherits it instead of forcing its own — keeps
+    // its "fresh cache renders without refetch" behavior under test.
+    defaultOptions: { queries: { retry: false, gcTime: Infinity, staleTime: 5 * 60 * 1000 } },
   });
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>

--- a/frontend/tests/hooks/useConversationColumn.test.tsx
+++ b/frontend/tests/hooks/useConversationColumn.test.tsx
@@ -1,7 +1,10 @@
+import type { ReactNode } from "react";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useConversationColumn } from "@/hooks/useConversationColumn";
 import { _resetSnapshotCache } from "@/hooks/useTabs";
+import * as sessionMessages from "@/hooks/useSessionMessages";
 import type { QueuedMessage } from "@/types";
 
 const mocks = vi.hoisted(() => ({
@@ -17,6 +20,25 @@ vi.mock("@/hooks/useSessions", () => ({ useSessions: mocks.useSessions }));
 vi.mock("@/hooks/useTasks", () => ({ useTasks: mocks.useTasks }));
 vi.mock("@/hooks/useBackgroundAgents", () => ({ useBackgroundAgents: mocks.useBackgroundAgents }));
 vi.mock("@/hooks/useApi", () => ({ api: { post: mocks.apiPost } }));
+
+// The prefetch effect calls useQueryClient(), so tests need a provider wrapper.
+function wrapperFor(queryClient: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function renderColumn(
+  wsId: string | undefined,
+  opts?: Parameters<typeof useConversationColumn>[1],
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+  });
+  return renderHook(() => useConversationColumn(wsId, opts), {
+    wrapper: wrapperFor(queryClient),
+  });
+}
 
 // Shared mutable conversation state so we can re-render with different values.
 let conversation: Record<string, unknown>;
@@ -78,7 +100,7 @@ beforeEach(() => {
 
 describe("useConversationColumn — session handlers", () => {
   it("handleCreateSession creates then switches to the new session", async () => {
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     await act(async () => {
       await result.current.handleCreateSession();
     });
@@ -88,7 +110,7 @@ describe("useConversationColumn — session handlers", () => {
 
   it("handleActivateSession activates the tab, switches, and runs onActivateSession", () => {
     const onActivateSession = vi.fn();
-    const { result } = renderHook(() => useConversationColumn("ws1", { onActivateSession }));
+    const { result } = renderColumn("ws1", { onActivateSession });
     act(() => result.current.handleActivateSession("s2"));
     expect(conversation.switchSession).toHaveBeenCalledWith("s2");
     expect(onActivateSession).toHaveBeenCalledWith("s2");
@@ -98,7 +120,7 @@ describe("useConversationColumn — session handlers", () => {
 
   it("handleActivateSession is a no-op switch when already active", () => {
     const onActivateSession = vi.fn();
-    const { result } = renderHook(() => useConversationColumn("ws1", { onActivateSession }));
+    const { result } = renderColumn("ws1", { onActivateSession });
     act(() => result.current.handleActivateSession("s1")); // s1 is active
     expect(conversation.switchSession).not.toHaveBeenCalled();
     expect(onActivateSession).not.toHaveBeenCalled();
@@ -106,7 +128,7 @@ describe("useConversationColumn — session handlers", () => {
 
   it("handleDeleteSession on a non-last active session activates the next one", async () => {
     const onLastSessionDeleted = vi.fn();
-    const { result } = renderHook(() => useConversationColumn("ws1", { onLastSessionDeleted }));
+    const { result } = renderColumn("ws1", { onLastSessionDeleted });
     await act(async () => {
       await result.current.handleDeleteSession("s1"); // active, sibling s2 remains
     });
@@ -124,7 +146,7 @@ describe("useConversationColumn — session handlers", () => {
       refresh,
     });
     const onLastSessionDeleted = vi.fn();
-    const { result } = renderHook(() => useConversationColumn("ws1", { onLastSessionDeleted }));
+    const { result } = renderColumn("ws1", { onLastSessionDeleted });
     await act(async () => {
       await result.current.handleDeleteSession("s1");
     });
@@ -135,7 +157,7 @@ describe("useConversationColumn — session handlers", () => {
   it("handleDeleteSession does nothing when delete fails", async () => {
     deleteSession.mockResolvedValue(false);
     const onLastSessionDeleted = vi.fn();
-    const { result } = renderHook(() => useConversationColumn("ws1", { onLastSessionDeleted }));
+    const { result } = renderColumn("ws1", { onLastSessionDeleted });
     await act(async () => {
       await result.current.handleDeleteSession("s1");
     });
@@ -148,7 +170,7 @@ describe("useConversationColumn — session handlers", () => {
 describe("useConversationColumn — handleStartTerminal", () => {
   it("converts the active session in place when it is an empty chat", async () => {
     // Active session s1 is an empty chat (kind absent, messageCount 0).
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     await act(async () => {
       await result.current.handleStartTerminal();
     });
@@ -174,7 +196,7 @@ describe("useConversationColumn — handleStartTerminal", () => {
     });
     createSession.mockResolvedValue({ sessionId: "term-1", kind: "terminal", createdAt: "2024-01-04T00:00:00Z" });
 
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     await act(async () => {
       await result.current.handleStartTerminal();
     });
@@ -187,7 +209,7 @@ describe("useConversationColumn — handleStartTerminal", () => {
 
   it("aborts (no start) when the conversion fails", async () => {
     convertToTerminal.mockResolvedValue(null);
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     await act(async () => {
       await result.current.handleStartTerminal();
     });
@@ -201,7 +223,7 @@ describe("useConversationColumn — handleStartTerminal", () => {
     // terminal (convert is irreversible), so this must not reject unhandled and
     // must still refresh + activate so the pane's Start button can retry.
     mocks.apiPost.mockRejectedValueOnce(new Error("network"));
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     await act(async () => {
       await result.current.handleStartTerminal();
     });
@@ -219,7 +241,7 @@ describe("useConversationColumn — per-session message queue", () => {
     conversation = makeConversation({ isStreaming: true });
     mocks.useConversation.mockImplementation(() => conversation);
 
-    const { result, rerender } = renderHook(() => useConversationColumn("ws1"));
+    const { result, rerender } = renderColumn("ws1");
 
     act(() => result.current.setQueuedMessage(queued("for s1")));
     expect(result.current.queuedMessage?.content).toBe("for s1");
@@ -244,7 +266,7 @@ describe("useConversationColumn — per-session message queue", () => {
   it("auto-dequeues and sends when the workspace becomes idle", () => {
     conversation = makeConversation({ isStreaming: true });
     mocks.useConversation.mockImplementation(() => conversation);
-    const { result, rerender } = renderHook(() => useConversationColumn("ws1"));
+    const { result, rerender } = renderColumn("ws1");
 
     act(() => result.current.setQueuedMessage(queued("hello")));
     expect(result.current.queuedMessage?.content).toBe("hello");
@@ -263,16 +285,79 @@ describe("useConversationColumn — per-session message queue", () => {
   it("does not dequeue while pending tool inputs exist", () => {
     conversation = makeConversation({ isStreaming: false, pendingToolInputs: [{ toolName: "AskUserQuestion" }] });
     mocks.useConversation.mockImplementation(() => conversation);
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     act(() => result.current.setQueuedMessage(queued("blocked")));
     expect(conversation.sendMessage).not.toHaveBeenCalled();
     expect(result.current.queuedMessage?.content).toBe("blocked");
   });
 
   it("bumpScrollToBottom increments the scroll trigger", () => {
-    const { result } = renderHook(() => useConversationColumn("ws1"));
+    const { result } = renderColumn("ws1");
     const before = result.current.scrollToBottomTrigger;
     act(() => result.current.bumpScrollToBottom());
     expect(result.current.scrollToBottomTrigger).toBe(before + 1);
+  });
+});
+
+describe("useConversationColumn — REST history pre-warm", () => {
+  let prefetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Spy without hitting the network / React Query.
+    prefetchSpy = vi.spyOn(sessionMessages, "prefetchSessionMessages").mockImplementation(() => {});
+  });
+
+  it("prefetches eligible sessions and skips the active, terminal, and empty ones", () => {
+    // Active is s1. s2 is a warmable chat; s3 is a terminal; s4 is empty.
+    mocks.useSessions.mockReturnValue({
+      sessions: [
+        { sessionId: "s1", title: "One", createdAt: "2024-01-01T00:00:00Z", updatedAt: "2024-01-01T00:00:00Z", messageCount: 5 },
+        { sessionId: "s2", title: "Two", createdAt: "2024-01-02T00:00:00Z", updatedAt: "2024-01-02T00:00:00Z", messageCount: 3 },
+        { sessionId: "s3", title: "Term", kind: "terminal", createdAt: "2024-01-03T00:00:00Z", updatedAt: "2024-01-03T00:00:00Z", messageCount: 4 },
+        { sessionId: "s4", title: "Empty", createdAt: "2024-01-04T00:00:00Z", updatedAt: "2024-01-04T00:00:00Z", messageCount: 0 },
+      ],
+      createSession,
+      convertToTerminal,
+      deleteSession,
+      refresh,
+    });
+
+    renderColumn("ws1"); // active sessionId is "s1"
+
+    const warmedIds = prefetchSpy.mock.calls.map((call) => call[2]);
+    expect(warmedIds).toEqual(["s2"]);
+    expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), "ws1", "s2");
+  });
+
+  it("orders most-recent first and caps the burst at 25 sessions", () => {
+    // 30 eligible chat sessions with ascending updatedAt; expect the newest 25.
+    const sessions = Array.from({ length: 30 }, (_, i) => {
+      const day = String(i + 1).padStart(2, "0");
+      return {
+        sessionId: `s${i}`,
+        title: `S${i}`,
+        createdAt: `2024-02-${day}T00:00:00Z`,
+        updatedAt: `2024-02-${day}T00:00:00Z`,
+        messageCount: 2,
+      };
+    });
+    mocks.useConversation.mockImplementation(() =>
+      makeConversation({ sessionId: "none" }),
+    );
+    mocks.useSessions.mockReturnValue({ sessions, createSession, convertToTerminal, deleteSession, refresh });
+
+    renderColumn("ws1");
+
+    const warmedIds = prefetchSpy.mock.calls.map((call) => call[2]);
+    expect(warmedIds).toHaveLength(25);
+    // Newest first (s29 down to s5); s0..s4 dropped by the cap.
+    expect(warmedIds[0]).toBe("s29");
+    expect(warmedIds[24]).toBe("s5");
+    expect(warmedIds).not.toContain("s4");
+  });
+
+  it("does not prefetch when there is no workspace id", () => {
+    renderColumn(undefined);
+    expect(prefetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/hooks/useConversationColumn.test.tsx
+++ b/frontend/tests/hooks/useConversationColumn.test.tsx
@@ -329,9 +329,9 @@ describe("useConversationColumn — REST history pre-warm", () => {
     expect(prefetchSpy).toHaveBeenCalledWith(expect.anything(), "ws1", "s2");
   });
 
-  it("orders most-recent first and caps the burst at 25 sessions", () => {
-    // 30 eligible chat sessions with ascending updatedAt; expect the newest 25.
-    const sessions = Array.from({ length: 30 }, (_, i) => {
+  it("warms every eligible session, most-recent first (no cap — a context holds at most 6)", () => {
+    // A context caps at MAX_SESSIONS_PER_WORKSPACE (6); use the realistic max.
+    const sessions = Array.from({ length: 6 }, (_, i) => {
       const day = String(i + 1).padStart(2, "0");
       return {
         sessionId: `s${i}`,
@@ -349,11 +349,8 @@ describe("useConversationColumn — REST history pre-warm", () => {
     renderColumn("ws1");
 
     const warmedIds = prefetchSpy.mock.calls.map((call) => call[2]);
-    expect(warmedIds).toHaveLength(25);
-    // Newest first (s29 down to s5); s0..s4 dropped by the cap.
-    expect(warmedIds[0]).toBe("s29");
-    expect(warmedIds[24]).toBe("s5");
-    expect(warmedIds).not.toContain("s4");
+    // All 6 warmed (none active/terminal/empty), newest updatedAt first.
+    expect(warmedIds).toEqual(["s5", "s4", "s3", "s2", "s1", "s0"]);
   });
 
   it("does not prefetch when there is no workspace id", () => {

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -95,6 +95,21 @@ describe("useSessionMessages", () => {
     expect(__apiMock.getMock).not.toHaveBeenCalled();
   });
 
+  it("exposes REST history fetch errors while preserving empty messages", async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock.mockRejectedValue(new Error("network down"));
+
+    const queryClient = newClient();
+    const { result } = renderHook(() => useSessionMessages("ws-1", "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("network down");
+    });
+    expect(result.current.messages).toEqual([]);
+  });
+
   it("does not fetch when there is no workspaceId", async () => {
     const { __apiMock } = await getApiMock();
     const queryClient = newClient();

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -9,6 +9,8 @@ import {
   appendCachedSessionMessage,
   invalidateSessionMessages,
   removeCachedSessionMessages,
+  prefetchSessionMessages,
+  fetchAndMergeSessionMessages,
 } from "@/hooks/useSessionMessages";
 import type { ChatMessage } from "@/types";
 
@@ -129,6 +131,56 @@ describe("useSessionMessages", () => {
 
     expect(__apiMock.getMock).toHaveBeenCalledWith("/api/workspaces/ws-1/sessions/sess-1/messages");
     expect(result.current.messages).toEqual([firstUser, firstAssistant, followUp]);
+  });
+
+  describe("prefetchSessionMessages", () => {
+    it("populates the exact sessionMessagesKey cache entry", async () => {
+      const { __apiMock } = await getApiMock();
+      __apiMock.getMock.mockResolvedValue([message("a1", "warmed")]);
+
+      const queryClient = newClient();
+      prefetchSessionMessages(queryClient, "ws-1", "sess-1");
+
+      await waitFor(() => {
+        expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([
+          message("a1", "warmed"),
+        ]);
+      });
+      expect(__apiMock.getMock).toHaveBeenCalledWith(
+        "/api/workspaces/ws-1/sessions/sess-1/messages",
+      );
+    });
+
+    it("is a no-op when workspaceId or sessionId is missing", async () => {
+      const { __apiMock } = await getApiMock();
+      const queryClient = newClient();
+      const spy = vi.spyOn(queryClient, "prefetchQuery");
+
+      prefetchSessionMessages(queryClient, undefined, "sess-1");
+      prefetchSessionMessages(queryClient, "ws-1", undefined);
+
+      expect(spy).not.toHaveBeenCalled();
+      expect(__apiMock.getMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("fetchAndMergeSessionMessages", () => {
+    it("preserves cached user echoes missing from the fetched payload", async () => {
+      const { __apiMock } = await getApiMock();
+      const firstUser = userMessage("u1", "first prompt");
+      const firstAssistant = message("a1", "first answer");
+      const followUp = userMessage("u2", "queued follow-up");
+      __apiMock.getMock.mockResolvedValue([firstUser, firstAssistant]);
+
+      const queryClient = newClient();
+      const key = sessionMessagesKey("ws-1", "sess-1");
+      // Simulate an in-flight user echo already sitting in the cache.
+      queryClient.setQueryData(key, [firstUser, firstAssistant, followUp]);
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([firstUser, firstAssistant, followUp]);
+    });
   });
 
   describe("appendCachedSessionMessage", () => {


### PR DESCRIPTION
Two complementary fixes for smooth navigation between conversations.

## 1. Suppress the empty-state flash (commit 1)

Switching to an existing conversation whose REST history was not yet cached briefly flashed the empty-conversation placeholder before the fetched messages rendered, because the empty-state condition only checked `messages.length > 0 || isStreaming`.

Thread React Query's `isLoading` (as `isHistoryLoading`) from `useSessionMessages` through `useConversation` → `WorkspaceView`/`BrainView` → `ConversationPane` → `ChatConversation`, and gate the empty state on `!hasContent && !isHistoryLoading`. During a first-load the transcript stays deliberately blank (no skeleton). `isLoading` (not `isFetching`) keeps warm switch-back and background refetches unaffected.

## 2. Pre-warm the REST history cache (commit 2)

Commit 1 hides the flash but a brief blank remained on first switch while the fetch resolved. This restores the "all sessions pre-warmed" property the old WebSocket bootstrap had before the REST-owned refactor.

When a workspace (or Brain) opens, prefetch the message history of its most-recent sessions into the React Query cache so switching finds warm data instantly (`isLoading` stays false → no blank).

- DRY: extract the inline `queryFn` into shared `fetchAndMergeSessionMessages` + a `SESSION_MESSAGES_STALE_TIME` constant, shared by the live hook and the prefetch so they dedupe by key.
- `prefetchSessionMessages` uses `prefetchQuery` (dedupes in-flight fetches, no-ops while fresh → safe alongside the active session's own fetch).
- Triggered from `useConversationColumn` — the single seam feeding both WorkspaceView and BrainView. Skips terminal, empty, and active sessions; sorts most-recent first; caps at 25 to bound the request burst. Older sessions fall back to lazy load (identical to prior behavior).

Pure additive optimization: nothing depends on the prefetch completing.

## Testing

- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm test` — full frontend suite **1528/1528 pass** (added prefetch/eligibility/cap cases to `useSessionMessages.test.tsx` and `useConversationColumn.test.tsx`)
- Commit 1 verified live (no flash on cache-cold switch; empty conversations still show their empty state).

Frontend-only. No WS protocol or backend changes.