### PR TITLE
Insert a newline on Return in the composer instead of sending (#289)

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -201,11 +201,7 @@ struct ChatInputBar: View {
             }
 
             TextField("Message", text: $draft, axis: .vertical)
-                .lineLimit(1...5)
-                .submitLabel(.send)
-                .onSubmit {
-                    if canSend { handleSend() }
-                }
+                .lineLimit(1...10)
                 .textFieldStyle(.plain)
                 .frame(maxWidth: .infinity, minHeight: 28, alignment: .leading)
 

--- a/ios/Tests/ChatDraftStoreTests/ChatDraftStoreTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ChatDraftStoreTests.swift
@@ -31,6 +31,27 @@ struct ChatDraftStoreTests {
     }
 
     @Test @MainActor
+    func multilineDraftRoundTripsNewlinesExactly() {
+        let workspaceId = "ws-\(UUID().uuidString)"
+        let sessionId = "sess-\(UUID().uuidString)"
+
+        let text = "\nfirst line\nsecond line\n\nfourth line\n"
+
+        ChatDraftStore.shared.save(
+            workspaceId: workspaceId,
+            sessionId: sessionId,
+            draft: .init(
+                text: text,
+                attachments: []
+            )
+        )
+
+        #expect(ChatDraftStore.shared.restore(workspaceId: workspaceId, sessionId: sessionId)?.text == text)
+
+        ChatDraftStore.shared.remove(workspaceId: workspaceId, sessionId: sessionId)
+    }
+
+    @Test @MainActor
     func saveEmptyDraftDoesNotPersist() {
         let workspaceId = "ws-\(UUID().uuidString)"
         let sessionId = "sess-\(UUID().uuidString)"


### PR DESCRIPTION
Closes #289.

## What changed
The message composer's `TextField` (already `axis: .vertical`) no longer submits on Return. Removed `.submitLabel(.send)` and the `.onSubmit` handler so Return inserts a newline natively, and raised the growth cap from `.lineLimit(1...5)` to `.lineLimit(1...10)`.

Sending is now exclusively via the send button; `canSend`/`handleSend` and all other composer behavior (attachments, plan mode, thinking level, stop) are unchanged. No Cmd+Return shortcut — the app is iPhone-only (deliberate, per the issue).

## Tests
- Added `multilineDraftRoundTripsNewlinesExactly` to `ChatDraftStoreTests`: saves a draft with a leading blank line, embedded newlines, an internal blank line, and a trailing newline, and asserts `restore` returns the byte-identical string.
- `cd ios && swift test` → 186 tests pass.
- `xcodebuild build -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO` → BUILD SUCCEEDED (view change compiles; `swift test` excludes `Views/`).

## Manual verification
Multi-line composing verified on the iPhone 17 Pro simulator (screenshot in the follow-up review).