### PR TITLE
Terminate dead hub sockets + drop the historyViaRest transition flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ Core model: Project -> Workspace -> Session. Projects are bare repositories; wor
 - Validate repository URLs with `validateRepositoryUrl()` before cloning.
 - Keep WebSocket protocol types aligned across `backend/src/types.ts`, `frontend/src/types.ts`, and `ios/HiveMobile/Models/WebSocketTypes.swift`.
 - When adding a WS event, update backend dispatch, frontend reducers/cache invalidation, iOS stores, and tests.
-- Conversation history is REST-owned for web and iOS. Keep session message endpoints, frontend React Query history, iOS per-session history cache, and WS live bootstrap (`historyViaRest`, `status`, `stream_snapshot`) aligned; keep WS `history` only as a legacy fallback.
+- Conversation history is REST-owned unconditionally for web and iOS. Keep session message endpoints, frontend React Query history, iOS per-session history cache, and WS live bootstrap (`status`, `stream_snapshot`) aligned. The backend never sends a WS `history` frame; keep the `history` event only as a legacy inbound clients tolerate.
 - When adding a provider, implement `AgentProvider`, register it in `providers/registry.ts`, expose capabilities, and add a stream adapter when the CLI format differs from Claude.
 - Keep provider capability fields synchronized across backend, frontend, and iOS models.
 - Automation actions reference Team agents by `agentId`; keep model, thinking level, system prompt, git-context injection, and read-only settings on the agent definition, not on each automation.

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Hub:
 - Endpoint: `ws://<host>/ws/hub`
 - Auth: `Authorization: Bearer <token>`, `x-hive-token`, or `?token=<token>`
 - Clients send hub-level `sync_workspaces` and `ping`; workspace events include `switch_session`, `user_message`, `stop`, and `tool_input_response`.
-- `sync_workspaces` accepts `historyViaRest`. Web and iOS send `true`, so finalized conversation history is fetched over REST (`GET /api/workspaces/:wsId/sessions/:sessionId/messages`) while the hub bootstrap sends status and live stream snapshots only. Absent or `false` keeps the legacy WS `history` bootstrap.
+- Finalized conversation history is fetched over REST for every client (`GET /api/workspaces/:wsId/sessions/:sessionId/messages`); the hub bootstrap sends only `status` and live stream snapshots and never a WS `history` frame. The `history` frame survives in the protocol as a legacy inbound clients still tolerate, but the backend no longer sends it.
 - Server wraps workspace events as `{ workspaceId, event }`; hub pings receive `{ type: "pong" }`.
 - Current server workspace events include `status`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `agent_activity`, `stream_snapshot`, `tool_input_required`, `tool_input_resolved`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `script_status`, `browser_status`, `plan_mode_changed`, and legacy `history`.
 

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -727,10 +727,11 @@ export interface UpdateCustomAgentRequest {
 
 /** Client -> Server (hub-level). */
 export type HubIncoming =
-  // `historyViaRest`: client fetches finalized history over REST (React Query),
-  // so the server skips the heavy `history` bootstrap event for this hub. Absent
-  // / false keeps the legacy behavior for clients that still rely on WS history.
-  | { type: "sync_workspaces"; workspaceIds: string[]; historyViaRest?: boolean }
+  // Finalized conversation history is REST-owned for all clients (React Query on
+  // web, per-session cache on iOS), so the server never sends the `history`
+  // bootstrap event; the hub bootstrap ships `status` and live stream snapshots
+  // only. The WS `history` frame survives only as a legacy inbound clients tolerate.
+  | { type: "sync_workspaces"; workspaceIds: string[] }
   // Application-level liveness probe. The browser WebSocket API never exposes
   // protocol-level ping/pong to JS, so clients send this to actively detect a
   // frozen-but-OPEN socket (e.g. after the OS wakes from sleep).

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -18,7 +18,7 @@ import {
   _clearActiveSessions,
 } from "../agents/agent-manager.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
-import { streamRoutes, broadcastToWorkspace, _getChannelsForTests, _getHubSocketsForTests } from "./stream.js";
+import { streamRoutes, broadcastToWorkspace, _getChannelsForTests, _getHubSocketsForTests, _tickHubLivenessForTests } from "./stream.js";
 import {
   _setScriptStatusForTests,
   _clearAll as clearScripts,
@@ -73,11 +73,10 @@ function hubEvent(workspaceId: string, event: object): string {
 }
 
 /** Send sync_workspaces via a hub WebSocket. */
-function syncWorkspaces(ws: WebSocket, workspaceIds: string[], historyViaRest?: boolean): void {
+function syncWorkspaces(ws: WebSocket, workspaceIds: string[]): void {
   ws.send(JSON.stringify({
     type: "sync_workspaces",
     workspaceIds,
-    ...(historyViaRest !== undefined ? { historyViaRest } : {}),
   }));
 }
 
@@ -94,8 +93,6 @@ function connectHub(
     query?: Record<string, string>;
     /** If set, collect ALL workspace messages (unfiltered). Default: first workspace. */
     collectAll?: boolean;
-    /** Subscribe as a REST-history client (no `history` frames over the WS). */
-    historyViaRest?: boolean;
   },
 ): {
   wsReady: Promise<WebSocket>;
@@ -124,7 +121,7 @@ function connectHub(
         });
         // Subscribe to workspaces after the connection is established
         ws.on("open", () => {
-          syncWorkspaces(ws, workspaceIds, opts?.historyViaRest);
+          syncWorkspaces(ws, workspaceIds);
         });
       },
     },
