### PR TITLE
Fix composer model picker, duplicate images, and remove-image control (iOS)

### DIFF
--- a/ios/HiveMobile/Stores/ModelCatalog.swift
+++ b/ios/HiveMobile/Stores/ModelCatalog.swift
@@ -15,15 +15,18 @@ final class ModelCatalog {
     private(set) var models: [ModelCatalogEntry] = []
     private(set) var defaultModelId: String = ""
     private(set) var isLoaded = false
+    private var isLoading = false
 
     private let api = APIClient()
 
     func loadIfNeeded() async {
-        guard !isLoaded else { return }
+        guard !isLoaded, !isLoading else { return }
         await load()
     }
 
     func load() async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             let response = try await api.fetchModels()
             models = response.models

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -68,6 +68,13 @@ struct ChatInputBar: View {
         models.first { $0.id == selectedModelId }?.label ?? "Model"
     }
 
+    /// When a session is locked to a provider, only that provider's models are
+    /// selectable, so show just those rather than greying the rest out.
+    private var selectableModelGroups: [ModelProviderGroup] {
+        guard let lockedProvider else { return groupedModels }
+        return groupedModels.filter { $0.provider == lockedProvider }
+    }
+
     private var thinkingLevels: [ThinkingLevel] { capabilities?.thinkingLevels ?? [] }
     private var supportsThinking: Bool { !thinkingLevels.isEmpty }
     private var supportsPlanMode: Bool { capabilities?.planMode ?? true }
@@ -88,27 +95,17 @@ struct ChatInputBar: View {
     private var controlBar: some View {
         HStack(spacing: 8) {
             Menu {
-                ForEach(groupedModels) { group in
-                    Section(group.providerLabel) {
-                        ForEach(group.models) { model in
-                            let isLocked = lockedProvider != nil && model.provider != lockedProvider
-                            Button {
-                                onModelSelect(model.id)
-                            } label: {
-                                HStack {
-                                    Text(model.label)
-                                    if model.isNew == true {
-                                        Text("NEW")
-                                    }
-                                    if model.id == selectedModelId {
-                                        Image(systemName: "checkmark")
-                                    }
-                                }
+                Picker("Model", selection: Binding(get: { selectedModelId }, set: { onModelSelect($0) })) {
+                    ForEach(selectableModelGroups) { group in
+                        Section(group.providerLabel) {
+                            ForEach(group.models) { model in
+                                Text(model.isNew == true ? "\(model.label)  ·  NEW" : model.label)
+                                    .tag(model.id)
                             }
-                            .disabled(isLocked)
                         }
                     }
                 }
+                .pickerStyle(.inline)
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "sparkles")

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -271,8 +271,17 @@ struct ChatInputBar: View {
                     if case .success(let data) = result, let data,
                        let uiImage = UIImage(data: data),
                        let attachment = ImageAttachment.makeFromDraftImage(uiImage) {
-                        attachedImages[index].attachment = attachment
-                        onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
+                        let isDuplicate = attachedImages.contains {
+                            $0.id != pending.id && $0.attachment?.dataUrl == attachment.dataUrl
+                        }
+                        if isDuplicate {
+                            withAnimation(.spring(duration: 0.25)) {
+                                attachedImages.removeAll { $0.id == pending.id }
+                            }
+                        } else {
+                            attachedImages[index].attachment = attachment
+                            onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
+                        }
                     } else {
                         withAnimation(.spring(duration: 0.25)) {
                             attachedImages.remove(at: index)
@@ -387,10 +396,11 @@ private struct AttachmentChip: View {
                 onRemove()
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 16))
-                    .foregroundStyle(.white)
-                    .background(WhisperColor.imageControlBg, in: Circle())
+                    .font(.system(size: 18))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.55))
             }
+            .accessibilityLabel("Remove image")
             .offset(x: 4, y: -4)
         }
     }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -235,6 +235,7 @@ struct ChatView: View {
             }
         }
         .task { await setup() }
+        .task { await modelCatalog.loadIfNeeded() }
         .onChange(of: modelCatalog.isLoaded) {
             if selectedModelId.isEmpty, !modelCatalog.defaultModelId.isEmpty {
                 selectedModelId = initialModelId()


### PR DESCRIPTION
From device testing of the integrated build.

## Fixes
- **Model button did nothing** — `ModelCatalog.loadIfNeeded()` guarded on `isLoaded` and never retried. If the catalog failed to load at launch (server unreachable on first run), it stayed empty forever, so the model `Menu` had no items and tapping it did nothing. The catalog now reloads when a conversation appears (with an in-flight guard against concurrent loads).
- **Same image could be uploaded twice** — image attachments are now de-duplicated by data URL.
- **Remove-image button looked wrong** — replaced the doubled circle (a white glyph on a near-white disc in light mode) with a crisp palette `xmark.circle.fill` (white X on a translucent dark disc), plus an accessibility label.

## Notes
- The reported *input bar too high / breaks behind the keyboard on first open* is a separate root cause (the tab-bar hide transition) and is handled in the navigation PR.
- iOS-only. `swift test` green (186), `xcodebuild` green, 0 warnings.