### PR TITLE
Fix chat disclosure scroll jump/blink + tool-open lag (iOS)

### DIFF
--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -628,7 +628,7 @@ private struct WhisperThinkingBlock: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: "brain", label: "Thinking", detail: isExpanded ? nil : preview)
             }
@@ -642,7 +642,6 @@ private struct WhisperThinkingBlock: View {
                         .lineSpacing(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -682,7 +681,7 @@ private struct WhisperToolCallsBlock: View {
                     isExpanded: groupExpanded,
                     isStreaming: showExecutingState,
                     onToggle: {
-                        withAnimation(.easeInOut(duration: 0.2)) { groupExpanded.toggle() }
+                        groupExpanded.toggle()
                     }
                 )
             }
@@ -698,7 +697,6 @@ private struct WhisperToolCallsBlock: View {
                         showExecutingState: showExecutingState
                     )
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -766,7 +764,7 @@ private struct WhisperToolCallRow: View {
 
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: display.icon, label: display.label, detail: display.detail, stats: display.stats, summary: summary, badgeText: display.badgeText, badgeIcon: display.badgeIcon, executing: display.executing)
             }
@@ -814,7 +812,6 @@ private struct WhisperToolCallRow: View {
                         }
                     }
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -867,8 +864,14 @@ private func computeDiffLines(oldString: String, newString: String) -> [DiffLine
 
 private struct DiffContentView: View {
     let tool: ToolCall
+    private let parsed: (filePath: String?, lines: [DiffLine])
 
-    private var parsed: (filePath: String?, lines: [DiffLine]) {
+    init(tool: ToolCall) {
+        self.tool = tool
+        self.parsed = DiffContentView.buildParsed(tool)
+    }
+
+    private static func buildParsed(_ tool: ToolCall) -> (filePath: String?, lines: [DiffLine]) {
         guard let input = parsedToolInputObject(tool.input) else {
             return (nil, [])
         }
@@ -907,7 +910,6 @@ private struct DiffContentView: View {
                 DiffLinesView(lines: result.lines)
             }
         }
-        .transition(.opacity)
     }
 }
 
@@ -950,7 +952,6 @@ private struct AskUserQuestionContent: View {
                 }
             }
         }
-        .transition(.opacity)
     }
 }
 


### PR DESCRIPTION
## What

Fixes two chat regressions reported by the repo leader, both stemming from the earlier switch to a `List`-based conversation view.

### 1. Collapsible-task open/close causes scroll jump + one-frame text blink
Expanding/collapsing a **Thinking** block or a **tool call** row animated the `List` row-height change (`withAnimation(.easeInOut(duration: 0.2))` around the `isExpanded`/`groupExpanded` toggles, plus paired `.transition(.opacity)` on the disclosed content). In a self-sizing `List`, that row-height animation yanked the scroll position and flashed the text for a frame.

**Fix:** drop the `withAnimation` wrappers and their now-inert `.transition(.opacity)` modifiers. Disclosure now snaps open/closed instantly with no layout animation.

### 2. Opening a diff tool is laggy
`DiffContentView.parsed` was a **computed property** that re-ran `computeDiffLines` on every `body` evaluation, so the first open of a diff-producing tool re-parsed the whole diff repeatedly.

**Fix:** compute the parse once in `init` and store it.

## Tradeoff
Disclosure expand/collapse no longer fades over 0.2s — it snaps instantly. This is deliberate: the fade was the direct cause of the `List` scroll-jump/blink, and an instant toggle is the standard, glitch-free behavior for `List` disclosure rows.

## Scope
- iOS only. Single file: `ios/HiveMobile/Views/Chat/MessageBubble.swift`.
- No behavior change to what's shown — only the animation and a parse-memoization.

## Testing
- `cd ios && swift test` → all pass (185 tests).
- `xcodebuild build … -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

## Screenshots
_UI change — before/after screencaps of expanding a Thinking block and a diff tool row to follow via the simulator._