### PR TITLE
docs: open-source README, MIT license, and logo asset

### DIFF
--- a/.github/assets/hive-logo.svg
+++ b/.github/assets/hive-logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1024" height="1024" viewBox="0 0 1024 1024" role="img" aria-label="Hive logo">
+  <title>Hive logo</title>
+  <rect width="1024" height="1024" rx="224" fill="#EFEDE6"/>
+  <g transform="translate(512 530) scale(1.5) translate(-512 -530)">
+    <rect x="370" y="312" width="88" height="394" rx="44" fill="#111111"/>
+    <rect x="566" y="312" width="88" height="394" rx="44" fill="#111111"/>
+    <rect x="414" y="474" width="196" height="76" rx="38" fill="#111111"/>
+    <rect x="474" y="716" width="76" height="32" rx="16" fill="#FF7048"/>
+  </g>
+</svg>

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 0xlny
+Copyright (c) 2026 419Labs
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 0xlny
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,134 +1,178 @@
+<div align="center">
+
+<img src=".github/assets/hive-logo.svg" alt="Hive" width="120" height="120" />
+
 # Hive
 
-Hive orchestrates AI coding agents across isolated git workspaces. It manages projects as bare repositories, creates workspaces as worktrees and branches, and stores each agent conversation as a resumable session.
+**Orchestrate AI coding agents across isolated git workspaces — from your desktop, browser, or phone.**
 
