### PR TITLE
Add sparse haptic feedback for key actions (#297)

### DIFF
--- a/ios/HiveMobile/Services/Haptics.swift
+++ b/ios/HiveMobile/Services/Haptics.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// The app's entire haptic vocabulary. Kept deliberately small so the sparse
+/// mapping (send/stop, plan and question outcomes, composer toggles) can be
+/// read in one place. `UIFeedbackGenerator` automatically respects the system
+/// haptics setting, so there is no in-app toggle.
+@MainActor
+enum Haptics {
+    static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+
+    static func notify(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        UINotificationFeedbackGenerator().notificationOccurred(type)
+    }
+
+    static func selection() {
+        UISelectionFeedbackGenerator().selectionChanged()
+    }
+}

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -63,6 +63,16 @@ final class ConversationStore {
     /// Per-session transient streaming state. Keyed by session ID.
     var sessionStreams: [String: SessionStreamState] = [:]
 
+    /// True while a ChatView for the focused session is the visible foreground
+    /// screen. Gates the turn-completion haptic to on-screen completions only;
+    /// set by ChatView on appear/disappear.
+    @ObservationIgnored var isChatVisible = false
+
+    /// Bumps once per agent turn that completes while its chat is the visible
+    /// screen. Background sessions, other tabs, and non-visible screens never
+    /// bump it. ChatView observes this to fire the success haptic.
+    private(set) var visibleCompletionCount = 0
+
     // Branch & diff info (pushed via WS)
     var branchInfo: BranchInfo?
     var diffStats: DiffStatResponse?
@@ -233,6 +243,7 @@ final class ConversationStore {
             lastHistoryFetchAt.removeValue(forKey: sid)
             bumpHistoryToken(for: sid)
             onTurnCompleted?(sid)
+            registerVisibleCompletion(for: sid)
 
         case .cancelled(let sid, let errorDetail, _, let durationMs):
             flushStreamingDeltas()
@@ -527,6 +538,14 @@ final class ConversationStore {
     }
 
     // MARK: - Private
+
+    /// A turn finished for `sid`. Only bump the observable completion counter
+    /// when that session's chat is the visible screen, so haptics never fire for
+    /// background sessions, other tabs, or non-visible screens.
+    private func registerVisibleCompletion(for sid: String) {
+        guard isChatVisible, sid == sessionId else { return }
+        visibleCompletionCount += 1
+    }
 
     /// Ensure a stream slot exists for the given session, defaulting to streaming state.
     private func ensureStream(for sid: String, streaming: Bool = true) {

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -93,6 +93,7 @@ struct ChatInputBar: View {
                         ForEach(group.models) { model in
                             let isLocked = lockedProvider != nil && model.provider != lockedProvider
                             Button {
+                                Haptics.selection()
                                 onModelSelect(model.id)
                             } label: {
                                 HStack {
@@ -220,6 +221,7 @@ struct ChatInputBar: View {
 
             if isBusy {
                 Button {
+                    Haptics.impact(.light)
                     onStop?()
                 } label: {
                     Image(systemName: "stop.circle.fill")
@@ -254,6 +256,7 @@ struct ChatInputBar: View {
     }
 
     private func handleSend() {
+        Haptics.impact(.light)
         let imageAttachments = attachedImages.compactMap(\.attachment)
         attachedImages = []
         onDraftAttachmentsChange([])
@@ -320,7 +323,10 @@ private struct ModeToggle: View {
     var highlightColor: Color = .white
 
     var body: some View {
-        Button { isActive.toggle() } label: {
+        Button {
+            Haptics.selection()
+            isActive.toggle()
+        } label: {
             HStack(spacing: 4) {
                 Image(systemName: systemImage)
                 Text(label)
@@ -349,7 +355,10 @@ private struct LevelCycleButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button { action() } label: {
+        Button {
+            Haptics.selection()
+            action()
+        } label: {
             HStack(spacing: 4) {
                 Image(systemName: systemImage)
                 Text(label)

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -226,6 +226,7 @@ struct ChatView: View {
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.hidden, for: .tabBar)
+        .sensoryFeedback(.success, trigger: store.visibleCompletionCount)
         .sheet(isPresented: Binding(
             get: { !store.pendingToolInputs.isEmpty },
             set: { if !$0 { store.clearPendingToolInputs() } }
@@ -255,6 +256,7 @@ struct ChatView: View {
             }
         }
         .onDisappear {
+            store.isChatVisible = false
             saveCurrentDraft()
             store.onTurnCompleted = nil
             projectStore.statusMonitor.clearViewingSession(workspaceId: workspace.id, sessionId: session.sessionId)
@@ -303,6 +305,7 @@ struct ChatView: View {
     // MARK: - Setup
 
     private func setup() async {
+        store.isChatVisible = true
         projectStore.statusMonitor.setViewingWorkspace(workspace.id, sessionId: session.sessionId)
         projectStore.statusMonitor.clearCompleted(workspace.id)
         projectStore.statusMonitor.clearUnread(workspaceId: workspace.id, sessionId: session.sessionId)
@@ -433,6 +436,15 @@ struct ChatView: View {
                 result: result,
                 sessionId: pending.sessionId
             )) ?? false
+
+            switch result {
+            case .approve:
+                Haptics.notify(.success)
+            case .reject, .dismiss:
+                Haptics.notify(.warning)
+            case .answer:
+                Haptics.notify(sent ? .success : .warning)
+            }
 
             if sent {
                 store.clearPendingToolInputs()

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -438,12 +438,10 @@ struct ChatView: View {
             )) ?? false
 
             switch result {
-            case .approve:
-                Haptics.notify(.success)
+            case .approve, .answer:
+                Haptics.notify(sent ? .success : .warning)
             case .reject, .dismiss:
                 Haptics.notify(.warning)
-            case .answer:
-                Haptics.notify(sent ? .success : .warning)
             }
 
             if sent {

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreCompletionHapticTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreCompletionHapticTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Drives the turn-completion haptic: the store must expose an observable
+/// completion transition that bumps only when the completing session's chat is
+/// the visible screen. These assert that external behaviour, not the haptic.
+struct ConversationStoreCompletionHapticTests {
+    @MainActor
+    private func streamingStore(session: String, visible: Bool) -> ConversationStore {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId(session)
+        store.applyFetchedHistory([], for: session)
+        store.isChatVisible = visible
+        store.handle(.status(
+            status: .busy,
+            sessionId: session,
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: session, text: "Answer"))
+        return store
+    }
+
+    private func done(_ session: String) -> WsOutgoing {
+        .done(
+            sessionId: session,
+            durationMs: 100,
+            inputTokens: nil,
+            outputTokens: nil,
+            contextUsedTokens: nil,
+            contextWindowTokens: nil,
+            pendingToolName: nil
+        )
+    }
+
+    @Test @MainActor
+    func completionWhileViewingChatBumpsCounter() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(done("session-A"))
+        #expect(store.visibleCompletionCount == 1)
+    }
+
+    @Test @MainActor
+    func completionWhileChatNotVisibleDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: false)
+        store.handle(done("session-A"))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func backgroundSessionCompletionDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: true)
+        // A second session streams in the background while A stays focused.
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-B",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-B", text: "Background"))
+        store.handle(done("session-B"))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func cancelledTurnDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(.cancelled(
+            sessionId: "session-A",
+            errorDetail: nil,
+            userInitiated: true,
+            durationMs: 100
+        ))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func successiveVisibleCompletionsAccumulate() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(done("session-A"))
+
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-A",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-A", text: "Second answer"))
+        store.handle(done("session-A"))
+
+        #expect(store.visibleCompletionCount == 2)
+    }
+}


### PR DESCRIPTION
Closes #297.

## What
Restrained, purposeful haptics for the moments that matter — sparse by design (never a buzz per event), firing only for events on the screen the user is viewing, and automatically respecting the system haptics setting (native `UIFeedbackGenerator` / SwiftUI `.sensoryFeedback`, so no in-app toggle).

## Vocabulary
| Action | Haptic |
|---|---|
| Send a message | light impact |
| Stop an agent | light impact |
| Agent turn completes **while its chat is the visible screen** | success notification |
| Approve a plan | success |
| Reject / dismiss a plan | warning |
| Submit an answer to a question | success / warning (matches whether it reached the socket) |
| Toggle mode / model / thinking level in the composer | selection |

## Design
- A tiny central `Haptics` helper (`Services/Haptics.swift`) holds the whole vocabulary in one place: `impact`, `notify`, `selection`.
- The turn-completion haptic is the **store-testable slice**: `ConversationStore` exposes an observable `visibleCompletionCount` that bumps only when a `.done` arrives for the **focused** session while `isChatVisible` is true. Background sessions, other tabs, and hidden screens never bump it. `ChatView` fires the success haptic via `.sensoryFeedback(.success, trigger:)`.
- Discrete button actions call the helper directly; composer wiring is confined to `ChatInputBar` to keep `ChatView` edits minimal.

## Scope
iOS only. New: `Services/Haptics.swift`, a test file. Modified: `Stores/ConversationStore.swift`, `Views/Chat/ChatView.swift`, `Views/Chat/ChatInputBar.swift`.

## Testing
- `cd ios && swift test` → **190 tests pass** (+5 new: visible-bumps, not-visible-no-bump, background-session-no-bump, cancelled-no-bump, accumulation).
- `xcodebuild build … -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

## Note
Touches `ChatView` (also edited by #306) and `ConversationStore`; edits are in disjoint regions, so this should rebase cleanly. Haptics are physical — best verified on a device (the simulator does not play them).