### PR TITLE
iOS mobile app improvements (consolidated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hive can run as a local web app, a Tauri desktop app connected to a local or rem
 
 **Apps and integrations**
 - React 19 + Vite frontend with Tauri v2 desktop packaging.
-- Native SwiftUI iOS client with Brain, workspace conversations, session switching, chat, model selection, PR status, scripts, push notifications, task tracker, and Codex activity rendering.
+- Native SwiftUI iOS client with first-run onboarding, Brain, workspace conversations, session switching, chat, model selection, PR status, scripts, push notifications, task tracker, connection status banner with tap-to-reconnect, and Codex activity rendering.
 - GitHub OAuth device flow through `gh`, PR status enrichment, project `.env` management, global instructions, skills, Team agents, subagents, prompt settings, theme/accent settings, Telegram notifications, APNs, Tailscale-friendly connection settings, external terminal opening, and VS Code remote SSH opening from Tauri.
 
 ## Prerequisites

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -605,6 +605,39 @@ describe("WS /ws/hub", () => {
     await endSession(wsId, dataDir).catch(() => {});
   });
 
+  it("authorizes a user_message that races the subscribe bootstrap on the same socket", async () => {
+    // Regression: a workspace event sent immediately after sync_workspaces, on
+    // the same socket, must not be rejected as "Not subscribed" just because the
+    // async bootstrap has not finished. Subscription intent is recorded before
+    // the bootstrap await, so the racing message is authorized.
+    const ws = (await app.injectWS("/ws/hub")) as WebSocket;
+    const messages: WsOutgoing[] = [];
+    ws.on("message", (data: Buffer) => {
+      const envelope = JSON.parse(data.toString()) as HubOutgoing;
+      if (!("workspaceId" in envelope)) return;
+      if (envelope.workspaceId === wsId) messages.push(envelope.event);
+    });
+
+    // Subscribe and immediately fire a workspace event, back to back, so the
+    // event frame arrives while sendWorkspaceBootstrap is still awaiting.
+    syncWorkspaces(ws, [wsId]);
+    ws.send(hubEvent(wsId, { type: "user_message", content: "race" }));
+
+    await waitForMessage(
+      messages,
+      (msgs) => msgs.some((m) => m.type === "status" && m.streaming === true),
+    );
+
+    expect(
+      messages.some(
+        (m) => m.type === "error" && m.message.includes("Not subscribed"),
+      ),
+    ).toBe(false);
+
+    ws.close();
+    await endSession(wsId, dataDir).catch(() => {});
+  });
+
   it("returns an error when user_message targets a deleted session id", async () => {
     const { session } = await getOrCreateSession(wsId, dataDir, CONV_CMD);
     const deletedSessionId = session.sessionId;

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -769,13 +769,17 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             socket.send(JSON.stringify({ type: "pong" }));
           }
         } else if ("type" in parsed && parsed.type === "sync_workspaces") {
-          await handleSyncWorkspaces(
-            hub,
-            parsed.workspaceIds,
-            parsed.focusWorkspaces,
-            parsed.prWorkspaces,
-            parsed.forceBootstrap === true,
-          );
+          try {
+            await handleSyncWorkspaces(
+              hub,
+              parsed.workspaceIds,
+              parsed.focusWorkspaces,
+              parsed.prWorkspaces,
+              parsed.forceBootstrap === true,
+            );
+          } catch (err) {
+            app.log.error({ err }, "sync_workspaces handler failed");
+          }
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);
         }

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -498,21 +498,29 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
     }
 
-    // Subscribe to new workspaces and bootstrap.
-    // The hub socket is added to the channel AFTER bootstrap completes so that
-    // live events broadcast during the async bootstrap don't reach this client
-    // before the streaming snapshot is replayed (which would cause duplicate
-    // content). Node.js single-threading guarantees no events fire between
-    // sendWorkspaceBootstrap returning and hubSockets.add.
+    // Subscribe to new workspaces and bootstrap. Subscription intent is recorded
+    // synchronously (the channel is created now and hub.subscribedWorkspaces is
+    // updated below, both before the first bootstrap `await`) so that a workspace
+    // message racing the async bootstrap on this same socket is authorized rather
+    // than rejected as "Not subscribed".
+    //
+    // The hub socket is added to channel.hubSockets only AFTER each bootstrap
+    // completes so that live events broadcast during the async bootstrap don't
+    // reach this client before its streaming snapshot is replayed (which would
+    // cause duplicate content).
+    const newlySubscribed: Array<[string, WorkspaceChannel]> = [];
     for (const wsId of desired) {
       if (!hub.subscribedWorkspaces.has(wsId)) {
-        const channel = getOrCreateChannel(wsId);
-        await sendWorkspaceBootstrap(hub, wsId, channel);
-        channel.hubSockets.add(hub);
+        newlySubscribed.push([wsId, getOrCreateChannel(wsId)]);
       }
     }
 
     hub.subscribedWorkspaces = desired;
+
+    for (const [wsId, channel] of newlySubscribed) {
+      await sendWorkspaceBootstrap(hub, wsId, channel);
+      channel.hubSockets.add(hub);
+    }
 
     // Resend full bootstrap for workspaces the client was already subscribed
     // to (e.g. iOS foreground refresh over a healthy socket). Newly subscribed
