### PR TITLE
Honest Hub server-unreachable state with retry (#285)

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -41,7 +41,7 @@ struct HiveApp: App {
                 }
                 Tab("Hub", systemImage: "square.grid.2x2.fill", value: .hub) {
                     NavigationStack(path: $hubPath) {
-                        HubView()
+                        HubView(openSettings: { selectedTab = .settings })
                             .navigationDestination(for: Workspace.self) { workspace in
                                 WorkspaceConversationsView(
                                     workspace: workspace,

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -69,9 +69,12 @@ struct HiveApp: App {
             .environment(modelCatalog)
             .overlay {
                 if showOnboarding {
-                    OnboardingView(onDone: { withAnimation { showOnboarding = false } })
-                        .background(WhisperColor.appBackground)
-                        .transition(.opacity)
+                    OnboardingView(onDone: {
+                        withAnimation { showOnboarding = false }
+                        Task { await projectStore.refresh(force: true) }
+                    })
+                    .background(WhisperColor.appBackground)
+                    .transition(.opacity)
                 }
             }
             .preferredColorScheme(themeMode.preferredColorScheme)

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -11,6 +11,7 @@ struct HiveApp: App {
     @State private var hubPath = NavigationPath()
     @State private var brainPath = NavigationPath()
     @State private var backgroundedAt: Date?
+    @State private var showOnboarding = UserDefaults.standard.object(forKey: "serverHost") == nil
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @AppStorage("hiveThemeMode") private var themeModeId = HiveThemeMode.system.rawValue
 
@@ -66,6 +67,13 @@ struct HiveApp: App {
             .environment(projectStore)
             .environment(storeCache)
             .environment(modelCatalog)
+            .overlay {
+                if showOnboarding {
+                    OnboardingView(onDone: { withAnimation { showOnboarding = false } })
+                        .background(WhisperColor.appBackground)
+                        .transition(.opacity)
+                }
+            }
             .preferredColorScheme(themeMode.preferredColorScheme)
             .task { await modelCatalog.loadIfNeeded() }
             .onChange(of: projectStore.pendingNavigation) { _, workspace in

--- a/ios/HiveMobile/Services/NetworkEnvironment.swift
+++ b/ios/HiveMobile/Services/NetworkEnvironment.swift
@@ -1,0 +1,19 @@
+import CFNetwork
+import Foundation
+
+enum NetworkEnvironment {
+    /// Best-effort detection of an active VPN tunnel. iOS exposes no API to
+    /// identify a specific VPN app (e.g. Tailscale), so this only reports whether
+    /// some tunnel interface is currently routing traffic — treat it as a hint,
+    /// not a guarantee.
+    static func isVPNActive() -> Bool {
+        guard let settings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() as? [String: Any],
+              let scoped = settings["__SCOPED__"] as? [String: Any] else {
+            return false
+        }
+        let tunnelPrefixes = ["tap", "tun", "ppp", "ipsec", "utun"]
+        return scoped.keys.contains { key in
+            tunnelPrefixes.contains { key.hasPrefix($0) }
+        }
+    }
+}

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -9,9 +9,19 @@ import Observation
 @MainActor
 @Observable
 final class ProjectStore {
+    /// Why the last project fetch failed, classified so the Hub can show
+    /// accurate copy. `nil` once a fetch succeeds.
+    enum FetchFailure: Equatable {
+        case unreachable
+        case authentication
+        case other
+    }
+
     private(set) var projects: [Project] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
+    private(set) var fetchFailure: FetchFailure?
+    private(set) var refreshFailedWithCachedData = false
     private(set) var creatingWorkspaceProjectIds: Set<String> = []
     private(set) var isCreatingProject = false
     private(set) var cloningRepoName: String?
@@ -23,15 +33,28 @@ final class ProjectStore {
     let statusMonitor: HubStatusMonitor
 
     private let api = APIClient()
+    private let fetchProjects: () async throws -> [Project]
+    private let fetchUiPreferences: () async throws -> UiPreferencesPayload
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
 
-    init(storeCache: ConversationStoreCache) {
+    init(
+        storeCache: ConversationStoreCache,
+        fetchProjects: (() async throws -> [Project])? = nil,
+        fetchUiPreferences: (() async throws -> UiPreferencesPayload)? = nil
+    ) {
         self.statusMonitor = HubStatusMonitor(storeCache: storeCache)
+        let client = api
+        self.fetchProjects = fetchProjects ?? { try await client.fetchProjects() }
+        self.fetchUiPreferences = fetchUiPreferences ?? { try await client.fetchUiPreferences() }
     }
 
     /// Whether the store has never successfully loaded data yet.
     var isInitialLoad: Bool { !hasFetchedOnce }
+
+    /// Whether a fetch has ever succeeded — gates the No Projects onboarding
+    /// state so it never masquerades as a failed fetch.
+    var hasLoadedSuccessfully: Bool { hasFetchedOnce }
 
     /// Sync the hub monitor with every workspace plus the synthetic Brain id, so
     /// the Brain always stays subscribed (streaming/done events, send wiring) and
@@ -155,13 +178,16 @@ final class ProjectStore {
     }
 
     /// Refresh projects from the API. Shows existing data while loading.
-    func refresh(force: Bool = false) async {
+    /// `userInitiated` marks an explicit pull-to-refresh so a failure over
+    /// cached data can surface a transient notice.
+    func refresh(force: Bool = false, userInitiated: Bool = false) async {
         if !force, hasFetchedOnce, Date().timeIntervalSince(lastRefreshedAt) < 45 { return }
         isLoading = true
         errorMessage = nil
+        refreshFailedWithCachedData = false
         do {
-            async let projectsTask = api.fetchProjects()
-            async let preferencesTask = api.fetchUiPreferences()
+            async let projectsTask = fetchProjects()
+            async let preferencesTask = fetchUiPreferences()
 
             var fresh = try await projectsTask
             let preferences = (try? await preferencesTask) ?? .empty
@@ -178,16 +204,39 @@ final class ProjectStore {
             uiPreferences = preferences
             hasFetchedOnce = true
             lastRefreshedAt = Date()
+            fetchFailure = nil
             syncMonitoredWorkspaces()
         } catch is CancellationError {
             // View disappeared — ignore
         } catch {
-            // Only surface error if we have no cached data to show
-            if projects.isEmpty {
-                errorMessage = error.localizedDescription
+            fetchFailure = Self.classify(error)
+            if !projects.isEmpty, userInitiated {
+                refreshFailedWithCachedData = true
             }
         }
         isLoading = false
+    }
+
+    /// Dismiss the transient pull-to-refresh failure notice.
+    func acknowledgeRefreshFailure() {
+        refreshFailedWithCachedData = false
+    }
+
+    private static func classify(_ error: Error) -> FetchFailure {
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .httpError(let statusCode, _):
+                return statusCode == 401 || statusCode == 403 ? .authentication : .other
+            case .networkError, .invalidURL:
+                return .unreachable
+            case .decodingError:
+                return .other
+            }
+        }
+        if error is URLError {
+            return .unreachable
+        }
+        return .other
     }
 
     private static func extractRepoName(from url: String) -> String {

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -77,7 +77,9 @@ struct HubView: View {
                 refreshFailedNotice
                     .task {
                         try? await Task.sleep(for: .seconds(3))
-                        store.acknowledgeRefreshFailure()
+                        if !Task.isCancelled {
+                            store.acknowledgeRefreshFailure()
+                        }
                     }
             }
         }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -9,6 +9,7 @@ private enum HubLayout {
 
 struct HubView: View {
     @Environment(ProjectStore.self) private var store
+    var openSettings: (() -> Void)?
     @State private var showAddProject = false
     @State private var workspaceToArchive: Workspace?
     @State private var sectionExpansionOverrides: [String: Bool] = HubView.loadExpansionOverrides(
@@ -28,15 +29,8 @@ struct HubView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: HiveSpacing.md) {
-                    if store.isLoading && store.projects.isEmpty {
-                        loadingState
-                    } else if store.projects.isEmpty && !store.isLoading {
-                        ContentUnavailableView(
-                            "No Projects",
-                            systemImage: "folder",
-                            description: Text("Tap + to add your first project, or connect to your Hive server from Settings.")
-                        )
-                        .padding(.top, 40)
+                    if store.projects.isEmpty {
+                        emptyState
                     } else {
                         denseHubContent(sections: sections)
                     }
@@ -57,7 +51,7 @@ struct HubView: View {
             // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
             await Task { @MainActor in
                 store.statusMonitor.forceRefresh()
-                await store.refresh(force: true)
+                await store.refresh(force: true, userInitiated: true)
             }.value
         }
         .task {
@@ -78,6 +72,16 @@ struct HubView: View {
                 errorBanner(errorMessage)
             }
         }
+        .overlay(alignment: .top) {
+            if store.refreshFailedWithCachedData {
+                refreshFailedNotice
+                    .task {
+                        try? await Task.sleep(for: .seconds(3))
+                        store.acknowledgeRefreshFailure()
+                    }
+            }
+        }
+        .animation(.default, value: store.refreshFailedWithCachedData)
         .safeAreaInset(edge: .top, spacing: 0) {
             if let repoName = store.cloningRepoName {
                 HStack(spacing: HiveSpacing.sm) {
@@ -130,6 +134,41 @@ struct HubView: View {
         }
         .frame(maxWidth: .infinity, minHeight: 420)
         .frame(maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if let failure = store.fetchFailure {
+            HubUnreachableState(
+                failure: failure,
+                isRetrying: store.isLoading,
+                onRetry: { Task { await store.refresh(force: true) } },
+                onOpenSettings: { openSettings?() }
+            )
+        } else if store.isLoading || !store.hasLoadedSuccessfully {
+            loadingState
+        } else {
+            ContentUnavailableView(
+                "No Projects",
+                systemImage: "folder",
+                description: Text("Tap + to add your first project, or connect to your Hive server from Settings.")
+            )
+            .padding(.top, 40)
+        }
+    }
+
+    private var refreshFailedNotice: some View {
+        HStack(spacing: HiveSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle")
+            Text("Couldn't refresh. Showing cached data.")
+                .font(.footnote)
+        }
+        .foregroundStyle(WhisperColor.textSecondary)
+        .padding(.horizontal, HiveSpacing.lg)
+        .padding(.vertical, HiveSpacing.sm)
+        .glassPill()
+        .padding(.top, HiveSpacing.sm)
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     @ToolbarContentBuilder
@@ -385,6 +424,79 @@ struct HubView: View {
         }
         .transition(.move(edge: .bottom))
         .animation(.default, value: store.errorMessage)
+    }
+}
+
+private struct HubUnreachableState: View {
+    let failure: ProjectStore.FetchFailure
+    let isRetrying: Bool
+    let onRetry: () -> Void
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: HiveSpacing.md) {
+            Image(systemName: icon)
+                .font(.system(size: 44))
+                .foregroundStyle(WhisperColor.textMuted)
+            Text(title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(WhisperColor.text)
+                .multilineTextAlignment(.center)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(WhisperColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: HiveSpacing.sm) {
+                Button(action: onRetry) {
+                    HStack(spacing: HiveSpacing.sm) {
+                        if isRetrying {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(isRetrying ? "Retrying..." : "Retry")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isRetrying)
+
+                Button("Open Settings", action: onOpenSettings)
+                    .buttonStyle(.bordered)
+                    .disabled(isRetrying)
+            }
+            .padding(.top, HiveSpacing.sm)
+        }
+        .padding(HiveSpacing.xl)
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var icon: String {
+        switch failure {
+        case .unreachable: "wifi.slash"
+        case .authentication: "lock.trianglebadge.exclamationmark"
+        case .other: "exclamationmark.triangle"
+        }
+    }
+
+    private var title: String {
+        switch failure {
+        case .unreachable: "Can't reach your Hive server"
+        case .authentication: "Can't sign in to your Hive server"
+        case .other: "Something went wrong"
+        }
+    }
+
+    private var message: String {
+        switch failure {
+        case .unreachable:
+            "Hive couldn't connect to your server. Check that it's running and reachable, then try again."
+        case .authentication:
+            "Your Hive server rejected the current credentials. Open Settings to check your server address and token."
+        case .other:
+            "Your Hive server returned an unexpected error. Try again in a moment."
+        }
     }
 }
 

--- a/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
+++ b/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
@@ -14,6 +14,7 @@ struct OnboardingView: View {
     @FocusState private var focused: Field?
     @State private var phase: Phase = .idle
     @State private var vpnActive = NetworkEnvironment.isVPNActive()
+    @State private var vpnRefreshSpin = 0.0
 
     private enum Field: Hashable { case host, port, token }
     private enum Phase: Equatable { case idle, testing, success, failed }
@@ -112,9 +113,11 @@ struct OnboardingView: View {
                 }
                 Spacer()
                 Button {
+                    withAnimation(.snappy(duration: 0.5)) { vpnRefreshSpin += 360 }
                     vpnActive = NetworkEnvironment.isVPNActive()
                 } label: {
                     Image(systemName: "arrow.clockwise")
+                        .rotationEffect(.degrees(vpnRefreshSpin))
                 }
                 .buttonStyle(.plain)
                 .foregroundStyle(WhisperColor.textSecondary)

--- a/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
+++ b/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
@@ -37,15 +37,12 @@ struct OnboardingView: View {
             .scrollContentBackground(.hidden)
             .hiveScreenBackground()
             .scrollDismissesKeyboard(.interactively)
+            .onTapGesture { focused = nil }
             .safeAreaInset(edge: .bottom) { connectBar }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("Set up later", action: onDone)
                         .foregroundStyle(WhisperColor.textSecondary)
-                }
-                ToolbarItemGroup(placement: .keyboard) {
-                    Spacer()
-                    Button("Done") { focused = nil }
                 }
             }
         }
@@ -155,7 +152,10 @@ struct OnboardingView: View {
         .controlSize(.large)
         .disabled(!canConnect)
         .padding(.horizontal, HiveSpacing.lg)
+        .padding(.top, HiveSpacing.sm)
         .padding(.bottom, HiveSpacing.sm)
+        .frame(maxWidth: .infinity)
+        .background(.bar)
     }
 
     private var connectLabel: String {

--- a/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
+++ b/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
@@ -134,28 +134,34 @@ struct OnboardingView: View {
     }
 
     private var connectBar: some View {
-        Button {
-            Task { await testAndConnect() }
-        } label: {
-            HStack(spacing: HiveSpacing.sm) {
-                if phase == .testing {
-                    ProgressView().controlSize(.small).tint(.white)
-                } else if phase == .success {
-                    Image(systemName: "checkmark.circle.fill")
+        VStack(spacing: 0) {
+            Divider().overlay(WhisperColor.separator)
+            Button {
+                Task { await testAndConnect() }
+            } label: {
+                HStack(spacing: HiveSpacing.sm) {
+                    if phase == .testing {
+                        ProgressView().controlSize(.small).tint(.white)
+                    } else if phase == .success {
+                        Image(systemName: "checkmark.circle.fill")
+                    }
+                    Text(connectLabel)
                 }
-                Text(connectLabel).fontWeight(.semibold)
+                .font(.headline)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 52)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(accent)
+                )
+                .opacity(canConnect ? 1 : 0.4)
             }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, HiveSpacing.xs)
+            .buttonStyle(.plain)
+            .disabled(!canConnect)
+            .padding(.horizontal, HiveSpacing.lg)
+            .padding(.vertical, HiveSpacing.md)
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
-        .disabled(!canConnect)
-        .padding(.horizontal, HiveSpacing.lg)
-        .padding(.top, HiveSpacing.sm)
-        .padding(.bottom, HiveSpacing.sm)
-        .frame(maxWidth: .infinity)
-        .background(.bar)
+        .background(WhisperColor.appBackground)
     }
 
     private var connectLabel: String {

--- a/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
+++ b/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,197 @@
+import SwiftUI
+
+/// First-run funnel shown when no server has been configured yet. Guides the user
+/// through entering their Hive server address, hints at VPN/Tailscale state, and
+/// verifies reachability before dismissing.
+struct OnboardingView: View {
+    let onDone: () -> Void
+
+    @AppStorage("serverHost") private var host = ""
+    @AppStorage("serverPort") private var port = "3000"
+    @AppStorage("authToken") private var token = ""
+    @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
+
+    @FocusState private var focused: Field?
+    @State private var phase: Phase = .idle
+    @State private var vpnActive = NetworkEnvironment.isVPNActive()
+
+    private enum Field: Hashable { case host, port, token }
+    private enum Phase: Equatable { case idle, testing, success, failed }
+
+    private var accent: Color { AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color }
+
+    private var canConnect: Bool {
+        !host.trimmingCharacters(in: .whitespaces).isEmpty
+            && !port.trimmingCharacters(in: .whitespaces).isEmpty
+            && phase != .testing
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                headerSection
+                serverSection
+                statusSection
+            }
+            .scrollContentBackground(.hidden)
+            .hiveScreenBackground()
+            .scrollDismissesKeyboard(.interactively)
+            .safeAreaInset(edge: .bottom) { connectBar }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Set up later", action: onDone)
+                        .foregroundStyle(WhisperColor.textSecondary)
+                }
+                ToolbarItemGroup(placement: .keyboard) {
+                    Spacer()
+                    Button("Done") { focused = nil }
+                }
+            }
+        }
+    }
+
+    private var headerSection: some View {
+        Section {
+            VStack(spacing: HiveSpacing.sm) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 40, weight: .semibold))
+                    .foregroundStyle(accent)
+                Text("Connect to your Hive server")
+                    .font(.title2.weight(.bold))
+                    .multilineTextAlignment(.center)
+                Text("Enter your server address to get started. If it's behind Tailscale, make sure the VPN is connected first.")
+                    .font(.subheadline)
+                    .foregroundStyle(WhisperColor.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, HiveSpacing.md)
+        }
+        .listRowBackground(Color.clear)
+    }
+
+    private var serverSection: some View {
+        Section("Server") {
+            LabeledContent("Host") {
+                TextField("hostname or IP", text: $host)
+                    .focused($focused, equals: .host)
+                    .textContentType(.URL)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .multilineTextAlignment(.trailing)
+            }
+            LabeledContent("Port") {
+                TextField("port", text: $port)
+                    .focused($focused, equals: .port)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+            }
+            LabeledContent("Token") {
+                SecureField("optional", text: $token)
+                    .focused($focused, equals: .token)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+        .listRowBackground(WhisperColor.surfaceRaised)
+    }
+
+    private var statusSection: some View {
+        Section {
+            HStack(spacing: HiveSpacing.sm) {
+                Image(systemName: vpnActive ? "lock.shield.fill" : "lock.shield")
+                    .font(.title3)
+                    .foregroundStyle(vpnActive ? WhisperColor.success : WhisperColor.textMuted)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(vpnActive ? "VPN active" : "No VPN detected")
+                        .font(.subheadline.weight(.medium))
+                    Text(vpnActive
+                        ? "A tunnel is up — good if your server needs Tailscale."
+                        : "If your server is behind Tailscale, connect the VPN first.")
+                        .font(.caption)
+                        .foregroundStyle(WhisperColor.textSecondary)
+                }
+                Spacer()
+                Button {
+                    vpnActive = NetworkEnvironment.isVPNActive()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(WhisperColor.textSecondary)
+                .accessibilityLabel("Re-check VPN")
+            }
+
+            if phase == .failed {
+                Label(
+                    "Couldn't reach \(host):\(port). Check the address\(vpnActive ? "" : " and your VPN"), then try again.",
+                    systemImage: "wifi.slash"
+                )
+                .font(.caption)
+                .foregroundStyle(.red)
+            }
+        }
+        .listRowBackground(WhisperColor.surfaceRaised)
+    }
+
+    private var connectBar: some View {
+        Button {
+            Task { await testAndConnect() }
+        } label: {
+            HStack(spacing: HiveSpacing.sm) {
+                if phase == .testing {
+                    ProgressView().controlSize(.small).tint(.white)
+                } else if phase == .success {
+                    Image(systemName: "checkmark.circle.fill")
+                }
+                Text(connectLabel).fontWeight(.semibold)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, HiveSpacing.xs)
+        }
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .disabled(!canConnect)
+        .padding(.horizontal, HiveSpacing.lg)
+        .padding(.bottom, HiveSpacing.sm)
+    }
+
+    private var connectLabel: String {
+        switch phase {
+        case .testing: "Connecting..."
+        case .success: "Connected"
+        default: "Connect"
+        }
+    }
+
+    private func testAndConnect() async {
+        focused = nil
+        vpnActive = NetworkEnvironment.isVPNActive()
+        phase = .testing
+        HiveHTTP.clearCache()
+        if await runHealthCheck() {
+            phase = .success
+            try? await Task.sleep(for: .milliseconds(500))
+            onDone()
+        } else {
+            phase = .failed
+        }
+    }
+
+    private func runHealthCheck() async -> Bool {
+        await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask { (try? await APIClient().checkHealth()) ?? false }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(5))
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(onDone: {})
+        .preferredColorScheme(.dark)
+}

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
                 "HiveApp.swift",
                 "HiveMobile.entitlements",
                 "Stores/ModelCatalog.swift",
-                "Stores/ProjectStore.swift",
                 "Theme",
                 "Views"
             ],
@@ -29,6 +28,7 @@ let package = Package(
                 "Models/ConversationSurfaceModels.swift",
                 "Models/Models.swift",
                 "Models/WebSocketTypes.swift",
+                "Services/APIClient.swift",
                 "Services/HiveHTTP.swift",
                 "Stores/BackgroundAgentDerivation.swift",
                 "Stores/ChatDraftStore.swift",
@@ -42,6 +42,7 @@ let package = Package(
                 "Stores/HubOrganization.swift",
                 "Stores/HubSubscriptionSync.swift",
                 "Stores/MarkdownStructure.swift",
+                "Stores/ProjectStore.swift",
                 "Stores/SubAgentStatus.swift",
                 "Stores/TaskDerivation.swift",
                 "Stores/TokenFormatting.swift",

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
@@ -65,6 +65,28 @@ struct ProjectStoreFetchStateTests {
     }
 
     @Test
+    func forbiddenFailureClassifiesAuthentication() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 403, message: "forbidden")
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .authentication)
+    }
+
+    @Test
+    func decodingFailureClassifiesOther() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.decodingError(URLError(.cannotDecodeContentData))
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .other)
+    }
+
+    @Test
     func emptyPlusSuccessSelectsOnboardingNotFailure() async {
         let store = makeStore(fetchProjects: { [] })
 

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
@@ -1,0 +1,170 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+@MainActor
+struct ProjectStoreFetchStateTests {
+    private func sampleProject(id: String = "p1") -> Project {
+        Project(
+            id: id,
+            name: "Project \(id)",
+            url: nil,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            workspaces: []
+        )
+    }
+
+    private func makeStore(
+        fetchProjects: @escaping () async throws -> [Project],
+        fetchUiPreferences: @escaping () async throws -> UiPreferencesPayload = { .empty }
+    ) -> ProjectStore {
+        ProjectStore(
+            storeCache: ConversationStoreCache(),
+            fetchProjects: fetchProjects,
+            fetchUiPreferences: fetchUiPreferences
+        )
+    }
+
+    @Test
+    func emptyPlusUnreachableFailureClassifiesUnreachable() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.networkError(URLError(.cannotConnectToHost))
+        })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.hasLoadedSuccessfully == false)
+        #expect(store.refreshFailedWithCachedData == false)
+        #expect(store.isLoading == false)
+    }
+
+    @Test
+    func emptyPlusUnauthorizedFailureClassifiesAuthentication() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 401, message: "unauthorized")
+        })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == .authentication)
+        #expect(store.hasLoadedSuccessfully == false)
+    }
+
+    @Test
+    func serverErrorClassifiesOther() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 500, message: "boom")
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .other)
+    }
+
+    @Test
+    func emptyPlusSuccessSelectsOnboardingNotFailure() async {
+        let store = makeStore(fetchProjects: { [] })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == nil)
+        #expect(store.hasLoadedSuccessfully == true)
+    }
+
+    @Test
+    func cachedDataFailedRefreshKeepsCacheAndSignalsFailure() async {
+        var shouldFail = false
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.timedOut)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == nil)
+
+        shouldFail = true
+        await store.refresh(force: true, userInitiated: true)
+
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.refreshFailedWithCachedData == true)
+
+        store.acknowledgeRefreshFailure()
+        #expect(store.refreshFailedWithCachedData == false)
+    }
+
+    @Test
+    func backgroundRefreshFailureWithCacheStaysSilent() async {
+        var shouldFail = false
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.timedOut)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        shouldFail = true
+        await store.refresh(force: true)
+
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.refreshFailedWithCachedData == false)
+    }
+
+    @Test
+    func successAfterFailureClearsAllFailureState() async {
+        var shouldFail = true
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.notConnectedToInternet)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.projects.isEmpty)
+
+        shouldFail = false
+        await store.refresh(force: true)
+
+        #expect(store.fetchFailure == nil)
+        #expect(store.projects.count == 1)
+        #expect(store.hasLoadedSuccessfully == true)
+        #expect(store.isLoading == false)
+    }
+
+    @Test
+    func retryShowsInFlightLoadingBeforeResolving() async {
+        final class Box { var store: ProjectStore? }
+        let box = Box()
+        var loadingDuringFetch = false
+        let store = makeStore(fetchProjects: {
+            loadingDuringFetch = box.store?.isLoading ?? false
+            return [self.sampleProject()]
+        })
+        box.store = store
+
+        await store.refresh()
+
+        #expect(loadingDuringFetch == true)
+        #expect(store.isLoading == false)
+        #expect(store.fetchFailure == nil)
+    }
+
+    @Test
+    func retryFailingAgainPreservesFailureState() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.networkError(URLError(.cannotConnectToHost))
+        })
+
+        await store.refresh()
+        #expect(store.fetchFailure == .unreachable)
+
+        await store.refresh(force: true)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.projects.isEmpty)
+    }
+}


