### PR TITLE
Optimize iOS streaming render performance (#283)

### DIFF
--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -260,6 +260,7 @@ private final class CachedActivityToolCalls {
 private let activityToolCallsCache: NSCache<NSString, CachedActivityToolCalls> = {
     let cache = NSCache<NSString, CachedActivityToolCalls>()
     cache.countLimit = 512
+    cache.totalCostLimit = 2_000_000
     return cache
 }()
 
@@ -279,7 +280,8 @@ extension AgentActivity {
         let computed = computeToolCalls()
         activityToolCallsCache.setObject(
             CachedActivityToolCalls(activity: self, toolCalls: computed),
-            forKey: key
+            forKey: key,
+            cost: activityToolCallsCacheCost(computed)
         )
         return computed
     }
@@ -322,6 +324,17 @@ extension AgentActivity {
         case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .diagnostic, .unknown:
             return []
         }
+    }
+}
+
+private func activityToolCallsCacheCost(_ toolCalls: [ToolCall]) -> Int {
+    toolCalls.reduce(0) { total, tool in
+        total
+            + tool.id.utf16.count
+            + tool.name.utf16.count
+            + tool.input.utf16.count
+            + (tool.output?.utf16.count ?? 0)
+            + (tool.parentToolUseId?.utf16.count ?? 0)
     }
 }
 

--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -247,8 +247,44 @@ enum AgentActivity: Codable, Equatable, Identifiable {
     }
 }
 