@@ -539,7 +547,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
   const handleWorkspaceMessage = async (hub: HubSocket, wsId: string, incoming: WsIncoming): Promise<void> => {
     const channel = channels.get(wsId);
-    if (!channel || !channel.hubSockets.has(hub)) {
+    if (!channel || !hub.subscribedWorkspaces.has(wsId)) {
       sendToHub(hub, wsId, { type: "error", message: `Not subscribed to workspace ${wsId}` });
       return;
     }

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -11,6 +11,7 @@ struct HiveApp: App {
     @State private var hubPath = NavigationPath()
     @State private var brainPath = NavigationPath()
     @State private var backgroundedAt: Date?
+    @State private var showOnboarding = UserDefaults.standard.object(forKey: "serverHost") == nil
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @AppStorage("hiveThemeMode") private var themeModeId = HiveThemeMode.system.rawValue
 
@@ -38,19 +39,20 @@ struct HiveApp: App {
                             navigationPath: $brainPath
                         )
                     }
+                    .toolbar(brainPath.isEmpty ? .automatic : .hidden, for: .tabBar)
                 }
                 Tab("Hub", systemImage: "square.grid.2x2.fill", value: .hub) {
                     NavigationStack(path: $hubPath) {
-                        HubView()
+                        HubView(openSettings: { selectedTab = .settings })
                             .navigationDestination(for: Workspace.self) { workspace in
                                 WorkspaceConversationsView(
                                     workspace: workspace,
                                     store: storeCache.getOrCreate(workspace.id),
                                     navigationPath: $hubPath
                                 )
-                                .toolbar(.hidden, for: .tabBar)
                             }
                     }
+                    .toolbar(hubPath.isEmpty ? .automatic : .hidden, for: .tabBar)
                 }
                 Tab("Settings", systemImage: "gearshape.fill", value: .settings) {
                     NavigationStack {
@@ -66,6 +68,16 @@ struct HiveApp: App {
             .environment(projectStore)
             .environment(storeCache)
             .environment(modelCatalog)
+            .overlay {
+                if showOnboarding {
+                    OnboardingView(onDone: {
+                        withAnimation { showOnboarding = false }
+                        Task { await projectStore.refresh(force: true) }
+                    })
+                    .background(WhisperColor.appBackground)
+                    .transition(.opacity)
+                }
+            }
             .preferredColorScheme(themeMode.preferredColorScheme)
             .task { await modelCatalog.loadIfNeeded() }
             .onChange(of: projectStore.pendingNavigation) { _, workspace in
@@ -76,10 +88,15 @@ struct HiveApp: App {
             }
             .onAppear {
                 mergePushCompletions()
+                handlePushNavigation()
             }
             .onChange(of: CompletedWorkspacesStore.shared.pending) { _, pending in
                 guard !pending.isEmpty else { return }
                 mergePushCompletions()
+            }
+            .onChange(of: CompletedWorkspacesStore.shared.navigationRequest) { _, request in
+                guard request != nil else { return }
+                handlePushNavigation()
             }
             .onChange(of: scenePhase) { _, newPhase in
                 switch newPhase {
@@ -108,6 +125,27 @@ struct HiveApp: App {
             projectStore.statusMonitor.markCompletedFromPush(wsId)
         }
         store.clearAll()
+    }
+
+    /// Resolve the most recent push tap and navigate to its workspace (and session),
+    /// falling back silently to the Hub tab when the workspace can't be resolved.
+    private func handlePushNavigation() {
+        guard let request = CompletedWorkspacesStore.shared.navigationRequest else { return }
+        CompletedWorkspacesStore.shared.clearNavigationRequest()
+        Task { @MainActor in
+            if let target = await projectStore.resolvePushTarget(
+                workspaceId: request.workspaceId,
+                sessionId: request.sessionId
+            ) {
+                projectStore.pendingSessionNavigation = target.sessionId.map {
+                    PendingSessionNavigation(workspaceId: target.workspace.id, sessionId: $0)
+                }
+                projectStore.pendingNavigation = target.workspace
+            } else {
+                projectStore.pendingSessionNavigation = nil
+                selectedTab = .hub
+            }
+        }
     }
 }
 

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -11,7 +11,8 @@ struct HiveApp: App {
     @State private var hubPath = NavigationPath()
     @State private var brainPath = NavigationPath()
     @State private var backgroundedAt: Date?
-    @State private var showOnboarding = UserDefaults.standard.object(forKey: "serverHost") == nil
+    @State private var showOnboarding = (UserDefaults.standard.string(forKey: "serverHost") ?? "")
+        .trimmingCharacters(in: .whitespaces).isEmpty
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @AppStorage("hiveThemeMode") private var themeModeId = HiveThemeMode.system.rawValue
 

--- a/ios/HiveMobile/Services/AppDelegate.swift
+++ b/ios/HiveMobile/Services/AppDelegate.swift
@@ -39,16 +39,17 @@ final class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCent
         return []
     }
 
-    /// Handle notification tap — mark workspace as completed so the completion dot appears.
+    /// Handle notification tap — mark the workspace completed and request navigation to it.
     func userNotificationCenter(
         _ center: UNUserNotificationCenter,
         didReceive response: UNNotificationResponse
     ) async {
         let userInfo = response.notification.request.content.userInfo
-        if let workspaceId = userInfo["workspaceId"] as? String {
-            await MainActor.run {
-                CompletedWorkspacesStore.shared.insert(workspaceId)
-            }
+        guard let workspaceId = userInfo["workspaceId"] as? String else { return }
+        let sessionId = userInfo["sessionId"] as? String
+        await MainActor.run {
+            CompletedWorkspacesStore.shared.insert(workspaceId)
+            CompletedWorkspacesStore.shared.requestNavigation(workspaceId: workspaceId, sessionId: sessionId)
         }
     }
 

--- a/ios/HiveMobile/Services/CompletedWorkspacesStore.swift
+++ b/ios/HiveMobile/Services/CompletedWorkspacesStore.swift
@@ -13,6 +13,9 @@ final class CompletedWorkspacesStore {
 
     private(set) var pending: Set<String>
 
+    /// Most recent push tap, consumed by HiveApp to navigate to the workspace.
+    private(set) var navigationRequest: PushNavigationRequest?
+
     private let key = "pushCompletedWorkspaces"
 
     private init() {
@@ -25,6 +28,14 @@ final class CompletedWorkspacesStore {
         persist()
     }
 
+    func requestNavigation(workspaceId: String, sessionId: String?) {
+        navigationRequest = PushNavigationRequest(workspaceId: workspaceId, sessionId: sessionId)
+    }
+
+    func clearNavigationRequest() {
+        navigationRequest = nil
+    }
+
     func clearAll() {
         guard !pending.isEmpty else { return }
         pending.removeAll()
@@ -34,4 +45,9 @@ final class CompletedWorkspacesStore {
     private func persist() {
         UserDefaults.standard.set(Array(pending), forKey: key)
     }
+}
+
+struct PushNavigationRequest: Equatable {
+    let workspaceId: String
+    let sessionId: String?
 }

--- a/ios/HiveMobile/Services/Haptics.swift
+++ b/ios/HiveMobile/Services/Haptics.swift
@@ -1,0 +1,20 @@
+import UIKit
+
+/// The app's entire haptic vocabulary. Kept deliberately small so the sparse
+/// mapping (send/stop, plan and question outcomes, composer toggles) can be
+/// read in one place. `UIFeedbackGenerator` automatically respects the system
+/// haptics setting, so there is no in-app toggle.
+@MainActor
+enum Haptics {
+    static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        UIImpactFeedbackGenerator(style: style).impactOccurred()
+    }
+
+    static func notify(_ type: UINotificationFeedbackGenerator.FeedbackType) {
+        UINotificationFeedbackGenerator().notificationOccurred(type)
+    }
+
+    static func selection() {
+        UISelectionFeedbackGenerator().selectionChanged()
+    }
+}

--- a/ios/HiveMobile/Services/NetworkEnvironment.swift
+++ b/ios/HiveMobile/Services/NetworkEnvironment.swift
@@ -1,0 +1,19 @@
+import CFNetwork
+import Foundation
+
+enum NetworkEnvironment {
+    /// Best-effort detection of an active VPN tunnel. iOS exposes no API to
+    /// identify a specific VPN app (e.g. Tailscale), so this only reports whether
+    /// some tunnel interface is currently routing traffic — treat it as a hint,
+    /// not a guarantee.
+    static func isVPNActive() -> Bool {
+        guard let settings = CFNetworkCopySystemProxySettings()?.takeRetainedValue() as? [String: Any],
+              let scoped = settings["__SCOPED__"] as? [String: Any] else {
+            return false
+        }
+        let tunnelPrefixes = ["tap", "tun", "ppp", "ipsec", "utun"]
+        return scoped.keys.contains { key in
+            tunnelPrefixes.contains { key.hasPrefix($0) }
+        }
+    }
+}

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -63,6 +63,16 @@ final class ConversationStore {
     /// Per-session transient streaming state. Keyed by session ID.
     var sessionStreams: [String: SessionStreamState] = [:]
 
+    /// True while a ChatView for the focused session is the visible foreground
+    /// screen. Gates the turn-completion haptic to on-screen completions only;
+    /// set by ChatView on appear/disappear.
+    @ObservationIgnored var isChatVisible = false
+
+    /// Bumps once per agent turn that completes while its chat is the visible
+    /// screen. Background sessions, other tabs, and non-visible screens never
+    /// bump it. ChatView observes this to fire the success haptic.
+    private(set) var visibleCompletionCount = 0
+
     // Branch & diff info (pushed via WS)
     var branchInfo: BranchInfo?
     var diffStats: DiffStatResponse?
@@ -233,6 +243,7 @@ final class ConversationStore {
             lastHistoryFetchAt.removeValue(forKey: sid)
             bumpHistoryToken(for: sid)
             onTurnCompleted?(sid)
+            registerVisibleCompletion(for: sid)
 
         case .cancelled(let sid, let errorDetail, _, let durationMs):
             flushStreamingDeltas()
@@ -527,6 +538,14 @@ final class ConversationStore {
     }
 
     // MARK: - Private
+
+    /// A turn finished for `sid`. Only bump the observable completion counter
+    /// when that session's chat is the visible screen, so haptics never fire for
+    /// background sessions, other tabs, or non-visible screens.
+    private func registerVisibleCompletion(for sid: String) {
+        guard isChatVisible, sid == sessionId else { return }
+        visibleCompletionCount += 1
+    }
 
     /// Ensure a stream slot exists for the given session, defaulting to streaming state.
     private func ensureStream(for sid: String, streaming: Bool = true) {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -286,6 +286,7 @@ final class ConversationStore {
                         sessionStreams[sid] = stream
                     }
                 } else if let stream = sessionStreams[sid] {
+                    let wasStreaming = stream.isStreaming
                     // Session stopped streaming. Clean up if no content.
                     if stream.currentText.isEmpty && stream.currentThinking.isEmpty
                         && stream.activeToolCalls.isEmpty && stream.activeAgentActivities.isEmpty
@@ -295,6 +296,13 @@ final class ConversationStore {
                         stream.isStreaming = false
                         stream.streamingStartedAt = nil
                         sessionStreams[sid] = stream
+                    }
+                    // Turn ended without a `done` (e.g. finished while backgrounded):
+                    // reconcile the finalized message from REST like `done` does.
+                    if wasStreaming {
+                        lastHistoryFetchAt.removeValue(forKey: sid)
+                        bumpHistoryToken(for: sid)
+                        onTurnCompleted?(sid)
                     }
                 }
             }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -90,6 +90,7 @@ final class HubStatusMonitor {
         store.send = { [weak self] message in
             guard let self else { return false }
             let event = HubIncoming.workspaceEvent(workspaceId: workspaceId, event: message)
+            await self.resubscribeIfNeeded()
             if await self.hubConnection?.send(event) == true { return true }
             // The socket was down or absent: (re)connect and retry once so a send
             // during a brief disconnect isn't silently dropped.
@@ -98,7 +99,25 @@ final class HubStatusMonitor {
                 if self.connectionState == .connected { break }
                 try? await Task.sleep(for: .milliseconds(100))
             }
+            await self.resubscribeIfNeeded()
             return await self.hubConnection?.send(event) == true
+        }
+    }
+
+    /// After a (re)connect, resend our subscription before the first workspace
+    /// event so the server registers it first (same ordered socket). Prevents a
+    /// "Not subscribed to workspace" rejection when a send races the reconnect.
+    private var needsResubscribe = true
+    private func resubscribeIfNeeded() async {
+        guard needsResubscribe, let hubConnection else { return }
+        let payload = currentSyncPayload
+        if await hubConnection.send(.syncWorkspaces(
+            workspaceIds: payload.workspaceIds,
+            focusWorkspaces: payload.focusWorkspaces,
+            prWorkspaces: payload.prWorkspaces,
+            forceBootstrap: false
+        )) {
+            needsResubscribe = false
         }
     }
 
@@ -265,6 +284,7 @@ final class HubStatusMonitor {
     // MARK: - Called by HubConnection
 
     func didChangeConnectionState(_ state: HubConnectionState) {
+        if state == .connecting { needsResubscribe = true }
         guard connectionState != state else { return }
         connectionState = state
     }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -88,7 +88,17 @@ final class HubStatusMonitor {
     /// Wire (or re-wire) the send closure for a workspace's store via the hub connection.
     fileprivate func wireSendClosure(for workspaceId: String, on store: ConversationStore) {
         store.send = { [weak self] message in
-            await self?.hubConnection?.send(.workspaceEvent(workspaceId: workspaceId, event: message)) ?? false
+            guard let self else { return false }
+            let event = HubIncoming.workspaceEvent(workspaceId: workspaceId, event: message)
+            if await self.hubConnection?.send(event) == true { return true }
+            // The socket was down or absent: (re)connect and retry once so a send
+            // during a brief disconnect isn't silently dropped.
+            self.handleSendFailure()
+            for _ in 0..<20 {
+                if self.connectionState == .connected { break }
+                try? await Task.sleep(for: .milliseconds(100))
+            }
+            return await self.hubConnection?.send(event) == true
         }
     }
 
@@ -175,6 +185,13 @@ final class HubStatusMonitor {
 
     // MARK: - Sync
 
+    private func ensureConnection() {
+        guard hubConnection == nil, !currentSyncPayload.workspaceIds.isEmpty else { return }
+        let conn = makeHubConnection(self)
+        hubConnection = conn
+        conn.connect()
+    }
+
     /// Sync monitored workspaces — manages hub connection and subscriptions.
     func sync(workspaceIds: [String]) {
         let desired = Set(workspaceIds)
@@ -198,9 +215,7 @@ final class HubStatusMonitor {
             hubConnection = nil
             connectionState = .disconnected
         } else if hubConnection == nil {
-            let conn = makeHubConnection(self)
-            hubConnection = conn
-            conn.connect()
+            ensureConnection()
         } else if let (_, payload) = change {
             hubConnection?.sendSync(payload)
         }
@@ -255,7 +270,21 @@ final class HubStatusMonitor {
     }
 
     func reconnectNow() {
-        hubConnection?.forceReconnect()
+        if let hubConnection {
+            hubConnection.forceReconnect()
+        } else {
+            ensureConnection()
+        }
+    }
+
+    /// A workspace send failed: probe the socket so the UI (and disconnect banner)
+    /// reconcile with reality, reconnecting if the connection silently dropped.
+    private func handleSendFailure() {
+        if hubConnection != nil {
+            forceRefresh()
+        } else {
+            ensureConnection()
+        }
     }
 
     /// Workspaces that were streaming when the app entered background.

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -44,6 +44,10 @@ final class HubStatusMonitor {
     }
     private(set) var connectionState: HubConnectionState = .connecting
 
+    /// Bumped each time the hub transitions into `.connected`. Lets a retry
+    /// distinguish a genuinely fresh connection from a stale `.connected` read.
+    private(set) var connectionGeneration = 0
+
     /// Workspace currently visible in ChatView (suppresses unread badge).
     var viewingWorkspaceId: String? { syncState.viewingWorkspaceId }
     /// Session currently visible in ChatView (suppresses unread badge for that session).
@@ -90,13 +94,17 @@ final class HubStatusMonitor {
         store.send = { [weak self] message in
             guard let self else { return false }
             let event = HubIncoming.workspaceEvent(workspaceId: workspaceId, event: message)
+            let generationAtSend = self.connectionGeneration
             await self.resubscribeIfNeeded()
             if await self.hubConnection?.send(event) == true { return true }
-            // The socket was down or absent: (re)connect and retry once so a send
-            // during a brief disconnect isn't silently dropped.
+            // The socket was down, absent, or died mid-send: (re)connect and retry
+            // once so a send during a brief disconnect isn't silently dropped. Wait
+            // for a genuinely fresh connection (a newer generation) rather than a
+            // stale `.connected` left over from the socket that just failed.
             self.handleSendFailure()
-            for _ in 0..<20 {
-                if self.connectionState == .connected { break }
+            for _ in 0..<30 {
+                if self.connectionState == .connected,
+                   self.connectionGeneration != generationAtSend { break }
                 try? await Task.sleep(for: .milliseconds(100))
             }
             await self.resubscribeIfNeeded()
@@ -287,6 +295,7 @@ final class HubStatusMonitor {
         if state == .connecting { needsResubscribe = true }
         guard connectionState != state else { return }
         connectionState = state
+        if state == .connected { connectionGeneration += 1 }
     }
 
     func reconnectNow() {

--- a/ios/HiveMobile/Stores/ModelCatalog.swift
+++ b/ios/HiveMobile/Stores/ModelCatalog.swift
@@ -15,15 +15,18 @@ final class ModelCatalog {
     private(set) var models: [ModelCatalogEntry] = []
     private(set) var defaultModelId: String = ""
     private(set) var isLoaded = false
+    private var isLoading = false
 
     private let api = APIClient()
 
     func loadIfNeeded() async {
-        guard !isLoaded else { return }
+        guard !isLoaded, !isLoading else { return }
         await load()
     }
 
     func load() async {
+        isLoading = true
+        defer { isLoading = false }
         do {
             let response = try await api.fetchModels()
             models = response.models

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -9,9 +9,19 @@ import Observation
 @MainActor
 @Observable
 final class ProjectStore {
+    /// Why the last project fetch failed, classified so the Hub can show
+    /// accurate copy. `nil` once a fetch succeeds.
+    enum FetchFailure: Equatable {
+        case unreachable
+        case authentication
+        case other
+    }
+
     private(set) var projects: [Project] = []
     private(set) var isLoading = false
     private(set) var errorMessage: String?
+    private(set) var fetchFailure: FetchFailure?
+    private(set) var refreshFailedWithCachedData = false
     private(set) var creatingWorkspaceProjectIds: Set<String> = []
     private(set) var isCreatingProject = false
     private(set) var cloningRepoName: String?
@@ -20,18 +30,36 @@ final class ProjectStore {
     /// Set after workspace creation so HiveApp can navigate to it.
     var pendingNavigation: Workspace?
 
+    /// Set alongside `pendingNavigation` when a push tap targets a specific session.
+    var pendingSessionNavigation: PendingSessionNavigation?
+
     let statusMonitor: HubStatusMonitor
 
-    private let api = APIClient()
+    private let api: APIClient
+    private let fetchProjectsClosure: @MainActor () async throws -> [Project]
+    private let fetchPreferencesClosure: @MainActor () async throws -> UiPreferencesPayload
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
 
-    init(storeCache: ConversationStoreCache) {
-        self.statusMonitor = HubStatusMonitor(storeCache: storeCache)
+    init(
+        storeCache: ConversationStoreCache,
+        statusMonitor: HubStatusMonitor? = nil,
+        fetchProjects: (@MainActor () async throws -> [Project])? = nil,
+        fetchPreferences: (@MainActor () async throws -> UiPreferencesPayload)? = nil
+    ) {
+        let client = APIClient()
+        self.api = client
+        self.statusMonitor = statusMonitor ?? HubStatusMonitor(storeCache: storeCache)
+        self.fetchProjectsClosure = fetchProjects ?? { try await client.fetchProjects() }
+        self.fetchPreferencesClosure = fetchPreferences ?? { try await client.fetchUiPreferences() }
     }
 
     /// Whether the store has never successfully loaded data yet.
     var isInitialLoad: Bool { !hasFetchedOnce }
+
+    /// Whether a fetch has ever succeeded — gates the No Projects onboarding
+    /// state so it never masquerades as a failed fetch.
+    var hasLoadedSuccessfully: Bool { hasFetchedOnce }
 
     /// Sync the hub monitor with every workspace plus the synthetic Brain id, so
     /// the Brain always stays subscribed (streaming/done events, send wiring) and
@@ -155,13 +183,16 @@ final class ProjectStore {
     }
 
     /// Refresh projects from the API. Shows existing data while loading.
-    func refresh(force: Bool = false) async {
+    /// `userInitiated` marks an explicit pull-to-refresh so a failure over
+    /// cached data can surface a transient notice.
+    func refresh(force: Bool = false, userInitiated: Bool = false) async {
         if !force, hasFetchedOnce, Date().timeIntervalSince(lastRefreshedAt) < 45 { return }
         isLoading = true
         errorMessage = nil
+        refreshFailedWithCachedData = false
         do {
-            async let projectsTask = api.fetchProjects()
-            async let preferencesTask = api.fetchUiPreferences()
+            async let projectsTask = fetchProjectsClosure()
+            async let preferencesTask = fetchPreferencesClosure()
 
             var fresh = try await projectsTask
             let preferences = (try? await preferencesTask) ?? .empty
@@ -178,16 +209,56 @@ final class ProjectStore {
             uiPreferences = preferences
             hasFetchedOnce = true
             lastRefreshedAt = Date()
+            fetchFailure = nil
             syncMonitoredWorkspaces()
         } catch is CancellationError {
             // View disappeared — ignore
         } catch {
-            // Only surface error if we have no cached data to show
-            if projects.isEmpty {
-                errorMessage = error.localizedDescription
+            fetchFailure = Self.classify(error)
+            if !projects.isEmpty, userInitiated {
+                refreshFailedWithCachedData = true
             }
         }
         isLoading = false
+    }
+
+    func resolvePushTarget(workspaceId: String, sessionId: String?) async -> PushNavigationTarget? {
+        if let target = Self.findTarget(workspaceId: workspaceId, sessionId: sessionId, in: projects) {
+            return target
+        }
+        await refresh(force: true)
+        return Self.findTarget(workspaceId: workspaceId, sessionId: sessionId, in: projects)
+    }
+
+    static func findTarget(workspaceId: String, sessionId: String?, in projects: [Project]) -> PushNavigationTarget? {
+        for project in projects {
+            if let workspace = project.workspaces.first(where: { $0.id == workspaceId }) {
+                return PushNavigationTarget(workspace: workspace, sessionId: sessionId)
+            }
+        }
+        return nil
+    }
+
+    /// Dismiss the transient pull-to-refresh failure notice.
+    func acknowledgeRefreshFailure() {
+        refreshFailedWithCachedData = false
+    }
+
+    private static func classify(_ error: Error) -> FetchFailure {
+        if let apiError = error as? APIError {
+            switch apiError {
+            case .httpError(let statusCode, _):
+                return statusCode == 401 || statusCode == 403 ? .authentication : .other
+            case .networkError, .invalidURL:
+                return .unreachable
+            case .decodingError:
+                return .other
+            }
+        }
+        if error is URLError {
+            return .unreachable
+        }
+        return .other
     }
 
     private static func extractRepoName(from url: String) -> String {
@@ -197,4 +268,14 @@ final class ProjectStore {
         if name.hasSuffix(".git") { name = String(name.dropLast(4)) }
         return name.isEmpty ? "repository" : name
     }
+}
+
+struct PushNavigationTarget: Equatable {
+    let workspace: Workspace
+    let sessionId: String?
+}
+
+struct PendingSessionNavigation: Equatable {
+    let workspaceId: String
+    let sessionId: String
 }

--- a/ios/HiveMobile/Theme/Animations.swift
+++ b/ios/HiveMobile/Theme/Animations.swift
@@ -3,14 +3,19 @@ import SwiftUI
 // MARK: - Shimmer (loading skeletons)
 
 struct ShimmerModifier: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: CGFloat = 0
 
     func body(content: Content) -> some View {
         content
-            .opacity(0.5 + 0.5 * Foundation.sin(phase))
-            .onAppear {
-                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
-                    phase = .pi
+            .opacity(reduceMotion ? 0.5 : 0.5 + 0.5 * Foundation.sin(phase))
+            .onChange(of: reduceMotion, initial: true) {
+                if reduceMotion {
+                    phase = 0
+                } else {
+                    withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                        phase = .pi
+                    }
                 }
             }
     }
@@ -20,13 +25,16 @@ struct ShimmerModifier: ViewModifier {
 
 struct PulseModifier: ViewModifier {
     let isActive: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var isPulsing = false
 
     func body(content: Content) -> some View {
         content
-            .scaleEffect(isActive && isPulsing ? 1.02 : 1.0)
+            .scaleEffect(!reduceMotion && isActive && isPulsing ? 1.02 : 1.0)
             .animation(
-                isActive ? .easeInOut(duration: 2).repeatForever(autoreverses: true) : .default,
+                reduceMotion
+                    ? nil
+                    : (isActive ? .easeInOut(duration: 2).repeatForever(autoreverses: true) : .default),
                 value: isPulsing
             )
             .onChange(of: isActive) { _, active in

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -9,6 +9,7 @@ struct ChatActivityStats {
 }
 
 struct ChatActivityRowLabel: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     var icon: String? = nil
     let label: String
     var detail: String?
@@ -106,21 +107,27 @@ struct ChatActivityRowLabel: View {
             }
 
             if executing {
-                // Opacity-only pulse, fully decoupled from the animation system so
-                // the dot can NEVER move. The opacity is recomputed every frame by
-                // TimelineView (no animation transaction), and `.transaction` nils
-                // out any animation inherited from ancestors — so streaming relayout
-                // (label/icons growing to its left) repositions the dot instantly
-                // instead of animating it. Matches the web's `bg-primary animate-pulse`.
-                TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
-                    let t = context.date.timeIntervalSinceReferenceDate
-                    let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
+                if reduceMotion {
                     Circle()
                         .fill(Color.accentColor)
                         .frame(width: 5, height: 5)
-                        .opacity(opacity)
+                } else {
+                    // Opacity-only pulse, fully decoupled from the animation system so
+                    // the dot can NEVER move. The opacity is recomputed every frame by
+                    // TimelineView (no animation transaction), and `.transaction` nils
+                    // out any animation inherited from ancestors — so streaming relayout
+                    // (label/icons growing to its left) repositions the dot instantly
+                    // instead of animating it. Matches the web's `bg-primary animate-pulse`.
+                    TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
+                        let t = context.date.timeIntervalSinceReferenceDate
+                        let opacity = 0.7 + 0.3 * sin(t * 2 * .pi / 1.6)
+                        Circle()
+                            .fill(Color.accentColor)
+                            .frame(width: 5, height: 5)
+                            .opacity(opacity)
+                    }
+                    .transaction { $0.animation = nil }
                 }
-                .transaction { $0.animation = nil }
             }
         }
         .padding(.vertical, 3)

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -24,6 +24,7 @@ struct ChatInputBar: View {
     @State private var attachedImages: [AttachedImage] = []
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var showAttachmentError = false
+    @State private var showModelMenu = false
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -68,6 +69,7 @@ struct ChatInputBar: View {
         models.first { $0.id == selectedModelId }?.label ?? "Model"
     }
 
+
     /// When a session is locked to a provider, only that provider's models are
     /// selectable, so show just those rather than greying the rest out.
     private var selectableModelGroups: [ModelProviderGroup] {
@@ -94,18 +96,8 @@ struct ChatInputBar: View {
 
     private var controlBar: some View {
         HStack(spacing: 8) {
-            Menu {
-                Picker("Model", selection: Binding(get: { selectedModelId }, set: { Haptics.selection(); onModelSelect($0) })) {
-                    ForEach(selectableModelGroups) { group in
-                        Section(group.providerLabel) {
-                            ForEach(group.models) { model in
-                                Text(model.isNew == true ? "\(model.label)  ·  NEW" : model.label)
-                                    .tag(model.id)
-                            }
-                        }
-                    }
-                }
-                .pickerStyle(.inline)
+            Button {
+                showModelMenu = true
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "sparkles")
@@ -115,8 +107,21 @@ struct ChatInputBar: View {
                 }
                 .font(.caption)
                 .foregroundStyle(WhisperColor.textSecondary)
+                .fixedSize()
             }
             .frame(minHeight: 44)
+            .popover(isPresented: $showModelMenu, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
+                ModelMenu(
+                    groups: selectableModelGroups,
+                    selectedModelId: selectedModelId,
+                    accent: hiveAccent
+                ) { id in
+                    Haptics.selection()
+                    onModelSelect(id)
+                    showModelMenu = false
+                }
+                .presentationCompactAdaptation(.popover)
+            }
 
             if supportsThinking {
                 LevelCycleButton(systemImage: "brain", label: effectiveThinkingLevel.label, highlightColor: hiveAccent) {
@@ -316,6 +321,53 @@ private struct AttachedImage: Identifiable {
 }
 
 // MARK: - Mode Toggle
+
+private struct ModelMenu: View {
+    let groups: [ModelProviderGroup]
+    let selectedModelId: String
+    let accent: Color
+    let onSelect: (String) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(Array(groups.enumerated()), id: \.element.id) { index, group in
+                if index > 0 {
+                    Divider().padding(.vertical, 5)
+                }
+                Text(group.providerLabel)
+                    .font(.caption2)
+                    .foregroundStyle(WhisperColor.textMuted)
+                    .padding(.horizontal, 14)
+                    .padding(.top, index == 0 ? 12 : 0)
+                    .padding(.bottom, 3)
+                ForEach(group.models) { model in
+                    Button {
+                        onSelect(model.id)
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "checkmark")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(accent)
+                                .opacity(model.id == selectedModelId ? 1 : 0)
+                                .frame(width: 15)
+                            Text(model.isNew == true ? "\(model.label)  ·  NEW" : model.label)
+                                .foregroundStyle(.primary)
+                            Spacer(minLength: 8)
+                        }
+                        .font(.subheadline)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 9)
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+        .padding(.vertical, 5)
+        .frame(width: 234)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
 
 private struct ModeToggle: View {
     let systemImage: String

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -68,6 +68,13 @@ struct ChatInputBar: View {
         models.first { $0.id == selectedModelId }?.label ?? "Model"
     }
 
+    /// When a session is locked to a provider, only that provider's models are
+    /// selectable, so show just those rather than greying the rest out.
+    private var selectableModelGroups: [ModelProviderGroup] {
+        guard let lockedProvider else { return groupedModels }
+        return groupedModels.filter { $0.provider == lockedProvider }
+    }
+
     private var thinkingLevels: [ThinkingLevel] { capabilities?.thinkingLevels ?? [] }
     private var supportsThinking: Bool { !thinkingLevels.isEmpty }
     private var supportsPlanMode: Bool { capabilities?.planMode ?? true }
@@ -88,27 +95,17 @@ struct ChatInputBar: View {
     private var controlBar: some View {
         HStack(spacing: 8) {
             Menu {
-                ForEach(groupedModels) { group in
-                    Section(group.providerLabel) {
-                        ForEach(group.models) { model in
-                            let isLocked = lockedProvider != nil && model.provider != lockedProvider
-                            Button {
-                                onModelSelect(model.id)
-                            } label: {
-                                HStack {
-                                    Text(model.label)
-                                    if model.isNew == true {
-                                        Text("NEW")
-                                    }
-                                    if model.id == selectedModelId {
-                                        Image(systemName: "checkmark")
-                                    }
-                                }
+                Picker("Model", selection: Binding(get: { selectedModelId }, set: { Haptics.selection(); onModelSelect($0) })) {
+                    ForEach(selectableModelGroups) { group in
+                        Section(group.providerLabel) {
+                            ForEach(group.models) { model in
+                                Text(model.isNew == true ? "\(model.label)  ·  NEW" : model.label)
+                                    .tag(model.id)
                             }
-                            .disabled(isLocked)
                         }
                     }
                 }
+                .pickerStyle(.inline)
             } label: {
                 HStack(spacing: 4) {
                     Image(systemName: "sparkles")
@@ -216,6 +213,7 @@ struct ChatInputBar: View {
 
             if isBusy {
                 Button {
+                    Haptics.impact(.light)
                     onStop?()
                 } label: {
                     Image(systemName: "stop.circle.fill")
@@ -250,6 +248,7 @@ struct ChatInputBar: View {
     }
 
     private func handleSend() {
+        Haptics.impact(.light)
         let imageAttachments = attachedImages.compactMap(\.attachment)
         attachedImages = []
         onDraftAttachmentsChange([])
@@ -271,8 +270,17 @@ struct ChatInputBar: View {
                     if case .success(let data) = result, let data,
                        let uiImage = UIImage(data: data),
                        let attachment = ImageAttachment.makeFromDraftImage(uiImage) {
-                        attachedImages[index].attachment = attachment
-                        onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
+                        let isDuplicate = attachedImages.contains {
+                            $0.id != pending.id && $0.attachment?.dataUrl == attachment.dataUrl
+                        }
+                        if isDuplicate {
+                            withAnimation(.spring(duration: 0.25)) {
+                                attachedImages.removeAll { $0.id == pending.id }
+                            }
+                        } else {
+                            attachedImages[index].attachment = attachment
+                            onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
+                        }
                     } else {
                         withAnimation(.spring(duration: 0.25)) {
                             attachedImages.remove(at: index)
@@ -316,7 +324,10 @@ private struct ModeToggle: View {
     var highlightColor: Color = .white
 
     var body: some View {
-        Button { isActive.toggle() } label: {
+        Button {
+            Haptics.selection()
+            isActive.toggle()
+        } label: {
             HStack(spacing: 4) {
                 Image(systemName: systemImage)
                 Text(label)
@@ -345,7 +356,10 @@ private struct LevelCycleButton: View {
     let action: () -> Void
 
     var body: some View {
-        Button { action() } label: {
+        Button {
+            Haptics.selection()
+            action()
+        } label: {
             HStack(spacing: 4) {
                 Image(systemName: systemImage)
                 Text(label)
@@ -387,10 +401,11 @@ private struct AttachmentChip: View {
                 onRemove()
             } label: {
                 Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 16))
-                    .foregroundStyle(.white)
-                    .background(WhisperColor.imageControlBg, in: Circle())
+                    .font(.system(size: 18))
+                    .symbolRenderingMode(.palette)
+                    .foregroundStyle(.white, .black.opacity(0.55))
             }
+            .accessibilityLabel("Remove image")
             .offset(x: 4, y: -4)
         }
     }

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -25,6 +25,7 @@ struct ChatInputBar: View {
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var showAttachmentError = false
     @State private var showModelMenu = false
+    @State private var showEffortMenu = false
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -125,7 +126,15 @@ struct ChatInputBar: View {
 
             if supportsThinking {
                 LevelCycleButton(systemImage: "brain", label: effectiveThinkingLevel.label, highlightColor: hiveAccent) {
-                    thinkingLevel = effectiveThinkingLevel.next(in: thinkingLevels)
+                    showEffortMenu = true
+                }
+                .popover(isPresented: $showEffortMenu, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
+                    EffortMenu(levels: thinkingLevels, selectedLevel: effectiveThinkingLevel, accent: hiveAccent) { level in
+                        Haptics.selection()
+                        thinkingLevel = level
+                        showEffortMenu = false
+                    }
+                    .presentationCompactAdaptation(.popover)
                 }
             }
             if supportsPlanMode {
@@ -365,6 +374,42 @@ private struct ModelMenu: View {
         }
         .padding(.vertical, 5)
         .frame(width: 234)
+        .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct EffortMenu: View {
+    let levels: [ThinkingLevel]
+    let selectedLevel: ThinkingLevel
+    let accent: Color
+    let onSelect: (ThinkingLevel) -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            ForEach(levels, id: \.self) { level in
+                Button {
+                    onSelect(level)
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(accent)
+                            .opacity(level == selectedLevel ? 1 : 0)
+                            .frame(width: 15)
+                        Text(level.label)
+                            .foregroundStyle(.primary)
+                        Spacer(minLength: 8)
+                    }
+                    .font(.subheadline)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.vertical, 5)
+        .frame(width: 180)
         .fixedSize(horizontal: false, vertical: true)
     }
 }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -8,6 +8,7 @@ struct ChatView: View {
 
     @State private var draft = ""
     @State private var isLoading = true
+    @State private var showSkeleton = false
     @State private var planModeEnabled = false
     @State private var thinkingLevel: ThinkingLevel = .high
     @State private var fastModeEnabled = false
@@ -87,7 +88,11 @@ struct ChatView: View {
     var body: some View {
         VStack(spacing: 0) {
             if isLoading {
-                Spacer()
+                if showSkeleton {
+                    ConversationLoadingSkeleton()
+                } else {
+                    Spacer()
+                }
             } else if store.messages.isEmpty && streamingMessage == nil && !store.isStreaming {
                 Spacer()
                 if isBrainWorkspaceId(workspace.id) {
@@ -225,7 +230,7 @@ struct ChatView: View {
         .navigationTitle(navigationTitle)
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)
-        .toolbar(.hidden, for: .tabBar)
+        .sensoryFeedback(.success, trigger: store.visibleCompletionCount)
         .sheet(isPresented: Binding(
             get: { !store.pendingToolInputs.isEmpty },
             set: { if !$0 { store.clearPendingToolInputs() } }
@@ -235,6 +240,17 @@ struct ChatView: View {
             }
         }
         .task { await setup() }
+        .task { await modelCatalog.loadIfNeeded() }
+        .task(id: isLoading) {
+            guard isLoading else {
+                showSkeleton = false
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(300))
+            if !Task.isCancelled {
+                showSkeleton = true
+            }
+        }
         .onChange(of: modelCatalog.isLoaded) {
             if selectedModelId.isEmpty, !modelCatalog.defaultModelId.isEmpty {
                 selectedModelId = initialModelId()
@@ -255,6 +271,7 @@ struct ChatView: View {
             }
         }
         .onDisappear {
+            store.isChatVisible = false
             saveCurrentDraft()
             store.onTurnCompleted = nil
             projectStore.statusMonitor.clearViewingSession(workspaceId: workspace.id, sessionId: session.sessionId)
@@ -303,6 +320,7 @@ struct ChatView: View {
     // MARK: - Setup
 
     private func setup() async {
+        store.isChatVisible = true
         projectStore.statusMonitor.setViewingWorkspace(workspace.id, sessionId: session.sessionId)
         projectStore.statusMonitor.clearCompleted(workspace.id)
         projectStore.statusMonitor.clearUnread(workspaceId: workspace.id, sessionId: session.sessionId)
@@ -433,6 +451,13 @@ struct ChatView: View {
                 result: result,
                 sessionId: pending.sessionId
             )) ?? false
+
+            switch result {
+            case .approve, .answer:
+                Haptics.notify(sent ? .success : .warning)
+            case .reject, .dismiss:
+                Haptics.notify(.warning)
+            }
 
             if sent {
                 store.clearPendingToolInputs()

--- a/ios/HiveMobile/Views/Chat/ConversationLoadingSkeleton.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationLoadingSkeleton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct ConversationLoadingSkeleton: View {
+    private struct Placeholder: Identifiable {
+        let id = UUID()
+        let fraction: CGFloat
+        let height: CGFloat
+        let trailing: Bool
+    }
+
+    private let placeholders: [Placeholder] = [
+        Placeholder(fraction: 0.52, height: 40, trailing: true),
+        Placeholder(fraction: 0.86, height: 104, trailing: false),
+        Placeholder(fraction: 0.38, height: 30, trailing: true),
+        Placeholder(fraction: 0.72, height: 72, trailing: false),
+        Placeholder(fraction: 0.6, height: 52, trailing: false)
+    ]
+
+    var body: some View {
+        GeometryReader { geometry in
+            VStack(spacing: HiveSpacing.lg) {
+                ForEach(placeholders) { placeholder in
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(WhisperColor.surfaceSubtle)
+                        .frame(width: geometry.size.width * placeholder.fraction, height: placeholder.height)
+                        .frame(maxWidth: .infinity, alignment: placeholder.trailing ? .trailing : .leading)
+                        .shimmer()
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.top, HiveSpacing.lg)
+        }
+        .padding(.horizontal, HiveSpacing.lg)
+    }
+}
+
+#Preview {
+    ConversationLoadingSkeleton()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .hiveScreenBackground()
+        .preferredColorScheme(.dark)
+}

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -201,12 +201,22 @@ struct ConversationsSection<Header: View>: View {
             sessions = try await api.fetchSessions(workspaceId: workspace.id)
                 .filter { $0.kind != "terminal" }
             errorMessage = nil
+            navigateToPendingSessionIfNeeded()
         } catch is CancellationError {
             // View disappeared.
         } catch {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    private func navigateToPendingSessionIfNeeded() {
+        guard let pending = projectStore.pendingSessionNavigation,
+              pending.workspaceId == workspace.id else { return }
+        projectStore.pendingSessionNavigation = nil
+        if let match = sessions.first(where: { $0.sessionId == pending.sessionId }) {
+            navigationPath.append(match)
+        }
     }
 
     private func createSession() {

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -628,7 +628,7 @@ private struct WhisperThinkingBlock: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: "brain", label: "Thinking", detail: isExpanded ? nil : preview)
             }
@@ -642,7 +642,6 @@ private struct WhisperThinkingBlock: View {
                         .lineSpacing(2)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -682,7 +681,7 @@ private struct WhisperToolCallsBlock: View {
                     isExpanded: groupExpanded,
                     isStreaming: showExecutingState,
                     onToggle: {
-                        withAnimation(.easeInOut(duration: 0.2)) { groupExpanded.toggle() }
+                        groupExpanded.toggle()
                     }
                 )
             }
@@ -698,7 +697,6 @@ private struct WhisperToolCallsBlock: View {
                         showExecutingState: showExecutingState
                     )
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -766,7 +764,7 @@ private struct WhisperToolCallRow: View {
 
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                isExpanded.toggle()
             } label: {
                 ChatActivityRowLabel(icon: display.icon, label: display.label, detail: display.detail, stats: display.stats, summary: summary, badgeText: display.badgeText, badgeIcon: display.badgeIcon, executing: display.executing)
             }
@@ -814,7 +812,6 @@ private struct WhisperToolCallRow: View {
                         }
                     }
                 }
-                .transition(.opacity)
             }
         }
     }
@@ -867,8 +864,14 @@ private func computeDiffLines(oldString: String, newString: String) -> [DiffLine
 
 private struct DiffContentView: View {
     let tool: ToolCall
+    private let parsed: (filePath: String?, lines: [DiffLine])
 
-    private var parsed: (filePath: String?, lines: [DiffLine]) {
+    init(tool: ToolCall) {
+        self.tool = tool
+        self.parsed = DiffContentView.buildParsed(tool)
+    }
+
+    private static func buildParsed(_ tool: ToolCall) -> (filePath: String?, lines: [DiffLine]) {
         guard let input = parsedToolInputObject(tool.input) else {
             return (nil, [])
         }
@@ -907,7 +910,6 @@ private struct DiffContentView: View {
                 DiffLinesView(lines: result.lines)
             }
         }
-        .transition(.opacity)
     }
 }
 
@@ -950,7 +952,6 @@ private struct AskUserQuestionContent: View {
                 }
             }
         }
-        .transition(.opacity)
     }
 }
 

--- a/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
+++ b/ios/HiveMobile/Views/Components/AgentActivityIndicator.swift
@@ -6,37 +6,46 @@ struct AgentActivityIndicator: View {
     var dotSize: CGFloat = 3
     var spacing: CGFloat = 1.5
 
-    var body: some View {
-        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
-            let t = timeline.date.timeIntervalSinceReferenceDate
-            Canvas { context, _ in
-                for row in 0..<3 {
-                    for col in 0..<3 {
-                        let angle = atan2(Double(row - 1), Double(col - 1))
-                        let normalizedPhase = (angle / (.pi * 2) + 1).truncatingRemainder(dividingBy: 1)
-                        let wave = ((t * 0.9 + normalizedPhase).truncatingRemainder(dividingBy: 1) + 1).truncatingRemainder(dividingBy: 1)
-                        let raw = (cos((wave - 0.5) * .pi * 2) + 1) / 2
-                        let val = max(0, (raw - 0.2) / 0.8)
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-                        let x = CGFloat(col) * (dotSize + spacing)
-                        let y = CGFloat(row) * (dotSize + spacing)
-                        let scale = 0.88 + val * 0.12
-                        let rect = CGRect(
-                            x: x + dotSize * (1 - scale) / 2,
-                            y: y + dotSize * (1 - scale) / 2,
-                            width: dotSize * scale,
-                            height: dotSize * scale
-                        )
-                        let path = Path(roundedRect: rect, cornerRadius: 1)
-                        context.fill(path, with: .color(WhisperColor.activityDot.opacity(val)))
-                    }
+    var body: some View {
+        if reduceMotion {
+            canvas(t: 0)
+        } else {
+            TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+                canvas(t: timeline.date.timeIntervalSinceReferenceDate)
+            }
+        }
+    }
+
+    private func canvas(t: Double) -> some View {
+        Canvas { context, _ in
+            for row in 0..<3 {
+                for col in 0..<3 {
+                    let angle = atan2(Double(row - 1), Double(col - 1))
+                    let normalizedPhase = (angle / (.pi * 2) + 1).truncatingRemainder(dividingBy: 1)
+                    let wave = ((t * 0.9 + normalizedPhase).truncatingRemainder(dividingBy: 1) + 1).truncatingRemainder(dividingBy: 1)
+                    let raw = (cos((wave - 0.5) * .pi * 2) + 1) / 2
+                    let val = max(0, (raw - 0.2) / 0.8)
+
+                    let x = CGFloat(col) * (dotSize + spacing)
+                    let y = CGFloat(row) * (dotSize + spacing)
+                    let scale = 0.88 + val * 0.12
+                    let rect = CGRect(
+                        x: x + dotSize * (1 - scale) / 2,
+                        y: y + dotSize * (1 - scale) / 2,
+                        width: dotSize * scale,
+                        height: dotSize * scale
+                    )
+                    let path = Path(roundedRect: rect, cornerRadius: 1)
+                    context.fill(path, with: .color(WhisperColor.activityDot.opacity(val)))
                 }
             }
-            .frame(
-                width: dotSize * 3 + spacing * 2,
-                height: dotSize * 3 + spacing * 2
-            )
         }
+        .frame(
+            width: dotSize * 3 + spacing * 2,
+            height: dotSize * 3 + spacing * 2
+        )
     }
 }
 

--- a/ios/HiveMobile/Views/Components/ConnectionBanner.swift
+++ b/ios/HiveMobile/Views/Components/ConnectionBanner.swift
@@ -7,7 +7,8 @@ struct ConnectionBanner: View {
     /// Only surface the disconnect banner once a server has been configured, so a
     /// never-configured first launch (handled by onboarding) stays clean.
     private var isServerConfigured: Bool {
-        UserDefaults.standard.string(forKey: "serverHost") != nil
+        !(UserDefaults.standard.string(forKey: "serverHost") ?? "")
+            .trimmingCharacters(in: .whitespaces).isEmpty
     }
 
     var body: some View {

--- a/ios/HiveMobile/Views/Components/ConnectionBanner.swift
+++ b/ios/HiveMobile/Views/Components/ConnectionBanner.swift
@@ -2,11 +2,17 @@ import SwiftUI
 
 struct ConnectionBanner: View {
     let monitor: HubStatusMonitor
-    @State private var showConnecting = false
+    @State private var showDisconnected = false
+
+    /// Only surface the disconnect banner once a server has been configured, so a
+    /// never-configured first launch (handled by onboarding) stays clean.
+    private var isServerConfigured: Bool {
+        UserDefaults.standard.string(forKey: "serverHost") != nil
+    }
 
     var body: some View {
         Group {
-            if monitor.connectionState == .disconnected {
+            if showDisconnected, isServerConfigured, monitor.connectionState != .connected {
                 Button {
                     monitor.reconnectNow()
                 } label: {
@@ -16,22 +22,17 @@ struct ConnectionBanner: View {
                 .accessibilityHint("Reconnects to the server.")
                 .padding(.vertical, 8)
                 .transition(.move(edge: .top).combined(with: .opacity))
-            } else if monitor.connectionState == .connecting, showConnecting {
-                capsule(text: "Connecting…", color: .orange.opacity(0.9))
-                    .padding(.vertical, 8)
-                    .transition(.move(edge: .top).combined(with: .opacity))
             }
         }
-        .animation(.default, value: monitor.connectionState)
-        .animation(.default, value: showConnecting)
-        .task(id: monitor.connectionState) {
-            guard monitor.connectionState == .connecting else {
-                showConnecting = false
+        .animation(.default, value: showDisconnected)
+        .task(id: monitor.connectionState == .connected) {
+            guard monitor.connectionState != .connected else {
+                showDisconnected = false
                 return
             }
-            try? await Task.sleep(for: .milliseconds(600))
+            try? await Task.sleep(for: .seconds(3))
             if !Task.isCancelled {
-                showConnecting = true
+                showDisconnected = true
             }
         }
     }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -9,6 +9,7 @@ private enum HubLayout {
 
 struct HubView: View {
     @Environment(ProjectStore.self) private var store
+    var openSettings: (() -> Void)?
     @State private var showAddProject = false
     @State private var workspaceToArchive: Workspace?
     @State private var sectionExpansionOverrides: [String: Bool] = HubView.loadExpansionOverrides(
@@ -28,15 +29,8 @@ struct HubView: View {
 
             ScrollView {
                 VStack(alignment: .leading, spacing: HiveSpacing.md) {
-                    if store.isLoading && store.projects.isEmpty {
-                        loadingState
-                    } else if store.projects.isEmpty && !store.isLoading {
-                        ContentUnavailableView(
-                            "No Projects",
-                            systemImage: "folder",
-                            description: Text("Tap + to add your first project, or connect to your Hive server from Settings.")
-                        )
-                        .padding(.top, 40)
+                    if store.projects.isEmpty {
+                        emptyState
                     } else {
                         denseHubContent(sections: sections)
                     }
@@ -57,7 +51,7 @@ struct HubView: View {
             // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
             await Task { @MainActor in
                 store.statusMonitor.forceRefresh()
-                await store.refresh(force: true)
+                await store.refresh(force: true, userInitiated: true)
             }.value
         }
         .task {
@@ -78,6 +72,18 @@ struct HubView: View {
                 errorBanner(errorMessage)
             }
         }
+        .overlay(alignment: .top) {
+            if store.refreshFailedWithCachedData {
+                refreshFailedNotice
+                    .task {
+                        try? await Task.sleep(for: .seconds(3))
+                        if !Task.isCancelled {
+                            store.acknowledgeRefreshFailure()
+                        }
+                    }
+            }
+        }
+        .animation(.default, value: store.refreshFailedWithCachedData)
         .safeAreaInset(edge: .top, spacing: 0) {
             if let repoName = store.cloningRepoName {
                 HStack(spacing: HiveSpacing.sm) {
@@ -130,6 +136,41 @@ struct HubView: View {
         }
         .frame(maxWidth: .infinity, minHeight: 420)
         .frame(maxHeight: .infinity)
+    }
+
+    @ViewBuilder
+    private var emptyState: some View {
+        if let failure = store.fetchFailure {
+            HubUnreachableState(
+                failure: failure,
+                isRetrying: store.isLoading,
+                onRetry: { Task { await store.refresh(force: true) } },
+                onOpenSettings: { openSettings?() }
+            )
+        } else if store.isLoading || !store.hasLoadedSuccessfully {
+            loadingState
+        } else {
+            ContentUnavailableView(
+                "No Projects",
+                systemImage: "folder",
+                description: Text("Tap + to add your first project, or connect to your Hive server from Settings.")
+            )
+            .padding(.top, 40)
+        }
+    }
+
+    private var refreshFailedNotice: some View {
+        HStack(spacing: HiveSpacing.sm) {
+            Image(systemName: "exclamationmark.triangle")
+            Text("Couldn't refresh. Showing cached data.")
+                .font(.footnote)
+        }
+        .foregroundStyle(WhisperColor.textSecondary)
+        .padding(.horizontal, HiveSpacing.lg)
+        .padding(.vertical, HiveSpacing.sm)
+        .glassPill()
+        .padding(.top, HiveSpacing.sm)
+        .transition(.move(edge: .top).combined(with: .opacity))
     }
 
     @ToolbarContentBuilder
@@ -385,6 +426,79 @@ struct HubView: View {
         }
         .transition(.move(edge: .bottom))
         .animation(.default, value: store.errorMessage)
+    }
+}
+
+private struct HubUnreachableState: View {
+    let failure: ProjectStore.FetchFailure
+    let isRetrying: Bool
+    let onRetry: () -> Void
+    let onOpenSettings: () -> Void
+
+    var body: some View {
+        VStack(spacing: HiveSpacing.md) {
+            Image(systemName: icon)
+                .font(.system(size: 44))
+                .foregroundStyle(WhisperColor.textMuted)
+            Text(title)
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(WhisperColor.text)
+                .multilineTextAlignment(.center)
+            Text(message)
+                .font(.subheadline)
+                .foregroundStyle(WhisperColor.textSecondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+            VStack(spacing: HiveSpacing.sm) {
+                Button(action: onRetry) {
+                    HStack(spacing: HiveSpacing.sm) {
+                        if isRetrying {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                        Text(isRetrying ? "Retrying..." : "Retry")
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isRetrying)
+
+                Button("Open Settings", action: onOpenSettings)
+                    .buttonStyle(.bordered)
+                    .disabled(isRetrying)
+            }
+            .padding(.top, HiveSpacing.sm)
+        }
+        .padding(HiveSpacing.xl)
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    private var icon: String {
+        switch failure {
+        case .unreachable: "wifi.slash"
+        case .authentication: "lock.trianglebadge.exclamationmark"
+        case .other: "exclamationmark.triangle"
+        }
+    }
+
+    private var title: String {
+        switch failure {
+        case .unreachable: "Can't reach your Hive server"
+        case .authentication: "Can't sign in to your Hive server"
+        case .other: "Something went wrong"
+        }
+    }
+
+    private var message: String {
+        switch failure {
+        case .unreachable:
+            "Hive couldn't connect to your server. Check that it's running and reachable, then try again."
+        case .authentication:
+            "Your Hive server rejected the current credentials. Open Settings to check your server address and token."
+        case .other:
+            "Your Hive server returned an unexpected error. Try again in a moment."
+        }
     }
 }
 

--- a/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
+++ b/ios/HiveMobile/Views/Onboarding/OnboardingView.swift
@@ -1,0 +1,206 @@
+import SwiftUI
+
+/// First-run funnel shown when no server has been configured yet. Guides the user
+/// through entering their Hive server address, hints at VPN/Tailscale state, and
+/// verifies reachability before dismissing.
+struct OnboardingView: View {
+    let onDone: () -> Void
+
+    @AppStorage("serverHost") private var host = ""
+    @AppStorage("serverPort") private var port = "3000"
+    @AppStorage("authToken") private var token = ""
+    @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
+
+    @FocusState private var focused: Field?
+    @State private var phase: Phase = .idle
+    @State private var vpnActive = NetworkEnvironment.isVPNActive()
+    @State private var vpnRefreshSpin = 0.0
+
+    private enum Field: Hashable { case host, port, token }
+    private enum Phase: Equatable { case idle, testing, success, failed }
+
+    private var accent: Color { AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color }
+
+    private var canConnect: Bool {
+        !host.trimmingCharacters(in: .whitespaces).isEmpty
+            && !port.trimmingCharacters(in: .whitespaces).isEmpty
+            && phase != .testing
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                headerSection
+                serverSection
+                statusSection
+            }
+            .scrollContentBackground(.hidden)
+            .hiveScreenBackground()
+            .scrollDismissesKeyboard(.interactively)
+            .onTapGesture { focused = nil }
+            .safeAreaInset(edge: .bottom) { connectBar }
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Set up later", action: onDone)
+                        .foregroundStyle(WhisperColor.textSecondary)
+                }
+            }
+        }
+    }
+
+    private var headerSection: some View {
+        Section {
+            VStack(spacing: HiveSpacing.sm) {
+                Image(systemName: "sparkles")
+                    .font(.system(size: 40, weight: .semibold))
+                    .foregroundStyle(accent)
+                Text("Connect to your Hive server")
+                    .font(.title2.weight(.bold))
+                    .multilineTextAlignment(.center)
+                Text("Enter your server address to get started. If it's behind Tailscale, make sure the VPN is connected first.")
+                    .font(.subheadline)
+                    .foregroundStyle(WhisperColor.textSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, HiveSpacing.md)
+        }
+        .listRowBackground(Color.clear)
+    }
+
+    private var serverSection: some View {
+        Section("Server") {
+            LabeledContent("Host") {
+                TextField("hostname or IP", text: $host)
+                    .focused($focused, equals: .host)
+                    .textContentType(.URL)
+                    .autocorrectionDisabled()
+                    .textInputAutocapitalization(.never)
+                    .multilineTextAlignment(.trailing)
+            }
+            LabeledContent("Port") {
+                TextField("port", text: $port)
+                    .focused($focused, equals: .port)
+                    .keyboardType(.numberPad)
+                    .multilineTextAlignment(.trailing)
+            }
+            LabeledContent("Token") {
+                SecureField("optional", text: $token)
+                    .focused($focused, equals: .token)
+                    .multilineTextAlignment(.trailing)
+            }
+        }
+        .listRowBackground(WhisperColor.surfaceRaised)
+    }
+
+    private var statusSection: some View {
+        Section {
+            HStack(spacing: HiveSpacing.sm) {
+                Image(systemName: vpnActive ? "lock.shield.fill" : "lock.shield")
+                    .font(.title3)
+                    .foregroundStyle(vpnActive ? WhisperColor.success : WhisperColor.textMuted)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(vpnActive ? "VPN active" : "No VPN detected")
+                        .font(.subheadline.weight(.medium))
+                    Text(vpnActive
+                        ? "A tunnel is up — good if your server needs Tailscale."
+                        : "If your server is behind Tailscale, connect the VPN first.")
+                        .font(.caption)
+                        .foregroundStyle(WhisperColor.textSecondary)
+                }
+                Spacer()
+                Button {
+                    withAnimation(.snappy(duration: 0.5)) { vpnRefreshSpin += 360 }
+                    vpnActive = NetworkEnvironment.isVPNActive()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                        .rotationEffect(.degrees(vpnRefreshSpin))
+                }
+                .buttonStyle(.plain)
+                .foregroundStyle(WhisperColor.textSecondary)
+                .accessibilityLabel("Re-check VPN")
+            }
+
+            if phase == .failed {
+                Label(
+                    "Couldn't reach \(host):\(port). Check the address\(vpnActive ? "" : " and your VPN"), then try again.",
+                    systemImage: "wifi.slash"
+                )
+                .font(.caption)
+                .foregroundStyle(.red)
+            }
+        }
+        .listRowBackground(WhisperColor.surfaceRaised)
+    }
+
+    private var connectBar: some View {
+        VStack(spacing: 0) {
+            Divider().overlay(WhisperColor.separator)
+            Button {
+                Task { await testAndConnect() }
+            } label: {
+                HStack(spacing: HiveSpacing.sm) {
+                    if phase == .testing {
+                        ProgressView().controlSize(.small).tint(.white)
+                    } else if phase == .success {
+                        Image(systemName: "checkmark.circle.fill")
+                    }
+                    Text(connectLabel)
+                }
+                .font(.headline)
+                .foregroundStyle(.white)
+                .frame(maxWidth: .infinity, minHeight: 52)
+                .background(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(accent)
+                )
+                .opacity(canConnect ? 1 : 0.4)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canConnect)
+            .padding(.horizontal, HiveSpacing.lg)
+            .padding(.vertical, HiveSpacing.md)
+        }
+        .background(WhisperColor.appBackground)
+    }
+
+    private var connectLabel: String {
+        switch phase {
+        case .testing: "Connecting..."
+        case .success: "Connected"
+        default: "Connect"
+        }
+    }
+
+    private func testAndConnect() async {
+        focused = nil
+        vpnActive = NetworkEnvironment.isVPNActive()
+        phase = .testing
+        HiveHTTP.clearCache()
+        if await runHealthCheck() {
+            phase = .success
+            try? await Task.sleep(for: .milliseconds(500))
+            onDone()
+        } else {
+            phase = .failed
+        }
+    }
+
+    private func runHealthCheck() async -> Bool {
+        await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+            group.addTask { (try? await APIClient().checkHealth()) ?? false }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(5))
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(onDone: {})
+        .preferredColorScheme(.dark)
+}

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -19,7 +19,6 @@ let package = Package(
                 "HiveApp.swift",
                 "HiveMobile.entitlements",
                 "Stores/ModelCatalog.swift",
-                "Stores/ProjectStore.swift",
                 "Theme",
                 "Views"
             ],
@@ -29,6 +28,7 @@ let package = Package(
                 "Models/ConversationSurfaceModels.swift",
                 "Models/Models.swift",
                 "Models/WebSocketTypes.swift",
+                "Services/APIClient.swift",
                 "Services/HiveHTTP.swift",
                 "Stores/BackgroundAgentDerivation.swift",
                 "Stores/ChatDraftStore.swift",
@@ -42,6 +42,7 @@ let package = Package(
                 "Stores/HubOrganization.swift",
                 "Stores/HubSubscriptionSync.swift",
                 "Stores/MarkdownStructure.swift",
+                "Stores/ProjectStore.swift",
                 "Stores/SubAgentStatus.swift",
                 "Stores/TaskDerivation.swift",
                 "Stores/TokenFormatting.swift",

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreCompletionHapticTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreCompletionHapticTests.swift
@@ -1,0 +1,97 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// Drives the turn-completion haptic: the store must expose an observable
+/// completion transition that bumps only when the completing session's chat is
+/// the visible screen. These assert that external behaviour, not the haptic.
+struct ConversationStoreCompletionHapticTests {
+    @MainActor
+    private func streamingStore(session: String, visible: Bool) -> ConversationStore {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId(session)
+        store.applyFetchedHistory([], for: session)
+        store.isChatVisible = visible
+        store.handle(.status(
+            status: .busy,
+            sessionId: session,
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: session, text: "Answer"))
+        return store
+    }
+
+    private func done(_ session: String) -> WsOutgoing {
+        .done(
+            sessionId: session,
+            durationMs: 100,
+            inputTokens: nil,
+            outputTokens: nil,
+            contextUsedTokens: nil,
+            contextWindowTokens: nil,
+            pendingToolName: nil
+        )
+    }
+
+    @Test @MainActor
+    func completionWhileViewingChatBumpsCounter() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(done("session-A"))
+        #expect(store.visibleCompletionCount == 1)
+    }
+
+    @Test @MainActor
+    func completionWhileChatNotVisibleDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: false)
+        store.handle(done("session-A"))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func backgroundSessionCompletionDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: true)
+        // A second session streams in the background while A stays focused.
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-B",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-B", text: "Background"))
+        store.handle(done("session-B"))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func cancelledTurnDoesNotBump() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(.cancelled(
+            sessionId: "session-A",
+            errorDetail: nil,
+            userInitiated: true,
+            durationMs: 100
+        ))
+        #expect(store.visibleCompletionCount == 0)
+    }
+
+    @Test @MainActor
+    func successiveVisibleCompletionsAccumulate() {
+        let store = streamingStore(session: "session-A", visible: true)
+        store.handle(done("session-A"))
+
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-A",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+        store.handle(.textDelta(sessionId: "session-A", text: "Second answer"))
+        store.handle(done("session-A"))
+
+        #expect(store.visibleCompletionCount == 2)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreForegroundReconcileTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreForegroundReconcileTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ConversationStoreForegroundReconcileTests {
+    /// The agent finishes its turn while the app is backgrounded, so the client
+    /// never receives `done`. On foreground the hub bootstrap only resends
+    /// `status: idle` for the finished session. The streaming indicator must
+    /// clear AND the finalized last message must be reconciled from REST — the
+    /// store has to request a history refetch (onTurnCompleted), otherwise the
+    /// last agent message stays missing until the conversation view reloads.
+    @Test @MainActor
+    func backgroundedTurnCompletionRequestsHistoryReconcileOnForeground() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s")
+
+        store.handle(.status(status: .busy, sessionId: "s", streaming: true,
+                             streamingStartedAt: nil, lockedProvider: nil))
+        store.handle(.textDelta(sessionId: "s", text: "partial"))
+        store.flushStreamingDeltas()
+        #expect(store.isStreaming)
+
+        var reconciledSession: String?
+        store.onTurnCompleted = { reconciledSession = $0 }
+
+        store.handle(.status(status: .idle, sessionId: "s", streaming: false,
+                             streamingStartedAt: nil, lockedProvider: nil))
+
+        #expect(!store.isStreaming)
+        #expect(reconciledSession == "s")
+    }
+
+    /// A plain idle status for a session that was never streaming must NOT
+    /// request a refetch — only a genuine streaming→idle transition does.
+    @Test @MainActor
+    func idleStatusForNonStreamingSessionDoesNotReconcile() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s")
+
+        var reconciledSession: String?
+        store.onTurnCompleted = { reconciledSession = $0 }
+
+        store.handle(.status(status: .idle, sessionId: "s", streaming: false,
+                             streamingStartedAt: nil, lockedProvider: nil))
+
+        #expect(reconciledSession == nil)
+    }
+
+    /// A normal live turn ends via `done`, which removes the stream slot before
+    /// any trailing `status: idle`. That trailing idle must not fire a second
+    /// reconcile (the slot is already gone).
+    @Test @MainActor
+    func trailingIdleAfterDoneDoesNotReconcileTwice() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s")
+
+        store.handle(.status(status: .busy, sessionId: "s", streaming: true,
+                             streamingStartedAt: nil, lockedProvider: nil))
+        store.handle(.textDelta(sessionId: "s", text: "answer"))
+        store.handle(.done(sessionId: "s", durationMs: 10, inputTokens: nil,
+                           outputTokens: nil, contextUsedTokens: nil,
+                           contextWindowTokens: nil, pendingToolName: nil))
+
+        var reconciledCount = 0
+        store.onTurnCompleted = { _ in reconciledCount += 1 }
+
+        store.handle(.status(status: .idle, sessionId: "s", streaming: false,
+                             streamingStartedAt: nil, lockedProvider: nil))
+
+        #expect(reconciledCount == 0)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -604,6 +604,32 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func cachedMessagesDrivesLoadingVersusContentState() {
+        let store = ConversationStore()
+        store.setFocusedSessionId("session-1")
+
+        #expect(store.cachedMessages(for: "session-1") == nil)
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "message-1",
+                sessionId: "session-1",
+                role: .user,
+                content: "Hello",
+                images: nil,
+                toolCalls: nil,
+                thinkingContent: nil,
+                timestamp: "2026-01-01T00:00:00.000Z",
+                cancelled: nil,
+                durationMs: nil
+            )
+        ], for: "session-1")
+
+        #expect(store.cachedMessages(for: "session-1")?.count == 1)
+        #expect(store.cachedMessages(for: "session-2") == nil)
+    }
+
+    @Test @MainActor
     func userMessageKeepsCacheInSyncForSwitchBack() {
         // A user message appended over WS must land in the cache so switching
         // away and back shows the turn without a refetch.

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -182,6 +182,26 @@ struct HubStatusMonitorTests {
     }
 
     @Test
+    func firstSendResubscribesBeforeEventThenNot() async {
+        let (monitor, cache, connection) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-1"])
+        let store = cache.getOrCreate("ws-1")
+
+        _ = await store.send?(.stop(sessionId: "s1"))
+
+        #expect(connection.sentMessages.count == 2)
+        if case .syncWorkspaces = connection.sentMessages.first {} else {
+            Issue.record("first sent message should be the resubscribe sync_workspaces")
+        }
+        if case .workspaceEvent = connection.sentMessages.last {} else {
+            Issue.record("second sent message should be the workspace event")
+        }
+
+        _ = await store.send?(.stop(sessionId: "s2"))
+        #expect(connection.sentMessages.count == 3)
+    }
+
+    @Test
     func failedWorkspaceSendProbesLiveness() async {
         let (monitor, cache, connection) = makeMonitor()
         connection.sendResult = false

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -213,4 +213,30 @@ struct HubStatusMonitorTests {
         #expect(sent == false)
         #expect(connection.probeLivenessCount == 1)
     }
+
+    @Test
+    func staleConnectedSendWaitsForFreshConnectionThenRetrySucceeds() async {
+        let (monitor, cache, connection) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-1"])
+        let store = cache.getOrCreate("ws-1")
+
+        // Simulate a live socket (generation 1) whose first send fails because it
+        // died silently — connectionState is still the stale `.connected`.
+        monitor.didChangeConnectionState(.connected)
+        connection.sendResult = false
+
+        let sendTask = Task { await store.send?(.stop(sessionId: "s1")) ?? false }
+
+        // Let the closure reach its wait loop.
+        try? await Task.sleep(for: .milliseconds(150))
+
+        // A fresh reconnect completes (generation 2) and the new socket sends fine.
+        connection.sendResult = true
+        monitor.didChangeConnectionState(.connecting)
+        monitor.didChangeConnectionState(.connected)
+
+        let sent = await sendTask.value
+        #expect(sent == true)
+        #expect(connection.probeLivenessCount == 1)
+    }
 }

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import HiveMobileStoresCore
 
@@ -9,6 +10,7 @@ private final class FakeHubConnection: HubConnectionClient {
     private(set) var probeLivenessCount = 0
     private(set) var syncCalls: [(payload: HubSyncPayload, forceBootstrap: Bool)] = []
     private(set) var sentMessages: [HubIncoming] = []
+    var sendResult = true
 
     func connect() {
         connectCount += 1
@@ -24,7 +26,7 @@ private final class FakeHubConnection: HubConnectionClient {
 
     func send(_ message: HubIncoming) async -> Bool {
         sentMessages.append(message)
-        return true
+        return sendResult
     }
 
     func sendSync(_ payload: HubSyncPayload, forceBootstrap: Bool) {
@@ -168,5 +170,27 @@ struct HubStatusMonitorTests {
         monitor.reconnectNow()
 
         #expect(connection.forceReconnectCount == 1)
+    }
+
+    @Test
+    func reconnectNowIsSafeNoOpWhenNothingSubscribed() {
+        let (monitor, _, connection) = makeMonitor()
+        monitor.disconnectAll()
+        monitor.reconnectNow()
+        #expect(connection.connectCount == 0)
+        #expect(connection.forceReconnectCount == 0)
+    }
+
+    @Test
+    func failedWorkspaceSendProbesLiveness() async {
+        let (monitor, cache, connection) = makeMonitor()
+        connection.sendResult = false
+        monitor.sync(workspaceIds: ["ws-1"])
+        let store = cache.getOrCreate("ws-1")
+
+        let sent = await store.send?(.stop(sessionId: "s1")) ?? true
+
+        #expect(sent == false)
+        #expect(connection.probeLivenessCount == 1)
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreFetchStateTests.swift
@@ -1,0 +1,192 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+@MainActor
+struct ProjectStoreFetchStateTests {
+    private func sampleProject(id: String = "p1") -> Project {
+        Project(
+            id: id,
+            name: "Project \(id)",
+            url: nil,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            workspaces: []
+        )
+    }
+
+    private func makeStore(
+        fetchProjects: @escaping () async throws -> [Project],
+        fetchUiPreferences: @escaping () async throws -> UiPreferencesPayload = { .empty }
+    ) -> ProjectStore {
+        ProjectStore(
+            storeCache: ConversationStoreCache(),
+            fetchProjects: fetchProjects,
+            fetchPreferences: fetchUiPreferences
+        )
+    }
+
+    @Test
+    func emptyPlusUnreachableFailureClassifiesUnreachable() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.networkError(URLError(.cannotConnectToHost))
+        })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.hasLoadedSuccessfully == false)
+        #expect(store.refreshFailedWithCachedData == false)
+        #expect(store.isLoading == false)
+    }
+
+    @Test
+    func emptyPlusUnauthorizedFailureClassifiesAuthentication() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 401, message: "unauthorized")
+        })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == .authentication)
+        #expect(store.hasLoadedSuccessfully == false)
+    }
+
+    @Test
+    func serverErrorClassifiesOther() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 500, message: "boom")
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .other)
+    }
+
+    @Test
+    func forbiddenFailureClassifiesAuthentication() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.httpError(statusCode: 403, message: "forbidden")
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .authentication)
+    }
+
+    @Test
+    func decodingFailureClassifiesOther() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.decodingError(URLError(.cannotDecodeContentData))
+        })
+
+        await store.refresh()
+
+        #expect(store.fetchFailure == .other)
+    }
+
+    @Test
+    func emptyPlusSuccessSelectsOnboardingNotFailure() async {
+        let store = makeStore(fetchProjects: { [] })
+
+        await store.refresh()
+
+        #expect(store.projects.isEmpty)
+        #expect(store.fetchFailure == nil)
+        #expect(store.hasLoadedSuccessfully == true)
+    }
+
+    @Test
+    func cachedDataFailedRefreshKeepsCacheAndSignalsFailure() async {
+        var shouldFail = false
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.timedOut)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == nil)
+
+        shouldFail = true
+        await store.refresh(force: true, userInitiated: true)
+
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.refreshFailedWithCachedData == true)
+
+        store.acknowledgeRefreshFailure()
+        #expect(store.refreshFailedWithCachedData == false)
+    }
+
+    @Test
+    func backgroundRefreshFailureWithCacheStaysSilent() async {
+        var shouldFail = false
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.timedOut)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        shouldFail = true
+        await store.refresh(force: true)
+
+        #expect(store.projects.count == 1)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.refreshFailedWithCachedData == false)
+    }
+
+    @Test
+    func successAfterFailureClearsAllFailureState() async {
+        var shouldFail = true
+        let store = makeStore(fetchProjects: {
+            if shouldFail { throw APIError.networkError(URLError(.notConnectedToInternet)) }
+            return [self.sampleProject()]
+        })
+
+        await store.refresh()
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.projects.isEmpty)
+
+        shouldFail = false
+        await store.refresh(force: true)
+
+        #expect(store.fetchFailure == nil)
+        #expect(store.projects.count == 1)
+        #expect(store.hasLoadedSuccessfully == true)
+        #expect(store.isLoading == false)
+    }
+
+    @Test
+    func retryShowsInFlightLoadingBeforeResolving() async {
+        final class Box { var store: ProjectStore? }
+        let box = Box()
+        var loadingDuringFetch = false
+        let store = makeStore(fetchProjects: {
+            loadingDuringFetch = box.store?.isLoading ?? false
+            return [self.sampleProject()]
+        })
+        box.store = store
+
+        await store.refresh()
+
+        #expect(loadingDuringFetch == true)
+        #expect(store.isLoading == false)
+        #expect(store.fetchFailure == nil)
+    }
+
+    @Test
+    func retryFailingAgainPreservesFailureState() async {
+        let store = makeStore(fetchProjects: {
+            throw APIError.networkError(URLError(.cannotConnectToHost))
+        })
+
+        await store.refresh()
+        #expect(store.fetchFailure == .unreachable)
+
+        await store.refresh(force: true)
+        #expect(store.fetchFailure == .unreachable)
+        #expect(store.projects.isEmpty)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ProjectStorePushNavigationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStorePushNavigationTests.swift
@@ -1,0 +1,119 @@
+import Testing
+@testable import HiveMobileStoresCore
+
+@MainActor
+private final class NoopHubConnection: HubConnectionClient {
+    func connect() {}
+    func cancel() {}
+    func forceReconnect() {}
+    func send(_ message: HubIncoming) async -> Bool { true }
+    func sendSync(_ payload: HubSyncPayload, forceBootstrap: Bool) {}
+    func probeLiveness() {}
+}
+
+@MainActor
+private final class FetchRecorder {
+    private let results: [[Project]]
+    private(set) var callCount = 0
+
+    init(_ results: [[Project]]) {
+        self.results = results
+    }
+
+    func next() -> [Project] {
+        let result = results[min(callCount, results.count - 1)]
+        callCount += 1
+        return result
+    }
+}
+
+@MainActor
+struct ProjectStorePushNavigationTests {
+    @Test
+    func resolvesLoadedWorkspaceWithoutRefreshing() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-1", sessionId: "sess-1")
+
+        #expect(target?.workspace.id == "ws-1")
+        #expect(target?.sessionId == "sess-1")
+        #expect(recorder.callCount == 1)
+    }
+
+    @Test
+    func refreshesThenRetriesForUnknownWorkspace() async {
+        let recorder = FetchRecorder([
+            [project("p1", workspace: "ws-1")],
+            [project("p1", workspace: "ws-1"), project("p2", workspace: "ws-2")]
+        ])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-2", sessionId: nil)
+
+        #expect(target?.workspace.id == "ws-2")
+        #expect(target?.sessionId == nil)
+        #expect(recorder.callCount == 2)
+    }
+
+    @Test
+    func fallsBackSilentlyWhenWorkspaceStaysUnresolved() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+        await store.refresh(force: true)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-archived", sessionId: "sess-x")
+
+        #expect(target == nil)
+        #expect(recorder.callCount == 2)
+    }
+
+    @Test
+    func coldLaunchResolvesByRefreshingEmptyProjects() async {
+        let recorder = FetchRecorder([[project("p1", workspace: "ws-1")]])
+        let store = makeStore(recorder)
+
+        let target = await store.resolvePushTarget(workspaceId: "ws-1", sessionId: nil)
+
+        #expect(target?.workspace.id == "ws-1")
+        #expect(recorder.callCount == 1)
+    }
+
+    private func makeStore(_ recorder: FetchRecorder) -> ProjectStore {
+        let cache = ConversationStoreCache()
+        let monitor = HubStatusMonitor(storeCache: cache) { _ in NoopHubConnection() }
+        return ProjectStore(
+            storeCache: cache,
+            statusMonitor: monitor,
+            fetchProjects: { recorder.next() },
+            fetchPreferences: { .empty }
+        )
+    }
+
+    private func project(_ id: String, workspace workspaceId: String) -> Project {
+        Project(
+            id: id,
+            name: id,
+            url: "https://github.com/acme/\(id).git",
+            createdAt: "2026-01-01T00:00:00Z",
+            workspaces: [
+                Workspace(
+                    id: workspaceId,
+                    name: workspaceId,
+                    branch: "main",
+                    status: .idle,
+                    createdAt: "2026-01-01T00:00:00Z",
+                    activeSessionId: nil,
+                    projectName: id,
+                    defaultBranch: "main",
+                    sessionCount: 1,
+                    projectId: id,
+                    hasFavicon: false
+                )
+            ],
+            hasFavicon: false
+        )
+    }
+}


### PR DESCRIPTION
Consolidates all the open iOS PRs into one branch so we can review, fix, and merge them together. Based directly on \`main\`; Push Notifications capability is intact (the dev-only removal for personal-team signing is **not** included here).

## What's included

| Area | Change | Issue |
|------|--------|-------|
| History | Loading skeleton while a conversation's history loads | #290 |
| Connection | Debounced connection banner, dropped the connecting toast | #304 |
| Chat | Fix disclosure scroll jump/blink + tool-open lag | — |
| Motion | Honor Reduce Motion in activity animations | #296 |
| Push | Navigate to the workspace on push-notification tap | #294 |
| Haptics | Sparse haptic feedback for key actions | #297 |
| Hub | Honest server-unreachable state with retry | #285 |
| Onboarding | First-run funnel (host/port/token + VPN/reachability hint) | — |
| Composer | Native model picker, image de-dup, clean remove-image control, model catalog retry | — |
| Navigation | Smooth bottom tab bar transition in/out of conversations | — |
| Send | Retry a failed send after reconnecting; honest disconnect banner; **resubscribe before the first send to fix "Not subscribed to workspace"** | — |

Closes #285, #290, #294, #296, #297, #304

## Supersedes
Replaces the individual PRs #306, #307, #308, #309, #310, #311, #312, #313, #314 (being closed in favor of this one).

## Verification
- \`swift test\` green (210), \`xcodebuild\` green, 0 warnings.
- Verified on simulator: onboarding funnel, connection + project load against a live backend, model picker, tab bar.
- iOS-only. No backend/frontend changes.