### PR TITLE
Ask for confirmation before deleting a conversation (#292)

### DIFF
--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -181,6 +181,13 @@ struct SessionMetadata: Codable, Hashable, Identifiable {
 
     var id: String { sessionId }
 
+    var displayTitle: String {
+        guard let title = title?.trimmingCharacters(in: .whitespacesAndNewlines), !title.isEmpty else {
+            return "Untitled Conversation"
+        }
+        return title
+    }
+
     init(
         sessionId: String,
         providerSessionId: String?,

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -485,6 +485,54 @@ final class ConversationStore {
         }
     }
 
+    /// Delete sessions via the injected `delete` call (REST in the app, a stub in
+    /// tests) and reconcile store state. Returns the remaining session list and an
+    /// error message naming the conversation when a delete fails.
+    func deleteSessions(
+        _ targets: [SessionMetadata],
+        from sessions: [SessionMetadata],
+        focusedSessionId: String?,
+        delete: (String) async throws -> Void
+    ) async -> (sessions: [SessionMetadata], errorMessage: String?) {
+        var deletedSessionIds = Set<String>()
+        var errorMessage: String?
+        for session in targets {
+            do {
+                try await delete(session.sessionId)
+                deletedSessionIds.insert(session.sessionId)
+                errorMessage = nil
+            } catch is CancellationError {
+                // View disappeared.
+            } catch {
+                errorMessage = "Failed to delete \"\(session.displayTitle)\": \(error.localizedDescription)"
+            }
+        }
+
+        guard !deletedSessionIds.isEmpty else {
+            return (sessions, errorMessage)
+        }
+
+        var remaining = sessions
+        remaining.removeAll { deletedSessionIds.contains($0.sessionId) }
+
+        if let focusedSessionId, deletedSessionIds.contains(focusedSessionId) {
+            let fallbackSessionId = remaining.first?.sessionId
+            if sessionId == nil {
+                setFocusedSessionId(focusedSessionId)
+            }
+            removeSessionState(focusedSessionId, fallbackSessionId: fallbackSessionId)
+            if let fallbackSessionId {
+                _ = await send?(.switchSession(sessionId: fallbackSessionId))
+            }
+        }
+
+        for deletedSessionId in deletedSessionIds where deletedSessionId != focusedSessionId {
+            removeSessionState(deletedSessionId, fallbackSessionId: nil)
+        }
+
+        return (remaining, errorMessage)
+    }
+
     // MARK: - Private
 
     /// Ensure a stream slot exists for the given session, defaulting to streaming state.

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -485,38 +485,25 @@ final class ConversationStore {
         }
     }
 
-    /// Delete sessions via the injected `delete` call (REST in the app, a stub in
-    /// tests) and reconcile store state. Returns the remaining session list and an
-    /// error message naming the conversation when a delete fails.
-    func deleteSessions(
-        _ targets: [SessionMetadata],
+    /// Delete one session via the injected `delete` call (REST in the app, a
+    /// stub in tests) and reconcile store state. Returns whether the delete
+    /// succeeded and an error message naming the conversation when it fails.
+    func deleteSession(
+        _ target: SessionMetadata,
         from sessions: [SessionMetadata],
         focusedSessionId: String?,
         delete: (String) async throws -> Void
-    ) async -> (sessions: [SessionMetadata], errorMessage: String?) {
-        var deletedSessionIds = Set<String>()
-        var errorMessage: String?
-        for session in targets {
-            do {
-                try await delete(session.sessionId)
-                deletedSessionIds.insert(session.sessionId)
-                errorMessage = nil
-            } catch is CancellationError {
-                // View disappeared.
-            } catch {
-                errorMessage = "Failed to delete \"\(session.displayTitle)\": \(error.localizedDescription)"
-            }
+    ) async -> (deleted: Bool, errorMessage: String?) {
+        do {
+            try await delete(target.sessionId)
+        } catch is CancellationError {
+            return (false, nil)
+        } catch {
+            return (false, "Failed to delete \"\(target.displayTitle)\": \(error.localizedDescription)")
         }
 
-        guard !deletedSessionIds.isEmpty else {
-            return (sessions, errorMessage)
-        }
-
-        var remaining = sessions
-        remaining.removeAll { deletedSessionIds.contains($0.sessionId) }
-
-        if let focusedSessionId, deletedSessionIds.contains(focusedSessionId) {
-            let fallbackSessionId = remaining.first?.sessionId
+        if let focusedSessionId, focusedSessionId == target.sessionId {
+            let fallbackSessionId = sessions.first { $0.sessionId != target.sessionId }?.sessionId
             if sessionId == nil {
                 setFocusedSessionId(focusedSessionId)
             }
@@ -524,13 +511,11 @@ final class ConversationStore {
             if let fallbackSessionId {
                 _ = await send?(.switchSession(sessionId: fallbackSessionId))
             }
+        } else {
+            removeSessionState(target.sessionId, fallbackSessionId: nil)
         }
 
-        for deletedSessionId in deletedSessionIds where deletedSessionId != focusedSessionId {
-            removeSessionState(deletedSessionId, fallbackSessionId: nil)
-        }
-
-        return (remaining, errorMessage)
+        return (true, nil)
     }
 
     // MARK: - Private

--- a/ios/HiveMobile/Views/Chat/ConversationRow.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationRow.swift
@@ -5,13 +5,7 @@ struct ConversationRow: View {
     let isStreaming: Bool
     let isUnread: Bool
 
-    private var title: String {
-        guard let title = session.title?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !title.isEmpty else {
-            return "Untitled Conversation"
-        }
-        return title
-    }
+    private var title: String { session.displayTitle }
 
     private var messageCountText: String {
         guard session.messageCount > 0 else { return "No messages yet" }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -234,8 +234,8 @@ struct ConversationsSection<Header: View>: View {
         let deletedFocusedSessionId = focusedSessionId
 
         Task {
-            let outcome = await store.deleteSessions(
-                [session],
+            let outcome = await store.deleteSession(
+                session,
                 from: sessions,
                 focusedSessionId: deletedFocusedSessionId
             ) { sessionId in
@@ -243,7 +243,9 @@ struct ConversationsSection<Header: View>: View {
                 ChatDraftStore.shared.remove(workspaceId: workspace.id, sessionId: sessionId)
                 projectStore.statusMonitor.clearUnread(workspaceId: workspace.id, sessionId: sessionId)
             }
-            sessions = outcome.sessions
+            if outcome.deleted {
+                sessions.removeAll { $0.sessionId == session.sessionId }
+            }
             errorMessage = outcome.errorMessage
         }
     }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -39,6 +39,7 @@ struct ConversationsSection<Header: View>: View {
     @State private var isLoading = true
     @State private var isCreatingSession = false
     @State private var errorMessage: String?
+    @State private var sessionToDelete: SessionMetadata?
     @State private var lastRefreshAt = Date.distantPast
 
     private let api = APIClient()
@@ -92,6 +93,21 @@ struct ConversationsSection<Header: View>: View {
                 Text(errorMessage)
             }
         }
+        .alert(
+            "Delete conversation?",
+            isPresented: Binding(
+                get: { sessionToDelete != nil },
+                set: { if !$0 { sessionToDelete = nil } }
+            ),
+            presenting: sessionToDelete
+        ) { session in
+            Button("Delete", role: .destructive) {
+                deleteSession(session)
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { session in
+            Text("\"\(session.displayTitle)\" will be permanently deleted.")
+        }
     }
 
     private var conversationsSection: some View {
@@ -136,8 +152,12 @@ struct ConversationsSection<Header: View>: View {
                 .listRowInsets(EdgeInsets(top: 5, leading: HiveSpacing.lg, bottom: 5, trailing: HiveSpacing.lg))
                 .listRowBackground(WhisperColor.appBackground)
                 .listRowSeparator(.hidden)
+                .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                    Button("Delete", role: .destructive) {
+                        sessionToDelete = session
+                    }
+                }
             }
-            .onDelete(perform: deleteSessions)
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
@@ -210,49 +230,21 @@ struct ConversationsSection<Header: View>: View {
         }
     }
 
-    private func deleteSessions(at offsets: IndexSet) {
-        let targets = offsets.compactMap { index -> SessionMetadata? in
-            sessions.indices.contains(index) ? sessions[index] : nil
-        }
+    private func deleteSession(_ session: SessionMetadata) {
         let deletedFocusedSessionId = focusedSessionId
 
         Task {
-            var deletedSessionIds = Set<String>()
-            for session in targets {
-                do {
-                    try await api.deleteSession(workspaceId: workspace.id, sessionId: session.sessionId)
-                    ChatDraftStore.shared.remove(workspaceId: workspace.id, sessionId: session.sessionId)
-                    projectStore.statusMonitor.clearUnread(workspaceId: workspace.id, sessionId: session.sessionId)
-                    deletedSessionIds.insert(session.sessionId)
-                    errorMessage = nil
-                } catch is CancellationError {
-                    // View disappeared.
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
+            let outcome = await store.deleteSessions(
+                [session],
+                from: sessions,
+                focusedSessionId: deletedFocusedSessionId
+            ) { sessionId in
+                try await api.deleteSession(workspaceId: workspace.id, sessionId: sessionId)
+                ChatDraftStore.shared.remove(workspaceId: workspace.id, sessionId: sessionId)
+                projectStore.statusMonitor.clearUnread(workspaceId: workspace.id, sessionId: sessionId)
             }
-
-            guard !deletedSessionIds.isEmpty else { return }
-
-            sessions.removeAll { deletedSessionIds.contains($0.sessionId) }
-
-            if let focusedSessionId = deletedFocusedSessionId, deletedSessionIds.contains(focusedSessionId) {
-                let fallbackSessionId = sessions.first?.sessionId
-                if store.sessionId == nil {
-                    store.setFocusedSessionId(focusedSessionId)
-                }
-                store.removeSessionState(focusedSessionId, fallbackSessionId: fallbackSessionId)
-                if let fallbackSessionId {
-                    _ = await store.send?(.switchSession(sessionId: fallbackSessionId))
-                }
-            }
-
-            for deletedSessionId in deletedSessionIds {
-                if let focusedSessionId = deletedFocusedSessionId, deletedSessionId == focusedSessionId {
-                    continue
-                }
-                store.removeSessionState(deletedSessionId, fallbackSessionId: nil)
-            }
+            sessions = outcome.sessions
+            errorMessage = outcome.errorMessage
         }
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -747,59 +747,73 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
-    func deleteSessionsSuccessRemovesOnlyTargetedSession() async {
+    func deleteSessionSuccessReportsDeleted() async {
         let store = ConversationStore()
         let target = makeSession(id: "session-1", title: "Fix login bug")
         let other = makeSession(id: "session-2", title: "Ship release")
 
-        let outcome = await store.deleteSessions(
-            [target],
+        let outcome = await store.deleteSession(
+            target,
             from: [target, other],
             focusedSessionId: nil
         ) { _ in }
 
-        #expect(outcome.sessions.map(\.sessionId) == ["session-2"])
+        #expect(outcome.deleted)
         #expect(outcome.errorMessage == nil)
     }
 
     @Test @MainActor
-    func deleteSessionsFailureKeepsSessionAndNamesConversation() async {
+    func deleteSessionFailureNamesConversation() async {
         struct DeleteError: LocalizedError {
             var errorDescription: String? { "Server unreachable" }
         }
         let store = ConversationStore()
         let target = makeSession(id: "session-1", title: "Fix login bug")
-        let other = makeSession(id: "session-2", title: "Ship release")
 
-        let outcome = await store.deleteSessions(
-            [target],
-            from: [target, other],
+        let outcome = await store.deleteSession(
+            target,
+            from: [target],
             focusedSessionId: nil
         ) { _ in throw DeleteError() }
 
-        #expect(outcome.sessions.map(\.sessionId) == ["session-1", "session-2"])
+        #expect(outcome.deleted == false)
         #expect(outcome.errorMessage?.contains("Fix login bug") == true)
         #expect(outcome.errorMessage?.contains("Server unreachable") == true)
     }
 
     @Test @MainActor
-    func deleteSessionsFailureNamesUntitledConversation() async {
+    func deleteSessionFailureNamesUntitledConversation() async {
         struct DeleteError: Error {}
         let store = ConversationStore()
         let target = makeSession(id: "session-1", title: "   ")
 
-        let outcome = await store.deleteSessions(
-            [target],
+        let outcome = await store.deleteSession(
+            target,
             from: [target],
             focusedSessionId: nil
         ) { _ in throw DeleteError() }
 
-        #expect(outcome.sessions.map(\.sessionId) == ["session-1"])
+        #expect(outcome.deleted == false)
         #expect(outcome.errorMessage?.contains("Untitled Conversation") == true)
     }
 
     @Test @MainActor
-    func deleteSessionsFocusedSessionFallsBackToNextSession() async {
+    func deleteSessionCancellationReportsNothing() async {
+        let store = ConversationStore()
+        let target = makeSession(id: "session-1", title: "Fix login bug")
+
+        let outcome = await store.deleteSession(
+            target,
+            from: [target],
+            focusedSessionId: nil
+        ) { _ in throw CancellationError() }
+
+        #expect(outcome.deleted == false)
+        #expect(outcome.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func deleteSessionFocusedSessionFallsBackToNextSession() async {
         let store = ConversationStore()
         store.setFocusedSessionId("session-1")
         store.applyFetchedHistory([
@@ -819,13 +833,13 @@ struct ConversationStoreSessionTests {
         let target = makeSession(id: "session-1", title: "Fix login bug")
         let other = makeSession(id: "session-2", title: "Ship release")
 
-        let outcome = await store.deleteSessions(
-            [target],
+        let outcome = await store.deleteSession(
+            target,
             from: [target, other],
             focusedSessionId: "session-1"
         ) { _ in }
 
-        #expect(outcome.sessions.map(\.sessionId) == ["session-2"])
+        #expect(outcome.deleted)
         #expect(outcome.errorMessage == nil)
         #expect(store.sessionId == "session-2")
         #expect(store.cachedMessages(for: "session-1") == nil)

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -731,4 +731,103 @@ struct ConversationStoreSessionTests {
         #expect(store.pendingToolInputs.isEmpty)
         #expect(store.isStreaming == false)
     }
+
+    private func makeSession(id: String, title: String?) -> SessionMetadata {
+        SessionMetadata(
+            sessionId: id,
+            providerSessionId: nil,
+            claudeSessionId: nil,
+            workspaceId: "ws-1",
+            title: title,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            updatedAt: "2026-01-01T00:00:00.000Z",
+            messageCount: 0,
+            lockedProvider: nil
+        )
+    }
+
+    @Test @MainActor
+    func deleteSessionsSuccessRemovesOnlyTargetedSession() async {
+        let store = ConversationStore()
+        let target = makeSession(id: "session-1", title: "Fix login bug")
+        let other = makeSession(id: "session-2", title: "Ship release")
+
+        let outcome = await store.deleteSessions(
+            [target],
+            from: [target, other],
+            focusedSessionId: nil
+        ) { _ in }
+
+        #expect(outcome.sessions.map(\.sessionId) == ["session-2"])
+        #expect(outcome.errorMessage == nil)
+    }
+
+    @Test @MainActor
+    func deleteSessionsFailureKeepsSessionAndNamesConversation() async {
+        struct DeleteError: LocalizedError {
+            var errorDescription: String? { "Server unreachable" }
+        }
+        let store = ConversationStore()
+        let target = makeSession(id: "session-1", title: "Fix login bug")
+        let other = makeSession(id: "session-2", title: "Ship release")
+
+        let outcome = await store.deleteSessions(
+            [target],
+            from: [target, other],
+            focusedSessionId: nil
+        ) { _ in throw DeleteError() }
+
+        #expect(outcome.sessions.map(\.sessionId) == ["session-1", "session-2"])
+        #expect(outcome.errorMessage?.contains("Fix login bug") == true)
+        #expect(outcome.errorMessage?.contains("Server unreachable") == true)
+    }
+
+    @Test @MainActor
+    func deleteSessionsFailureNamesUntitledConversation() async {
+        struct DeleteError: Error {}
+        let store = ConversationStore()
+        let target = makeSession(id: "session-1", title: "   ")
+
+        let outcome = await store.deleteSessions(
+            [target],
+            from: [target],
+            focusedSessionId: nil
+        ) { _ in throw DeleteError() }
+
+        #expect(outcome.sessions.map(\.sessionId) == ["session-1"])
+        #expect(outcome.errorMessage?.contains("Untitled Conversation") == true)
+    }
+
+    @Test @MainActor
+    func deleteSessionsFocusedSessionFallsBackToNextSession() async {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Hello",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], for: "session-1")
+        let target = makeSession(id: "session-1", title: "Fix login bug")
+        let other = makeSession(id: "session-2", title: "Ship release")
+
+        let outcome = await store.deleteSessions(
+            [target],
+            from: [target, other],
+            focusedSessionId: "session-1"
+        ) { _ in }
+
+        #expect(outcome.sessions.map(\.sessionId) == ["session-2"])
+        #expect(outcome.errorMessage == nil)
+        #expect(store.sessionId == "session-2")
+        #expect(store.cachedMessages(for: "session-1") == nil)
+    }
 }


### PR DESCRIPTION
## Summary
- Swipe-to-delete on a conversation now shows a confirmation alert naming the conversation and stating the deletion is permanent, mirroring the workspace-archive confirmation pattern in HubView. Cancel is side-effect free.
- Full swipe no longer bypasses confirmation: `.onDelete` is replaced with `.swipeActions(edge: .trailing, allowsFullSwipe: false)`, so every delete routes through the alert. Both the workspace and Brain conversation lists share `ConversationsSection`, so behavior is identical on both.
- The delete flow (non-optimistic removal, focus-fallback, per-session state cleanup) moved from the view into `ConversationStore.deleteSessions(_:from:focusedSessionId:delete:)` with the API call injected as an async throwing closure for testability.
- On failure the session stays in the list and the error names the conversation: `Failed to delete "<title>": <reason>`.
- Added a shared `SessionMetadata.displayTitle` ("Untitled Conversation" fallback) reused by `ConversationRow`, the confirmation message, and the failure error.

## Testing
- `cd ios && swift test` — 121 tests in 18 suites passed (includes 4 new ConversationStore delete-flow tests).
- `xcodebuild -project HiveMobile.xcodeproj -scheme HiveMobile -destination 'generic/platform=iOS Simulator' build` — BUILD SUCCEEDED.

Closes #292