### PR TITLE
Navigate to the workspace on push notification tap (#294)

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -76,10 +76,15 @@ struct HiveApp: App {
             }
             .onAppear {
                 mergePushCompletions()
+                handlePushNavigation()
             }
             .onChange(of: CompletedWorkspacesStore.shared.pending) { _, pending in
                 guard !pending.isEmpty else { return }
                 mergePushCompletions()
+            }
+            .onChange(of: CompletedWorkspacesStore.shared.navigationRequest) { _, request in
+                guard request != nil else { return }
+                handlePushNavigation()
             }
             .onChange(of: scenePhase) { _, newPhase in
                 switch newPhase {
@@ -108,6 +113,27 @@ struct HiveApp: App {
             projectStore.statusMonitor.markCompletedFromPush(wsId)
         }
         store.clearAll()
+    }
+
+    /// Resolve the most recent push tap and navigate to its workspace (and session),
+    /// falling back silently to the Hub tab when the workspace can't be resolved.
+    private func handlePushNavigation() {
+        guard let request = CompletedWorkspacesStore.shared.navigationRequest else { return }
+        CompletedWorkspacesStore.shared.clearNavigationRequest()
+        Task { @MainActor in
+            if let target = await projectStore.resolvePushTarget(
+                workspaceId: request.workspaceId,
+                sessionId: request.sessionId
+            ) {
+                projectStore.pendingSessionNavigation = target.sessionId.map {
+                    PendingSessionNavigation(workspaceId: target.workspace.id, sessionId: $0)
+                }
+                projectStore.pendingNavigation = target.workspace
+            } else {
+                projectStore.pendingSessionNavigation = nil
+                selectedTab = .hub
+            }
+        }
     }
 }
 

--- a/ios/HiveMobile/Services/AppDelegate.swift
+++ b/ios/HiveMobile/Services/AppDelegate.swift
@@ -39,16 +39,17 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         return []
     }
 
-    /// Handle notification tap — mark workspace as completed so the completion dot appears.
+    /// Handle notification tap — mark the workspace completed and request navigation to it.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
         let userInfo = response.notification.request.content.userInfo
-        if let workspaceId = userInfo["workspaceId"] as? String {
-            await MainActor.run {
-                CompletedWorkspacesStore.shared.insert(workspaceId)
-            }
+        guard let workspaceId = userInfo["workspaceId"] as? String else { return }
+        let sessionId = userInfo["sessionId"] as? String
+        await MainActor.run {
+            CompletedWorkspacesStore.shared.insert(workspaceId)
+            CompletedWorkspacesStore.shared.requestNavigation(workspaceId: workspaceId, sessionId: sessionId)
         }
     }
 

