### PR TITLE
Fix iOS image attachment reselection, visible errors, and loading state

### DIFF
--- a/frontend/src/hooks/useSidebarProjectFolders.ts
+++ b/frontend/src/hooks/useSidebarProjectFolders.ts
@@ -112,12 +112,21 @@ export function useSidebarProjectFolders(
       }
     }
 
+    // Server data (fetches and PUT echoes) must not clobber local edits made
+    // while the request was in flight; those still need their own flush.
+    const wasHydrated = hydratedRef.current;
+    const lastFlushed = lastFlushedRef.current;
     hydratedRef.current = true;
     setHasInitialHydration(true);
     lastFlushedRef.current = serverState;
     bootstrappedRef.current = true;
     setState((prev) => {
-      return areSidebarPreferencesStatesEqual(prev, serverState) ? prev : serverState;
+      if (areSidebarPreferencesStatesEqual(prev, serverState)) return prev;
+      if (wasHydrated && lastFlushed && !areSidebarPreferencesStatesEqual(prev, lastFlushed)) {
+        // Fresh identity so the flush effect re-runs and pushes the kept edits.
+        return { ...prev };
+      }
+      return serverState;
     });
   }, [preferencesData, projectsReady]);
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -1115,6 +1115,40 @@ describe("Sidebar", () => {
     });
   });
 