@@ -285,143 +282,12 @@ describe("WS /ws/hub", () => {
     ws.close();
   });
 
-  it("sends persisted history even when no active session exists", async () => {
-    const sessionId = "sess-persisted";
-    const sessionDir = join(dataDir, projectId, "sessions", sessionId);
-    await mkdir(sessionDir, { recursive: true });
-    await writeFile(
-      join(sessionDir, "metadata.json"),
-      JSON.stringify({
-        sessionId,
-        workspaceId: wsId,
-        createdAt: "2026-02-11T00:00:00.000Z",
-        updatedAt: "2026-02-11T00:00:01.000Z",
-        messageCount: 1,
-      }),
-      "utf-8",
-    );
-    await writeFile(
-      join(sessionDir, "messages.jsonl"),
-      JSON.stringify({
-        id: "m-1",
-        sessionId,
-        role: "assistant",
-        content: "persisted response",
-        timestamp: "2026-02-11T00:00:00.000Z",
-      }) + "\n",
-      "utf-8",
-    );
-
-    const { wsReady, messages } = connectHub([wsId]);
-    const ws = await wsReady;
-
-    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "history"));
-
-    const history = messages.find((m) => m.type === "history");
-    expect(history).toBeDefined();
-    if (history?.type === "history") {
-      expect(history.messages).toEqual([
-        expect.objectContaining({
-          content: "persisted response",
-          role: "assistant",
-        }),
-      ]);
-    }
-
-    ws.close();
-  });
-
-  it("delivers persisted history when listener is attached after injectWS resolves", async () => {
-    const sessionId = "sess-persisted-late";
-    const sessionDir = join(dataDir, projectId, "sessions", sessionId);
-    await mkdir(sessionDir, { recursive: true });
-    await writeFile(
-      join(sessionDir, "metadata.json"),
-      JSON.stringify({
-        sessionId,
-        workspaceId: wsId,
-        createdAt: "2026-02-11T00:00:00.000Z",
-        updatedAt: "2026-02-11T00:00:01.000Z",
-        messageCount: 1,
-      }),
-      "utf-8",
-    );
-    await writeFile(
-      join(sessionDir, "messages.jsonl"),
-      JSON.stringify({
-        id: "m-1",
-        sessionId,
-        role: "assistant",
-        content: "persisted response late listener",
-        timestamp: "2026-02-11T00:00:00.000Z",
-      }) + "\n",
-      "utf-8",
-    );
-
-    const { ws, messages } = await connectHubLateListener([wsId]);
-
-    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "history"));
-
-    const history = messages.find((m) => m.type === "history");
-    expect(history).toBeDefined();
-    if (history?.type === "history") {
-      expect(history.messages).toEqual([
-        expect.objectContaining({
-          content: "persisted response late listener",
-          role: "assistant",
-        }),
-      ]);
-    }
-
-    ws.close();
-  });
-
-  it("bootstraps the default non-empty chat when the active loaded session is empty", async () => {
+  it("redirects to the default non-empty chat via status only when the active loaded session is empty", async () => {
     const { session: emptyActive } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
     const defaultSessionId = "sess-default-non-empty";
     await writePersistedChatSession(defaultSessionId, "persisted default response");
 
     const { wsReady, messages } = connectHub([wsId]);
-    const ws = await wsReady;
-
-    await waitForMessage(
-      messages,
-      (msgs) =>
-        msgs.some((m) => m.type === "status") &&
-        msgs.some((m) => m.type === "history"),
-    );
-
-    const status = messages.find((m) => m.type === "status");
-    expect(status).toEqual({
-      type: "status",
-      status: "idle",
-      streaming: false,
-      sessionId: defaultSessionId,
-    });
-    expect(status).not.toEqual(expect.objectContaining({ sessionId: emptyActive.sessionId }));
-
-    const history = messages.find((m) => m.type === "history");
-    expect(history).toBeDefined();
-    if (history?.type === "history") {
-      expect(history.sessionId).toBe(defaultSessionId);
-      expect(history.messages).toEqual([
-        expect.objectContaining({
-          content: "persisted default response",
-          sessionId: defaultSessionId,
-        }),
-      ]);
-    }
-
-    ws.close();
-    await endSession(wsId, dataDir);
-  });
-
-  it("redirects a historyViaRest client to the default chat via status only, without a WS history frame", async () => {
-    await getOrCreateSession(wsId, dataDir, CONV_CMD); // empty active session
-    const defaultSessionId = "sess-default-rest";
-    await writePersistedChatSession(defaultSessionId, "persisted default for rest client");
-
-    const { wsReady, messages } = connectHub([wsId], { historyViaRest: true });
     const ws = await wsReady;
 
     await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
@@ -435,6 +301,9 @@ describe("WS /ws/hub", () => {
       streaming: false,
       sessionId: defaultSessionId,
     });
+    expect(status).not.toEqual(expect.objectContaining({ sessionId: emptyActive.sessionId }));
+
+    // History is REST-owned: the backend never ships a WS `history` frame at bootstrap.
     expect(messages.some((m) => m.type === "history")).toBe(false);
 
     ws.close();
@@ -508,7 +377,7 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir).catch(() => {});
   });
 
-  it("sends idle status + history when session exists but is not streaming", async () => {
+  it("sends idle status when session exists but is not streaming", async () => {
     await getOrCreateSession(wsId, dataDir, CONV_CMD);
 
     const { wsReady, messages } = connectHub([wsId]);
@@ -1092,7 +961,7 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir);
   });
 
-  it("skips the history bootstrap when the client opts into historyViaRest", async () => {
+  it("never sends a WS history frame at bootstrap for a loaded non-streaming session", async () => {
     await getOrCreateSession(wsId, dataDir, CONV_CMD);
 
     const received: WsOutgoing[] = [];
@@ -1103,7 +972,7 @@ describe("WS /ws/hub", () => {
           if ("workspaceId" in env && env.workspaceId === wsId) received.push(env.event);
         });
         clientWs.on("open", () => {
-          clientWs.send(JSON.stringify({ type: "sync_workspaces", workspaceIds: [wsId], historyViaRest: true }));
+          clientWs.send(JSON.stringify({ type: "sync_workspaces", workspaceIds: [wsId] }));
         });
       },
     })) as WebSocket;
@@ -1314,6 +1183,44 @@ describe("WS /ws/hub", () => {
     ws2.terminate();
     await ws2Closed;
     await waitForCondition(() => !_getChannelsForTests().has(wsId));
+  });
+
+  it("reaps a hub socket that missed a WS heartbeat cycle via the existing close cleanup", async () => {
+    const { wsReady, messages } = connectHub([wsId]);
+    await wsReady;
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+    await waitForCondition(() => _getChannelsForTests().get(wsId)?.hubSockets.size === 1);
+
+    // The injectWS client auto-answers protocol pings, so it can never die
+    // naturally. Force the missed-cycle state and drive one tick by hand.
+    const hub = [..._getHubSocketsForTests()].find((h) => h.subscribedWorkspaces.has(wsId));
+    expect(hub).toBeDefined();
+    hub!.isAlive = false;
+    _tickHubLivenessForTests(hub!);
+
+    // terminate() emits "close", which runs the existing cleanup: unsubscribe
+    // from every channel, drop empty channels, and remove the hub from the set.
+    await waitForCondition(() => !_getHubSocketsForTests().has(hub!));
+    expect(_getChannelsForTests().has(wsId)).toBe(false);
+  });
+
+  it("keeps a hub socket alive when it responded before the heartbeat tick", async () => {
+    const { wsReady, messages } = connectHub([wsId]);
+    await wsReady;
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "status"));
+    await waitForCondition(() => _getChannelsForTests().get(wsId)?.hubSockets.size === 1);
+
+    const hub = [..._getHubSocketsForTests()].find((h) => h.subscribedWorkspaces.has(wsId));
+    expect(hub).toBeDefined();
+    expect(hub!.isAlive).toBe(true);
+
+    // A live socket survives one tick but has its flag cleared, arming the
+    // next cycle to reap it if no pong arrives in the meantime.
+    _tickHubLivenessForTests(hub!);
+    expect(_getHubSocketsForTests().has(hub!)).toBe(true);
+    expect(hub!.isAlive).toBe(false);
   });
 
   it("does not broadcast stale idle status when a session is replaced", async () => {

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -5,8 +5,6 @@ import {
   getSession,
   getSessionById,
   getOrCreateSession,
-  getSessionMessages,
-  getSpecificSessionMessages,
   getDefaultSessionId,
   getStreamingSessionIds,
   isLoadedDefaultSessionCandidate,
@@ -42,8 +40,8 @@ type ActiveSession = NonNullable<ReturnType<typeof getSession>>;
 interface HubSocket {
   ws: WebSocket;
   subscribedWorkspaces: Set<string>;
-  /** Client fetches finalized history over REST, so skip the `history` bootstrap event. */
-  historyViaRest: boolean;
+  /** WS-level heartbeat flag: set true on `pong`, cleared each ping tick. A missed cycle reaps the socket. */
+  isAlive: boolean;
 }
 
 interface WorkspaceChannel {
@@ -118,12 +116,31 @@ export function broadcastToWorkspace(workspaceId: string, msg: WsOutgoing): void
   }
 }
 
+/**
+ * WS-level heartbeat tick (canonical `ws` pattern). A peer that missed the
+ * previous cycle (`isAlive` still false) is terminated; `terminate()` emits
+ * `close`, which runs the existing cleanup. Otherwise arm the next cycle by
+ * clearing the flag and pinging so the client's `pong` can re-set it.
+ */
+function tickHubLiveness(hub: HubSocket): void {
+  if (!hub.isAlive) {
+    hub.ws.terminate();
+    return;
+  }
+  hub.isAlive = false;
+  if (hub.ws.readyState === hub.ws.OPEN) hub.ws.ping();
+}
+
 export function _getChannelsForTests(): Map<string, WorkspaceChannel> {
   return channels;
 }
 
 export function _getHubSocketsForTests(): Set<HubSocket> {
   return hubSockets;
+}
+
+export function _tickHubLivenessForTests(hub: HubSocket): void {
+  tickHubLiveness(hub);
 }
 
 // ── Route registration ──────────────────────────────────────────────
@@ -182,14 +199,6 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         : {}),
       lockedProvider: session.metadata.lockedProvider,
     });
