### PR TITLE
Honor Reduce Motion in iOS activity animations (#296)

### DIFF
--- a/ios/HiveMobile/Theme/Animations.swift
+++ b/ios/HiveMobile/Theme/Animations.swift
@@ -9,10 +9,13 @@ struct ShimmerModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
             .opacity(reduceMotion ? 0.5 : 0.5 + 0.5 * Foundation.sin(phase))
-            .onAppear {
-                guard !reduceMotion else { return }
-                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                    phase = .pi
+            .onChange(of: reduceMotion, initial: true) {
+                if reduceMotion {
+                    phase = 0
+                } else {
+                    withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                        phase = .pi
+                    }
                 }
             }
     }

--- a/ios/HiveMobile/Theme/Animations.swift
+++ b/ios/HiveMobile/Theme/Animations.swift
@@ -3,12 +3,14 @@ import SwiftUI
 // MARK: - Shimmer (loading skeletons)
 
 struct ShimmerModifier: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: CGFloat = 0
 
     func body(content: Content) -> some View {
         content
-            .opacity(0.5 + 0.5 * Foundation.sin(phase))
+            .opacity(reduceMotion ? 0.5 : 0.5 + 0.5 * Foundation.sin(phase))
             .onAppear {
+                guard !reduceMotion else { return }
                 withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
                     phase = .pi
                 }
@@ -20,13 +22,16 @@ struct ShimmerModifier: ViewModifier {
 
 struct PulseModifier: ViewModifier {
     let isActive: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
 
     func body(content: Content) -> some View {
         content
-            .scaleEffect(isActive && isPulsing ? 1.02 : 1.0)
+            .scaleEffect(!reduceMotion && isActive && isPulsing ? 1.02 : 1.0)
             .animation(
-                isActive ? .easeInOut(duration: 2).repeatForever(autoreverses: true) : .default,
+                reduceMotion
+                    ? nil
+                    : (isActive ? .easeInOut(duration: 2).repeatForever(autoreverses: true) : .default),
                 value: isPulsing
             )
             .onChange(of: isActive) { _, active in

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -9,6 +9,7 @@ struct ChatActivityStats {
 }
 
 struct ChatActivityRowLabel: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     var icon: String? = nil
     let label: String
     var detail: String?
@@ -106,21 +107,27 @@ struct ChatActivityRowLabel: View {
             }
 
             if executing {
-                // Opacity-only pulse, fully decoupled from the animation system so
-                // the dot can NEVER move. The opacity is recomputed every frame by
-                // TimelineView (no animation transaction), and `.transaction` nils
-                // out any animation inherited from ancestors — so streaming relayout
-                // (label/icons growing to its left) repositions the dot instantly
-                // instead of animating it. Matches the web's `bg-primary animate-pulse`.
-                TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
-                    let t = context.date.timeIntervalSinceReferenceDate
-                    let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
+                if reduceMotion {
                     Circle()
                         .fill(Color.accentColor)
                         .frame(width: 5, height: 5)
-                        .opacity(opacity)
+                } else {
+                    // Opacity-only pulse, fully decoupled from the animation system so
+                    // the dot can NEVER move. The opacity is recomputed every frame by
+                    // TimelineView (no animation transaction), and `.transaction` nils
+                    // out any animation inherited from ancestors — so streaming relayout
+                    // (label/icons growing to its left) repositions the dot instantly
+                    // instead of animating it. Matches the web's `bg-primary animate-pulse`.
+                    TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 5, height: 5)
+                            .opacity(opacity)
+                    }
+                    .transaction { $0.animation = nil }
                 }
-                .transaction { $0.animation = nil }
             }
         }
         .padding(.vertical, 3)

--- a/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
+++ b/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
@@ -6,37 +6,46 @@ struct AgentActivityIndicator: View {
     var dotSize: CGFloat = 3
     var spacing: CGFloat = 1.5
 
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            Canvas { context, _ in
-                for row in 0..<3 {
-                    for col in 0..<3 {
-                        let angle = atan2(Double(row - 1), Double(col - 1))
-                        let normalizedPhase = (angle / (.pi * 2) + 1).truncatingRemainder(dividingBy: 1)
-                        let wave = ((t * 0.9 + normalizedPhase).truncatingRemainder(dividingBy: 1) + 1).truncatingRemainder(dividingBy: 1)
-                        let raw = (cos((wave - 0.5) * .pi * 2) + 1) / 2
-                        let val = max(0, (raw - 0.2) / 0.8)
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-                        let x = CGFloat(col) * (dotSize + spacing)
-                        let y = CGFloat(row) * (dotSize + spacing)
-                        let scale = 0.88 + val * 0.12
-                        let rect = CGRect(
-                            x: x + dotSize * (1 - scale) / 2,
-                            y: y + dotSize * (1 - scale) / 2,
-                            width: dotSize * scale,
-                            height: dotSize * scale
-                        )
-                        let path = Path(roundedRect: rect, cornerRadius: 1)
-                        context.fill(path, with: .color(WhisperColor.activityDot.opacity(val)))
-                    }
+    var body: some View {
+        if reduceMotion {
+            canvas(t: 0)
+        } else {
+            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+                canvas(t: timeline.date.timeIntervalSinceReferenceDate)
+            }
+        }
+    }
+
+    private func canvas(t: Double) -> some View {
+        Canvas { context, _ in
+            for row in 0..<3 {
+                for col in 0..<3 {
+                    let angle = atan2(Double(row - 1), Double(col - 1))
+                    let normalizedPhase = (angle / (.pi * 2) + 1).truncatingRemainder(dividingBy: 1)
+                    let wave = ((t * 0.9 + normalizedPhase).truncatingRemainder(dividingBy: 1) + 1).truncatingRemainder(dividingBy: 1)
+                    let raw = (cos((wave - 0.5) * .pi * 2) + 1) / 2
+                    let val = max(0, (raw - 0.2) / 0.8)
+
+                    let x = CGFloat(col) * (dotSize + spacing)
+                    let y = CGFloat(row) * (dotSize + spacing)
+                    let scale = 0.88 + val * 0.12
+                    let rect = CGRect(
+                        x: x + dotSize * (1 - scale) / 2,
+                        y: y + dotSize * (1 - scale) / 2,
+                        width: dotSize * scale,
+                        height: dotSize * scale
+                    )
+                    let path = Path(roundedRect: rect, cornerRadius: 1)
+                    context.fill(path, with: .color(WhisperColor.activityDot.opacity(val)))
                 }
             }
-            .frame(
-                width: dotSize * 3 + spacing * 2,
-                height: dotSize * 3 + spacing * 2
-            )
         }
+        .frame(
+            width: dotSize * 3 + spacing * 2,
+            height: dotSize * 3 + spacing * 2
+        )
     }
 }
 


### PR DESCRIPTION
Closes #296.

## What
The app never read the system **Reduce Motion** setting, so continuous animations ran regardless. Each of the three shared animated components now reads `@Environment(\.accessibilityReduceMotion)` internally and renders a static equivalent when Reduce Motion is on. Every call site inherits the behavior — no per-screen work, no app-level setting.

| Component | Motion on (unchanged) | Reduce Motion on |
|---|---|---|
| `ShimmerModifier` | opacity oscillates via `repeatForever` | fixed 0.5 opacity, no animation pass |
| `PulseModifier` | scale pulses to 1.02 | stays at scale 1.0, no animation |
| `ChatActivityRowLabel` streaming dot | `TimelineView` opacity pulse | steady filled dot |
| `AgentActivityIndicator` | `TimelineView` wave over the dot grid | static `canvas(t: 0)` frame (reads as "working") |

Same information conveyed, no motion. The default (motion-on) path is byte-for-byte unchanged.

## Scope
- iOS only. Files: `Theme/Animations.swift`, `Views/Chat/ChatActivityChrome.swift`, `Views/Components/AgentActivityIndicator.swift`.
- Out of scope (unchanged): the `TimelineView` frame-rate cap from #283, Reduce Transparency, any new animations.

## Testing
- `cd ios && swift test` → all pass (185 tests).
- `xcodebuild build … -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

## Screenshots
_UI/behavior change. A still screenshot of a paused vs. static animation looks identical, so before/after captures of the static Reduce-Motion states (Settings → Accessibility → Motion → Reduce Motion ON) will be attached from the simulator for the record._