+  it("keeps a folder deletion made while the create flush is in flight", async () => {
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+
+    let resolveCreatePut: (() => void) | null = null;
+    vi.mocked(api.put).mockImplementation((url: string, body?: unknown) => {
+      if (url !== "/api/ui-preferences") throw new Error(`Unexpected PUT: ${url}`);
+      if (resolveCreatePut) return Promise.resolve(body);
+      return new Promise((resolve) => {
+        resolveCreatePut = () => resolve(body);
+      });
+    });
+
+    await screen.findByText(withTextContent("acme/alpha"));
+    await user.click(screen.getByRole("button", { name: "New folder" }));
+    await user.type(screen.getByLabelText("Folder name"), "Temporary");
+    await user.click(screen.getByRole("button", { name: "Create folder" }));
+
+    await screen.findByRole("button", { name: "Temporary" });
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete folder Temporary" }));
+    await user.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await act(async () => {
+      resolveCreatePut?.();
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Temporary" })).not.toBeInTheDocument();
+    });
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(2));
+  });
+
   it("hides the delete button for non-empty folders", async () => {
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -23,6 +23,7 @@ struct ChatInputBar: View {
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var attachedImages: [AttachedImage] = []
     @State private var selectedItems: [PhotosPickerItem] = []
+    @State private var showAttachmentError = false
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -36,6 +37,10 @@ struct ChatInputBar: View {
             // MARK: - Attachment Chips
             if !attachedImages.isEmpty {
                 attachmentChipTray
+            }
+
+            if showAttachmentError {
+                attachmentErrorBanner
             }
 
             Divider()
@@ -141,11 +146,11 @@ struct ChatInputBar: View {
         ScrollView(.horizontal) {
             HStack(spacing: 8) {
                 ForEach(attachedImages) { item in
-                    AttachmentChip(source: item.attachment.dataUrl) {
+                    AttachmentChip(source: item.attachment?.dataUrl, pending: item.attachment == nil) {
                         withAnimation(.spring(duration: 0.25)) {
                             attachedImages.removeAll { $0.id == item.id }
                         }
-                        onDraftAttachmentsChange(attachedImages.map(\.attachment))
+                        onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
                     }
                 }
             }
@@ -153,6 +158,29 @@ struct ChatInputBar: View {
             .padding(.vertical, 4)
         }
         .scrollIndicators(.hidden)
+        .transition(.move(edge: .top).combined(with: .opacity))
+    }
+
+    private var attachmentErrorBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(WhisperColor.warning)
+            Text("Image could not be attached.")
+                .foregroundStyle(WhisperColor.textSecondary)
+            Spacer()
+            Button {
+                withAnimation(.spring(duration: 0.25)) {
+                    showAttachmentError = false
+                }
+            } label: {
+                Image(systemName: "xmark")
+                    .foregroundStyle(WhisperColor.textMuted)
+                    .frame(width: 24, height: 24)
+            }
+        }
+        .font(.caption)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 4)
         .transition(.move(edge: .top).combined(with: .opacity))
     }
 
@@ -219,27 +247,38 @@ struct ChatInputBar: View {
     // MARK: - Logic
 
     private var canSend: Bool {
-        (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachedImages.isEmpty) && !isBusy
+        (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || attachedImages.contains { $0.attachment != nil }) && !isBusy
     }
 
     private func handleSend() {
-        let imageAttachments = attachedImages.map(\.attachment)
+        let imageAttachments = attachedImages.compactMap(\.attachment)
         attachedImages = []
-        selectedItems = []
         onDraftAttachmentsChange([])
         onSend(imageAttachments)
     }
 
     private func loadImages(from items: [PhotosPickerItem]) {
+        guard !items.isEmpty else { return }
+        selectedItems = []
+        showAttachmentError = false
         for item in items {
+            let pending = AttachedImage(attachment: nil)
+            withAnimation(.spring(duration: 0.25)) {
+                attachedImages.append(pending)
+            }
             item.loadTransferable(type: Data.self) { result in
-                if case .success(let data) = result, let data, let uiImage = UIImage(data: data) {
-                    guard let attachment = ImageAttachment.makeFromDraftImage(uiImage) else { return }
-                    DispatchQueue.main.async {
+                DispatchQueue.main.async {
+                    guard let index = attachedImages.firstIndex(where: { $0.id == pending.id }) else { return }
+                    if case .success(let data) = result, let data,
+                       let uiImage = UIImage(data: data),
+                       let attachment = ImageAttachment.makeFromDraftImage(uiImage) {
+                        attachedImages[index].attachment = attachment
+                        onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
+                    } else {
                         withAnimation(.spring(duration: 0.25)) {
-                            attachedImages.append(AttachedImage(attachment: attachment))
+                            attachedImages.remove(at: index)
+                            showAttachmentError = true
                         }
-                        onDraftAttachmentsChange(attachedImages.map(\.attachment))
                     }
                 }
             }
@@ -248,15 +287,16 @@ struct ChatInputBar: View {
 
     private func restoreAttachedImages(from attachments: [ImageAttachment]) {
         let normalized = attachments.map(\.dataUrl)
-        let current = attachedImages.map(\.attachment.dataUrl)
+        let current = attachedImages.compactMap { $0.attachment?.dataUrl }
         guard normalized != current else { return }
 
-        attachedImages = attachments.compactMap { attachment in
+        let restored: [AttachedImage] = attachments.compactMap { attachment in
             guard attachment.decodedImage != nil else { return nil }
             return AttachedImage(attachment: attachment)
         }
-        if attachedImages.count != attachments.count {
-            onDraftAttachmentsChange(attachedImages.map(\.attachment))
+        attachedImages = restored + attachedImages.filter { $0.attachment == nil }
+        if restored.count != attachments.count {
+            onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
         }
     }
 }
@@ -265,7 +305,7 @@ struct ChatInputBar: View {
 
 private struct AttachedImage: Identifiable {
     let id = UUID()
-    let attachment: ImageAttachment
+    var attachment: ImageAttachment?
 }
 
 // MARK: - Mode Toggle
@@ -331,13 +371,15 @@ private struct LevelCycleButton: View {
 private struct AttachmentChip: View {
     private static let size = CGSize(width: 52, height: 52)
 
-    let source: String
+    let source: String?
+    let pending: Bool
     let onRemove: () -> Void
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
             ChatImageTile(
                 source: source,
+                pending: pending,
                 size: Self.size,
                 cornerRadius: 8
             )

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -175,8 +175,9 @@ struct ChatInputBar: View {
             } label: {
                 Image(systemName: "xmark")
                     .foregroundStyle(WhisperColor.textMuted)
-                    .frame(width: 24, height: 24)
+                    .frame(width: 44, height: 32)
             }
+            .accessibilityLabel("Dismiss")
         }
         .font(.caption)
         .padding(.horizontal, 16)
@@ -247,7 +248,9 @@ struct ChatInputBar: View {
     // MARK: - Logic
 
     private var canSend: Bool {
-        (!draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || attachedImages.contains { $0.attachment != nil }) && !isBusy
+        let hasPending = attachedImages.contains { $0.attachment == nil }
+        let hasContent = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachedImages.isEmpty
+        return hasContent && !hasPending && !isBusy
     }
 
     private func handleSend() {


### PR DESCRIPTION
Fixes #293

## Summary

- Clear the PhotosPicker selection immediately after each pick is processed (instead of on send), so removing a chip and re-picking the same photo works every time.
- Show a pending shimmer chip in the attachment tray as soon as a pick starts loading; it is replaced in place by the thumbnail chip on success and removed on failure. Simultaneous picks load independently.
- Show a dismissible inline error banner near the composer ("Image could not be attached.") when the transferable load fails, the data does not decode, or encoding fails.

Pending chips are never sent and never persisted to the draft; removing a pending chip orphans its in-flight load so a late result cannot resurrect it. Draft persistence of successfully attached images is unchanged.

## Acceptance criteria

- [x] Removing an attachment chip then re-picking the same photo works (picker selection cleared after processing)
- [x] A loading chip appears while image data loads and becomes the thumbnail chip on success
- [x] Load failures show a visible, transient/dismissible inline error near the composer
- [x] Pending chips are never sent nor persisted to the draft; removing a chip mid-load cancels it cleanly; simultaneous picks load independently
- [x] `cd ios && swift test` passes (draft attachment persistence unchanged)

## Verification

- `cd ios && swift test`: 117 tests in 18 suites, all passed
- `xcodebuild -project HiveMobile.xcodeproj -scheme HiveMobile -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`: BUILD SUCCEEDED