### PR TITLE
Show a loading skeleton while conversation history loads (#290)

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -8,6 +8,7 @@ struct ChatView: View {
 
     @State private var draft = ""
     @State private var isLoading = true
+    @State private var showSkeleton = false
     @State private var planModeEnabled = false
     @State private var thinkingLevel: ThinkingLevel = .high
     @State private var fastModeEnabled = false
@@ -87,7 +88,11 @@ struct ChatView: View {
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
-                Spacer()
+                if showSkeleton {
+                    ConversationLoadingSkeleton()
+                } else {
+                    Spacer()
+                }
             } else if store.messages.isEmpty && streamingMessage == nil && !store.isStreaming {
                 Spacer()
                 if isBrainWorkspaceId(workspace.id) {
@@ -235,6 +240,16 @@ struct ChatView: View {
             }
         }
         .task { await setup() }
+        .task(id: isLoading) {
+            guard isLoading else {
+                showSkeleton = false
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(300))
+            if !Task.isCancelled {
+                showSkeleton = true
+            }
+        }
         .onChange(of: modelCatalog.isLoaded) {
             if selectedModelId.isEmpty, !modelCatalog.defaultModelId.isEmpty {
                 selectedModelId = initialModelId()

--- a/ios/HiveMobile/Views/Chat/ConversationLoadingSkeleton.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationLoadingSkeleton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ConversationLoadingSkeleton: View {
+    private struct Placeholder: Identifiable {
+        let id = UUID()
+        let fraction: CGFloat
+        let height: CGFloat
+        let trailing: Bool
+    }
+
+    private let placeholders: [Placeholder] = [
+        Placeholder(fraction: 0.52, height: 40, trailing: true),
+        Placeholder(fraction: 0.86, height: 104, trailing: false),
+        Placeholder(fraction: 0.38, height: 30, trailing: true),
+        Placeholder(fraction: 0.72, height: 72, trailing: false),
+        Placeholder(fraction: 0.6, height: 52, trailing: false)
+    ]
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: HiveSpacing.lg) {
+                ForEach(placeholders) { placeholder in
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(WhisperColor.surfaceSubtle)
+                        .frame(width: geometry.size.width * placeholder.fraction, height: placeholder.height)
+                        .frame(maxWidth: .infinity, alignment: placeholder.trailing ? .trailing : .leading)
+                        .shimmer()
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.top, HiveSpacing.lg)
+        }
+        .padding(.horizontal, HiveSpacing.lg)
+    }
+}
+
+#Preview {
+    ConversationLoadingSkeleton()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .hiveScreenBackground()
+        .preferredColorScheme(.dark)
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -604,6 +604,32 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func cachedMessagesDrivesLoadingVersusContentState() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        #expect(store.cachedMessages(for: "session-1") == nil)
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Hello",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], for: "session-1")
+
+        #expect(store.cachedMessages(for: "session-1")?.count == 1)
+        #expect(store.cachedMessages(for: "session-2") == nil)
+    }
+
+    @Test @MainActor
     func userMessageKeepsCacheInSyncForSwitchBack() {
         // A user message appended over WS must land in the cache so switching
         // away and back shows the turn without a refetch.


### PR DESCRIPTION
Closes #290.

## What changed
The chat message area used to render a blank `Spacer()` while a first conversation's REST history loaded. It now shows a shimmering skeleton (`ConversationLoadingSkeleton` — alternating leading/trailing rounded-rect "bubbles" using the existing `.shimmer()` modifier and theme tokens), gated behind a ~300ms appearance delay so fast/cached loads never flash it. The empty-state and message-list branches and `loadMessages` are unchanged.

Skeleton shows only when a history fetch is in flight AND there are no cached messages; content renders the instant it arrives.

## Tests
- Added `cachedMessagesDrivesLoadingVersusContentState` to `ConversationStoreSessionTests` asserting the exact combos the view keys off: no cache → `cachedMessages` nil (loading branch); after `applyFetchedHistory` → returns messages (instant content).
- `cd ios && swift test` → 186 tests pass.
- `xcodebuild build -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro' CODE_SIGNING_ALLOWED=NO` → BUILD SUCCEEDED.

## Manual verification
Screenshot of the loading skeleton to follow.