--- a/ios/HiveMobile/Services/CompletedWorkspacesStore.swift
+++ b/ios/HiveMobile/Services/CompletedWorkspacesStore.swift
@@ -13,6 +13,9 @@ final class CompletedWorkspacesStore {
 
     private(set) var pending: Set<String>
 
+    /// Most recent push tap, consumed by HiveApp to navigate to the workspace.
+    private(set) var navigationRequest: PushNavigationRequest?
+
     private let key = "pushCompletedWorkspaces"
 
     private init() {
@@ -25,6 +28,14 @@ final class CompletedWorkspacesStore {
         persist()
     }
 
+    func requestNavigation(workspaceId: String, sessionId: String?) {
+        navigationRequest = PushNavigationRequest(workspaceId: workspaceId, sessionId: sessionId)
+    }
+
+    func clearNavigationRequest() {
+        navigationRequest = nil
+    }
+
     func clearAll() {
         guard !pending.isEmpty else { return }
         pending.removeAll()
@@ -34,4 +45,9 @@ final class CompletedWorkspacesStore {
     private func persist() {
         UserDefaults.standard.set(Array(pending), forKey: key)
     }
+}
+
+struct PushNavigationRequest: Equatable {
+    let workspaceId: String
+    let sessionId: String?
 }

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -20,14 +20,28 @@ final class ProjectStore {
     /// Set after workspace creation so HiveApp can navigate to it.
     var pendingNavigation: Workspace?
 
+    /// Set alongside `pendingNavigation` when a push tap targets a specific session.
+    var pendingSessionNavigation: PendingSessionNavigation?
+
     let statusMonitor: HubStatusMonitor
 
-    private let api = APIClient()
+    private let api: APIClient
+    private let fetchProjectsClosure: @MainActor () async throws -> [Project]
+    private let fetchPreferencesClosure: @MainActor () async throws -> UiPreferencesPayload
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
 
-    init(storeCache: ConversationStoreCache) {
-        self.statusMonitor = HubStatusMonitor(storeCache: storeCache)
+    init(
+        storeCache: ConversationStoreCache,
+        statusMonitor: HubStatusMonitor? = nil,
+        fetchProjects: (@MainActor () async throws -> [Project])? = nil,
+        fetchPreferences: (@MainActor () async throws -> UiPreferencesPayload)? = nil
+    ) {
+        let client = APIClient()
+        self.api = client
+        self.statusMonitor = statusMonitor ?? HubStatusMonitor(storeCache: storeCache)
+        self.fetchProjectsClosure = fetchProjects ?? { try await client.fetchProjects() }
+        self.fetchPreferencesClosure = fetchPreferences ?? { try await client.fetchUiPreferences() }
     }
 
     /// Whether the store has never successfully loaded data yet.
@@ -160,8 +174,8 @@ final class ProjectStore {
         isLoading = true
         errorMessage = nil
         do {
-            async let projectsTask = api.fetchProjects()
-            async let preferencesTask = api.fetchUiPreferences()
+            async let projectsTask = fetchProjectsClosure()
+            async let preferencesTask = fetchPreferencesClosure()
 
             var fresh = try await projectsTask
             let preferences = (try? await preferencesTask) ?? .empty
@@ -190,6 +204,23 @@ final class ProjectStore {
         isLoading = false
     }
 
+    func resolvePushTarget(workspaceId: String, sessionId: String?) async -> PushNavigationTarget? {
+        if let target = Self.findTarget(workspaceId: workspaceId, sessionId: sessionId, in: projects) {
+            return target
+        }
+        await refresh(force: true)
+        return Self.findTarget(workspaceId: workspaceId, sessionId: sessionId, in: projects)
+    }
+
+    static func findTarget(workspaceId: String, sessionId: String?, in projects: [Project]) -> PushNavigationTarget? {
+        for project in projects {
+            if let workspace = project.workspaces.first(where: { $0.id == workspaceId }) {
+                return PushNavigationTarget(workspace: workspace, sessionId: sessionId)
+            }
+        }
+        return nil
+    }
+
     private static func extractRepoName(from url: String) -> String {
         let trimmed = url.hasSuffix("/") ? String(url.dropLast()) : url
         guard let last = trimmed.split(separator: "/").last else { return "repository" }
@@ -197,4 +228,14 @@ final class ProjectStore {
         if name.hasSuffix(".git") { name = String(name.dropLast(4)) }
         return name.isEmpty ? "repository" : name
     }
+}
+
+struct PushNavigationTarget: Equatable {
+    let workspace: Workspace
+    let sessionId: String?
+}
+
+struct PendingSessionNavigation: Equatable {
+    let workspaceId: String
+    let sessionId: String
 }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -201,12 +201,22 @@ struct ConversationsSection<Header: View>: View {
             sessions = try await api.fetchSessions(workspaceId: workspace.id)
                 .filter { $0.kind != "terminal" }
             errorMessage = nil
+            navigateToPendingSessionIfNeeded()
         } catch is CancellationError {
             // View disappeared.
         } catch {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func navigateToPendingSessionIfNeeded() {
+        guard let pending = projectStore.pendingSessionNavigation,
+              pending.workspaceId == workspace.id else { return }
+        projectStore.pendingSessionNavigation = nil
+        if let match = sessions.first(where: { $0.sessionId == pending.sessionId }) {
+            navigationPath.append(match)
+        }
     }
 
     private func createSession() {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
                 "HiveApp.swift",
                 "HiveMobile.entitlements",
                 "Stores/ModelCatalog.swift",
-                "Stores/ProjectStore.swift",
                 "Theme",
                 "Views"
             ],
@@ -29,6 +28,7 @@ let package = Package(
                 "Models/ConversationSurfaceModels.swift",
                 "Models/Models.swift",
                 "Models/WebSocketTypes.swift",
+                "Services/APIClient.swift",
                 "Services/HiveHTTP.swift",
                 "Stores/BackgroundAgentDerivation.swift",
                 "Stores/ChatDraftStore.swift",
@@ -42,6 +42,7 @@ let package = Package(
                 "Stores/HubOrganization.swift",
                 "Stores/HubSubscriptionSync.swift",
                 "Stores/MarkdownStructure.swift",
+                "Stores/ProjectStore.swift",
                 "Stores/SubAgentStatus.swift",
                 "Stores/TaskDerivation.swift",
                 "Stores/TokenFormatting.swift",

--- a/ios/Tests/ChatDraftStoreTests/ProjectStorePushNavigationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStorePushNavigationTests.swift
@@ -1,0 +1,119 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+@MainActor
+private final class NoopHubConnection: HubConnectionClient {
+    func connect() {}
+    func cancel() {}
+    func forceReconnect() {}
+    func send(_ message: HubIncoming) async -> Bool { true }
+    func sendSync(_ payload: HubSyncPayload, forceBootstrap: Bool) {}
+    func probeLiveness() {}
+}
+
+@MainActor
+private final class FetchRecorder {
+    private let results: [[Project]]
+    private(set) var callCount = 0
+
+    init(_ results: [[Project]]) {
+        self.results = results
+    }
+
+    func next() -> [Project] {
+        let result = results[min(callCount, results.count - 1)]
+        callCount += 1
+        return result
+    }
+}
+
+@MainActor
+struct ProjectStorePushNavigationTests {
+    @Test
+    func resolvesLoadedWorkspaceWithoutRefreshing() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-1", sessionId: "sess-1")
+
+        #expect(target?.workspace.id == "ws-1")
+        #expect(target?.sessionId == "sess-1")
+        #expect(recorder.callCount == 1)
+    }
+
+    @Test
+    func refreshesThenRetriesForUnknownWorkspace() async {
+        let recorder = FetchRecorder([
+            [project("p1", workspace: "ws-1")],
+            [project("p1", workspace: "ws-1"), project("p2", workspace: "ws-2")]
+        ])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-2", sessionId: nil)
+
+        #expect(target?.workspace.id == "ws-2")
+        #expect(target?.sessionId == nil)
+        #expect(recorder.callCount == 2)
+    }
+
+    @Test
+    func fallsBackSilentlyWhenWorkspaceStaysUnresolved() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-archived", sessionId: "sess-x")
+
+        #expect(target == nil)
+        #expect(recorder.callCount == 2)
+    }
+
+    @Test
+    func coldLaunchResolvesByRefreshingEmptyProjects() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-1", sessionId: nil)
+
+        #expect(target?.workspace.id == "ws-1")
+        #expect(recorder.callCount == 1)
+    }
+
+    private func makeStore(_ recorder: FetchRecorder) -> ProjectStore {
+        let cache = ConversationStoreCache()
+        let monitor = HubStatusMonitor(storeCache: cache) { _ in NoopHubConnection() }
+        return ProjectStore(
+            storeCache: cache,
+            statusMonitor: monitor,
+            fetchProjects: { recorder.next() },
+            fetchPreferences: { .empty }
+        )
+    }
+
+    private func project(_ id: String, workspace workspaceId: String) -> Project {
+        Project(
+            id: id,
+            name: id,
+            url: "https://github.com/acme/\(id).git",
+            createdAt: "2026-01-01T00:00:00Z",
+            workspaces: [
+                Workspace(
+                    id: workspaceId,
+                    name: workspaceId,
+                    branch: "main",
+                    status: .idle,
+                    createdAt: "2026-01-01T00:00:00Z",
+                    activeSessionId: nil,
+                    projectName: id,
+                    defaultBranch: "main",
+                    sessionCount: 1,
+                    projectId: id,
+                    hasFavicon: false
+                )
+            ],
+            hasFavicon: false
+        )
+    }
+}


### PR DESCRIPTION
Closes #294.

## What
Tapping a "turn completed" push previously only marked the Hub completion dot and left the user wherever they were. It now **navigates to the workspace** via the existing `pendingNavigation` mechanism (the same path used after workspace creation) — no parallel navigation system introduced.

## Behavior
- **Tap → navigate**: `AppDelegate` forwards `workspaceId` (and `sessionId` if the payload carries it) as a navigation request, while still marking the completed indicator.
- **Resolution**: `ProjectStore.resolvePushTarget` finds the workspace in loaded projects; if absent it refreshes the project list once and retries; if still unresolved (archived/deleted/unknown) it returns nil.
- **Silent fallback**: an unresolved target lands the user on the Hub root — no alert.
- **Cold launch**: handled in `onAppear` (the resolve awaits the project refresh before navigating); warm taps handled via `onChange`.
- **Session continuation**: a targeted session is pushed once its `ConversationsSection` loads; a stale/absent session degrades gracefully to the conversation list.

> Note: the backend `agent_turn_complete` payload currently carries only `workspaceId`, so the session-continuation path is plumbed but dormant until a `sessionId` is added server-side. It degrades correctly today.

## Testability
`ProjectStore`'s project/preferences fetches are now injectable (optional init params; production defaults unchanged), so the resolution logic is unit-tested without the network.

## Scope
iOS only. `HiveApp.swift`, `Services/AppDelegate.swift`, `Services/CompletedWorkspacesStore.swift`, `Stores/ProjectStore.swift`, `Views/Chat/ConversationsSection.swift`, `Package.swift` (adds `ProjectStore`/`APIClient` to the test target), plus a new test file.

## Testing
- `cd ios && swift test` → **189 tests pass** (+4 new: loaded, refresh-retry, unresolved-fallback, cold-launch).
- `xcodebuild build … -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

## Screenshots
_This is a navigation-flow change (tap push → land on the workspace) rather than a static visual change; a screen recording of the tap-to-workspace flow will be captured from the simulator for the record._