### PR TITLE
Add connection status banner with tap-to-reconnect (iOS)

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -60,6 +60,7 @@ struct HiveApp: App {
             }
             .hiveScreenBackground()
             .tint(accent)
+            .overlay(alignment: .top) { ConnectionBanner(monitor: projectStore.statusMonitor) }
             .environment(projectStore)
             .environment(storeCache)
             .environment(modelCatalog)

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -60,7 +60,9 @@ struct HiveApp: App {
             }
             .hiveScreenBackground()
             .tint(accent)
-            .overlay(alignment: .top) { ConnectionBanner(monitor: projectStore.statusMonitor) }
+            .safeAreaInset(edge: .top, spacing: 0) {
+                ConnectionBanner(monitor: projectStore.statusMonitor)
+            }
             .environment(projectStore)
             .environment(storeCache)
             .environment(modelCatalog)

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -1,10 +1,13 @@
 import Foundation
 import Observation
 
+enum HubConnectionState { case connecting; case connected; case disconnected }
+
 @MainActor
 protocol HubConnectionClient: AnyObject {
     func connect()
     func cancel()
+    func forceReconnect()
     @discardableResult
     func send(_ message: HubIncoming) async -> Bool
     func sendSync(_ payload: HubSyncPayload, forceBootstrap: Bool)
@@ -39,6 +42,7 @@ final class HubStatusMonitor {
     private(set) var completedWorkspaces: Set<String> = [] {
         didSet { persistCompleted() }
     }
+    private(set) var connectionState: HubConnectionState = .connecting
 
     /// Workspace currently visible in ChatView (suppresses unread badge).
     var viewingWorkspaceId: String? { syncState.viewingWorkspaceId }
@@ -192,6 +196,7 @@ final class HubStatusMonitor {
         if desired.isEmpty {
             hubConnection?.cancel()
             hubConnection = nil
+            connectionState = .disconnected
         } else if hubConnection == nil {
             let conn = makeHubConnection(self)
             hubConnection = conn
@@ -230,6 +235,7 @@ final class HubStatusMonitor {
     func disconnectAll() {
         hubConnection?.cancel()
         hubConnection = nil
+        connectionState = .disconnected
         syncState = HubSubscriptionSync()
         streamingSessions.removeAll()
         unreadSessions.removeAll()
@@ -242,6 +248,15 @@ final class HubStatusMonitor {
     }
 
     // MARK: - Called by HubConnection
+
+    func didChangeConnectionState(_ state: HubConnectionState) {
+        guard connectionState != state else { return }
+        connectionState = state
+    }
+
+    func reconnectNow() {
+        hubConnection?.forceReconnect()
+    }
 
     /// Workspaces that were streaming when the app entered background.
     /// Used to detect streaming→idle transitions after reconnect and mark them as completed.
@@ -467,6 +482,7 @@ private final class HubConnection: HubConnectionClient {
         task.maximumMessageSize = 10 * 1024 * 1024
         self.wsTask = task
         task.resume()
+        monitor?.didChangeConnectionState(.connecting)
 
         // Re-wire send closures on all existing stores so they target the fresh socket.
         // We deliberately do NOT wipe streaming state here: the reconnect is
@@ -495,6 +511,7 @@ private final class HubConnection: HubConnectionClient {
                 do {
                     let message = try await task.receive()
                     self.backoff = 1
+                    self.monitor?.didChangeConnectionState(.connected)
                     await self.pipeline?.submit(message)
                 } catch {
                     if !Task.isCancelled, self.wsTask === task {
@@ -585,6 +602,7 @@ private final class HubConnection: HubConnectionClient {
         wsTask = nil
 
         guard !intentionallyClosed else { return }
+        monitor?.didChangeConnectionState(.disconnected)
 
         reconnectTask?.cancel()
         reconnectTask = Task { [weak self] in

--- a/ios/HiveMobile/Views/Components/ConnectionBanner.swift
+++ b/ios/HiveMobile/Views/Components/ConnectionBanner.swift
@@ -2,15 +2,11 @@ import SwiftUI
 
 struct ConnectionBanner: View {
     let monitor: HubStatusMonitor
+    @State private var showConnecting = false
 
     var body: some View {
         Group {
-            switch monitor.connectionState {
-            case .connected:
-                EmptyView()
-            case .connecting:
-                capsule(text: "Connecting…", color: .orange.opacity(0.9))
-            case .disconnected:
+            if monitor.connectionState == .disconnected {
                 Button {
                     monitor.reconnectNow()
                 } label: {
@@ -18,11 +14,26 @@ struct ConnectionBanner: View {
                 }
                 .buttonStyle(.plain)
                 .accessibilityHint("Reconnects to the server.")
+                .padding(.vertical, 8)
+                .transition(.move(edge: .top).combined(with: .opacity))
+            } else if monitor.connectionState == .connecting, showConnecting {
+                capsule(text: "Connecting…", color: .orange.opacity(0.9))
+                    .padding(.vertical, 8)
+                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .padding(.top, 8)
-        .transition(.move(edge: .top))
         .animation(.default, value: monitor.connectionState)
+        .animation(.default, value: showConnecting)
+        .task(id: monitor.connectionState) {
+            guard monitor.connectionState == .connecting else {
+                showConnecting = false
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(600))
+            if !Task.isCancelled {
+                showConnecting = true
+            }
+        }
     }
 
     private func capsule(text: String, color: Color) -> some View {

--- a/ios/HiveMobile/Views/Components/ConnectionBanner.swift
+++ b/ios/HiveMobile/Views/Components/ConnectionBanner.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ConnectionBanner: View {
+    let monitor: HubStatusMonitor
+
+    var body: some View {
+        Group {
+            switch monitor.connectionState {
+            case .connected:
+                EmptyView()
+            case .connecting:
+                capsule(text: "Connecting…", color: .orange.opacity(0.9))
+            case .disconnected:
+                Button {
+                    monitor.reconnectNow()
+                } label: {
+                    capsule(text: "Disconnected. Tap to reconnect", color: .red.opacity(0.85))
+                }
+                .buttonStyle(.plain)
+                .accessibilityHint("Reconnects to the server.")
+            }
+        }
+        .padding(.top, 8)
+        .transition(.move(edge: .top))
+        .animation(.default, value: monitor.connectionState)
+    }
+
+    private func capsule(text: String, color: Color) -> some View {
+        Text(text)
+            .font(.footnote)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .frame(minHeight: 44)
+            .background(color, in: Capsule())
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -5,6 +5,7 @@ import Testing
 private final class FakeHubConnection: HubConnectionClient {
     private(set) var connectCount = 0
     private(set) var cancelCount = 0
+    private(set) var forceReconnectCount = 0
     private(set) var probeLivenessCount = 0
     private(set) var syncCalls: [(payload: HubSyncPayload, forceBootstrap: Bool)] = []
     private(set) var sentMessages: [HubIncoming] = []
@@ -15,6 +16,10 @@ private final class FakeHubConnection: HubConnectionClient {
 
     func cancel() {
         cancelCount += 1
+    }
+
+    func forceReconnect() {
+        forceReconnectCount += 1
     }
 
     func send(_ message: HubIncoming) async -> Bool {
@@ -135,5 +140,33 @@ struct HubStatusMonitorTests {
         monitor.forceRefresh()
 
         #expect(connection.probeLivenessCount == 1)
+    }
+
+    @Test
+    func initialConnectionStateIsConnecting() {
+        let (monitor, _, _) = makeMonitor()
+
+        #expect(monitor.connectionState == .connecting)
+    }
+
+    @Test
+    func didChangeConnectionStateUpdatesState() {
+        let (monitor, _, _) = makeMonitor()
+
+        monitor.didChangeConnectionState(.connected)
+        #expect(monitor.connectionState == .connected)
+
+        monitor.didChangeConnectionState(.disconnected)
+        #expect(monitor.connectionState == .disconnected)
+    }
+
+    @Test
+    func reconnectNowDelegatesToForceReconnect() {
+        let (monitor, _, connection) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-1"])
+
+        monitor.reconnectNow()
+
+        #expect(connection.forceReconnectCount == 1)
     }
 }


### PR DESCRIPTION
Closes #284

## What

Surfaces the hub WebSocket connection state to the user on iOS, and lets them force a reconnect. Until now the socket reconnected internally (`HubConnection` backoff / probe) but the UI showed nothing when the connection dropped — the app just went silent.

A small banner sits at the top of the app:
- **Connected** → nothing shown (no reserved space).
- **Connecting…** → informational orange capsule, shown only if connecting lasts >600 ms (fast connects never flash).
- **Disconnected. Tap to reconnect** → red capsule; tapping forces an immediate reconnect (`reconnectNow()` → `forceReconnect()`), bypassing the backoff wait.

## How

Minimal, reuses the existing reconnect plumbing.

- **`HubStatusMonitor.swift`** — new `HubConnectionState` enum; observable `connectionState`; `didChangeConnectionState(_:)` (deduped to avoid observable churn) and `reconnectNow()`. `HubConnection` reports transitions: `.connecting` on connect, `.connected` on first inbound frame, `.disconnected` on unintentional disconnect (never on intentional `cancel()`). `forceReconnect()` added to the `HubConnectionClient` protocol.
- **`ConnectionBanner.swift`** (new) — small SwiftUI view. Conditional content (renders nothing when connected) so the slide-in `.transition` actually fires; a `.task`-driven 600 ms grace delay before showing `Connecting…`; tappable `Button` (≥44 pt tap target + accessibility hint) when disconnected. Auto-included via the Xcode synchronized folder group (no `project.pbxproj` change).
- **`HiveApp.swift`** — one line: `.safeAreaInset(edge: .top)` on the root `TabView`, so the banner is anchored below the navigation bar instead of floating over it.
- **Tests** — initial state, state transitions, and reconnect delegation.

## Verification

- `swift test` → 154 tests / 23 suites pass.
- `xcodebuild -scheme HiveMobile` (iOS Simulator) → **BUILD SUCCEEDED** (validates the new view + app wiring, which `swift test` does not compile).

## Notes

- `.connected` means "first WS frame received", not "socket open". In practice the client sends `sync_workspaces` immediately and the backend replies with bootstrap frames promptly, so the window is tiny.

Branched off `main`; scope is exactly 4 files (no `pbxproj` / `Package.swift` / local-only changes).