-    try {
-      if (!hub.historyViaRest) {
-        const messages = await session.getMessages();
-        sendToHub(hub, workspaceId, { type: "history", sessionId: session.sessionId, messages });
-      }
-    } catch {
-      // History load failure is non-fatal.
-    }
 
     // Replay in-progress streaming content so late-connecting clients see
     // text, thinking, and tool calls accumulated since the turn started.
@@ -366,19 +375,6 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           streaming: false,
           ...(defaultSessionId ? { sessionId: defaultSessionId } : {}),
         });
-        if (!hub.historyViaRest) {
-          try {
-            const messages = defaultSessionId
-              ? await getSpecificSessionMessages(wsId, defaultSessionId, dataDir)
-              : await getSessionMessages(wsId, dataDir);
-            if (messages.length > 0) {
-              const firstSessionId = messages[0]?.sessionId;
-              sendToHub(hub, wsId, { type: "history", sessionId: firstSessionId, messages });
-            }
-          } catch {
-            // Ignore missing/corrupt persisted history.
-          }
-        }
         sendStreamingBootstraps();
       }
     }
@@ -431,10 +427,10 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     // Subscribe to new workspaces and bootstrap.
     // The hub socket is added to the channel AFTER bootstrap completes so that
-    // live events broadcast during the async getMessages() call don't reach
-    // this client before the streaming snapshot is replayed (which would cause
-    // duplicate content). Node.js single-threading guarantees no events fire
-    // between sendWorkspaceBootstrap returning and hubSockets.add.
+    // live events broadcast during the async bootstrap don't reach this client
+    // before the streaming snapshot is replayed (which would cause duplicate
+    // content). Node.js single-threading guarantees no events fire between
+    // sendWorkspaceBootstrap returning and hubSockets.add.
     for (const wsId of desired) {
       if (!hub.subscribedWorkspaces.has(wsId)) {
         const channel = getOrCreateChannel(wsId);
@@ -622,12 +618,13 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         return;
       }
 
-      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set(), historyViaRest: false };
+      // Start alive so the socket gets a full cycle before it can be reaped.
+      const hub: HubSocket = { ws: socket, subscribedWorkspaces: new Set(), isAlive: true };
       hubSockets.add(hub);
 