### PR DESCRIPTION
Closes #285.

## What
When the project fetch fails and there's no cached data, the Hub showed a misleading **"No Projects"** onboarding state. It now shows an honest **"can't reach your Hive server"** state with **Retry** and **Open Settings**, and a failed pull-to-refresh over cached data surfaces a lightweight transient notice instead of silence.

## Behavior
- **Failure classification in the store** (`ProjectStore`): `unreachable` (transport/URLError), `authentication` (401/403), `other` (5xx, decoding) — observable state, not just a string. Any successful fetch clears it.
- **Honest empty state**: `fetchFailure != nil` → unreachable state; otherwise loading, or the "No Projects" onboarding **only after a fetch has actually succeeded** (`hasLoadedSuccessfully`). Onboarding can no longer masquerade as a failed fetch.
- **Failure-appropriate copy**: auth failures point the user at Settings.
- **Retry** drives the standard forced fetch with a visible in-flight state (spinner + disabled button); success clears all failure state.
- **Pull-to-refresh over cache**: an explicit (`userInitiated`) refresh that fails while cached projects are visible shows a transient top notice ("Showing cached data") that auto-dismisses; background refresh failures stay silent.

## Scope
iOS only. `Stores/ProjectStore.swift`, `Views/Hub/HubView.swift`, `HiveApp.swift` (wires Open Settings via the existing tab nav), `Package.swift` (adds `ProjectStore`/`APIClient` to the test target), new test file.

## Testing
- `cd ios && swift test` → **194 tests pass** (+9: unreachable/auth/other classification, onboarding-not-failure, cached-failure notice + acknowledge, background-silent, success-clears, in-flight-loading, retry-preserves-failure).
- `xcodebuild build … -scheme HiveMobile -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → **BUILD SUCCEEDED**.

## ⚠️ Merge ordering
This branch and **#294 (PR #310)** both make `ProjectStore` testable — they independently add optional fetch closures to `ProjectStore.init` and add `ProjectStore`/`APIClient` to `Package.swift`'s test target. **Merge one, then rebase the other** (the conflict is mechanical: reconcile the two init signatures into one and keep the single Package.swift additions).

## Screenshots
_UI change — captures of the unreachable state (Retry + Open Settings) and the transient cached-data notice will be attached from the simulator._