-Hive can run as a local web app, a Tauri desktop app connected to a local or remote backend, and a SwiftUI iOS client connected to the same backend.
+[![CI](https://github.com/0xlny/hive/actions/workflows/ci.yml/badge.svg)](https://github.com/0xlny/hive/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-FF7048.svg)](LICENSE)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-5FA04E?logo=node.js&logoColor=white)](https://nodejs.org)
 
-## Current Capabilities
+[![React 19](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)](https://react.dev)
+[![Fastify](https://img.shields.io/badge/Fastify-5-000000?logo=fastify&logoColor=white)](https://fastify.dev)
+[![Tauri](https://img.shields.io/badge/Tauri-2-FFC131?logo=tauri&logoColor=black)](https://tauri.app)
+[![SwiftUI](https://img.shields.io/badge/SwiftUI-iOS-F05138?logo=swift&logoColor=white)](https://developer.apple.com/xcode/swiftui/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
-**Agent workspaces**
-- Clone or create git-backed projects, then create isolated workspaces from them.
-- Run Claude and Codex sessions with provider-aware model selection and per-session provider locking.
-- Keep up to 4 sessions per workspace, with REST-fetched per-session history, queued follow-up messages, unread indicators, and interrupt/stop handling.
-- Stream live assistant text, thinking, tool calls, file changes, diagnostics, tasks, images, plan updates, branch info, diff stats, and script status over the multiplexed hub WebSocket.
-- Attach images to chat messages; backend resizes and stores attachments per session.
-- Browse workspace files, preview raw files, inspect inline diffs, paste selected diff comments into prompts, and use `#file`, `/command`, and `@agent` autocomplete.
-- Open a conversation tab as a full-pane interactive terminal (login shell in the worktree) from the workspace empty state. A tab commits to terminal before its first message and cannot revert; multiple terminal tabs per workspace are allowed. Terminal tabs are a desktop surface and are hidden on iOS.
+[Features](#features) · [Quick Start](#quick-start) · [Screenshots](#screenshots) · [Architecture](#architecture) · [Roadmap](#roadmap) · [Contributing](#contributing)
 
-**Brain**
-- Maintain one normal git clone as the Brain knowledge base.
-- Create/connect/delete the Brain repository, edit Markdown notes, review working-tree changes, and Save by committing and pushing.
-- Chat with the Brain through the same session stack as workspaces using the synthetic workspace id `brain`.
-- Refresh Brain files, status, and open notes after agent writes.
+</div>
 
-**Providers**
-- Claude uses streaming JSON from the Claude CLI.
-- Interactive Codex chat uses `codex app-server`; Codex automations use `codex exec --json`.
-- Codex App Server command execution, file changes, plan updates, goals, diagnostics, image views/generations, token usage, and collaborative agent tool calls are normalized into Hive events.
+---
 
-**Automation**
-- Define reusable Team agents with a model, thinking level, system prompt, optional git context injection, and read-only execution.
-- Schedule cron-based agent runs for a project or a standalone directory.
-- Build automation prompts from a Team agent plus an inline run prompt or user prompt template.
-- Store run history, messages, resolved system prompts, summaries, status, duration, and errors.
-- Trigger runs manually and send completion/failure notifications.
+## What is Hive?
 
-**Apps and integrations**
-- React 19 + Vite frontend with Tauri v2 desktop packaging.
-- Native SwiftUI iOS client with Brain, workspace conversations, session switching, chat, model selection, PR status, scripts, push notifications, task tracker, and Codex activity rendering.
-- GitHub OAuth device flow through `gh`, PR status enrichment, project `.env` management, global instructions, skills, Team agents, subagents, prompt settings, theme/accent settings, Telegram notifications, APNs, Tailscale-friendly connection settings, external terminal opening, and VS Code remote SSH opening from Tauri.
+Hive is a control plane for AI coding agents. It manages your projects as **bare git repositories**, spins up **isolated workspaces** as git worktrees and branches, and keeps every agent conversation as a **resumable session** — so multiple agents can work in parallel without stepping on each other.
 
-## Prerequisites
+Run Hive as a **local web app**, a **Tauri desktop app** (pointed at a local or remote backend), or a **native SwiftUI iOS client** — all speaking the same REST and WebSocket protocols.
 
-- Node.js >= 20
-- Git >= 2.17
-- Claude CLI installed and authenticated (`claude`)
-- GitHub CLI installed and authenticated when using GitHub-backed flows (`gh`)
-- Optional: Codex CLI (`codex`) for OpenAI model support
-- Optional desktop build: Rust >= 1.77 for Tauri
-- Optional remote setup: Tailscale
+- 🧠 **Multi-agent** — run Claude and Codex sessions side by side, with provider-aware model selection and per-session provider locking.
+- 🌳 **Isolated by design** — every workspace is its own worktree and branch; up to 4 concurrent sessions per workspace.
+- 📡 **Live streaming** — assistant text, thinking, tool calls, file changes, diffs, tasks, plans, and images stream over a single multiplexed WebSocket hub.
+- 🤖 **Automation** — reusable Team agents plus cron-scheduled runs with full run history and notifications.
+- 📱 **Everywhere** — desktop, web, and iOS from one backend, with push notifications and Tailscale-friendly remote access.
 
-The backend preflight requires `git`, `claude`, and `gh`. `codex` is optional and only affects its provider features.
+## Features
 
-## Installation
+<table>
+<tr>
+<td width="50%" valign="top">
+
+### 🌳 Agent workspaces
+- Clone or create git-backed projects, then spin up isolated workspaces from them.
+- Run **Claude** and **Codex** sessions with provider-aware model selection and per-session provider locking.
+- Up to **4 sessions per workspace**, with REST-fetched per-session history, queued follow-ups, unread indicators, and interrupt/stop handling.
+- Stream live assistant text, thinking, tool calls, file changes, diagnostics, tasks, images, plan updates, branch info, and diff stats over the hub WebSocket.
+- Attach images to messages; the backend resizes and stores them per session.
+- Browse files, preview raw content, inspect inline diffs, paste diff comments into prompts, and use `#file`, `/command`, and `@agent` autocomplete.
+- Open a conversation tab as a full-pane interactive **terminal** (login shell in the worktree) on desktop.
+
+</td>
+<td width="50%" valign="top">
+
+### 🧠 Brain
+- Maintain one normal git clone as a shared **knowledge base**.
+- Create/connect/delete the Brain repo, edit Markdown notes, review working-tree changes, and **Save** by committing and pushing.
+- Chat with the Brain through the same session stack as workspaces.
+
+### 🔌 Providers
+- **Claude** via streaming JSON from the Claude CLI.
+- **Codex** interactive chat via `codex app-server`; automations via `codex exec --json`.
+- Command execution, file changes, plans, goals, diagnostics, image views, token usage, and collaborative tool calls normalized into Hive events.
+
+### 🤖 Automation
+- Define reusable **Team agents** (model, thinking level, system prompt, git-context injection, read-only mode).
+- **Cron-schedule** agent runs for a project or standalone directory.
+- Store run history, resolved prompts, summaries, status, duration, and errors; trigger manually and get completion/failure notifications.
+
+</td>
+</tr>
+</table>
+
+**Apps & integrations** — React 19 + Vite web UI with Tauri v2 desktop packaging · native SwiftUI iOS client (Brain, conversations, session switching, model selection, PR status, scripts, push notifications, task tracker) · GitHub OAuth device flow via `gh`, PR status enrichment, `.env` management, global instructions, skills, subagents, Telegram/APNs notifications, Tailscale-friendly remote settings, external terminal & VS Code remote-SSH opening.
+
+## Screenshots
+
+> _Add screenshots or a short demo GIF here — e.g. the workspace chat, live diff view, and the iOS client. Drop images into `.github/assets/` and reference them below._
+
+<!--
+<p align="center">
+  <img src=".github/assets/screenshot-workspace.png" alt="Workspace chat" width="80%" />
+</p>
+-->
+
+## Quick Start
+
+### Prerequisites
+
+- **Node.js** ≥ 20
+- **Git** ≥ 2.17
+- **Claude CLI** installed and authenticated (`claude`)
+- **GitHub CLI** installed and authenticated for GitHub-backed flows (`gh`)
+- _Optional:_ **Codex CLI** (`codex`) for OpenAI model support
+- _Optional (desktop build):_ **Rust** ≥ 1.77 for Tauri
+- _Optional (remote):_ **Tailscale**
+
+> The backend preflight requires `git`, `claude`, and `gh`. `codex` is optional and only affects its provider features.
+
+### Install
 
 ```bash
-git clone <repo-url> hive
+git clone https://github.com/0xlny/hive.git
 cd hive
 npm install
 ```
 
-## Local Development
+### Run (local dev)
 
-Run backend and frontend in separate terminals:
+Backend and frontend run in separate terminals:
 
 ```bash
-cd backend
-npm run dev
+cd backend && npm run dev      # → http://127.0.0.1:3000
 ```
+
+```bash
+cd frontend && npm run dev     # → http://localhost:5173
+```
+
+Desktop app:
 
 ```bash
 cd frontend
-npm run dev
+npm run tauri dev              # develop
+npm run tauri build           # package
 ```
 
-Defaults:
+Remote backend + Tauri setup lives in **[GETTING_STARTED.md](GETTING_STARTED.md)**.
 
-- Backend: `http://127.0.0.1:3000`
-- Frontend: `http://localhost:5173`
-
-Run the desktop app:
+### Scripts
 
 ```bash
-cd frontend
-npm run tauri dev
-```
-
-Build the desktop app:
-
-```bash
-cd frontend
-npm run tauri build
-```
-
-Remote backend and Tauri setup lives in [GETTING_STARTED.md](GETTING_STARTED.md).
-
-## Scripts
-
-From the repository root:
-
-```bash
+# From the repository root
 npm run lint
 npm run typecheck
 npm run test
 ```
 
-Per package:
+Per-package commands (`backend`, `frontend`, `ios`) are documented in **[AGENTS.md](AGENTS.md)**.
 
-```bash
-cd backend
-npm run dev
-npm run build
-npm run lint
-npm run typecheck
-npm test
+## Configuration
 
-cd ../frontend
-npm run dev
-npm run build
-npm run lint
-npm run typecheck
-npm test
-npm run tauri dev
-npm run tauri build
+<details>
+<summary><b>Backend environment variables</b></summary>
 
-cd ../ios
-swift test
-```
+| Variable | Default | Description |
+|---|---|---|
+| `HOST` | `127.0.0.1` | Backend bind address |
+| `PORT` | `3000` | Backend HTTP port |
+| `DATA_DIR` | `~/.hive` | Root storage for projects, workspaces, sessions, prompts, Brain, config, and automations |
+| `HIVE_AUTH_TOKEN` | unset | Requires bearer/token auth for API and WS when set; `/health` stays public |
+| `HIVE_RATE_LIMIT_MAX` | `120` | Max requests per IP per window |
+| `HIVE_RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window (ms) |
+| `HIVE_CLAUDE_SKIP_PERMISSIONS` | `true` | Controls Claude `--dangerously-skip-permissions` |
+| `GITHUB_CLIENT_ID` | built in | Override GitHub OAuth app client id |
 
-## Production Backend
+</details>
 
-The backend includes `backend/ecosystem.config.cjs` for pm2:
+<details>
+<summary><b>Frontend environment variables</b></summary>
+
+| Variable | Default | Description |
+|---|---|---|
+| `VITE_WS_URL` | derived from browser location | Override WS base URL |
+| `VITE_HIVE_AUTH_TOKEN` | unset | Bearer token for API and `token` query for WS |
+
+</details>
+
+Connection host/port, Telegram, APNs, theme, accent color, CLI status, prompt settings, instructions, skills, Team agents, and subagents are configured **in the UI**.
+
+<details>
+<summary><b>Production backend (pm2)</b></summary>
+
+The backend ships `backend/ecosystem.config.cjs` for pm2:
 
 | Environment | Host | Port | Data dir |
 |---|---:|---:|---|
@@ -140,81 +184,30 @@ cd backend
 npm run build
 pm2 start ecosystem.config.cjs --env production
 pm2 logs hive-backend
-pm2 restart hive-backend
-pm2 stop hive-backend
 ```
 
-## Configuration
-
-Backend:
-
-| Variable | Default | Description |
-|---|---|---|
-| `HOST` | `127.0.0.1` | Backend bind address |
-| `PORT` | `3000` | Backend HTTP port |
-| `DATA_DIR` | `~/.hive` | Root storage for projects, workspaces, sessions, prompts, Brain, config, and automations |
-| `HIVE_AUTH_TOKEN` | unset | Requires bearer/token auth for API and WS when set; `/health` remains public |
-| `HIVE_RATE_LIMIT_MAX` | `120` | Max requests per IP per window |
-| `HIVE_RATE_LIMIT_WINDOW_MS` | `60000` | Rate-limit window in milliseconds |
-| `HIVE_CLAUDE_SKIP_PERMISSIONS` | `true` | Controls Claude `--dangerously-skip-permissions` |
-| `GITHUB_CLIENT_ID` | built in | Override GitHub OAuth app client id |
-
-Frontend:
-
-| Variable | Default | Description |
-|---|---|---|
-| `VITE_WS_URL` | derived from browser location | Override WS base URL |
-| `VITE_HIVE_AUTH_TOKEN` | unset | Bearer token for API and `token` query for WS |
-
-Connection host/port, Telegram, APNs, theme, accent color, CLI status, prompt settings, instructions, skills, Team agents, and subagents are configured in the UI.
+</details>
 
 ## Architecture
 
-Monorepo layout:
+Hive is a TypeScript monorepo with a native iOS client.
 
-- `backend/`: Fastify REST API, WebSocket hub, provider runners, git/worktree management, Brain, automation scheduler, notifications, and state persistence.
-- `frontend/`: React app, Vite build, Tauri shell, shared chat/file/diff components, settings, and hooks.
-- `ios/`: SwiftUI app using the same REST and hub protocols.
-- `shared/`: TypeScript helpers shared by backend and frontend.
+```
+backend/    Fastify REST API, WebSocket hub, provider runners, git/worktree management,
+            Brain, automation scheduler, notifications, file-backed state
+frontend/   React 19 + Vite web UI and Tauri v2 desktop shell
+ios/        SwiftUI client sharing the same REST and hub protocols
+shared/     TypeScript helpers shared by backend and frontend
+```
 
-Core domain:
+**Core model:** `Project → Workspace → Session`
+- **Project** — a bare git repository.
+- **Workspace** — a git worktree and branch under a project.
+- **Session** — a persisted, resumable agent conversation.
+- **Brain** — a singleton normal git clone addressed through the synthetic workspace id `brain`.
 
-- **Project**: a bare git repository.
-- **Workspace**: a git worktree and branch under a project.
-- **Session**: a persisted agent conversation for a workspace.
-- **Brain**: a singleton normal git clone addressed through workspace id `brain`.
-
-Important backend areas:
-
-- `backend/src/index.ts`: app wiring, auth/rate limiting, route registration, startup checks, git sync, scheduler, shutdown.
-- `backend/src/api/`: REST route groups.
-- `backend/src/ws/`: hub, script, and browser WebSockets.
-- `backend/src/agents/`: session lifecycle, providers, runners, stream normalization, system prompts, session dispatch.
-- `backend/src/brain/`: Brain repository, file, git, and Save operations.
-- `backend/src/workspaces/`: project workspace lifecycle, diffs, merge/archive, file reads.
-- `backend/src/services/`: git sync, automation scheduling, script runner, provider usage, browser session support.
-- `backend/src/state/`: JSON and file-backed persisted state.
-- `backend/src/utils/`: git wrapper, path safety, raw-file serving, GitHub integration, preflight, prompt/config parsing.
-
-Important frontend areas:
-
-- `frontend/src/App.tsx`: routing and global hub subscription.
-- `frontend/src/pages/WorkspaceView.tsx`: workspace chat, file tabs, diffs, scripts, browser panel, PR status.
-- `frontend/src/pages/BrainView.tsx`: Brain chat, notes tree, file tabs, modified list, Save flow.
-- `frontend/src/pages/settings/`: settings surfaces.
-- `frontend/src/components/chat/`: shared conversation, provider, task, question, plan, image, and activity rendering.
-- `frontend/src/hooks/`: API, WS, conversation, sessions, files, Brain, automations, provider usage, preferences, and settings hooks.
-- `frontend/src/lib/ws-transport.ts`: single multiplexed hub transport.
-
-Important iOS areas:
-
-- `ios/HiveMobile/HiveApp.swift`: app entry, tabs, navigation stacks.
-- `ios/HiveMobile/Services/APIClient.swift`: REST client.
-- `ios/HiveMobile/Stores/HubStatusMonitor.swift`: single hub WebSocket, workspace subscriptions, PR status interest, unread/streaming state.
-- `ios/HiveMobile/Stores/ConversationStore.swift`: chat state and WS event handling.
-- `ios/HiveMobile/Views/Brain/` and `ios/HiveMobile/Views/Chat/`: Brain, workspace, conversation, dashboard, task, tool, image, and activity UI.
-
-## Data Layout
+<details>
+<summary><b>Data layout (<code>$DATA_DIR</code>)</b></summary>
 
 ```text
 $DATA_DIR/
@@ -253,9 +246,12 @@ $DATA_DIR/
     `-- logs/
 ```
 
-## HTTP API
+</details>
 
-This is the public backend surface exposed by route modules under `backend/src/api/`.
+<details>
+<summary><b>HTTP API</b></summary>
+
+Public backend surface exposed by route modules under `backend/src/api/`.
 
 | Area | Endpoints |
 |---|---|
@@ -264,69 +260,58 @@ This is the public backend surface exposed by route modules under `backend/src/a
 | Workspaces | `GET/POST /api/projects/:id/workspaces`, `GET/DELETE /api/workspaces/:wsId`, `GET /api/workspaces/:wsId/files`, `GET /api/workspaces/:wsId/file`, `GET /api/workspaces/:wsId/file/raw`, `GET /api/workspaces/:wsId/file-completions`, `GET /api/workspaces/:wsId/diff`, `GET /api/workspaces/:wsId/diff/stat`, `POST /api/workspaces/:wsId/merge`, `POST /api/workspaces/:wsId/archive` |
 | Sessions | `GET/POST/DELETE /api/workspaces/:wsId/session`, `GET /api/workspaces/:wsId/session/messages`, `GET/POST /api/workspaces/:wsId/sessions`, `POST /api/workspaces/:wsId/sessions/:sessionId/convert-to-terminal`, `DELETE /api/workspaces/:wsId/sessions/:sessionId`, `GET /api/workspaces/:wsId/sessions/:sessionId/messages`, `GET /api/workspaces/:wsId/sessions/:sessionId/attachments/:filename` |
 | Brain | `GET/POST/DELETE /api/brain`, `GET /api/brain/files`, `GET/PUT /api/brain/file`, `GET /api/brain/file/raw`, `GET /api/brain/status`, `GET /api/brain/diff`, `POST /api/brain/save` |
-| Models and provider usage | `GET /api/models`, `GET /api/provider-usage` |
+| Models & usage | `GET /api/models`, `GET /api/provider-usage` |
 | Completions | `GET /api/workspaces/:wsId/completions?provider=claude\|codex` |
 | Automations | `GET/POST /api/automations`, `GET/PUT/DELETE /api/automations/:id`, `POST /api/automations/:id/trigger`, `GET /api/automations/:id/runs`, `GET /api/automations/:id/runs/:runId/messages` |
 | Team agents | `GET/POST /api/agents`, `PATCH/DELETE /api/agents/:id` |
 | Prompts | `GET/POST /api/prompt-templates`, `PUT/DELETE /api/prompt-templates/:id`, `GET/PUT/DELETE /api/prompts/base`, `GET/PUT/DELETE /api/prompts/brain` |
 | Settings | `GET/PUT /api/settings/notifications`, `POST /api/settings/notifications/test`, `POST /api/settings/notifications/test-apns`, `POST /api/devices/apns`, `GET /api/settings/cli`, `GET/PUT/DELETE /api/settings/instructions`, `POST /api/settings/instructions/sync`, `GET/POST /api/settings/skills`, `GET/PUT/DELETE /api/settings/skills/:id`, `POST /api/settings/skills/:id/sync`, `POST /api/settings/skills/sync-missing`, `GET/POST /api/settings/subagents`, `GET /api/settings/subagents/:id`, `PUT/DELETE /api/settings/subagents/:id/providers/:provider`, `POST /api/settings/subagents/:id/providers/:provider/counterpart` |
 | Account | `GET /api/account/status`, `POST /api/account/connect`, `POST /api/account/connect/poll`, `POST /api/account/disconnect` |
-| Scripts and preferences | `GET /api/workspaces/:wsId/scripts`, `POST /api/workspaces/:wsId/scripts/:type/start`, `POST /api/workspaces/:wsId/scripts/:type/stop`, `POST /api/workspaces/:wsId/terminal/start`, `POST /api/workspaces/:wsId/terminal/stop`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop`, `GET/PUT /api/ui-preferences` |
+| Scripts & prefs | `GET /api/workspaces/:wsId/scripts`, `POST /api/workspaces/:wsId/scripts/:type/start`, `POST /api/workspaces/:wsId/scripts/:type/stop`, `POST /api/workspaces/:wsId/terminal/start`, `POST /api/workspaces/:wsId/terminal/stop`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/start`, `POST /api/workspaces/:wsId/terminal-tabs/:sessionId/stop`, `GET/PUT /api/ui-preferences` |
 
 `wsId=brain` is valid for session and hub routes through the shared session dispatcher.
 
-## WebSocket API
+</details>
 
-Hub:
+<details>
+<summary><b>WebSocket API</b></summary>
 
-- Endpoint: `ws://<host>/ws/hub`
-- Auth: `Authorization: Bearer <token>`, `x-hive-token`, or `?token=<token>`
-- Clients send hub-level `sync_workspaces` and `ping`; workspace events include `switch_session`, `user_message`, `stop`, and `tool_input_response`.
-- Finalized conversation history is fetched over REST for every client (`GET /api/workspaces/:wsId/sessions/:sessionId/messages`); the hub bootstrap sends only `status` and live stream snapshots and never a WS `history` frame. The `history` frame survives in the protocol as a legacy inbound clients still tolerate, but the backend no longer sends it.
-- Server wraps workspace events as `{ workspaceId, event }`; hub pings receive `{ type: "pong" }`.
-- Current server workspace events include `status`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `agent_activity`, `stream_snapshot`, `tool_input_required`, `tool_input_resolved`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `pr_status`, `script_status`, `browser_status`, `plan_mode_changed`, and legacy `history`.
+**Hub** — `ws://<host>/ws/hub`
+- Auth: `Authorization: Bearer <token>`, `x-hive-token`, or `?token=<token>`.
+- Clients send hub-level `sync_workspaces` and `ping`; workspace events include `switch_session`, `user_message`, `stop`, `tool_input_response`.
+- Finalized history is fetched over REST for every client; the hub bootstrap sends only `status` and live stream snapshots and never a WS `history` frame.
+- Server workspace events: `status`, `user_message`, `text_delta`, `thinking`, `tool_use`, `tool_result`, `agent_activity`, `stream_snapshot`, `tool_input_required`, `tool_input_resolved`, `done`, `cancelled`, `error`, `branch_info`, `diff_stats`, `pr_status`, `script_status`, `browser_status`, `plan_mode_changed`, and legacy `history`.
 
-Script stream:
+**Script stream** — `ws://<host>/ws/script/:wsId?type=<scriptType>` · binary frames are PTY bytes; JSON control messages are `ready`, `exit`, `error`.
 
-- Endpoint: `ws://<host>/ws/script/:wsId?type=<scriptType>`
-- Binary frames are PTY bytes; JSON control messages include `ready`, `exit`, and `error`.
+**Terminal stream** — `ws://<host>/ws/terminal/:wsId?sessionId=<sessionId>` · same PTY protocol, keyed by terminal-tab session id.
 
-Terminal stream:
+**Browser stream** — `ws://<host>/ws/browser/:wsId/:sessionId` · proxies `agent-browser` screencast output and viewport resize messages.
 
-- Endpoint: `ws://<host>/ws/terminal/:wsId?sessionId=<sessionId>`
-- Same PTY protocol as the script stream, keyed by the terminal-tab session id.
+</details>
 
-Browser stream:
+## Testing & CI
 
-- Endpoint: `ws://<host>/ws/browser/:wsId/:sessionId`
-- Proxies `agent-browser` screencast output and viewport resize messages.
+- Backend/frontend tests use **Vitest**; iOS uses **Swift Testing**.
+- Tests live next to source: `backend/src/**/*.test.ts`, `frontend/tests/**`, `ios/Tests/**`.
+- CI runs Node lint, typecheck, build, and tests, plus iOS Swift package tests and an iOS app compile on every push/PR to `main`.
 
-## Testing and CI
+Run the narrowest relevant checks during development, then the root checks before considering broad changes done. For iOS changes, also run `cd ios && swift test`.
 
-- Backend tests: `backend/src/**/*.test.ts`
-- Frontend tests: `frontend/tests/**/*.test.ts(x)`
-- iOS tests: `ios/Tests/**/*.swift`
-- Backend/frontend use Vitest.
-- iOS uses Swift Testing.
-- CI runs Node lint, typecheck, build, tests, iOS Swift package tests, and an iOS app compile on push/PR to `main`.
-- CI sets `NODE_ENV=test` so React 19 exports `act()` from the development bundle.
+## Roadmap
 
-Run the narrowest relevant checks during development, then run the root checks before broad changes are considered done. For iOS changes, also run `cd ios && swift test` and an Xcode simulator build when available.
+> This is the single approved place for documented remaining work. Do not add TODO / roadmap / "future" notes to `AGENTS.md`, `GETTING_STARTED.md`, or standalone docs.
 
-## Backlog
-
-This section is the single approved place for documented remaining work. Do not add TODO, roadmap, "future", or "not yet" notes to `AGENTS.md`, `GETTING_STARTED.md`, or standalone docs.
-
-**Workspace and git UX**
+**Workspace & git UX**
 - Structure merge-conflict API responses instead of returning generic merge errors.
 - Expose project fetch and workspace merge actions in the frontend.
 - Add manual workspace rename/alias support.
 
-**Provider and protocol polish**
+**Provider & protocol polish**
 - Visually distinguish `redacted_thinking` from normal thinking blocks.
 - Harden Codex App Server resume verification after process loss or forced interruption.
 - Continue promoting useful Codex App Server diagnostics into richer UI when a product surface is clear.
-- Support Claude Code session-scoped scheduling (`/loop` dynamic mode, `ScheduleWakeup`, `Monitor`, `CronCreate/List/Delete`) and background-task tools (`run_in_background` Bash/Agent). These depend on a persistent, idle harness process that fires wakeups between turns and listens for `task_notification` `system` events — neither exists in Hive's one-shot `claude --print` per-turn model (the process exits at end of turn, orphaning any scheduled wakeup, and the `runner.on("system")` handlers are no-ops). The model would promise to "ping back later" or spawn background subagents that then appear crashed/missing on the next `--resume`. These tools are currently suppressed at the provider so the model stays synchronous: the harness scheduling tools (`ScheduleWakeup`, `Monitor`, `CronCreate/List/Delete`) are in `--disallowedTools`, and the env sets `CLAUDE_CODE_DISABLE_CRON=1` plus `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` (the latter also blocks auto-backgrounding of long subagents). `CLAUDE_CODE_ENABLE_TASKS=true` stays on so synchronous subagents keep working. Full support requires a per-session scheduler that persists wakeups, re-invokes `claude --resume -p` at the deadline, forwards `task_notification` to the UI, and surfaces background tasks — likely reusing the automation-scheduler timer infrastructure.
+- Support Claude Code session-scoped scheduling (`/loop` dynamic mode, `ScheduleWakeup`, `Monitor`, `CronCreate/List/Delete`) and background-task tools (`run_in_background` Bash/Agent). These depend on a persistent, idle harness process that fires wakeups between turns and listens for `task_notification` `system` events — neither exists in Hive's one-shot `claude --print` per-turn model. These tools are currently suppressed at the provider (`--disallowedTools` plus `CLAUDE_CODE_DISABLE_CRON=1` and `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1`) so the model stays synchronous; `CLAUDE_CODE_ENABLE_TASKS=true` keeps synchronous subagents working. Full support requires a per-session scheduler that persists wakeups, re-invokes `claude --resume -p` at the deadline, forwards `task_notification` to the UI, and surfaces background tasks — likely reusing the automation-scheduler timer infrastructure.
 
 **Automation**
 - Add GitHub event automations with webhook validation, PR/issue context enrichment, prompt variables, and GitHub comment/review output.
@@ -335,8 +320,25 @@ This section is the single approved place for documented remaining work. Do not 
 
 **iOS**
 - Add iOS UI for automations and prompt template management.
-- Add repository file browsing and richer diff inspection on iOS beyond dashboard summaries and chat-rendered diffs.
+- Add repository file browsing and richer diff inspection beyond dashboard summaries and chat-rendered diffs.
+
+## Contributing
+
+Contributions are welcome! Before opening a PR:
+
+1. Read **[AGENTS.md](AGENTS.md)** — it covers commands, the repository map, coding rules, and architecture guardrails.
+2. Run the relevant `lint`, `typecheck`, and targeted tests for the packages you touched (root checks for cross-cutting changes).
+3. Keep the WebSocket protocol types aligned across `backend`, `frontend`, and `ios`.
+4. Use English for all code, comments, UI copy, and commit messages.
+
+Found a bug or have an idea? [Open an issue](https://github.com/0xlny/hive/issues).
 
 ## License
 
-Private.
+Released under the [MIT License](LICENSE).
+
+---
+
+<div align="center">
+<sub>Built with 🧡 for people who run many agents at once.</sub>
+</div>


### PR DESCRIPTION
## What

Prepares the repo for its open-source release with a welcoming front page.

- **README** reworked into an open-source showcase: centered logo, CI/license/stack badges, a "What is Hive?" pitch, a two-column features table, quick start, and a Contributing section. All the dense technical reference (config, data layout, HTTP API, WebSocket API, architecture internals) is preserved inside collapsible `<details>` sections so nothing is lost, and the **Backlog is kept in the README as "Roadmap"** per `AGENTS.md`.
- **LICENSE** — MIT (`Copyright (c) 2026 0xlny`). Replaces the previous "Private" note.
- **Logo asset** — `.github/assets/hive-logo.svg`, reusing the exact favicon geometry (cream tile + orange pill) so it renders correctly on both light and dark GitHub themes.

## Notes / follow-ups

- Copyright holder is set to `0xlny` — change if you prefer a real name or org.
- Screenshots section is a placeholder; adding 2-3 captures (workspace chat, live diff, iOS) would give the README real impact.
- No source code changed — docs and assets only.