+private final class CachedActivityToolCalls {
+    let activity: AgentActivity
+    let toolCalls: [ToolCall]
+
+    init(activity: AgentActivity, toolCalls: [ToolCall]) {
+        self.activity = activity
+        self.toolCalls = toolCalls
+    }
+}
+
+private let activityToolCallsCache: NSCache<NSString, CachedActivityToolCalls> = {
+    let cache = NSCache<NSString, CachedActivityToolCalls>()
+    cache.countLimit = 512
+    return cache
+}()
+
 extension AgentActivity {
     var toolCalls: [ToolCall] {
+        switch self {
+        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .diagnostic, .unknown:
+            return []
+        case .commandExecution, .fileChange:
+            break
+        }
+
+        let key = id as NSString
+        if let cached = activityToolCallsCache.object(forKey: key), cached.activity == self {
+            return cached.toolCalls
+        }
+        let computed = computeToolCalls()
+        activityToolCallsCache.setObject(
+            CachedActivityToolCalls(activity: self, toolCalls: computed),
+            forKey: key
+        )
+        return computed
+    }
+
+    private func computeToolCalls() -> [ToolCall] {
         switch self {
         case .commandExecution(let activity):
             return [toolCall(for: activity)]

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -219,7 +219,7 @@ struct FileMention: Codable, Equatable {
     let relativePath: String
 }
 
-struct ToolCall: Codable, Identifiable {
+struct ToolCall: Codable, Equatable, Identifiable {
     let id: String
     let name: String
     let input: String
@@ -256,7 +256,7 @@ struct ToolCall: Codable, Identifiable {
     }
 }
 
-struct ChatMessage: Codable, Identifiable {
+struct ChatMessage: Codable, Equatable, Identifiable {
     let id: String
     let sessionId: String
     let role: MessageRole

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -324,6 +324,33 @@ enum WsOutgoing: Decodable {
     }
 }
 
+// MARK: - Hub Activity Marking
+
+/// How a hub-level event should update a workspace's last-activity timestamp
+/// (used for hub sorting). Per-token events are ignored so streaming does not
+/// write observable hub state on every fragment.
+enum HubActivityMarking: Equatable {
+    case ignore
+    case markNow
+    case markLatestMessageTimestamp
+    case markIfStreaming
+}
+
+func hubActivityMarking(for event: WsOutgoing) -> HubActivityMarking {
+    switch event {
+    case .textDelta, .thinking,
+         .branchInfo, .diffStats, .prStatus, .scriptStatus, .planModeChanged, .streamSnapshot:
+        return .ignore
+    case .history:
+        return .markLatestMessageTimestamp
+    case .status:
+        return .markIfStreaming
+    case .toolUse, .toolResult, .agentActivity, .toolInputRequired, .toolInputResolved,
+         .done, .error, .cancelled, .userMessage, .unknown:
+        return .markNow
+    }
+}
+
 // MARK: - AnyCodableValue (for decoding unknown JSON)
 
 enum AnyCodableValue: Codable {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -107,7 +107,7 @@ final class ConversationStore {
     private(set) var backgroundAgents: BackgroundAgentsState =
         deriveBackgroundAgents(from: [], activeToolCalls: [])
     private(set) var dismissedToolCallIds: Set<String> = []
-    private(set) var derivationRunCount = 0
+    @ObservationIgnored private(set) var derivationRunCount = 0
 
     private func recomputeDerivations() {
         derivationRunCount += 1

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -70,6 +70,16 @@ final class ConversationStore {
     /// Provider locked for this session (pushed via WS status events).
     var lockedProvider: String?
 
+    private let streamFlushInterval: TimeInterval?
+    @ObservationIgnored private var pendingTextBySession: [String: String] = [:]
+    @ObservationIgnored private var pendingThinkingBySession: [String: String] = [:]
+    @ObservationIgnored private var flushTask: Task<Void, Never>?
+
+    /// `nil` disables the scheduled auto-flush (tests flush manually).
+    init(streamFlushInterval: TimeInterval? = 0.05) {
+        self.streamFlushInterval = streamFlushInterval
+    }
+
     // MARK: - Computed
 
     /// The active session's stream state (convenience accessor).
@@ -96,8 +106,11 @@ final class ConversationStore {
         deriveGoalState(from: [], activeAgentActivities: [])
     private(set) var backgroundAgents: BackgroundAgentsState =
         deriveBackgroundAgents(from: [], activeToolCalls: [])
+    private(set) var dismissedToolCallIds: Set<String> = []
+    private(set) var derivationRunCount = 0
 
     private func recomputeDerivations() {
+        derivationRunCount += 1
         let toolCalls = activeStream?.activeToolCalls ?? []
         let activities = activeStream?.activeAgentActivities ?? []
         tasksState = deriveTasks(
@@ -107,6 +120,32 @@ final class ConversationStore {
         )
         goalState = deriveGoalState(from: messages, activeAgentActivities: activities)
         backgroundAgents = deriveBackgroundAgents(from: messages, activeToolCalls: toolCalls)
+        dismissedToolCallIds = deriveDismissedToolCallIds(from: messages)
+    }
+
+    // MARK: - Streaming delta buffering
+
+    func flushStreamingDeltas() {
+        flushTask?.cancel()
+        flushTask = nil
+        guard !pendingTextBySession.isEmpty || !pendingThinkingBySession.isEmpty else { return }
+        for (sid, text) in pendingTextBySession {
+            sessionStreams[sid]?.currentText += text
+        }
+        for (sid, text) in pendingThinkingBySession {
+            sessionStreams[sid]?.currentThinking += text
+        }
+        pendingTextBySession = [:]
+        pendingThinkingBySession = [:]
+    }
+
+    private func scheduleStreamFlush() {
+        guard let interval = streamFlushInterval, flushTask == nil else { return }
+        flushTask = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(interval))
+            guard !Task.isCancelled else { return }
+            self?.flushStreamingDeltas()
+        }
     }
 
     // MARK: - Event handling
@@ -115,11 +154,13 @@ final class ConversationStore {
         switch event {
         case .textDelta(let sid, let text):
             guard sessionStreams[sid] != nil else { return }
-            sessionStreams[sid]?.currentText += text
+            pendingTextBySession[sid, default: ""] += text
+            scheduleStreamFlush()
 
         case .thinking(let sid, let text):
             guard sessionStreams[sid] != nil else { return }
-            sessionStreams[sid]?.currentThinking += text
+            pendingThinkingBySession[sid, default: ""] += text
+            scheduleStreamFlush()
 
         case .toolUse(let sid, let id, let name, let input, let parentToolUseId):
             guard sessionStreams[sid] != nil else { return }
@@ -127,7 +168,9 @@ final class ConversationStore {
                 id: id, name: name, input: input,
                 output: nil, parentToolUseId: parentToolUseId
             ))
-            recomputeDerivations()
+            if sid == sessionId {
+                recomputeDerivations()
+            }
 
         case .toolResult(let sid, let toolUseId, let output):
             guard let stream = sessionStreams[sid],
@@ -137,13 +180,17 @@ final class ConversationStore {
                 id: tc.id, name: tc.name, input: tc.input,
                 output: output, parentToolUseId: tc.parentToolUseId
             )
-            recomputeDerivations()
+            if sid == sessionId {
+                recomputeDerivations()
+            }
 
         case .agentActivity(let sid, let activity):
             upsertAgentActivity(activity, for: sid)
 
         case .streamSnapshot(let sid, let text, let thinking, let toolCalls,
                              let agentActivities, let agentPlanMode, let startedAt):
+            pendingTextBySession.removeValue(forKey: sid)
+            pendingThinkingBySession.removeValue(forKey: sid)
             let stream = sessionStreams[sid] ?? SessionStreamState()
             stream.currentText = text
             stream.currentThinking = thinking
@@ -157,9 +204,12 @@ final class ConversationStore {
             if sessionId == nil {
                 sessionId = sid
             }
-            recomputeDerivations()
+            if sid == sessionId {
+                recomputeDerivations()
+            }
 
         case .toolInputRequired(let sid, let requestId, let toolName, let toolUseId, let input):
+            flushStreamingDeltas()
             if sessionStreams[sid] == nil && hasTerminalAssistantMessage(for: sid) {
                 return
             }
@@ -175,6 +225,7 @@ final class ConversationStore {
 
         case .done(let sid, let durationMs, let inputTokens, let outputTokens,
                    let contextUsedTokens, let contextWindowTokens, _):
+            flushStreamingDeltas()
             finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: false,
                             inputTokens: inputTokens, outputTokens: outputTokens,
                             contextUsedTokens: contextUsedTokens,
@@ -183,6 +234,7 @@ final class ConversationStore {
             onTurnCompleted?(sid)
 
         case .cancelled(let sid, let errorDetail, _, let durationMs):
+            flushStreamingDeltas()
             finalizeMessage(sessionId: sid, durationMs: durationMs, cancelled: true, errorDetail: errorDetail)
             lastHistoryFetchAt.removeValue(forKey: sid)
             onTurnCompleted?(sid)
@@ -200,6 +252,7 @@ final class ConversationStore {
             ))
 
         case .status(let status, let incomingSessionId, let streaming, let startedAt, let provider):
+            flushStreamingDeltas()
             let newIsStreaming = streaming ?? (status == .idle ? false : nil)
 
             if let sid = incomingSessionId, let newIsStreaming {
@@ -241,26 +294,31 @@ final class ConversationStore {
             if sessionId == nil, let incomingSessionId {
                 sessionId = incomingSessionId
             }
-            recomputeDerivations()
+            if let incomingSessionId, incomingSessionId == sessionId {
+                recomputeDerivations()
+            }
 
         case .userMessage(let msg):
             let sid = msg.sessionId
             let isActive = sessionId == nil || sid == sessionId
             let alreadyExists = messages.contains { $0.id == msg.id }
-            if isActive && !alreadyExists {
-                messages.append(msg)
-                cacheMessages(messages, for: sid)
-            } else if !isActive {
-                lastHistoryFetchAt.removeValue(forKey: sid)
-            }
             sessionId = sessionId ?? sid
             ensureStream(for: sid)
+            pendingTextBySession.removeValue(forKey: sid)
+            pendingThinkingBySession.removeValue(forKey: sid)
             sessionStreams[sid]?.currentText = ""
             sessionStreams[sid]?.currentThinking = ""
             sessionStreams[sid]?.activeToolCalls = []
             sessionStreams[sid]?.activeAgentActivities = []
             sessionStreams[sid]?.pendingToolInputs = []
-            recomputeDerivations()
+            if isActive && !alreadyExists {
+                messages.append(msg)
+                cacheMessages(messages, for: sid)
+            } else if isActive {
+                recomputeDerivations()
+            } else {
+                lastHistoryFetchAt.removeValue(forKey: sid)
+            }
 
         case .history(let msgs, let incomingSessionId):
             // Conversation history is REST-owned unconditionally, so the backend
@@ -316,8 +374,6 @@ final class ConversationStore {
 
         guard sessionId == self.sessionId else { return }
 
-        messages = msgs
-
         // Reconcile any stale in-progress stream slot for a non-streaming session.
         // History only carries finalized turns, so when it arrives for a session
         // that is NOT actively streaming, any leftover stream slot has already been
@@ -325,6 +381,8 @@ final class ConversationStore {
         // backgrounded zombie). Rebuild a CLEAN slot containing only pending tool
         // inputs (an unanswered question/plan), or drop the stale slot entirely.
         // During streaming, live WS state takes precedence, so we leave it untouched.
+        // Runs before the `messages` assignment so its `didSet` derivation pass
+        // sees the reconciled stream state (one recompute, not two).
         let existingStream = sessionStreams[sessionId]
         if existingStream?.isStreaming != true {
             let derived = derivePendingToolInputsFromHistory(msgs)
@@ -335,8 +393,9 @@ final class ConversationStore {
             } else if existingStream != nil {
                 sessionStreams.removeValue(forKey: sessionId)
             }
-            recomputeDerivations()
         }
+
+        messages = msgs
     }
 
     func lastServerMessageId(for sessionId: String?) -> String? {
@@ -451,7 +510,9 @@ final class ConversationStore {
         } else {
             stream.activeAgentActivities.append(activity)
         }
-        recomputeDerivations()
+        if sid == sessionId {
+            recomputeDerivations()
+        }
     }
 
     private func hasTerminalAssistantMessage(for sid: String) -> Bool {
@@ -565,6 +626,20 @@ final class ConversationStore {
                 )
             }
     }
+}
+
+/// Tool-call ids of AskUserQuestion calls whose question was dismissed —
+/// an assistant message immediately followed by a user "Question dismissed.".
+func deriveDismissedToolCallIds(from messages: [ChatMessage]) -> Set<String> {
+    var ids = Set<String>()
+    for (message, next) in zip(messages, messages.dropFirst()) {
+        guard message.role == .assistant, next.role == .user,
+              next.content == "Question dismissed." else { continue }
+        for tool in message.toolCalls ?? [] where tool.name == "AskUserQuestion" {
+            ids.insert(tool.id)
+        }
+    }
+    return ids
 }
 
 // MARK: - Pending Tool Input

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -240,6 +240,7 @@ final class ConversationStore {
             onTurnCompleted?(sid)
 
         case .error(let message, let errorSessionId):
+            flushStreamingDeltas()
             if let errorSessionId, let currentSessionId = sessionId, errorSessionId != currentSessionId {
                 return
             }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -288,20 +288,19 @@ final class HubStatusMonitor {
     }
 
     fileprivate func didReceiveActivity(_ event: WsOutgoing, for workspaceId: String) {
-        switch event {
-        case .history(let messages, _):
-            guard let latest = messages.compactMap({ parseTimestamp($0.timestamp) }).max() else {
+        switch hubActivityMarking(for: event) {
+        case .ignore:
+            break
+        case .markNow:
+            markActivity(for: workspaceId)
+        case .markLatestMessageTimestamp:
+            guard case .history(let messages, _) = event,
+                  let latest = messages.compactMap({ parseTimestamp($0.timestamp) }).max() else {
                 return
             }
             markActivity(for: workspaceId, at: latest)
-        case .status(_, _, let streaming, _, _):
-            if streaming == true {
-                markActivity(for: workspaceId)
-            }
-        case .branchInfo, .diffStats, .prStatus, .scriptStatus, .planModeChanged,
-             .streamSnapshot(_, _, _, _, _, _, _):
-            break
-        default:
+        case .markIfStreaming:
+            guard case .status(_, _, let streaming, _, _) = event, streaming == true else { return }
             markActivity(for: workspaceId)
         }
     }

--- a/ios/HiveMobile/Stores/SubAgentStatus.swift
+++ b/ios/HiveMobile/Stores/SubAgentStatus.swift
@@ -96,7 +96,7 @@ private func toolOutputPayload(_ output: String) -> [String: Any]? {
 }
 
 private func jsonObject(from string: String) -> [String: Any]? {
-    jsonValue(from: string) as? [String: Any]
+    parsedToolInputObject(string)
 }
 
 private func jsonValue(from string: String) -> Any? {

--- a/ios/HiveMobile/Stores/TaskDerivation.swift
+++ b/ios/HiveMobile/Stores/TaskDerivation.swift
@@ -36,17 +36,12 @@ func parseTaskId(from output: String) -> String? {
 }
 
 private func parseInput(_ tool: ToolCall) -> [String: Any] {
-    guard let data = tool.input.data(using: .utf8),
-          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-        return [:]
-    }
-    return obj
+    parsedToolInputObject(tool.input) ?? [:]
 }
 
 private func parseTodoList(_ tool: ToolCall) -> [(text: String, completed: Bool)] {
     let source = tool.output ?? tool.input
-    guard let data = source.data(using: .utf8),
-          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+    guard let obj = parsedToolInputObject(source),
           let items = obj["items"] as? [[String: Any]] else {
         return []
     }

--- a/ios/HiveMobile/Stores/ToolInputParsing.swift
+++ b/ios/HiveMobile/Stores/ToolInputParsing.swift
@@ -3,6 +3,7 @@ import Foundation
 private let parsedToolInputCache: NSCache<NSString, NSDictionary> = {
     let cache = NSCache<NSString, NSDictionary>()
     cache.countLimit = 512
+    cache.totalCostLimit = 2_000_000
     return cache
 }()
 
@@ -15,6 +16,6 @@ func parsedToolInputObject(_ input: String) -> [String: Any]? {
           let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         return nil
     }
-    parsedToolInputCache.setObject(obj as NSDictionary, forKey: key)
+    parsedToolInputCache.setObject(obj as NSDictionary, forKey: key, cost: input.utf16.count)
     return obj
 }

--- a/ios/HiveMobile/Stores/ToolInputParsing.swift
+++ b/ios/HiveMobile/Stores/ToolInputParsing.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+private let parsedToolInputCache: NSCache<NSString, NSDictionary> = {
+    let cache = NSCache<NSString, NSDictionary>()
+    cache.countLimit = 512
+    return cache
+}()
+
+func parsedToolInputObject(_ input: String) -> [String: Any]? {
+    let key = input as NSString
+    if let cached = parsedToolInputCache.object(forKey: key) {
+        return cached as? [String: Any]
+    }
+    guard let data = input.data(using: .utf8),
+          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        return nil
+    }
+    parsedToolInputCache.setObject(obj as NSDictionary, forKey: key)
+    return obj
+}

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -112,7 +112,7 @@ struct ChatActivityRowLabel: View {
                 // out any animation inherited from ancestors — so streaming relayout
                 // (label/icons growing to its left) repositions the dot instantly
                 // instead of animating it. Matches the web's `bg-primary animate-pulse`.
-                TimelineView(.animation) { context in
+                TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
                     let t = context.date.timeIntervalSinceReferenceDate
                     let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
                     Circle()

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -13,12 +13,6 @@ struct ChatView: View {
     @State private var fastModeEnabled = false
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
-    @State private var renderedStreamingText = ""
-    @State private var renderedStreamingThinking = ""
-    @State private var pendingStreamingText = ""
-    @State private var pendingStreamingThinking = ""
-    @State private var lastStreamingRenderAt = Date.distantPast
-    @State private var streamingRenderTask: Task<Void, Never>?
     @State private var isNearScrollBottom = true
 
     @Environment(ModelCatalog.self) private var modelCatalog
@@ -90,21 +84,6 @@ struct ChatView: View {
         Set(store.pendingToolInputs.map(\.toolUseId))
     }
 
-    private var dismissedToolCallIds: Set<String> {
-        var ids = Set<String>()
-        let msgs = store.messages
-        for i in 0..<(msgs.count - 1) {
-            let msg = msgs[i]
-            let next = msgs[i + 1]
-            if msg.role == .assistant, next.role == .user, next.content == "Question dismissed." {
-                for tc in msg.toolCalls ?? [] where tc.name == "AskUserQuestion" {
-                    ids.insert(tc.id)
-                }
-            }
-        }
-        return ids
-    }
-
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
@@ -130,7 +109,7 @@ struct ChatView: View {
                                 MessageBubble(
                                     message: message,
                                     pendingToolUseIds: pendingToolUseIds,
-                                    dismissedToolCallIds: dismissedToolCallIds
+                                    dismissedToolCallIds: store.dismissedToolCallIds
                                 )
                                 .id(message.id)
                                 .chatTranscriptRow()
@@ -141,7 +120,7 @@ struct ChatView: View {
                             MessageBubble(
                                 message: message,
                                 pendingToolUseIds: pendingToolUseIds,
-                                dismissedToolCallIds: dismissedToolCallIds
+                                dismissedToolCallIds: store.dismissedToolCallIds
                             )
                             .id(message.id)
                             .chatTranscriptRow()
@@ -177,10 +156,10 @@ struct ChatView: View {
                     .onChange(of: store.messages.count) {
                         scrollToBottomIfNeeded(proxy)
                     }
-                    .onChange(of: renderedStreamingText) {
+                    .onChange(of: store.currentText) {
                         scrollToBottomIfNeeded(proxy)
                     }
-                    .onChange(of: renderedStreamingThinking) {
+                    .onChange(of: store.currentThinking) {
                         scrollToBottomIfNeeded(proxy)
                     }
                     .onChange(of: store.activeToolCalls.count) {
@@ -266,15 +245,6 @@ struct ChatView: View {
                 planModeEnabled = active
             }
         }
-        .onChange(of: store.currentText) { _, text in
-            scheduleStreamingRender(text: text)
-        }
-        .onChange(of: store.currentThinking) { _, thinking in
-            scheduleStreamingRender(thinking: thinking)
-        }
-        .onChange(of: store.isStreaming) { _, _ in
-            syncStreamingRenderFromStore()
-        }
         .onChange(of: lockedProvider) { _, newProvider in
             guard let newProvider, !selectedModelId.isEmpty else { return }
             let currentProvider = selectedModelId.split(separator: ":").first.map(String.init) ?? ""
@@ -285,7 +255,6 @@ struct ChatView: View {
             }
         }
         .onDisappear {
-            streamingRenderTask?.cancel()
             saveCurrentDraft()
             store.onTurnCompleted = nil
             if projectStore.statusMonitor.viewingWorkspaceId == workspace.id,
@@ -297,12 +266,11 @@ struct ChatView: View {
 
     // MARK: - Streaming Activity
 
-    private static let streamingRenderInterval: TimeInterval = 0.05
     private static let scrollBottomTolerance: CGFloat = 96
 
     private var streamingMessage: ChatMessage? {
         guard store.isStreaming else { return nil }
-        let hasContent = !renderedStreamingText.isEmpty || !renderedStreamingThinking.isEmpty
+        let hasContent = !store.currentText.isEmpty || !store.currentThinking.isEmpty
             || !store.activeToolCalls.isEmpty || !store.activeAgentActivities.isEmpty
         guard hasContent else { return nil }
 
@@ -310,75 +278,15 @@ struct ChatView: View {
             id: "streaming",
             sessionId: store.sessionId ?? "",
             role: .assistant,
-            content: renderedStreamingText,
+            content: store.currentText,
             images: nil,
             toolCalls: store.activeToolCalls.isEmpty ? nil : store.activeToolCalls,
             agentActivities: store.activeAgentActivities.isEmpty ? nil : store.activeAgentActivities,
-            thinkingContent: renderedStreamingThinking.isEmpty ? nil : renderedStreamingThinking,
+            thinkingContent: store.currentThinking.isEmpty ? nil : store.currentThinking,
             timestamp: ConversationStore.timestamp(),
             cancelled: nil,
             durationMs: nil
         )
-    }
-
-    private func scheduleStreamingRender(text: String? = nil, thinking: String? = nil) {
-        if let text {
-            pendingStreamingText = text
-        }
-        if let thinking {
-            pendingStreamingThinking = thinking
-        }
-
-        let elapsed = Date().timeIntervalSince(lastStreamingRenderAt)
-        if elapsed >= Self.streamingRenderInterval {
-            streamingRenderTask?.cancel()
-            streamingRenderTask = nil
-            applyPendingStreamingRender()
-            return
-        }
-
-        guard streamingRenderTask == nil else { return }
-
-        let delay = Self.streamingRenderInterval - elapsed
-        let milliseconds = Int64(max(1, (delay * 1000).rounded(.up)))
-        streamingRenderTask = Task {
-            do {
-                try await Task.sleep(for: .milliseconds(milliseconds))
-            } catch {
-                return
-            }
-
-            await MainActor.run {
-                applyPendingStreamingRender()
-                streamingRenderTask = nil
-            }
-        }
-    }
-
-    private func applyPendingStreamingRender() {
-        lastStreamingRenderAt = Date()
-        renderedStreamingText = pendingStreamingText
-        renderedStreamingThinking = pendingStreamingThinking
-    }
-
-    private func resetStreamingRender() {
-        streamingRenderTask?.cancel()
-        streamingRenderTask = nil
-        pendingStreamingText = ""
-        pendingStreamingThinking = ""
-        renderedStreamingText = ""
-        renderedStreamingThinking = ""
-        lastStreamingRenderAt = .distantPast
-    }
-
-    private func syncStreamingRenderFromStore() {
-        if store.isStreaming {
-            pendingStreamingText = store.currentText
-            pendingStreamingThinking = store.currentThinking
-            applyPendingStreamingRender()
-        } else {
-            resetStreamingRender()
-        }
     }
 
     private var streamingActivityRow: some View {
@@ -442,7 +350,6 @@ struct ChatView: View {
             store.prepareSessionSwitch(selectedSessionId)
             _ = await store.send?(.switchSession(sessionId: selectedSessionId))
         }
-        syncStreamingRenderFromStore()
         restoreDraft(for: selectedSessionId)
 
         if selectedModelId.isEmpty {
@@ -450,7 +357,6 @@ struct ChatView: View {
         }
 
         await loadMessages()
-        syncStreamingRenderFromStore()
     }
 
     private func loadMessages() async {

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -238,13 +238,27 @@ struct MessageBubble: View {
         return result
     }
 
-    private func formatTimestamp(_ ts: String) -> String {
+    private static let isoWithFractional: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        guard let date = formatter.date(from: ts) else { return "" }
-        let display = DateFormatter()
-        display.timeStyle = .short
-        return display.string(from: date)
+        return formatter
+    }()
+
+    private static let iso: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private func formatTimestamp(_ ts: String) -> String {
+        guard let date = Self.isoWithFractional.date(from: ts) ?? Self.iso.date(from: ts) else { return "" }
+        return Self.timeFormatter.string(from: date)
     }
 
 }
@@ -306,19 +320,8 @@ private func computeEditDiffStats(oldString: String, newString: String) -> (adde
     return (added, removed)
 }
 
-private let toolInputParseCache = NSCache<NSString, NSDictionary>()
-
-private func parsedToolInput(_ tool: ToolCall) -> [String: Any]? {
-    let key = tool.id as NSString
-    if let cached = toolInputParseCache.object(forKey: key) { return cached as? [String: Any] }
-    guard let data = tool.input.data(using: .utf8),
-          let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { return nil }
-    toolInputParseCache.setObject(obj as NSDictionary, forKey: key)
-    return obj
-}
-
 private func computeToolStats(_ tool: ToolCall) -> ChatActivityStats? {
-    guard let input = parsedToolInput(tool) else {
+    guard let input = parsedToolInputObject(tool.input) else {
         return nil
     }
 
@@ -367,7 +370,7 @@ private func getToolDisplay(
     isDismissed: Bool = false,
     showExecutingState: Bool = false
 ) -> ToolDisplay {
-    guard let input = parsedToolInput(tool) else {
+    guard let input = parsedToolInputObject(tool.input) else {
         return ToolDisplay(icon: toolIcon(for: tool.name), label: tool.name, detail: String(tool.input.prefix(40)))
     }
 
@@ -740,7 +743,7 @@ private struct DiffContentView: View {
     let tool: ToolCall
 
     private var parsed: (filePath: String?, lines: [DiffLine]) {
-        guard let input = parsedToolInput(tool) else {
+        guard let input = parsedToolInputObject(tool.input) else {
             return (nil, [])
         }
         let filePath = resolveFilePath(input)
@@ -788,7 +791,7 @@ private struct AskUserQuestionContent: View {
     let tool: ToolCall
 
     private var questions: [(text: String, options: [String])] {
-        guard let input = parsedToolInput(tool),
+        guard let input = parsedToolInputObject(tool.input),
               let arr = input["questions"] as? [[String: Any]] else {
             return []
         }

--- a/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
+++ b/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
@@ -6,10 +6,8 @@ struct AgentActivityIndicator: View {
     var dotSize: CGFloat = 3
     var spacing: CGFloat = 1.5
 
-    @State private var phase: Double = 0
-
     var body: some View {
-        TimelineView(.animation) { timeline in
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
             let t = timeline.date.timeIntervalSinceReferenceDate
             Canvas { context, _ in
                 for row in 0..<3 {
@@ -38,7 +36,6 @@ struct AgentActivityIndicator: View {
                 width: dotSize * 3 + spacing * 2,
                 height: dotSize * 3 + spacing * 2
             )
-            .shadow(color: WhisperColor.activityDot.opacity(0.25), radius: dotSize * 2)
         }
     }
 }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -19,6 +19,9 @@ struct HubView: View {
     )
 
     var body: some View {
+        let sections = baseSections
+        let prIds = visiblePrWorkspaceIds(in: sections)
+
         ZStack {
             WhisperColor.appBackground
                 .ignoresSafeArea()
@@ -35,7 +38,7 @@ struct HubView: View {
                         )
                         .padding(.top, 40)
                     } else {
-                        denseHubContent
+                        denseHubContent(sections: sections)
                     }
                 }
                 .padding(.horizontal, HiveSpacing.lg)
@@ -64,13 +67,13 @@ struct HubView: View {
         .onAppear {
             store.statusMonitor.viewingWorkspaceId = nil
             store.statusMonitor.viewingSessionId = nil
-            store.statusMonitor.syncVisiblePrWorkspaces(visiblePrWorkspaceIds)
+            store.statusMonitor.syncVisiblePrWorkspaces(prIds)
         }
         .onDisappear {
             store.statusMonitor.syncVisiblePrWorkspaces([])
         }
-        .task(id: visiblePrWorkspaceIdsKey) {
-            store.statusMonitor.syncVisiblePrWorkspaces(visiblePrWorkspaceIds)
+        .task(id: prIds) {
+            store.statusMonitor.syncVisiblePrWorkspaces(prIds)
         }
         .overlay {
             if let errorMessage = store.errorMessage {
@@ -147,9 +150,9 @@ struct HubView: View {
 
     // MARK: - Dense Hub
 
-    private var denseHubContent: some View {
+    private func denseHubContent(sections: [HubSection]) -> some View {
         LazyVStack(alignment: .leading, spacing: HiveSpacing.md) {
-            ForEach(baseSections) { section in
+            ForEach(sections) { section in
                 sectionView(section)
             }
         }
@@ -162,18 +165,14 @@ struct HubView: View {
         )
     }
 
-    private var visiblePrWorkspaceIds: [String] {
+    private func visiblePrWorkspaceIds(in sections: [HubSection]) -> [String] {
         var ids: [String] = []
-        for section in baseSections where isSectionExpanded(section) {
+        for section in sections where isSectionExpanded(section) {
             for node in section.projects where isProjectExpanded(node.project) {
                 ids.append(contentsOf: node.project.workspaces.map(\.id))
             }
         }
         return ids
-    }
-
-    private var visiblePrWorkspaceIdsKey: String {
-        visiblePrWorkspaceIds.sorted().joined(separator: ",")
     }
 
     private func sectionView(_ section: HubSection) -> some View {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
                 "Stores/HubOrganization.swift",
                 "Stores/SubAgentStatus.swift",
                 "Stores/TaskDerivation.swift",
-                "Stores/TokenFormatting.swift"
+                "Stores/TokenFormatting.swift",
+                "Stores/ToolInputParsing.swift"
             ]
         ),
         .testTarget(

--- a/ios/Tests/ChatDraftStoreTests/ActivityToolCallCacheTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ActivityToolCallCacheTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ActivityToolCallCacheTests {
+    @Test
+    func repeatedAccessesReturnStableToolCalls() {
+        let activity = AgentActivity.fileChange(.init(
+            id: "file-stability-1",
+            status: "completed",
+            files: [.init(path: "a.swift", diff: "+new", kind: "update", status: nil)]
+        ))
+
+        let first = activity.toolCalls
+        let second = activity.toolCalls
+
+        #expect(first == second)
+        #expect(first.count == 1)
+        #expect(first.first?.id == "file-stability-1:0:a.swift")
+    }
+
+    @Test
+    func sameIdActivityWithChangedDiffInvalidatesCache() throws {
+        let initial = AgentActivity.fileChange(.init(
+            id: "file-invalidation-1",
+            status: "inProgress",
+            files: [.init(path: "a.swift", diff: "+one", kind: "update", status: nil)]
+        ))
+        #expect(initial.toolCalls.first?.output == "+one")
+
+        let updated = AgentActivity.fileChange(.init(
+            id: "file-invalidation-1",
+            status: "completed",
+            files: [.init(path: "a.swift", diff: "+one\n+two", kind: "update", status: nil)]
+        ))
+        let tool = try #require(updated.toolCalls.first)
+        let input = try #require(parsedToolInputObject(tool.input))
+
+        #expect(input["diff"] as? String == "+one\n+two")
+        #expect(tool.output == "+one\n+two")
+    }
+
+    @Test
+    func kindsWithoutToolCallsReturnEmpty() {
+        let plan = AgentActivity.planUpdate(.init(
+            id: "plan-1",
+            steps: [.init(text: "Inspect", status: "completed")]
+        ))
+        #expect(plan.toolCalls.isEmpty)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreAgentActivityTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreAgentActivityTests.swift
@@ -88,7 +88,7 @@ struct ConversationStoreAgentActivityTests {
 
     @Test @MainActor
     func ignoresLateLiveFragmentsAfterDone() {
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.userMessage(message: ChatMessage(
             id: "user-1",
             sessionId: "session-1",
@@ -146,6 +146,7 @@ struct ConversationStoreAgentActivityTests {
             input: "{}"
         ))
         store.handle(.planModeChanged(sessionId: "session-1", active: true))
+        store.flushStreamingDeltas()
 
         #expect(store.isStreaming == false)
         #expect(store.currentText.isEmpty)

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
@@ -1,0 +1,104 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ConversationStoreDerivationTests {
+    private func message(
+        id: String,
+        role: MessageRole,
+        content: String,
+        toolCalls: [ToolCall]? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            sessionId: "session-1",
+            role: role,
+            content: content,
+            images: nil,
+            toolCalls: toolCalls,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    @Test @MainActor
+    func derivationsSkipNonActiveSessions() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy, sessionId: "session-1", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+        store.handle(.status(
+            status: .busy, sessionId: "session-2", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+        let base = store.derivationRunCount
+
+        store.handle(.toolUse(sessionId: "session-2", id: "tool-1", name: "Read", input: "{}", parentToolUseId: nil))
+        store.handle(.toolResult(sessionId: "session-2", toolUseId: "tool-1", output: "ok"))
+        store.handle(.agentActivity(sessionId: "session-2", activity: .commandExecution(.init(
+            id: "cmd-1", command: "ls", cwd: nil, status: "completed",
+            output: nil, exitCode: 0, durationMs: nil
+        ))))
+        store.handle(.streamSnapshot(
+            sessionId: "session-2", text: "background", thinking: "",
+            toolCalls: [], agentActivities: [], agentPlanMode: false, streamingStartedAt: nil
+        ))
+        #expect(store.derivationRunCount == base)
+
+        store.handle(.toolUse(sessionId: "session-1", id: "tool-2", name: "Read", input: "{}", parentToolUseId: nil))
+        #expect(store.derivationRunCount == base + 1)
+    }
+
+    @Test @MainActor
+    func historyApplicationRecomputesExactlyOnce() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("session-1")
+        let base = store.derivationRunCount
+
+        store.applyFetchedHistory([
+            message(id: "message-1", role: .user, content: "Hello")
+        ], for: "session-1")
+
+        #expect(store.derivationRunCount == base + 1)
+        #expect(store.messages.count == 1)
+    }
+
+    @Test
+    func deriveDismissedToolCallIdsHandlesEmptyHistory() {
+        #expect(deriveDismissedToolCallIds(from: []).isEmpty)
+    }
+
+    @Test @MainActor
+    func emptyHistoryWithStreamingStatusFromAnotherClientDoesNotTrap() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("session-1")
+
+        store.handle(.status(
+            status: .busy, sessionId: "session-1", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        ))
+
+        #expect(store.messages.isEmpty)
+        #expect(store.dismissedToolCallIds.isEmpty)
+    }
+
+    @Test @MainActor
+    func detectsDismissedAskUserQuestionToolCalls() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("session-1")
+        let history = [
+            message(id: "message-1", role: .assistant, content: "Which option?", toolCalls: [
+                ToolCall(id: "ask-1", name: "AskUserQuestion", input: "{}", output: nil, parentToolUseId: nil),
+                ToolCall(id: "read-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+            ]),
+            message(id: "message-2", role: .user, content: "Question dismissed.")
+        ]
+
+        #expect(deriveDismissedToolCallIds(from: history) == ["ask-1"])
+
+        store.applyFetchedHistory(history, for: "session-1")
+        #expect(store.dismissedToolCallIds == ["ask-1"])
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -5,7 +5,7 @@ import Testing
 struct ConversationStoreSessionTests {
     @Test @MainActor
     func prepareSessionSwitchClearsVisibleStateAndInvalidatesHistoryTokens() {
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.history(messages: [
             ChatMessage(
                 id: "message-1",
@@ -28,6 +28,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: "codex"
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "Streaming in the background"))
+        store.flushStreamingDeltas()
         store.handle(.status(
             status: .busy,
             sessionId: "session-2",
@@ -199,7 +200,7 @@ struct ConversationStoreSessionTests {
 
     @Test @MainActor
     func streamSnapshotReplacesAccumulatedStreamingState() {
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -209,6 +210,7 @@ struct ConversationStoreSessionTests {
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "Before "))
         store.handle(.thinking(sessionId: "session-1", text: "old thinking"))
+        store.flushStreamingDeltas()
 
         store.handle(.streamSnapshot(
             sessionId: "session-1",
@@ -329,7 +331,7 @@ struct ConversationStoreSessionTests {
 
     @Test @MainActor
     func streamSnapshotReplacesBackgroundAccumulationAfterSwitch() {
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy, sessionId: "session-A", streaming: true,
             streamingStartedAt: nil, lockedProvider: nil
@@ -340,6 +342,7 @@ struct ConversationStoreSessionTests {
         ))
         store.handle(.textDelta(sessionId: "session-B", text: "partial "))
         store.handle(.textDelta(sessionId: "session-B", text: "delta"))
+        store.flushStreamingDeltas()
         #expect(store.sessionStreams["session-B"]?.currentText == "partial delta")
 
         store.prepareSessionSwitch("session-B")
@@ -368,7 +371,7 @@ struct ConversationStoreSessionTests {
         // Models the non-destructive reconnect (issue #259): the hub no longer wipes
         // sessionStreams on (re)connect, so an in-progress stream must survive a fresh
         // bootstrap and be reconciled in place by the authoritative stream_snapshot.
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -377,6 +380,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: nil
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "In progress before reconnect"))
+        store.flushStreamingDeltas()
         store.handle(.toolUse(
             sessionId: "session-1",
             id: "tool-1",
@@ -426,7 +430,7 @@ struct ConversationStoreSessionTests {
         // status arrives as idle (not streaming) and history carries the finalized turn.
         // The stale in-progress stream slot must be dropped so it is not rendered as a
         // duplicate bubble alongside the persisted message (issue #259).
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -435,6 +439,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: nil
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "Half-finished answer"))
+        store.flushStreamingDeltas()
         #expect(store.sessionStreams["session-1"]?.currentText == "Half-finished answer")
 
         // The turn is no longer streaming (e.g. idle status from bootstrap).
@@ -484,7 +489,7 @@ struct ConversationStoreSessionTests {
         // The last finalized assistant turn ends on an unanswered AskUserQuestion. History
         // must rebuild a CLEAN slot carrying only those pending inputs (no stale streaming
         // text/tool calls), so the question prompt survives reconnect.
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -493,6 +498,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: nil
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "stale streaming text"))
+        store.flushStreamingDeltas()
         store.handle(.status(
             status: .idle,
             sessionId: "session-1",
@@ -531,7 +537,7 @@ struct ConversationStoreSessionTests {
     func historyLeavesActiveStreamingSessionUntouched() {
         // While a session is actively streaming, history (finalized turns) must not
         // disturb the live stream slot — live WS state wins.
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.handle(.status(
             status: .busy,
             sessionId: "session-1",
@@ -540,6 +546,7 @@ struct ConversationStoreSessionTests {
             lockedProvider: nil
         ))
         store.handle(.textDelta(sessionId: "session-1", text: "Live streaming content"))
+        store.flushStreamingDeltas()
 
         store.applyFetchedHistory([
             ChatMessage(
@@ -630,7 +637,7 @@ struct ConversationStoreSessionTests {
     func doneKeepsCacheInSyncForSwitchBack() {
         // A finalized assistant turn (done) must land in the cache so switching
         // away and back shows the finalized turn from cache.
-        let store = ConversationStore()
+        let store = ConversationStore(streamFlushInterval: nil)
         store.setFocusedSessionId("session-A")
         store.applyFetchedHistory([], for: "session-A")
         store.handle(.status(

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
@@ -112,6 +112,24 @@ struct ConversationStoreStreamingBufferTests {
         #expect(store.currentThinking == "canonical thinking")
     }
 
+    @Test @MainActor
+    func errorFlushesBufferedDeltasBeforeAppendingErrorMessage() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "partial tail"))
+        store.handle(.error(message: "boom", sessionId: "session-1"))
+
+        #expect(store.currentText == "partial tail")
+        #expect(store.messages.last?.content == "Error: boom")
+    }
+
     @MainActor
     private func waitUntil(
         _ condition: @MainActor () -> Bool,

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ConversationStoreStreamingBufferTests {
+    @Test @MainActor
+    func buffersDeltasUntilFlushAppliesThemInOrder() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "A"))
+        store.handle(.textDelta(sessionId: "session-1", text: "B"))
+        store.handle(.textDelta(sessionId: "session-1", text: "C"))
+        #expect(store.currentText == "")
+
+        store.flushStreamingDeltas()
+        #expect(store.currentText == "ABC")
+    }
+
+    @Test @MainActor
+    func interleavedTextAndThinkingDeltasLandInTheirOwnBuffers() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "Hello"))
+        store.handle(.thinking(sessionId: "session-1", text: "Consider"))
+        store.handle(.textDelta(sessionId: "session-1", text: " world"))
+        store.handle(.thinking(sessionId: "session-1", text: " options"))
+        #expect(store.currentText == "")
+        #expect(store.currentThinking == "")
+
+        store.flushStreamingDeltas()
+        #expect(store.currentText == "Hello world")
+        #expect(store.currentThinking == "Consider options")
+    }
+
+    @Test @MainActor
+    func doneIncludesBufferedTailWithoutManualFlush() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "Partial"))
+        store.handle(.textDelta(sessionId: "session-1", text: " tail"))
+        store.handle(.done(
+            sessionId: "session-1",
+            durationMs: 100,
+            inputTokens: nil,
+            outputTokens: nil,
+            contextUsedTokens: nil,
+            contextWindowTokens: nil,
+            pendingToolName: nil
+        ))
+
+        #expect(store.messages.last?.content == "Partial tail")
+        #expect(store.sessionStreams["session-1"] == nil)
+    }
+
+    @Test @MainActor
+    func deltasForUnknownSessionsAreDropped() {
+        let store = ConversationStore(streamFlushInterval: nil)
+
+        store.handle(.textDelta(sessionId: "ghost", text: "x"))
+        store.handle(.thinking(sessionId: "ghost", text: "y"))
+        store.flushStreamingDeltas()
+
+        #expect(store.sessionStreams["ghost"] == nil)
+    }
+
+    @Test @MainActor
+    func streamSnapshotDiscardsPendingBuffers() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "buffered tail"))
+        store.handle(.thinking(sessionId: "session-1", text: "buffered thinking"))
+        store.handle(.streamSnapshot(
+            sessionId: "session-1",
+            text: "canonical",
+            thinking: "canonical thinking",
+            toolCalls: [],
+            agentActivities: [],
+            agentPlanMode: false,
+            streamingStartedAt: nil
+        ))
+        store.flushStreamingDeltas()
+
+        #expect(store.currentText == "canonical")
+        #expect(store.currentThinking == "canonical thinking")
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
@@ -111,4 +111,74 @@ struct ConversationStoreStreamingBufferTests {
         #expect(store.currentText == "canonical")
         #expect(store.currentThinking == "canonical thinking")
     }
+
+    @MainActor
+    private func waitUntil(
+        _ condition: @MainActor () -> Bool,
+        timeout: Duration = .seconds(2)
+    ) async throws {
+        let deadline = ContinuousClock.now.advanced(by: timeout)
+        while !condition() && ContinuousClock.now < deadline {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+
+    @Test @MainActor
+    func scheduledFlushAppliesDeltasWithoutManualFlush() async throws {
+        let store = ConversationStore(streamFlushInterval: 0.01)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "auto"))
+        store.handle(.thinking(sessionId: "session-1", text: "thought"))
+        #expect(store.currentText == "")
+
+        try await waitUntil { store.currentText == "auto" }
+        #expect(store.currentText == "auto")
+        #expect(store.currentThinking == "thought")
+    }
+
+    @Test @MainActor
+    func scheduledFlushCoalescesBurstInOrder() async throws {
+        let store = ConversationStore(streamFlushInterval: 0.01)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "A"))
+        store.handle(.textDelta(sessionId: "session-1", text: "B"))
+        store.handle(.textDelta(sessionId: "session-1", text: "C"))
+
+        try await waitUntil { store.currentText == "ABC" }
+        #expect(store.currentText == "ABC")
+    }
+
+    @Test @MainActor
+    func manualFlushDoesNotBreakSubsequentScheduling() async throws {
+        let store = ConversationStore(streamFlushInterval: 0.01)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.handle(.textDelta(sessionId: "session-1", text: "first"))
+        store.flushStreamingDeltas()
+        #expect(store.currentText == "first")
+
+        store.handle(.textDelta(sessionId: "session-1", text: " second"))
+        try await waitUntil { store.currentText == "first second" }
+        #expect(store.currentText == "first second")
+    }
 }

--- a/ios/Tests/ChatDraftStoreTests/HubActivityMarkingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubActivityMarkingTests.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+struct HubActivityMarkingTests {
+    private var sampleMessage: ChatMessage {
+        ChatMessage(
+            id: "message-1",
+            sessionId: "session-1",
+            role: .user,
+            content: "Hello",
+            images: nil,
+            toolCalls: nil,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    @Test
+    func perTokenAndSidebandEventsAreIgnored() {
+        #expect(hubActivityMarking(for: .textDelta(sessionId: "s", text: "x")) == .ignore)
+        #expect(hubActivityMarking(for: .thinking(sessionId: "s", text: "x")) == .ignore)
+        #expect(hubActivityMarking(for: .branchInfo(info: BranchInfo(
+            name: "main", lastSyncedAt: "2026-01-01T00:00:00.000Z"
+        ))) == .ignore)
+        #expect(hubActivityMarking(for: .diffStats(stats: DiffStatResponse(
+            committed: [], uncommitted: []
+        ))) == .ignore)
+        #expect(hubActivityMarking(for: .prStatus(status: PrStatusResponse(pr: nil, error: nil))) == .ignore)
+        #expect(hubActivityMarking(for: .scriptStatus(scriptType: "setup", state: "running", exitCode: nil)) == .ignore)
+        #expect(hubActivityMarking(for: .planModeChanged(sessionId: "s", active: true)) == .ignore)
+        #expect(hubActivityMarking(for: .streamSnapshot(
+            sessionId: "s", text: "", thinking: "", toolCalls: [],
+            agentActivities: [], agentPlanMode: false, streamingStartedAt: nil
+        )) == .ignore)
+    }
+
+    @Test
+    func historyMarksLatestMessageTimestamp() {
+        #expect(hubActivityMarking(for: .history(messages: [sampleMessage], sessionId: "s"))
+            == .markLatestMessageTimestamp)
+    }
+
+    @Test
+    func statusMarksOnlyIfStreaming() {
+        #expect(hubActivityMarking(for: .status(
+            status: .busy, sessionId: "s", streaming: true,
+            streamingStartedAt: nil, lockedProvider: nil
+        )) == .markIfStreaming)
+        #expect(hubActivityMarking(for: .status(
+            status: .idle, sessionId: "s", streaming: false,
+            streamingStartedAt: nil, lockedProvider: nil
+        )) == .markIfStreaming)
+    }
+
+    @Test
+    func remainingEventsMarkNow() {
+        #expect(hubActivityMarking(for: .toolUse(
+            sessionId: "s", id: "t", name: "Read", input: "{}", parentToolUseId: nil
+        )) == .markNow)
+        #expect(hubActivityMarking(for: .toolResult(sessionId: "s", toolUseId: "t", output: "ok")) == .markNow)
+        #expect(hubActivityMarking(for: .agentActivity(
+            sessionId: "s",
+            activity: .planUpdate(.init(id: "plan-1", steps: []))
+        )) == .markNow)
+        #expect(hubActivityMarking(for: .toolInputRequired(
+            sessionId: "s", requestId: "r", toolName: "AskUserQuestion", toolUseId: "t", input: "{}"
+        )) == .markNow)
+        #expect(hubActivityMarking(for: .toolInputResolved(sessionId: "s")) == .markNow)
+        #expect(hubActivityMarking(for: .done(
+            sessionId: "s", durationMs: nil, inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil, pendingToolName: nil
+        )) == .markNow)
+        #expect(hubActivityMarking(for: .error(message: "boom", sessionId: nil)) == .markNow)
+        #expect(hubActivityMarking(for: .cancelled(
+            sessionId: "s", errorDetail: nil, userInitiated: nil, durationMs: nil
+        )) == .markNow)
+        #expect(hubActivityMarking(for: .userMessage(message: sampleMessage)) == .markNow)
+        #expect(hubActivityMarking(for: .unknown(type: "future_event")) == .markNow)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ModelEquatableTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ModelEquatableTests.swift
@@ -1,0 +1,46 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ModelEquatableTests {
+    private func message(
+        content: String = "Hello",
+        toolCalls: [ToolCall]? = nil
+    ) -> ChatMessage {
+        ChatMessage(
+            id: "message-1",
+            sessionId: "session-1",
+            role: .assistant,
+            content: content,
+            images: nil,
+            toolCalls: toolCalls,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    @Test
+    func toolCallEquality() {
+        let tool = ToolCall(id: "tool-1", name: "Read", input: "{}", output: nil, parentToolUseId: nil)
+        let same = ToolCall(id: "tool-1", name: "Read", input: "{}", output: nil, parentToolUseId: nil)
+        let withOutput = ToolCall(id: "tool-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+
+        #expect(tool == same)
+        #expect(tool != withOutput)
+    }
+
+    @Test
+    func chatMessageEquality() {
+        #expect(message() == message())
+        #expect(message() != message(content: "Changed"))
+        #expect(message() != message(toolCalls: [
+            ToolCall(id: "tool-1", name: "Read", input: "{}", output: nil, parentToolUseId: nil)
+        ]))
+        #expect(message(toolCalls: [
+            ToolCall(id: "tool-1", name: "Read", input: "{}", output: nil, parentToolUseId: nil)
+        ]) != message(toolCalls: [
+            ToolCall(id: "tool-1", name: "Read", input: "{}", output: "ok", parentToolUseId: nil)
+        ]))
+    }
+}


### PR DESCRIPTION
Closes #283

## Summary

Streaming a long turn on iOS previously mutated observable state and re-ran expensive derivations on every WS token, re-parsed tool-input JSON on every render pass, and drove uncapped animation timelines. This PR moves token coalescing into the store, makes hot models Equatable so SwiftUI can skip unchanged bubbles, caches derivations and JSON parses, and caps hub/indicator work — with no visual or UX changes beyond the cadence caps.

- **Store-side 50ms token coalescing with injectable flush; view throttle deleted** — `ConversationStore` buffers `text_delta`/`thinking` fragments in `@ObservationIgnored` per-session buffers and applies them on a 50ms cadence (`init(streamFlushInterval:)`, `nil` = manual flush for tests). Buffers flush before `done`/`cancelled`/`status`/`tool_input_required` and are discarded on `stream_snapshot` (authoritative) and `user_message`. ChatView's render-throttle state machine is deleted; the view reads `store.currentText`/`store.currentThinking` directly.
- **`ChatMessage` and `ToolCall` are `Equatable`** — synthesized `==` (all stored fields are value types), letting SwiftUI diff message bubbles cheaply.
- **Derivation gating, single post-history recompute, and shared caches** — task/goal/background-agent derivations now run only for the active session; applying fetched history recomputes exactly once (stream-slot reconciliation moved before the `messages` assignment). Tool-input JSON parsing goes through one shared content-keyed `NSCache` (`ToolInputParsing.swift`) used by `TaskDerivation`, `SubAgentStatus`, and `MessageBubble`; the `AgentActivity` → `[ToolCall]` conversion is cached by activity value with early-return for kinds that never produce tool calls.
- **Store-derived dismissed AskUserQuestion ids with empty-history crash fix** — `deriveDismissedToolCallIds(from:)` uses `zip(messages, messages.dropFirst())` (inherently empty-safe), replacing ChatView's `0..<(msgs.count - 1)` loop that trapped on empty history when a turn started from another client before history loaded.
- **Hub and UI hot paths** — new pure `hubActivityMarking(for:)` helper classifies WS events for last-activity marking and ignores per-token deltas; `HubView` computes sections and visible PR-workspace ids once per body pass and uses the `[String]` directly as the `.task` id (sort+join key deleted); `MessageBubble` timestamp formatters are static; `AgentActivityIndicator` and the chat pulse `TimelineView`s are capped at 30fps and the indicator's per-frame shadow is removed.
- **Tests** — 5 new suites (streaming buffer, model equatability, derivation gating/dismissed ids, activity tool-call cache, hub activity marking); existing delta-sending store tests switched to manual flushing so they never rely on the async auto-flush.

## Behavior notes

- **Deliberate, spec-mandated change:** hub `lastActivityAt` no longer advances on `text_delta`/`thinking` events, so Hub sort order updates at tool-use/turn boundaries during pure-text streams instead of on every token. Sorting-only impact and self-correcting (the next tool use, status, or turn completion marks activity).
- **Fixed latent bug:** the old MessageBubble parse cache was keyed by tool id only, so activity-synthesized tool calls whose input grows across upserts (stable id, growing diff) could render stale input. The shared cache is content-keyed, so updated input is always re-parsed.

## Testing

- `cd ios && swift test` → **113 tests / 18 suites green** (baseline on main: 94/13; 19 new tests across 5 suites).
- `xcodebuild build` for the iOS Simulator → **BUILD SUCCEEDED** (covers the view files SwiftPM excludes from the test target).
- Both checks were also re-run independently by two reviewers (conformance + adversarial), with zero blockers/majors.