-      const pingTimer = setInterval(() => {
-        if (socket.readyState === socket.OPEN) socket.ping();
-      }, PING_INTERVAL_MS);
+      socket.on("pong", () => { hub.isAlive = true; });
+
+      const pingTimer = setInterval(() => tickHubLiveness(hub), PING_INTERVAL_MS);
       hubPingTimers.set(hub, pingTimer);
 
       socket.on("close", () => {
@@ -666,7 +663,6 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             socket.send(JSON.stringify({ type: "pong" }));
           }
         } else if ("type" in parsed && parsed.type === "sync_workspaces") {
-          if (parsed.historyViaRest !== undefined) hub.historyViaRest = parsed.historyViaRest;
           await handleSyncWorkspaces(hub, parsed.workspaceIds);
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -370,9 +370,6 @@ class WsTransport {
     this.hub.ws.send(JSON.stringify({
       type: "sync_workspaces",
       workspaceIds: [...this.subscribedWorkspaceIds],
-      // Finalized history is loaded over REST (React Query); skip the heavy WS
-      // `history` bootstrap event.
-      historyViaRest: true,
     }));
   }
 

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -19,9 +19,6 @@ enum HubIncoming: Encodable {
             var container = encoder.container(keyedBy: SyncCodingKeys.self)
             try container.encode("sync_workspaces", forKey: .type)
             try container.encode(workspaceIds, forKey: .workspaceIds)
-            // iOS is fully migrated to REST-owned history: always opt in so the
-            // backend skips the WS `history` bootstrap event for this client.
-            try container.encode(true, forKey: .historyViaRest)
         case .workspaceEvent(let workspaceId, let event):
             var container = encoder.container(keyedBy: EventCodingKeys.self)
             try container.encode(workspaceId, forKey: .workspaceId)
@@ -30,7 +27,7 @@ enum HubIncoming: Encodable {
     }
 
     private enum SyncCodingKeys: String, CodingKey {
-        case type, workspaceIds, historyViaRest
+        case type, workspaceIds
     }
 
     private enum EventCodingKeys: String, CodingKey {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -254,10 +254,11 @@ final class ConversationStore {
             sessionStreams[sid]?.pendingToolInputs = []
 
         case .history(let msgs, let incomingSessionId):
-            // iOS opts into `historyViaRest`, so the backend no longer sends a
-            // `history` bootstrap event. This case remains only as a defensive
-            // fallback (e.g. an older backend) and routes through the same path
-            // the REST fetch uses, so reconciliation logic lives in one place.
+            // Conversation history is REST-owned unconditionally, so the backend
+            // no longer sends a `history` bootstrap event. This case remains only
+            // as a defensive fallback (e.g. an older backend) and routes through
+            // the same path the REST fetch uses, so reconciliation logic lives in
+            // one place.
             let historySessionId = incomingSessionId ?? msgs.first?.sessionId ?? sessionId
             guard let sid = historySessionId else { return }
             // Adopt the session when none is focused yet so the messages land on

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -451,8 +451,8 @@ struct ChatView: View {
                 isLoading = false
                 return
             }
-            // Skip if a newer event (WS history, send, session switch) arrived while
-            // this REST call was in-flight — their data is more authoritative.
+            // Skip if a newer event (send or session switch) bumped the token
+            // while this REST call was in-flight — their data is more authoritative.
             guard store.historyToken(for: sessionId) == requestToken else {
                 isLoading = false
                 return
@@ -463,7 +463,9 @@ struct ChatView: View {
         } catch is CancellationError {
             // View disappeared
         } catch {
-            // Fall through to WS history
+            // REST fetch failed — keep the cached/streamed messages. History is
+            // REST-owned; a WS `history` frame only arrives from an older backend
+            // and reconciles through the same applyFetchedHistory path.
         }
         isLoading = false
     }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -660,13 +660,15 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
-    func syncWorkspacesEncodesHistoryViaRest() throws {
+    func syncWorkspacesOmitsHistoryViaRest() throws {
+        // History is REST-owned unconditionally, so the transition flag is gone:
+        // the encoded payload carries only `type` and `workspaceIds`.
         let message = HubIncoming.syncWorkspaces(workspaceIds: ["ws-1"])
         let data = try JSONEncoder().encode(message)
         let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
 
         #expect(object?["type"] as? String == "sync_workspaces")
-        #expect(object?["historyViaRest"] as? Bool == true)
+        #expect(object?["historyViaRest"] == nil)
         #expect((object?["workspaceIds"] as? [String]) == ["ws-1"])
     }
 


### PR DESCRIPTION
Two post-#272 follow-ups from the streaming tracking issue #277. Bundled in one PR as requested; the two changes are logically independent.

## 1. Backend dead-peer termination (issue #277 §3) — real leak fix
The hub sent a WS-level `socket.ping()` every 30s but **never tracked the `pong`**, so a vanished client (crash, network drop, mobile backgrounded forever) left a zombie `HubSocket` in `channels`/`hubSockets` forever → listener/memory leak + broadcasts to dead sockets. (The app-level `{type:"pong"}` reply is unrelated — that answers a *client* ping.)

- `isAlive` flag per `HubSocket`, set on `socket.on("pong", …)`.
- Each ping tick (`tickHubLiveness`): if the socket missed a full cycle → `socket.terminate()` (which fires `close`, **reusing the existing channel-unsubscribe + timer-clear + `hubSockets` delete cleanup**); otherwise clear the flag and ping.
- Starts `isAlive = true` so a socket gets one full cycle before it can be reaped (~2 cycles worst-case before a truly dead peer is dropped).
- +2 deterministic tests via an exported `_tickHubLivenessForTests` (the `injectWS` client auto-pongs, so a socket can't die naturally — the tick is driven by hand): a non-responding socket is terminated and removed from `hubSockets` + its emptied channel is dropped; a live socket survives a tick and has its flag cleared.

**This is a behavior change**, not cleanup: the server now actively reaps unresponsive sockets. Low risk for healthy clients (WS pong is handled at the protocol layer, not app JS).

## 2. Drop the `historyViaRest` transition flag (issue #277 §2) — cleanup
Both web and iOS already ship `historyViaRest: true` on `main`, so the transition seam (which let iOS migrate to REST-owned history independently) is done.

- Backend skips the WS `history` bootstrap **unconditionally**; both `if (!hub.historyViaRest)` guards removed + dead imports pruned.
- Flag removed from `HubIncoming` (`types.ts`), the hub plumbing (`stream.ts`), `frontend/src/lib/ws-transport.ts`, and iOS (`WebSocketTypes.swift` encode + `CodingKeys`).
- Docs updated (README + AGENTS.md). The WS `history` **event** stays in the protocol as a legacy inbound clients still tolerate; the backend just never sends it.
- Legacy WS-history bootstrap tests removed/merged (REST now owns that coverage); iOS encode test flipped to assert the flag is absent.

**No observable change for current clients** — they already used REST; this only removes the dead legacy path.

## Testing
- Backend: `typecheck` ✅ · `lint` ✅ · full suite **1552** ✅
- Frontend: `typecheck` ✅ · `lint` ✅ · full suite **1541** ✅
- ⚠️ **iOS UNCOMPILED** — no Swift toolchain in the dev env where this was written. Needs a build + `cd ios && swift test` before merge. Touched iOS files: `WebSocketTypes.swift`, `ConversationStore.swift`, `ConversationStoreSessionTests.swift`.

## Manual test checklist before merge
1. **iOS**: `cd ios && swift test` (blocking — uncompiled edits).
2. **Web non-regression (§2)**: open a conversation, switch conversations (instant, no flash), send → stream → done persists, reload page → history intact.
3. **Dead-peer smoke (§3)**: sleep the laptop / background iOS >1 min, wake → conversation reconnects, does not wipe, history intact.

Closes the §2 and §3 items of #277.