### PR TITLE
Smooth the bottom tab bar transition in and out of conversations (iOS)

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -38,6 +38,7 @@ struct HiveApp: App {
                             navigationPath: $brainPath
                         )
                     }
+                    .toolbar(brainPath.isEmpty ? .automatic : .hidden, for: .tabBar)
                 }
                 Tab("Hub", systemImage: "square.grid.2x2.fill", value: .hub) {
                     NavigationStack(path: $hubPath) {
@@ -48,9 +49,9 @@ struct HiveApp: App {
                                     store: storeCache.getOrCreate(workspace.id),
                                     navigationPath: $hubPath
                                 )
-                                .toolbar(.hidden, for: .tabBar)
                             }
                     }
+                    .toolbar(hubPath.isEmpty ? .automatic : .hidden, for: .tabBar)
                 }
                 Tab("Settings", systemImage: "gearshape.fill", value: .settings) {
                     NavigationStack {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -225,7 +225,6 @@ struct ChatView: View {
         .navigationTitle(navigationTitle)
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .tabBar)
         .sheet(isPresented: Binding(
             get: { !store.pendingToolInputs.isEmpty },
             set: { if !$0 { store.clearPendingToolInputs() } }


### PR DESCRIPTION
From device testing.

## Problem
- The bottom tab bar (Brain/Hub/Settings) reappeared with a **multi-second delay** when navigating back from a conversation to the workspace list.
- On **first open** of a conversation the composer input bar sat **too high** and could end up behind the keyboard — the bottom safe area still reserved the tab bar's height until its hide animation settled. Leaving and returning fixed it (tab bar already hidden the second time).

## Fix
Bind tab bar visibility to each `NavigationStack`'s **path depth** on the stable stack view (`.toolbar(path.isEmpty ? .automatic : .hidden, for: .tabBar)`) instead of hiding it per pushed destination. Visibility now flips together with the push/pop transition: hidden *before* the conversation lays out (so the composer's safe area is correct on first frame), and restored immediately when the stack pops to its root.

## Verification
- `xcodebuild` green, 0 warnings; store tests unaffected.
- ⚠️ This is a navigation/animation change I could **not** visually verify on-simulator (no UI-automation tap available in this environment). Please confirm the transition feels right on your device — this is the 'keep hidden but smooth' approach you picked.