### PR TITLE
iOS backlog: retryable sends, question chip, Dynamic Type, small polish (#287 #288 #295 #298)

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -55,6 +55,7 @@ struct HiveApp: App {
                     }
                     .toolbar(hubPath.isEmpty ? .automatic : .hidden, for: .tabBar)
                 }
+                .badge(projectStore.statusMonitor.hubBadgeCount)
                 Tab("Settings", systemImage: "gearshape.fill", value: .settings) {
                     NavigationStack {
                         SettingsView()

--- a/ios/HiveMobile/Services/APIClient.swift
+++ b/ios/HiveMobile/Services/APIClient.swift
@@ -14,6 +14,30 @@ enum APIError: Error, LocalizedError {
         case .networkError(let err): "Network error: \(err.localizedDescription)"
         }
     }
+
+    /// A rejected-credentials failure (wrong or expired token) rather than a
+    /// transport problem.
+    var isAuthFailure: Bool {
+        if case .httpError(let code, _) = self { return code == 401 || code == 403 }
+        return false
+    }
+}
+
+/// Classified outcome of a connection health probe, so a wrong token can be
+/// surfaced distinctly from an unreachable server.
+enum ConnectionHealth: Equatable {
+    case connected
+    case unreachable
+    case invalidToken
+
+    /// Map a failed probe to a health state: a 401/403 means the token is
+    /// invalid; anything else is treated as unreachable.
+    static func classify(error: Error) -> ConnectionHealth {
+        if let apiError = error as? APIError, apiError.isAuthFailure {
+            return .invalidToken
+        }
+        return .unreachable
+    }
 }
 
 final class APIClient {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -361,7 +361,11 @@ final class ConversationStore {
             sessionStreams[sid]?.activeAgentActivities = []
             sessionStreams[sid]?.pendingToolInputs = []
             if isActive && !alreadyExists {
-                messages.append(msg)
+                // The echo confirms delivery of an optimistically-appended
+                // message: swap it in place instead of appending a duplicate.
+                if !resolveOptimisticSend(with: msg) {
+                    messages.append(msg)
+                }
                 cacheMessages(messages, for: sid)
             } else if isActive {
                 recomputeDerivations()
@@ -453,7 +457,23 @@ final class ConversationStore {
             }
         }
 
-        messages = msgs
+        // Carry unresolved optimistic sends across the refetch: history that
+        // already contains the content confirms delivery; anything else is
+        // re-appended so a pending/failed message never silently vanishes.
+        var merged = msgs
+        for local in messages where userSendStates[local.id] != nil && local.sessionId == sessionId {
+            if userSendStates[local.id] == .sending,
+               msgs.contains(where: { $0.role == .user && $0.content == local.content }) {
+                userSendStates.removeValue(forKey: local.id)
+                optimisticPayloads.removeValue(forKey: local.id)
+            } else {
+                merged.append(local)
+            }
+        }
+        messages = merged
+        if merged.count != msgs.count {
+            cacheMessages(merged, for: sessionId)
+        }
     }
 
     func lastServerMessageId(for sessionId: String?) -> String? {
@@ -492,33 +512,112 @@ final class ConversationStore {
         sessionStreams[sessionId]?.failedSend = nil
     }
 
-    /// Retry a failed send. A message replays through the normal send path and
-    /// clears on success (kept, with reason refreshed, on failure). A tool-input
-    /// answer re-presents its pending question instead of blind-resending.
-    /// Returns `true` when the failed-send state was resolved.
+    /// Retry a failed tool-input answer: re-present the pending question so the
+    /// user can confirm it before it is resent.
     @discardableResult
     func retryFailedSend(for sessionId: String) async -> Bool {
         guard let failed = sessionStreams[sessionId]?.failedSend else { return false }
-        switch failed.retry {
-        case let .message(content, images, options):
-            let sent = await send?(.userMessage(
-                content: content, images: images, fileMentions: nil,
-                options: options, sessionId: sessionId
-            )) ?? false
-            if sent {
-                sessionStreams[sessionId]?.failedSend = nil
-                bumpHistoryToken(for: sessionId)
-            }
-            return sent
-        case let .toolInput(pending):
-            sessionStreams[sessionId]?.failedSend = nil
-            ensureStream(for: sessionId, streaming: false)
-            if let stream = sessionStreams[sessionId],
-               !stream.pendingToolInputs.contains(where: { $0.requestId == pending.requestId }) {
-                stream.pendingToolInputs.append(pending)
-            }
-            return true
+        sessionStreams[sessionId]?.failedSend = nil
+        ensureStream(for: sessionId, streaming: false)
+        if let stream = sessionStreams[sessionId],
+           !stream.pendingToolInputs.contains(where: { $0.requestId == failed.pending.requestId }) {
+            stream.pendingToolInputs.append(failed.pending)
         }
+        return true
+    }
+
+    // MARK: - Optimistic user sends
+
+    /// Delivery state of a user message the client appended optimistically.
+    /// Absent from the map = confirmed by the server (or plain history).
+    enum UserSendState: Equatable {
+        case sending
+        case failed
+    }
+
+    /// Per-message delivery state, keyed by (local) message ID.
+    private(set) var userSendStates: [String: UserSendState] = [:]
+    @ObservationIgnored private var optimisticPayloads: [String: (images: [ImageAttachment]?, options: MessageOptions?)] = [:]
+
+    /// Delivery state for a message, if it is a locally-appended send.
+    func sendState(for messageId: String) -> UserSendState? {
+        userSendStates[messageId]
+    }
+
+    /// Append the user's message to the transcript immediately (before the
+    /// server echo) so sending feels instant. Returns the local message ID used
+    /// to track delivery.
+    @discardableResult
+    func appendOptimisticUserMessage(
+        content: String,
+        images: [ImageAttachment]?,
+        options: MessageOptions?,
+        sessionId sid: String
+    ) -> String {
+        let localId = "local-\(UUID().uuidString)"
+        let message = ChatMessage(
+            id: localId, sessionId: sid, role: .user, content: content,
+            images: images, toolCalls: nil, thinkingContent: nil,
+            timestamp: Self.timestamp(), cancelled: nil, durationMs: nil
+        )
+        userSendStates[localId] = .sending
+        optimisticPayloads[localId] = (images, options)
+        if sid == sessionId {
+            messages.append(message)
+            cacheMessages(messages, for: sid)
+        }
+        return localId
+    }
+
+    /// Mark a locally-appended send as failed (kept in the transcript with a
+    /// retry affordance — the user's text is never lost).
+    func markSendFailed(_ localId: String) {
+        guard userSendStates[localId] != nil else { return }
+        userSendStates[localId] = .failed
+    }
+
+    /// Resend a failed (or stuck) local message through the normal send path.
+    @discardableResult
+    func retryOptimisticSend(_ localId: String) async -> Bool {
+        guard let message = messages.first(where: { $0.id == localId }),
+              userSendStates[localId] != nil else { return false }
+        let payload = optimisticPayloads[localId]
+        userSendStates[localId] = .sending
+        let sent = await send?(.userMessage(
+            content: message.content, images: payload?.images, fileMentions: nil,
+            options: payload?.options, sessionId: message.sessionId
+        )) ?? false
+        if sent {
+            bumpHistoryToken(for: message.sessionId)
+        } else {
+            userSendStates[localId] = .failed
+        }
+        return sent
+    }
+
+    /// Remove a failed local message the user no longer wants to deliver.
+    func discardOptimisticSend(_ localId: String) {
+        guard userSendStates[localId] != nil else { return }
+        userSendStates.removeValue(forKey: localId)
+        optimisticPayloads.removeValue(forKey: localId)
+        if let idx = messages.firstIndex(where: { $0.id == localId }) {
+            let sid = messages[idx].sessionId
+            messages.remove(at: idx)
+            cacheMessages(messages, for: sid)
+        }
+    }
+
+    private func resolveOptimisticSend(with serverMessage: ChatMessage) -> Bool {
+        guard serverMessage.role == .user,
+              let idx = messages.firstIndex(where: {
+                  userSendStates[$0.id] != nil && $0.role == .user && $0.content == serverMessage.content
+              })
+        else { return false }
+        let localId = messages[idx].id
+        userSendStates.removeValue(forKey: localId)
+        optimisticPayloads.removeValue(forKey: localId)
+        messages[idx] = serverMessage
+        return true
     }
 
     /// Set plan-mode state for a specific session.
@@ -831,17 +930,14 @@ struct PendingToolInput: Identifiable, Equatable {
     let input: String
 }
 
-/// A store-owned failed send. Rendered as a distinct error row (never a fake
-/// assistant message) so it survives history refetches and can be retried.
+/// A store-owned failed tool-input answer. Rendered as a distinct error row
+/// (never a fake assistant message) so it survives history refetches; retrying
+/// re-presents the pending question. Failed chat messages are handled as
+/// optimistic transcript messages instead (see `UserSendState`).
 struct FailedSend: Identifiable, Equatable {
-    enum Retry: Equatable {
-        case message(content: String, images: [ImageAttachment]?, options: MessageOptions?)
-        case toolInput(PendingToolInput)
-    }
-
     let id: String
     let sessionId: String
     let content: String
     var reason: String
-    let retry: Retry
+    let pending: PendingToolInput
 }

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -13,6 +13,7 @@ final class SessionStreamState {
     var streamingStartedAt: Date?
     var pendingToolInputs: [PendingToolInput] = []
     var agentPlanMode: Bool?
+    var failedSend: FailedSend?
 }
 
 @MainActor
@@ -109,6 +110,9 @@ final class ConversationStore {
     var activeToolCalls: [ToolCall] { activeStream?.activeToolCalls ?? [] }
     var activeAgentActivities: [AgentActivity] { activeStream?.activeAgentActivities ?? [] }
     var pendingToolInputs: [PendingToolInput] { activeStream?.pendingToolInputs ?? [] }
+
+    /// Store-owned failed send for the focused session, if any.
+    var failedSend: FailedSend? { activeStream?.failedSend }
 
     private(set) var tasksState: TasksState =
         deriveTasks(from: [], activeToolCalls: [], activeAgentActivities: [])
@@ -408,10 +412,18 @@ final class ConversationStore {
         // sees the reconciled stream state (one recompute, not two).
         let existingStream = sessionStreams[sessionId]
         if existingStream?.isStreaming != true {
+            // A store-owned failed send is not part of REST history; carry it
+            // across the reconciliation so a refetch never erases the error row.
+            let preservedFailedSend = existingStream?.failedSend
             let derived = derivePendingToolInputsFromHistory(msgs)
             if !derived.isEmpty {
                 let rebuilt = SessionStreamState()
                 rebuilt.pendingToolInputs = derived
+                rebuilt.failedSend = preservedFailedSend
+                sessionStreams[sessionId] = rebuilt
+            } else if preservedFailedSend != nil {
+                let rebuilt = SessionStreamState()
+                rebuilt.failedSend = preservedFailedSend
                 sessionStreams[sessionId] = rebuilt
             } else if existingStream != nil {
                 sessionStreams.removeValue(forKey: sessionId)
@@ -441,6 +453,49 @@ final class ConversationStore {
     func clearPendingToolInputs() {
         guard let sid = sessionId else { return }
         sessionStreams[sid]?.pendingToolInputs = []
+    }
+
+    // MARK: - Failed sends
+
+    /// Record a send that failed to reach the WebSocket as a store-owned error
+    /// state. Replaces any prior failed send for the same session.
+    func recordFailedSend(_ failed: FailedSend) {
+        ensureStream(for: failed.sessionId, streaming: false)
+        sessionStreams[failed.sessionId]?.failedSend = failed
+    }
+
+    /// Dismiss a failed send without retrying.
+    func discardFailedSend(for sessionId: String) {
+        sessionStreams[sessionId]?.failedSend = nil
+    }
+
+    /// Retry a failed send. A message replays through the normal send path and
+    /// clears on success (kept, with reason refreshed, on failure). A tool-input
+    /// answer re-presents its pending question instead of blind-resending.
+    /// Returns `true` when the failed-send state was resolved.
+    @discardableResult
+    func retryFailedSend(for sessionId: String) async -> Bool {
+        guard let failed = sessionStreams[sessionId]?.failedSend else { return false }
+        switch failed.retry {
+        case let .message(content, images, options):
+            let sent = await send?(.userMessage(
+                content: content, images: images, fileMentions: nil,
+                options: options, sessionId: sessionId
+            )) ?? false
+            if sent {
+                sessionStreams[sessionId]?.failedSend = nil
+                bumpHistoryToken(for: sessionId)
+            }
+            return sent
+        case let .toolInput(pending):
+            sessionStreams[sessionId]?.failedSend = nil
+            ensureStream(for: sessionId, streaming: false)
+            if let stream = sessionStreams[sessionId],
+               !stream.pendingToolInputs.contains(where: { $0.requestId == pending.requestId }) {
+                stream.pendingToolInputs.append(pending)
+            }
+            return true
+        }
     }
 
     /// Set plan-mode state for a specific session.
@@ -737,11 +792,26 @@ func deriveDismissedToolCallIds(from messages: [ChatMessage]) -> Set<String> {
 
 // MARK: - Pending Tool Input
 
-struct PendingToolInput: Identifiable {
+struct PendingToolInput: Identifiable, Equatable {
     var id: String { requestId }
     let sessionId: String
     let requestId: String
     let toolName: String
     let toolUseId: String
     let input: String
+}
+
+/// A store-owned failed send. Rendered as a distinct error row (never a fake
+/// assistant message) so it survives history refetches and can be retried.
+struct FailedSend: Identifiable, Equatable {
+    enum Retry: Equatable {
+        case message(content: String, images: [ImageAttachment]?, options: MessageOptions?)
+        case toolInput(PendingToolInput)
+    }
+
+    let id: String
+    let sessionId: String
+    let content: String
+    var reason: String
+    let retry: Retry
 }

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -139,6 +139,20 @@ final class ConversationStore {
 
     // MARK: - Streaming delta buffering
 
+    /// While a finger is on the transcript, scheduled flushes keep buffering
+    /// instead of applying, so the content under the touch never moves (a
+    /// moving transcript cancels the long-press copy interaction). Event
+    /// handlers still flush explicitly for turn-lifecycle correctness.
+    @ObservationIgnored private var streamingUIHeld = false
+
+    func setStreamingUIHold(_ active: Bool) {
+        guard streamingUIHeld != active else { return }
+        streamingUIHeld = active
+        if !active {
+            flushStreamingDeltas()
+        }
+    }
+
     func flushStreamingDeltas() {
         flushTask?.cancel()
         flushTask = nil
@@ -157,8 +171,13 @@ final class ConversationStore {
         guard let interval = streamFlushInterval, flushTask == nil else { return }
         flushTask = Task { [weak self] in
             try? await Task.sleep(for: .seconds(interval))
-            guard !Task.isCancelled else { return }
-            self?.flushStreamingDeltas()
+            guard !Task.isCancelled, let self else { return }
+            if self.streamingUIHeld {
+                self.flushTask = nil
+                self.scheduleStreamFlush()
+                return
+            }
+            self.flushStreamingDeltas()
         }
     }
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -422,6 +422,7 @@ final class ConversationStore {
     /// History contains only finalized turns. Streaming content lives in
     /// `sessionStreams` and is rendered as a separate in-progress bubble.
     func applyFetchedHistory(_ msgs: [ChatMessage], for sessionId: String) {
+        let previouslyKnownIds = Set((serverHistory[sessionId] ?? []).map(\.id))
         serverHistory[sessionId] = msgs
         cacheMessages(msgs, for: sessionId)
         lastHistoryFetchAt[sessionId] = Date()
@@ -463,7 +464,10 @@ final class ConversationStore {
         var merged = msgs
         for local in messages where userSendStates[local.id] != nil && local.sessionId == sessionId {
             if userSendStates[local.id] == .sending,
-               msgs.contains(where: { $0.role == .user && $0.content == local.content }) {
+               msgs.contains(where: {
+                   $0.role == .user && $0.content == local.content
+                       && !previouslyKnownIds.contains($0.id)
+               }) {
                 userSendStates.removeValue(forKey: local.id)
                 optimisticPayloads.removeValue(forKey: local.id)
             } else {

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -228,10 +228,14 @@ final class ConversationStore {
                 return
             }
             ensureStream(for: sid, streaming: false)
-            sessionStreams[sid]?.pendingToolInputs.append(PendingToolInput(
-                sessionId: sid, requestId: requestId,
-                toolName: toolName, toolUseId: toolUseId, input: input
-            ))
+            // Idempotent by requestId so a snapshot/replay on reconnect can never
+            // produce a duplicate pending question.
+            if sessionStreams[sid]?.pendingToolInputs.contains(where: { $0.requestId == requestId }) != true {
+                sessionStreams[sid]?.pendingToolInputs.append(PendingToolInput(
+                    sessionId: sid, requestId: requestId,
+                    toolName: toolName, toolUseId: toolUseId, input: input
+                ))
+            }
 
         case .toolInputResolved(let sid):
             // A client (possibly another device) answered or dismissed the question.
@@ -660,8 +664,15 @@ final class ConversationStore {
             || !stream.activeAgentActivities.isEmpty || !stream.currentThinking.isEmpty
 
         // Remove the stream slot before appending the finalized message so the
-        // chat view never shows both at once.
+        // chat view never shows both at once. A store-owned failed send is not
+        // tied to this turn, so it is carried across the finalization.
+        let preservedFailedSend = stream.failedSend
         sessionStreams.removeValue(forKey: sid)
+        if let preservedFailedSend {
+            let slot = SessionStreamState()
+            slot.failedSend = preservedFailedSend
+            sessionStreams[sid] = slot
+        }
 
         if isActive {
             if hasContent {

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Network
 import Observation
 
 enum HubConnectionState { case connecting; case connected; case disconnected }
@@ -44,6 +45,12 @@ final class HubStatusMonitor {
     }
     private(set) var connectionState: HubConnectionState = .connecting
 
+    /// True while the device reports a usable network path. Airplane mode flips
+    /// this instantly — long before a socket send or the 30s ping would notice —
+    /// so sends fail fast and the disconnect banner shows without delay.
+    private(set) var isNetworkAvailable = true
+    @ObservationIgnored private var pathMonitor: NWPathMonitor?
+
     /// Bumped each time the hub transitions into `.connected`. Lets a retry
     /// distinguish a genuinely fresh connection from a stale `.connected` read.
     private(set) var connectionGeneration = 0
@@ -73,6 +80,35 @@ final class HubStatusMonitor {
 
     convenience init(storeCache: ConversationStoreCache) {
         self.init(storeCache: storeCache, makeHubConnection: { HubConnection(monitor: $0) })
+        startNetworkPathMonitoring()
+    }
+
+    private func startNetworkPathMonitoring() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            let available = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                self?.setNetworkAvailable(available)
+            }
+        }
+        monitor.start(queue: DispatchQueue.global(qos: .utility))
+        pathMonitor = monitor
+    }
+
+    func setNetworkAvailable(_ available: Bool) {
+        guard isNetworkAvailable != available else { return }
+        isNetworkAvailable = available
+        if available {
+            // Network is back: probe (or create) the connection right away
+            // instead of waiting for the next ping cycle.
+            if hubConnection != nil {
+                forceRefresh()
+            } else {
+                ensureConnection()
+            }
+        } else {
+            didChangeConnectionState(.disconnected)
+        }
     }
 
     init(
@@ -93,6 +129,10 @@ final class HubStatusMonitor {
     fileprivate func wireSendClosure(for workspaceId: String, on store: ConversationStore) {
         store.send = { [weak self] message in
             guard let self else { return false }
+            // No network path (airplane mode): fail fast so the failed-send
+            // error state appears immediately instead of hanging on a dead
+            // socket send that TCP won't give up on for tens of seconds.
+            guard self.isNetworkAvailable else { return false }
             let event = HubIncoming.workspaceEvent(workspaceId: workspaceId, event: message)
             let generationAtSend = self.connectionGeneration
             await self.resubscribeIfNeeded()
@@ -103,10 +143,12 @@ final class HubStatusMonitor {
             // stale `.connected` left over from the socket that just failed.
             self.handleSendFailure()
             for _ in 0..<30 {
+                if !self.isNetworkAvailable { return false }
                 if self.connectionState == .connected,
                    self.connectionGeneration != generationAtSend { break }
                 try? await Task.sleep(for: .milliseconds(100))
             }
+            guard self.isNetworkAvailable else { return false }
             await self.resubscribeIfNeeded()
             return await self.hubConnection?.send(event) == true
         }

--- a/ios/HiveMobile/Stores/HubStatusMonitor.swift
+++ b/ios/HiveMobile/Stores/HubStatusMonitor.swift
@@ -178,6 +178,14 @@ final class HubStatusMonitor {
         completedWorkspaces.contains(workspaceId)
     }
 
+    /// Number of workspaces with new activity (a completed turn or an unread
+    /// session), for the Hub tab badge. Clears as workspaces are viewed.
+    var hubBadgeCount: Int {
+        completedWorkspaces
+            .union(unreadSessions.compactMap { $0.value.isEmpty ? nil : $0.key })
+            .count
+    }
+
     func lastActivityDate(for workspaceId: String) -> Date? {
         workspaceLastActivityAt[workspaceId]
     }

--- a/ios/HiveMobile/Theme/DesignTokens.swift
+++ b/ios/HiveMobile/Theme/DesignTokens.swift
@@ -119,7 +119,32 @@ enum WhisperColor {
 // MARK: - Whisper Font Helpers
 
 enum WhisperFont {
+    /// Monospaced font that scales with Dynamic Type. The base point size is
+    /// mapped to the nearest semantic text style so every call site grows and
+    /// shrinks with the system setting while keeping the monospaced design.
     static func mono(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight, design: .monospaced)
+        .system(textStyle(for: size), design: .monospaced).weight(weight)
+    }
+
+    /// Dynamic-Type-scaling font matching a fixed point size to the nearest
+    /// semantic text style (default design). Lets fixed-size call sites scale
+    /// with a near-identical default-size appearance.
+    static func scaled(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        .system(textStyle(for: size), design: .default).weight(weight)
+    }
+
+    static func textStyle(for size: CGFloat) -> Font.TextStyle {
+        switch size {
+        case ..<12: return .caption2       // 9–11
+        case ..<13: return .caption        // 12
+        case ..<14: return .footnote       // 13
+        case ..<15.5: return .subheadline  // 14–15
+        case ..<16.5: return .callout      // 16
+        case ..<19: return .body           // 17–18
+        case ..<21: return .title3         // 20
+        case ..<25: return .title2         // 22
+        case ..<31: return .title          // 28
+        default: return .largeTitle        // 34+
+        }
     }
 }

--- a/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
+++ b/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
@@ -110,7 +110,7 @@ struct BrainConversationsView: View {
     }
 
     private var loadingPlaceholder: some View {
-        ProgressView()
+        ListLoadingSkeleton()
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .hiveScreenBackground()
             .navigationTitle("Brain")

--- a/ios/HiveMobile/Views/Chat/AgentActivityList.swift
+++ b/ios/HiveMobile/Views/Chat/AgentActivityList.swift
@@ -46,7 +46,7 @@ private struct DiagnosticActivityRow: View {
             expanded: AnyView(
                 VStack(alignment: .leading, spacing: 8) {
                     Text(activity.message)
-                        .font(.system(size: 12))
+                        .font(WhisperFont.scaled(12))
                         .foregroundStyle(WhisperColor.textSecondary)
                         .frame(maxWidth: .infinity, alignment: .leading)
 
@@ -89,7 +89,7 @@ private struct UnknownActivityRow: View {
             detail: activity.kind,
             expanded: AnyView(
                 Text(activity.kind)
-                    .font(.system(size: 12))
+                    .font(WhisperFont.scaled(12))
                     .foregroundStyle(WhisperColor.textMuted)
             )
         )

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -1,5 +1,14 @@
 import SwiftUI
 
+/// Collapse/expand toggles in the transcript must never animate: an animated
+/// row-height change makes the List re-align its scroll position, which
+/// glitches on tall content. All disclosure toggles go through this.
+func withoutAnimation(_ body: () -> Void) {
+    var transaction = Transaction()
+    transaction.disablesAnimations = true
+    withTransaction(transaction, body)
+}
+
 struct ChatActivityStats {
     enum Kind { case diff, plain }
     let kind: Kind
@@ -197,7 +206,7 @@ struct ActivityDisclosureRow: View {
 
                 Button {
                     guard canExpand else { return }
-                    withAnimation(.easeInOut(duration: 0.2)) { isExpanded.toggle() }
+                    withoutAnimation { isExpanded.toggle() }
                 } label: {
                     ChatActivityRowLabel(
                         icon: icon,

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -78,6 +78,11 @@ struct ChatInputBar: View {
         return groupedModels.filter { $0.provider == lockedProvider }
     }
 
+    private var lockedProviderLabel: String? {
+        guard lockedProvider != nil else { return nil }
+        return selectableModelGroups.first?.providerLabel
+    }
+
     private var thinkingLevels: [ThinkingLevel] { capabilities?.thinkingLevels ?? [] }
     private var supportsThinking: Bool { !thinkingLevels.isEmpty }
     private var supportsPlanMode: Bool { capabilities?.planMode ?? true }
@@ -115,7 +120,8 @@ struct ChatInputBar: View {
                 ModelMenu(
                     groups: selectableModelGroups,
                     selectedModelId: selectedModelId,
-                    accent: hiveAccent
+                    accent: hiveAccent,
+                    lockedProviderLabel: lockedProviderLabel
                 ) { id in
                     Haptics.selection()
                     onModelSelect(id)
@@ -335,6 +341,7 @@ private struct ModelMenu: View {
     let groups: [ModelProviderGroup]
     let selectedModelId: String
     let accent: Color
+    var lockedProviderLabel: String? = nil
     let onSelect: (String) -> Void
 
     var body: some View {
@@ -370,6 +377,15 @@ private struct ModelMenu: View {
                     }
                     .buttonStyle(.plain)
                 }
+            }
+            if let lockedProviderLabel {
+                Divider().padding(.vertical, 5)
+                Text("This conversation continues with \(lockedProviderLabel).")
+                    .font(.caption2)
+                    .foregroundStyle(WhisperColor.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 14)
+                    .padding(.bottom, 8)
             }
         }
         .padding(.vertical, 5)

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -15,6 +15,7 @@ struct ChatView: View {
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
     @State private var isNearScrollBottom = true
+    @State private var showQuestionSheet = false
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -201,6 +202,11 @@ struct ChatView: View {
                         isStreaming: store.isStreaming
                     )
                 }
+                if !store.pendingToolInputs.isEmpty, !showQuestionSheet {
+                    PendingQuestionChip(count: store.pendingToolInputs.count) {
+                        showQuestionSheet = true
+                    }
+                }
                 if let failed = store.failedSend {
                     FailedSendRow(
                         failed: failed,
@@ -238,12 +244,19 @@ struct ChatView: View {
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)
         .sensoryFeedback(.success, trigger: store.visibleCompletionCount)
-        .sheet(isPresented: Binding(
-            get: { !store.pendingToolInputs.isEmpty },
-            set: { if !$0 { store.clearPendingToolInputs() } }
-        )) {
+        .sheet(isPresented: $showQuestionSheet) {
             ToolInputSheet(pendingInputs: store.pendingToolInputs) { pending, result in
                 respondToTool(pending: pending, result: result)
+            }
+        }
+        .onChange(of: store.pendingToolInputs.map(\.requestId)) { oldIds, newIds in
+            // A newly-arrived question auto-presents the sheet; answering or the
+            // turn ending clears the questions and closes it. Dismissing only
+            // hides the sheet — the questions persist and surface as a chip.
+            if !Set(newIds).subtracting(oldIds).isEmpty {
+                showQuestionSheet = true
+            } else if newIds.isEmpty {
+                showQuestionSheet = false
             }
         }
         .task { await setup() }
@@ -550,6 +563,46 @@ struct ChatView: View {
     .environment(ModelCatalog())
     .environment(ProjectStore(storeCache: ConversationStoreCache()))
     .preferredColorScheme(.dark)
+}
+
+private struct PendingQuestionChip: View {
+    let count: Int
+    let onTap: () -> Void
+
+    @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
+    private var accent: Color {
+        AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
+    }
+
+    private var label: String {
+        count == 1 ? "1 question waiting" : "\(count) questions waiting"
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 8) {
+                Image(systemName: "questionmark.bubble.fill")
+                Text(label)
+                    .font(.caption.weight(.semibold))
+                Spacer(minLength: 4)
+                Image(systemName: "chevron.up")
+                    .font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(accent)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(accent.opacity(0.12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(accent.opacity(0.3), lineWidth: 0.5)
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint("Reopens the agent's question.")
+    }
 }
 
 private struct FailedSendRow: View {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -116,7 +116,10 @@ struct ChatView: View {
                                 MessageBubble(
                                     message: message,
                                     pendingToolUseIds: pendingToolUseIds,
-                                    dismissedToolCallIds: store.dismissedToolCallIds
+                                    dismissedToolCallIds: store.dismissedToolCallIds,
+                                    sendState: store.sendState(for: message.id),
+                                    onRetrySend: { Task { await store.retryOptimisticSend(message.id) } },
+                                    onDiscardSend: { store.discardOptimisticSend(message.id) }
                                 )
                                 .id(message.id)
                                 .chatTranscriptRow()
@@ -446,6 +449,15 @@ struct ChatView: View {
             fastMode: (supportsFastMode && fastModeEnabled) ? true : nil
         )
 
+        // Show the message in the transcript immediately; the server echo
+        // confirms delivery, a send failure marks it Not delivered with Retry.
+        let localId = store.appendOptimisticUserMessage(
+            content: content,
+            images: images.isEmpty ? nil : images,
+            options: options,
+            sessionId: targetSessionId
+        )
+
         Task {
             let sent = await store.send?(.userMessage(
                 content: content,
@@ -460,17 +472,7 @@ struct ChatView: View {
                 // user_message echo that the backend is about to broadcast.
                 store.bumpHistoryToken(for: targetSessionId)
             } else {
-                store.recordFailedSend(FailedSend(
-                    id: UUID().uuidString,
-                    sessionId: targetSessionId,
-                    content: content,
-                    reason: "Disconnected from server",
-                    retry: .message(
-                        content: content,
-                        images: images.isEmpty ? nil : images,
-                        options: options
-                    )
-                ))
+                store.markSendFailed(localId)
             }
         }
     }
@@ -505,7 +507,7 @@ struct ChatView: View {
                     sessionId: pending.sessionId,
                     content: "Answer to the agent's question",
                     reason: "Disconnected from server",
-                    retry: .toolInput(pending)
+                    pending: pending
                 ))
             }
         }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -611,16 +611,26 @@ private struct TranscriptTouchProbe: UIViewRepresentable {
     final class ProbeView: UIView, UIGestureRecognizerDelegate {
         var onChange: ((Bool) -> Void)?
         private weak var attachedTo: UIView?
+        private var attachAttemptsRemaining = 0
 
         override func didMoveToWindow() {
             super.didMoveToWindow()
+            attachAttemptsRemaining = 20
             DispatchQueue.main.async { [weak self] in
                 self?.attachIfNeeded()
             }
         }
 
         private func attachIfNeeded() {
-            guard window != nil, attachedTo == nil, let target = findCollectionView() else { return }
+            guard window != nil, attachedTo == nil else { return }
+            guard let target = findCollectionView() else {
+                attachAttemptsRemaining -= 1
+                guard attachAttemptsRemaining > 0 else { return }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { [weak self] in
+                    self?.attachIfNeeded()
+                }
+                return
+            }
             let press = UILongPressGestureRecognizer(target: self, action: #selector(pressChanged(_:)))
             press.minimumPressDuration = 0
             press.cancelsTouchesInView = false

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -201,6 +201,13 @@ struct ChatView: View {
                         isStreaming: store.isStreaming
                     )
                 }
+                if let failed = store.failedSend {
+                    FailedSendRow(
+                        failed: failed,
+                        onRetry: { Task { await store.retryFailedSend(for: failed.sessionId) } },
+                        onDiscard: { store.discardFailedSend(for: failed.sessionId) }
+                    )
+                }
                 ChatInputBar(
                     draft: $draft,
                     draftAttachments: draftAttachments,
@@ -377,13 +384,6 @@ struct ChatView: View {
         guard !content.isEmpty || !images.isEmpty else { return }
 
         let targetSessionId = session.sessionId
-        // Snapshot draft so we can restore on failure
-        let savedDraft = draft
-        let savedAttachments = draftAttachments
-        let savedDraftState = ChatDraftStore.Draft(
-            text: savedDraft,
-            attachments: savedAttachments.map(ChatDraftStore.Attachment.init)
-        )
         draft = ""
         draftAttachments = []
 
@@ -422,22 +422,16 @@ struct ChatView: View {
                 // user_message echo that the backend is about to broadcast.
                 store.bumpHistoryToken(for: targetSessionId)
             } else {
-                // Persist draft for the originating session, even if the user switched away.
-                draftStore.save(
-                    workspaceId: workspace.id,
+                store.recordFailedSend(FailedSend(
+                    id: UUID().uuidString,
                     sessionId: targetSessionId,
-                    draft: savedDraftState
-                )
-                // Restore inline only if the user is still on the same session.
-                guard store.sessionId == targetSessionId else { return }
-                draft = savedDraft
-                draftAttachments = savedAttachments
-                store.messages.append(ChatMessage(
-                    id: UUID().uuidString, sessionId: "", role: .assistant,
-                    content: "Message not sent: disconnected from server.",
-                    images: nil, toolCalls: nil, thinkingContent: nil,
-                    timestamp: ConversationStore.timestamp(),
-                    cancelled: nil, durationMs: nil
+                    content: content,
+                    reason: "Disconnected from server",
+                    retry: .message(
+                        content: content,
+                        images: images.isEmpty ? nil : images,
+                        options: options
+                    )
                 ))
             }
         }
@@ -467,13 +461,13 @@ struct ChatView: View {
                     planModeEnabled = false
                     store.setAgentPlanMode(false, for: pending.sessionId)
                 }
-            } else if pending.sessionId == session.sessionId {
-                store.messages.append(ChatMessage(
-                    id: UUID().uuidString, sessionId: "", role: .assistant,
-                    content: "Tool response not sent: disconnected from server.",
-                    images: nil, toolCalls: nil, thinkingContent: nil,
-                    timestamp: ConversationStore.timestamp(),
-                    cancelled: nil, durationMs: nil
+            } else {
+                store.recordFailedSend(FailedSend(
+                    id: UUID().uuidString,
+                    sessionId: pending.sessionId,
+                    content: "Answer to the agent's question",
+                    reason: "Disconnected from server",
+                    retry: .toolInput(pending)
                 ))
             }
         }
@@ -556,6 +550,53 @@ struct ChatView: View {
     .environment(ModelCatalog())
     .environment(ProjectStore(storeCache: ConversationStoreCache()))
     .preferredColorScheme(.dark)
+}
+
+private struct FailedSendRow: View {
+    let failed: FailedSend
+    let onRetry: () -> Void
+    let onDiscard: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundStyle(WhisperColor.danger)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(failed.reason)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(WhisperColor.danger)
+                Text(failed.content)
+                    .font(.caption)
+                    .foregroundStyle(WhisperColor.textSecondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 8)
+            Button(action: onRetry) {
+                Label("Retry", systemImage: "arrow.clockwise")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption.weight(.semibold))
+            }
+            .buttonStyle(.plain)
+            .foregroundStyle(WhisperColor.danger)
+            Button(action: onDiscard) {
+                Image(systemName: "xmark")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(WhisperColor.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Discard failed send")
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(WhisperColor.danger.opacity(0.12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(WhisperColor.danger.opacity(0.3), lineWidth: 0.5)
+                )
+        )
+    }
 }
 
 private extension ChatDraftStore.Attachment {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -15,6 +15,7 @@ struct ChatView: View {
     @State private var selectedModelId: String = ""
     @State private var draftAttachments: [ImageAttachment] = []
     @State private var isNearScrollBottom = true
+    @State private var isTouchingTranscript = false
     @State private var showQuestionSheet = false
 
     @Environment(ModelCatalog.self) private var modelCatalog
@@ -156,6 +157,18 @@ struct ChatView: View {
                     } action: { _, isNearBottom in
                         isNearScrollBottom = isNearBottom
                     }
+                    .background(
+                        // A finger on the transcript pauses auto-scroll AND the
+                        // streaming delta flush: any transcript movement (our
+                        // scrollTo or the List's own bottom-anchoring on content
+                        // growth) cancels the long-press copy interaction while
+                        // streaming. SwiftUI gestures on a List never fire for
+                        // stationary touches, so this observes at the UIKit level.
+                        TranscriptTouchProbe { touching in
+                            isTouchingTranscript = touching
+                            store.setStreamingUIHold(touching)
+                        }
+                    )
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
                         scrollToBottomIfNeeded(proxy)
                     }
@@ -530,7 +543,7 @@ struct ChatView: View {
     }
 
     private func scrollToBottom(_ proxy: ScrollViewProxy, force: Bool) {
-        guard force || isNearScrollBottom else { return }
+        guard force || (isNearScrollBottom && !isTouchingTranscript) else { return }
         proxy.scrollTo(bottomAnchorID, anchor: .bottom)
     }
 
@@ -575,6 +588,79 @@ struct ChatView: View {
     .environment(ModelCatalog())
     .environment(ProjectStore(storeCache: ConversationStoreCache()))
     .preferredColorScheme(.dark)
+}
+
+/// Reports whether a finger is currently down on the transcript List, via a
+/// zero-duration UIKit long-press attached to the List's UICollectionView
+/// (SwiftUI gestures on a List never fire for stationary touches).
+private struct TranscriptTouchProbe: UIViewRepresentable {
+    let onChange: (Bool) -> Void
+
+    func makeUIView(context: Context) -> ProbeView {
+        let view = ProbeView()
+        view.onChange = onChange
+        return view
+    }
+
+    func updateUIView(_ uiView: ProbeView, context: Context) {
+        uiView.onChange = onChange
+    }
+
+    final class ProbeView: UIView, UIGestureRecognizerDelegate {
+        var onChange: ((Bool) -> Void)?
+        private weak var attachedTo: UIView?
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            DispatchQueue.main.async { [weak self] in
+                self?.attachIfNeeded()
+            }
+        }
+
+        private func attachIfNeeded() {
+            guard window != nil, attachedTo == nil, let target = findCollectionView() else { return }
+            let press = UILongPressGestureRecognizer(target: self, action: #selector(pressChanged(_:)))
+            press.minimumPressDuration = 0
+            press.cancelsTouchesInView = false
+            press.delegate = self
+            target.addGestureRecognizer(press)
+            attachedTo = target
+        }
+
+        private func findCollectionView() -> UICollectionView? {
+            var ancestor = superview
+            while let current = ancestor {
+                var queue: [UIView] = [current]
+                var visited = 0
+                while !queue.isEmpty, visited < 500 {
+                    let view = queue.removeFirst()
+                    visited += 1
+                    if let collection = view as? UICollectionView { return collection }
+                    queue.append(contentsOf: view.subviews)
+                }
+                ancestor = current.superview
+            }
+            return nil
+        }
+
+        @objc private func pressChanged(_ gesture: UILongPressGestureRecognizer) {
+            switch gesture.state {
+            case .began:
+                onChange?(true)
+            case .ended, .cancelled, .failed:
+                onChange?(false)
+            default:
+                break
+            }
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
+    }
 }
 
 private struct PendingQuestionChip: View {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -334,7 +334,19 @@ struct ChatView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.leading, 2)
             .id("streaming-indicator")
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(streamingAccessibilityLabel(at: timeline.date))
         }
+    }
+
+    /// One natural-language label for the streaming indicator, bucketed to whole
+    /// minutes so VoiceOver announces "Agent working, 2 minutes" instead of
+    /// re-reading a sub-second timer.
+    private func streamingAccessibilityLabel(at date: Date) -> String {
+        guard let startedAt = store.streamingStartedAt else { return "Agent working" }
+        let minutes = Int(max(0, date.timeIntervalSince(startedAt))) / 60
+        guard minutes >= 1 else { return "Agent working" }
+        return "Agent working, \(minutes) minute\(minutes == 1 ? "" : "s")"
     }
 
     // MARK: - Setup

--- a/ios/HiveMobile/Views/Chat/ConversationRow.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationRow.swift
@@ -53,12 +53,12 @@ struct ConversationRow: View {
         HStack(alignment: .center, spacing: HiveSpacing.md) {
             VStack(alignment: .leading, spacing: HiveSpacing.xs) {
                 Text(title)
-                    .font(.system(size: 16, weight: .semibold))
+                    .font(WhisperFont.scaled(16, weight: .semibold))
                     .foregroundStyle(WhisperColor.text)
                     .lineLimit(1)
 
                 Text(messageCountText)
-                    .font(.system(size: 15))
+                    .font(WhisperFont.scaled(15))
                     .foregroundStyle(WhisperColor.textSecondary)
                     .lineLimit(1)
             }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -166,9 +166,9 @@ struct ConversationsSection<Header: View>: View {
             await refreshContent(force: true)
         }
         .overlay {
-            if isLoading {
-                ProgressView()
-            } else if sessions.isEmpty {
+            if isLoading, sessions.isEmpty {
+                ListLoadingSkeleton()
+            } else if !isLoading, sessions.isEmpty {
                 VStack(spacing: HiveSpacing.sm) {
                     Text(labels.emptyTitle)
                         .font(.headline)

--- a/ios/HiveMobile/Views/Chat/ImageActivity.swift
+++ b/ios/HiveMobile/Views/Chat/ImageActivity.swift
@@ -92,7 +92,7 @@ private struct ImageActivityBodyText: View {
 
     var body: some View {
         Text(text)
-            .font(.system(size: 12))
+            .font(WhisperFont.scaled(12))
             .foregroundStyle(WhisperColor.textSecondary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -9,6 +9,9 @@ struct MessageBubble: View {
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var copied = false
     @State private var bubbleMenuVisible = false
+    /// Scales the Markdown base font with Dynamic Type; the theme's relative
+    /// (`.em`) sizes grow proportionally from it.
+    @ScaledMetric(relativeTo: .body) private var markdownBaseSize: CGFloat = 14
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -83,7 +86,7 @@ struct MessageBubble: View {
                     Image(systemName: "stop.circle")
                         .font(.system(size: 11))
                     Text("Stopped")
-                        .font(.system(size: 13))
+                        .font(WhisperFont.scaled(13))
                         .italic()
                 }
                 .foregroundStyle(.red.opacity(0.7))
@@ -99,7 +102,7 @@ struct MessageBubble: View {
             switch message.role {
             case .user:
                 Text(highlightedUserContent(message.content, fileMentions: message.fileMentions))
-                    .font(.system(size: 14))
+                    .font(WhisperFont.scaled(14))
                     .foregroundStyle(WhisperColor.text)
                     .lineSpacing(3)
                     .padding(.horizontal, 14)
@@ -120,10 +123,12 @@ struct MessageBubble: View {
             case .assistant:
                 if message.id == "streaming" {
                     Markdown(message.content)
+                        .markdownTextStyle { FontSize(markdownBaseSize) }
                         .markdownTheme(.whisperChat)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else if markdownNeedsRichRenderer(message.content) {
                     Markdown(message.content)
+                        .markdownTextStyle { FontSize(markdownBaseSize) }
                         .markdownTheme(.whisperChat)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
@@ -936,7 +941,7 @@ private struct AskUserQuestionContent: View {
                 ForEach(Array(questions.enumerated()), id: \.offset) { _, q in
                     VStack(alignment: .leading, spacing: 4) {
                         Text(q.text)
-                            .font(.system(size: 12, weight: .medium))
+                            .font(WhisperFont.scaled(12, weight: .medium))
                             .foregroundStyle(WhisperColor.textSecondary)
                         ForEach(q.options, id: \.self) { option in
                             HStack(spacing: 5) {
@@ -965,11 +970,10 @@ private extension Theme {
         .text {
             BackgroundColor(.clear)
             ForegroundColor(WhisperColor.text)
-            FontSize(14)
         }
         .code {
             FontFamilyVariant(.monospaced)
-            FontSize(12)
+            FontSize(.em(12.0 / 14))
             ForegroundColor(WhisperColor.codeText)
             BackgroundColor(WhisperColor.codeBg)
         }
@@ -993,7 +997,7 @@ private extension Theme {
                 .markdownMargin(top: .em(1.2), bottom: .em(0.4))
                 .markdownTextStyle {
                     FontWeight(.semibold)
-                    FontSize(20)
+                    FontSize(.em(20.0 / 14))
                 }
         }
         .heading2 { configuration in
@@ -1002,7 +1006,7 @@ private extension Theme {
                 .markdownMargin(top: .em(1), bottom: .em(0.3))
                 .markdownTextStyle {
                     FontWeight(.semibold)
-                    FontSize(17)
+                    FontSize(.em(17.0 / 14))
                 }
         }
         .heading3 { configuration in
@@ -1011,7 +1015,7 @@ private extension Theme {
                 .markdownMargin(top: .em(0.8), bottom: .em(0.2))
                 .markdownTextStyle {
                     FontWeight(.semibold)
-                    FontSize(15)
+                    FontSize(.em(15.0 / 14))
                 }
         }
         .heading4 { configuration in
@@ -1019,7 +1023,7 @@ private extension Theme {
                 .markdownMargin(top: .em(0.6), bottom: .em(0.2))
                 .markdownTextStyle {
                     FontWeight(.medium)
-                    FontSize(14)
+                    FontSize(.em(1.0))
                 }
         }
         .heading5 { configuration in
@@ -1027,7 +1031,7 @@ private extension Theme {
                 .markdownMargin(top: .em(0.5), bottom: .em(0.1))
                 .markdownTextStyle {
                     FontWeight(.medium)
-                    FontSize(13)
+                    FontSize(.em(13.0 / 14))
                     ForegroundColor(WhisperColor.textSecondary)
                 }
         }
@@ -1036,7 +1040,7 @@ private extension Theme {
                 .markdownMargin(top: .em(0.5), bottom: .em(0.1))
                 .markdownTextStyle {
                     FontWeight(.medium)
-                    FontSize(12)
+                    FontSize(.em(12.0 / 14))
                     ForegroundColor(WhisperColor.textSecondary)
                 }
         }
@@ -1049,7 +1053,7 @@ private extension Theme {
             .scrollIndicators(.hidden)
             .markdownTextStyle {
                 FontFamilyVariant(.monospaced)
-                FontSize(12)
+                FontSize(.em(12.0 / 14))
                 ForegroundColor(WhisperColor.codeText)
             }
             .padding(12)

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -5,6 +5,9 @@ struct MessageBubble: View {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
+    var sendState: ConversationStore.UserSendState? = nil
+    var onRetrySend: (() -> Void)? = nil
+    var onDiscardSend: (() -> Void)? = nil
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var copied = false
@@ -53,10 +56,49 @@ struct MessageBubble: View {
                     AgentActivityList(activities: activities, showExecutingState: message.id == "streaming")
                 }
 
-                messageFooter
+                deliveryStatus
+
+                if sendState == nil {
+                    messageFooter
+                }
             }
 
             if message.role == .assistant { Spacer(minLength: 40) }
+        }
+    }
+
+    // MARK: - Delivery Status
+
+    @ViewBuilder
+    private var deliveryStatus: some View {
+        switch sendState {
+        case .sending:
+            Text("Sending…")
+                .font(.caption2)
+                .foregroundStyle(WhisperColor.textMuted)
+        case .failed:
+            HStack(spacing: 12) {
+                Text("Not delivered")
+                    .foregroundStyle(WhisperColor.danger)
+                if let onRetrySend {
+                    Button(action: onRetrySend) {
+                        Label("Retry", systemImage: "arrow.clockwise")
+                    }
+                    .buttonStyle(.plain)
+                    .foregroundStyle(WhisperColor.danger)
+                }
+                if let onDiscardSend {
+                    Button(action: onDiscardSend) {
+                        Image(systemName: "xmark")
+                            .foregroundStyle(WhisperColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Discard message")
+                }
+            }
+            .font(.caption2.weight(.semibold))
+        case nil:
+            EmptyView()
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -633,7 +633,7 @@ private struct WhisperThinkingBlock: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                isExpanded.toggle()
+                withoutAnimation { isExpanded.toggle() }
             } label: {
                 ChatActivityRowLabel(icon: "brain", label: "Thinking", detail: isExpanded ? nil : preview)
             }
@@ -686,7 +686,7 @@ private struct WhisperToolCallsBlock: View {
                     isExpanded: groupExpanded,
                     isStreaming: showExecutingState,
                     onToggle: {
-                        groupExpanded.toggle()
+                        withoutAnimation { groupExpanded.toggle() }
                     }
                 )
             }
@@ -769,7 +769,7 @@ private struct WhisperToolCallRow: View {
 
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                isExpanded.toggle()
+                withoutAnimation { isExpanded.toggle() }
             } label: {
                 ChatActivityRowLabel(icon: display.icon, label: display.label, detail: display.detail, stats: display.stats, summary: summary, badgeText: display.badgeText, badgeIcon: display.badgeIcon, executing: display.executing)
             }

--- a/ios/HiveMobile/Views/Chat/TrackerSection.swift
+++ b/ios/HiveMobile/Views/Chat/TrackerSection.swift
@@ -15,9 +15,7 @@ struct TrackerSection<Rows: View>: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             Button {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
-                    isExpanded.toggle()
-                }
+                withoutAnimation { isExpanded.toggle() }
             } label: {
                 collapsedRow
             }
@@ -29,7 +27,6 @@ struct TrackerSection<Rows: View>: View {
                 }
                 .padding(.top, 6)
                 .padding(.bottom, 2)
-                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
     }

--- a/ios/HiveMobile/Views/Components/ListLoadingSkeleton.swift
+++ b/ios/HiveMobile/Views/Components/ListLoadingSkeleton.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Placeholder rows shaped like list rows (leading avatar + two text lines),
+/// animated with the theme shimmer. Used for empty initial loads of the Hub,
+/// Brain, and workspace conversation lists. Reduce Motion is handled by
+/// `shimmer()`.
+struct ListLoadingSkeleton: View {
+    var rowCount = 6
+
+    private let titleWidths: [CGFloat] = [220, 150, 240, 130, 190, 170]
+
+    var body: some View {
+        VStack(spacing: HiveSpacing.md) {
+            ForEach(0..<rowCount, id: \.self) { index in
+                HStack(spacing: HiveSpacing.md) {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .fill(WhisperColor.surfaceSubtle)
+                        .frame(width: 40, height: 40)
+                    VStack(alignment: .leading, spacing: 7) {
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(WhisperColor.surfaceSubtle)
+                            .frame(width: titleWidths[index % titleWidths.count], height: 14)
+                        RoundedRectangle(cornerRadius: 5, style: .continuous)
+                            .fill(WhisperColor.surfaceSubtle)
+                            .frame(width: 100, height: 11)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .shimmer()
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(HiveSpacing.lg)
+        .accessibilityHidden(true)
+    }
+}
+
+#Preview {
+    ListLoadingSkeleton()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .hiveScreenBackground()
+}

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -130,12 +130,9 @@ struct HubView: View {
     }
 
     private var loadingState: some View {
-        VStack {
-            ProgressView()
-                .tint(Color.accentColor)
-        }
-        .frame(maxWidth: .infinity, minHeight: 420)
-        .frame(maxHeight: .infinity)
+        ListLoadingSkeleton()
+            .frame(maxWidth: .infinity, minHeight: 420)
+            .frame(maxHeight: .infinity)
     }
 
     @ViewBuilder

--- a/ios/HiveMobile/Views/Settings/SettingsView.swift
+++ b/ios/HiveMobile/Views/Settings/SettingsView.swift
@@ -8,7 +8,7 @@ struct SettingsView: View {
     @AppStorage("hiveThemeMode") private var themeModeId = HiveThemeMode.system.rawValue
 
     @FocusState private var focusedField: Field?
-    @State private var healthStatus: HealthStatus = .disconnected
+    @State private var healthStatus: ConnectionHealth = .unreachable
     @State private var pollingTask: Task<Void, Never>?
     @State private var debouncedCheckTask: Task<Void, Never>?
     private enum Field: Hashable {
@@ -166,6 +166,8 @@ struct SettingsView: View {
             }
         } header: {
             connectionHeader
+        } footer: {
+            Text("Enter your server's hostname or IP and port, plus the auth token shown when the backend starts.")
         }
         .listRowBackground(WhisperColor.surfaceRaised)
     }
@@ -211,49 +213,48 @@ struct SettingsView: View {
 
     @MainActor
     private func checkHealth() async {
-        let isConnected = await runHealthCheck()
+        let health = await runHealthCheck()
         guard !Task.isCancelled else { return }
-        healthStatus = isConnected ? .connected : .disconnected
+        healthStatus = health
     }
 
-    private func runHealthCheck() async -> Bool {
-        await withTaskGroup(of: Bool.self, returning: Bool.self) { group in
+    private func runHealthCheck() async -> ConnectionHealth {
+        await withTaskGroup(of: ConnectionHealth.self, returning: ConnectionHealth.self) { group in
             group.addTask {
                 do {
-                    return try await APIClient().checkHealth()
+                    return try await APIClient().checkHealth() ? .connected : .unreachable
                 } catch {
-                    return false
+                    return ConnectionHealth.classify(error: error)
                 }
             }
             group.addTask {
                 try? await Task.sleep(for: .seconds(4))
-                return false
+                return .unreachable
             }
 
-            let result = await group.next() ?? false
+            let result = await group.next() ?? .unreachable
             group.cancelAll()
             return result
         }
     }
 }
 
-// MARK: - Health Status
+// MARK: - Health Status Presentation
 
-private enum HealthStatus {
-    case connected
-    case disconnected
-
+private extension ConnectionHealth {
     var color: Color {
         switch self {
         case .connected: WhisperColor.success
-        case .disconnected: .red
+        case .unreachable: .red
+        case .invalidToken: .orange
         }
     }
 
     var label: String {
         switch self {
         case .connected: "Connected"
-        case .disconnected: "Disconnected"
+        case .unreachable: "Disconnected"
+        case .invalidToken: "Invalid token"
         }
     }
 

--- a/ios/Tests/ChatDraftStoreTests/ConnectionHealthClassificationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConnectionHealthClassificationTests.swift
@@ -1,0 +1,25 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// #298 Settings connection guidance: an authentication failure is classified
+/// distinctly from an unreachable server.
+struct ConnectionHealthClassificationTests {
+    @Test
+    func authFailureMapsToInvalidToken() {
+        #expect(ConnectionHealth.classify(error: APIError.httpError(statusCode: 401, message: "unauthorized")) == .invalidToken)
+        #expect(ConnectionHealth.classify(error: APIError.httpError(statusCode: 403, message: "forbidden")) == .invalidToken)
+    }
+
+    @Test
+    func networkErrorMapsToUnreachable() {
+        let underlying = URLError(.cannotConnectToHost)
+        #expect(ConnectionHealth.classify(error: APIError.networkError(underlying)) == .unreachable)
+        #expect(ConnectionHealth.classify(error: underlying) == .unreachable)
+    }
+
+    @Test
+    func otherHTTPErrorMapsToUnreachable() {
+        #expect(ConnectionHealth.classify(error: APIError.httpError(statusCode: 500, message: "server error")) == .unreachable)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
@@ -1,0 +1,106 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// #287 retryable failed sends: a failed send is a store-owned error state, not
+/// a synthetic assistant message. It survives history refetches and is resolved
+/// only by retry-success or discard.
+struct ConversationStoreFailedSendTests {
+    @MainActor
+    private func store(session: String) -> ConversationStore {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId(session)
+        return store
+    }
+
+    private func messageFailure(session: String, content: String) -> FailedSend {
+        FailedSend(
+            id: "failed-1",
+            sessionId: session,
+            content: content,
+            reason: "Disconnected from server",
+            retry: .message(content: content, images: nil, options: nil)
+        )
+    }
+
+    @Test @MainActor
+    func recordingCreatesErrorStateWithoutSyntheticMessage() {
+        let store = store(session: "s1")
+        store.recordFailedSend(messageFailure(session: "s1", content: "hello agent"))
+
+        #expect(store.failedSend?.content == "hello agent")
+        #expect(store.messages.isEmpty)
+    }
+
+    @Test @MainActor
+    func retrySuccessClearsState() async {
+        let store = store(session: "s1")
+        store.send = { _ in true }
+        store.recordFailedSend(messageFailure(session: "s1", content: "hi"))
+
+        let resolved = await store.retryFailedSend(for: "s1")
+
+        #expect(resolved)
+        #expect(store.failedSend == nil)
+    }
+
+    @Test @MainActor
+    func retryFailurePreservesState() async {
+        let store = store(session: "s1")
+        store.send = { _ in false }
+        store.recordFailedSend(messageFailure(session: "s1", content: "hi"))
+
+        let resolved = await store.retryFailedSend(for: "s1")
+
+        #expect(!resolved)
+        #expect(store.failedSend?.content == "hi")
+    }
+
+    @Test @MainActor
+    func failedSendSurvivesHistoryRefetch() {
+        let store = store(session: "s1")
+        store.recordFailedSend(messageFailure(session: "s1", content: "keep me"))
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .user, content: "earlier",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: ConversationStore.timestamp(), cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+
+        #expect(store.failedSend?.content == "keep me")
+        #expect(store.messages.count == 1)
+    }
+
+    @Test @MainActor
+    func discardRemovesState() {
+        let store = store(session: "s1")
+        store.recordFailedSend(messageFailure(session: "s1", content: "bye"))
+
+        store.discardFailedSend(for: "s1")
+
+        #expect(store.failedSend == nil)
+    }
+
+    @Test @MainActor
+    func toolInputFailureRetryRepresentsQuestion() async {
+        let store = store(session: "s1")
+        let pending = PendingToolInput(
+            sessionId: "s1", requestId: "req-1", toolName: "AskUserQuestion",
+            toolUseId: "tu-1", input: "{}"
+        )
+        store.recordFailedSend(FailedSend(
+            id: "failed-tool", sessionId: "s1",
+            content: "Answer to the agent's question",
+            reason: "Disconnected from server",
+            retry: .toolInput(pending)
+        ))
+
+        let resolved = await store.retryFailedSend(for: "s1")
+
+        #expect(resolved)
+        #expect(store.failedSend == nil)
+        #expect(store.pendingToolInputs.contains(pending))
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
@@ -105,6 +105,65 @@ struct ConversationStoreFailedSendTests {
     }
 
     @Test @MainActor
+    func oldIdenticalMessageDoesNotConfirmInFlightSend() {
+        let store = store(session: "s1")
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .user, content: "ok",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "ok", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .user, content: "ok",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+
+        #expect(store.messages.count == 2)
+        #expect(store.messages.last?.id == localId)
+        #expect(store.sendState(for: localId) == .sending)
+    }
+
+    @Test @MainActor
+    func newIdenticalMessageConfirmsInFlightSend() {
+        let store = store(session: "s1")
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .user, content: "ok",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "ok", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .user, content: "ok",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            ),
+            ChatMessage(
+                id: "srv-2", sessionId: "s1", role: .user, content: "ok",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+
+        #expect(store.messages.count == 2)
+        #expect(store.messages.map(\.id) == ["m1", "srv-2"])
+        #expect(store.sendState(for: localId) == nil)
+    }
+
+    @Test @MainActor
     func retrySuccessGoesBackToSendingThenEchoResolves() async {
         let store = store(session: "s1")
         store.send = { _ in true }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
@@ -2,9 +2,11 @@ import Foundation
 import Testing
 @testable import HiveMobileStoresCore
 
-/// #287 retryable failed sends: a failed send is a store-owned error state, not
-/// a synthetic assistant message. It survives history refetches and is resolved
-/// only by retry-success or discard.
+/// #287 + optimistic sends: a user message appears in the transcript the moment
+/// it is sent, the server echo confirms it (no duplicate), and a failed send is
+/// kept on the bubble with retry/discard — the text is never lost. Failed
+/// tool-input answers stay a store-owned error state that re-presents the
+/// question on retry.
 struct ConversationStoreFailedSendTests {
     @MainActor
     private func store(session: String) -> ConversationStore {
@@ -13,74 +15,141 @@ struct ConversationStoreFailedSendTests {
         return store
     }
 
-    private func messageFailure(session: String, content: String) -> FailedSend {
-        FailedSend(
-            id: "failed-1",
-            sessionId: session,
-            content: content,
-            reason: "Disconnected from server",
-            retry: .message(content: content, images: nil, options: nil)
+    private func serverEcho(_ content: String, session: String) -> WsOutgoing {
+        .userMessage(message: ChatMessage(
+            id: "srv-1", sessionId: session, role: .user, content: content,
+            images: nil, toolCalls: nil, thinkingContent: nil,
+            timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil
+        ))
+    }
+
+    @Test @MainActor
+    func optimisticMessageAppearsImmediately() {
+        let store = store(session: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "hello", images: nil, options: nil, sessionId: "s1"
         )
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages[0].content == "hello")
+        #expect(store.sendState(for: localId) == .sending)
     }
 
     @Test @MainActor
-    func recordingCreatesErrorStateWithoutSyntheticMessage() {
+    func serverEchoConfirmsWithoutDuplicate() {
         let store = store(session: "s1")
-        store.recordFailedSend(messageFailure(session: "s1", content: "hello agent"))
+        let localId = store.appendOptimisticUserMessage(
+            content: "hello", images: nil, options: nil, sessionId: "s1"
+        )
 
-        #expect(store.failedSend?.content == "hello agent")
-        #expect(store.messages.isEmpty)
+        store.handle(serverEcho("hello", session: "s1"))
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages[0].id == "srv-1")
+        #expect(store.sendState(for: localId) == nil)
+        #expect(store.sendState(for: "srv-1") == nil)
     }
 
     @Test @MainActor
-    func retrySuccessClearsState() async {
+    func failedSendKeepsMessageWithFailedState() {
         let store = store(session: "s1")
-        store.send = { _ in true }
-        store.recordFailedSend(messageFailure(session: "s1", content: "hi"))
+        let localId = store.appendOptimisticUserMessage(
+            content: "keep me", images: nil, options: nil, sessionId: "s1"
+        )
 
-        let resolved = await store.retryFailedSend(for: "s1")
+        store.markSendFailed(localId)
 
-        #expect(resolved)
-        #expect(store.failedSend == nil)
+        #expect(store.messages.count == 1)
+        #expect(store.sendState(for: localId) == .failed)
     }
 
     @Test @MainActor
-    func retryFailurePreservesState() async {
+    func failedMessageSurvivesHistoryRefetch() {
         let store = store(session: "s1")
-        store.send = { _ in false }
-        store.recordFailedSend(messageFailure(session: "s1", content: "hi"))
-
-        let resolved = await store.retryFailedSend(for: "s1")
-
-        #expect(!resolved)
-        #expect(store.failedSend?.content == "hi")
-    }
-
-    @Test @MainActor
-    func failedSendSurvivesHistoryRefetch() {
-        let store = store(session: "s1")
-        store.recordFailedSend(messageFailure(session: "s1", content: "keep me"))
+        let localId = store.appendOptimisticUserMessage(
+            content: "keep me", images: nil, options: nil, sessionId: "s1"
+        )
+        store.markSendFailed(localId)
 
         store.applyFetchedHistory([
             ChatMessage(
                 id: "m1", sessionId: "s1", role: .user, content: "earlier",
                 images: nil, toolCalls: nil, thinkingContent: nil,
-                timestamp: ConversationStore.timestamp(), cancelled: nil, durationMs: nil
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
             )
         ], for: "s1")
 
-        #expect(store.failedSend?.content == "keep me")
+        #expect(store.messages.count == 2)
+        #expect(store.messages.last?.content == "keep me")
+        #expect(store.sendState(for: localId) == .failed)
+    }
+
+    @Test @MainActor
+    func refetchContainingTheMessageResolvesPendingSend() {
+        let store = store(session: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "made it", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "srv-9", sessionId: "s1", role: .user, content: "made it",
+                images: nil, toolCalls: nil, thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+
+        #expect(store.messages.count == 1)
+        #expect(store.messages[0].id == "srv-9")
+        #expect(store.sendState(for: localId) == nil)
+    }
+
+    @Test @MainActor
+    func retrySuccessGoesBackToSendingThenEchoResolves() async {
+        let store = store(session: "s1")
+        store.send = { _ in true }
+        let localId = store.appendOptimisticUserMessage(
+            content: "again", images: nil, options: nil, sessionId: "s1"
+        )
+        store.markSendFailed(localId)
+
+        let sent = await store.retryOptimisticSend(localId)
+
+        #expect(sent)
+        #expect(store.sendState(for: localId) == .sending)
+        store.handle(serverEcho("again", session: "s1"))
+        #expect(store.messages.count == 1)
+        #expect(store.sendState(for: localId) == nil)
+    }
+
+    @Test @MainActor
+    func retryFailureKeepsFailedState() async {
+        let store = store(session: "s1")
+        store.send = { _ in false }
+        let localId = store.appendOptimisticUserMessage(
+            content: "again", images: nil, options: nil, sessionId: "s1"
+        )
+        store.markSendFailed(localId)
+
+        let sent = await store.retryOptimisticSend(localId)
+
+        #expect(!sent)
+        #expect(store.sendState(for: localId) == .failed)
         #expect(store.messages.count == 1)
     }
 
     @Test @MainActor
-    func discardRemovesState() {
+    func discardRemovesTheMessage() {
         let store = store(session: "s1")
-        store.recordFailedSend(messageFailure(session: "s1", content: "bye"))
+        let localId = store.appendOptimisticUserMessage(
+            content: "bye", images: nil, options: nil, sessionId: "s1"
+        )
+        store.markSendFailed(localId)
 
-        store.discardFailedSend(for: "s1")
+        store.discardOptimisticSend(localId)
 
-        #expect(store.failedSend == nil)
+        #expect(store.messages.isEmpty)
+        #expect(store.sendState(for: localId) == nil)
     }
 
     @Test @MainActor
@@ -94,13 +163,33 @@ struct ConversationStoreFailedSendTests {
             id: "failed-tool", sessionId: "s1",
             content: "Answer to the agent's question",
             reason: "Disconnected from server",
-            retry: .toolInput(pending)
+            pending: pending
         ))
+        #expect(store.failedSend != nil)
 
         let resolved = await store.retryFailedSend(for: "s1")
 
         #expect(resolved)
         #expect(store.failedSend == nil)
         #expect(store.pendingToolInputs.contains(pending))
+    }
+
+    @Test @MainActor
+    func toolInputFailureSurvivesHistoryRefetch() {
+        let store = store(session: "s1")
+        let pending = PendingToolInput(
+            sessionId: "s1", requestId: "req-1", toolName: "AskUserQuestion",
+            toolUseId: "tu-1", input: "{}"
+        )
+        store.recordFailedSend(FailedSend(
+            id: "failed-tool", sessionId: "s1",
+            content: "Answer to the agent's question",
+            reason: "Disconnected from server",
+            pending: pending
+        ))
+
+        store.applyFetchedHistory([], for: "s1")
+
+        #expect(store.failedSend?.id == "failed-tool")
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStorePendingQuestionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStorePendingQuestionTests.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+/// #288 reopenable pending-question chip: pending questions are store-owned and
+/// only cleared by answering or turn end — never by dismissing the sheet — and
+/// reconcile to a single set with no duplicates.
+struct ConversationStorePendingQuestionTests {
+    @MainActor
+    private func storeWithQuestion(session: String, requestId: String = "req-1") -> ConversationStore {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId(session)
+        store.handle(.toolInputRequired(
+            sessionId: session, requestId: requestId,
+            toolName: "AskUserQuestion", toolUseId: "tool-1", input: "{}"
+        ))
+        return store
+    }
+
+    private func done(_ session: String) -> WsOutgoing {
+        .done(
+            sessionId: session, durationMs: 100,
+            inputTokens: nil, outputTokens: nil,
+            contextUsedTokens: nil, contextWindowTokens: nil, pendingToolName: nil
+        )
+    }
+
+    @Test @MainActor
+    func redeliveredRequestDoesNotDuplicate() {
+        let store = storeWithQuestion(session: "s1")
+        // Reconnect replays the same request.
+        store.handle(.toolInputRequired(
+            sessionId: "s1", requestId: "req-1",
+            toolName: "AskUserQuestion", toolUseId: "tool-1", input: "{}"
+        ))
+        #expect(store.pendingToolInputs.count == 1)
+    }
+
+    @Test @MainActor
+    func turnEndClearsPendingQuestions() {
+        let store = storeWithQuestion(session: "s1")
+        #expect(store.pendingToolInputs.count == 1)
+        store.handle(done("s1"))
+        #expect(store.pendingToolInputs.isEmpty)
+    }
+
+    @Test @MainActor
+    func answeringClearsPendingQuestions() {
+        let store = storeWithQuestion(session: "s1")
+        store.clearPendingToolInputs()
+        #expect(store.pendingToolInputs.isEmpty)
+    }
+
+    @Test @MainActor
+    func pendingQuestionSurvivesSessionSwitch() {
+        let store = storeWithQuestion(session: "s1")
+        // Navigate to another session and back.
+        store.setFocusedSessionId("s2")
+        #expect(store.pendingToolInputs.isEmpty)
+        store.setFocusedSessionId("s1")
+        #expect(store.pendingToolInputs.count == 1)
+    }
+
+    @Test @MainActor
+    func toolInputResolvedFromAnotherClientClears() {
+        let store = storeWithQuestion(session: "s1")
+        store.handle(.toolInputResolved(sessionId: "s1"))
+        #expect(store.pendingToolInputs.isEmpty)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
@@ -200,3 +200,29 @@ struct ConversationStoreStreamingBufferTests {
         #expect(store.currentText == "first second")
     }
 }
+
+extension ConversationStoreStreamingBufferTests {
+    @Test @MainActor
+    func uiHoldKeepsBufferingUntilReleased() async throws {
+        let store = ConversationStore(streamFlushInterval: 0.01)
+        store.handle(.status(
+            status: .busy,
+            sessionId: "session-1",
+            streaming: true,
+            streamingStartedAt: nil,
+            lockedProvider: nil
+        ))
+
+        store.setStreamingUIHold(true)
+        store.handle(.textDelta(sessionId: "session-1", text: "held"))
+        try await Task.sleep(for: .milliseconds(60))
+        #expect(store.currentText == "")
+
+        store.handle(.textDelta(sessionId: "session-1", text: " too"))
+        store.setStreamingUIHold(false)
+        #expect(store.currentText == "held too")
+
+        store.handle(.textDelta(sessionId: "session-1", text: ", resumed"))
+        try await waitUntil { store.currentText == "held too, resumed" }
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -239,4 +239,22 @@ struct HubStatusMonitorTests {
         #expect(sent == true)
         #expect(connection.probeLivenessCount == 1)
     }
+
+    @Test
+    func hubBadgeCountsWorkspacesWithActivityAndClearsOnView() {
+        let (monitor, _, _) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-a", "ws-b"])
+        #expect(monitor.hubBadgeCount == 0)
+
+        monitor.didReceiveStreaming(true, for: "ws-a", sessionId: "s1")
+        monitor.didReceiveDone(for: "ws-a", sessionId: "s1", markWorkspaceCompleted: true)
+        monitor.didReceiveStreaming(true, for: "ws-b", sessionId: "s2")
+        monitor.didReceiveDone(for: "ws-b", sessionId: "s2", markWorkspaceCompleted: true)
+        #expect(monitor.hubBadgeCount == 2)
+
+        // Viewing ws-a clears its completed and unread state.
+        monitor.clearCompleted("ws-a")
+        monitor.clearUnread(workspaceId: "ws-a", sessionId: "s1")
+        #expect(monitor.hubBadgeCount == 1)
+    }
 }

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -244,6 +244,9 @@ struct HubStatusMonitorTests {
     func hubBadgeCountsWorkspacesWithActivityAndClearsOnView() {
         let (monitor, _, _) = makeMonitor()
         monitor.sync(workspaceIds: ["ws-a", "ws-b"])
+        // Completed state persists across launches; start from a clean baseline.
+        monitor.clearCompleted("ws-a")
+        monitor.clearCompleted("ws-b")
         #expect(monitor.hubBadgeCount == 0)
 
         monitor.didReceiveStreaming(true, for: "ws-a", sessionId: "s1")

--- a/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubStatusMonitorTests.swift
@@ -241,6 +241,32 @@ struct HubStatusMonitorTests {
     }
 
     @Test
+    func sendFailsImmediatelyWithoutNetwork() async {
+        let (monitor, cache, connection) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-net"])
+        let store = cache.getOrCreate("ws-net")
+
+        monitor.setNetworkAvailable(false)
+        let sent = await store.send?(.stop(sessionId: "s1")) ?? true
+
+        #expect(sent == false)
+        #expect(connection.sentMessages.isEmpty)
+        #expect(monitor.connectionState == .disconnected)
+    }
+
+    @Test
+    func networkRestoreProbesTheConnection() {
+        let (monitor, _, connection) = makeMonitor()
+        monitor.sync(workspaceIds: ["ws-net"])
+
+        monitor.setNetworkAvailable(false)
+        #expect(monitor.connectionState == .disconnected)
+        monitor.setNetworkAvailable(true)
+
+        #expect(connection.probeLivenessCount == 1)
+    }
+
+    @Test
     func hubBadgeCountsWorkspacesWithActivityAndClearsOnView() {
         let (monitor, _, _) = makeMonitor()
         monitor.sync(workspaceIds: ["ws-a", "ws-b"])


### PR DESCRIPTION
Implements the remaining independent open iOS issues plus two field-feedback fixes, one commit per issue / per item. All 230 Swift tests pass; every change builds for the simulator.

## #287 — Retryable failed sends
A send that fails to reach the WebSocket no longer appends a fake assistant message (which history refetches then silently erased). It becomes a store-owned `FailedSend`, rendered as a distinct error row above the composer with **Retry** and **discard**. Retry replays the saved content through the normal send path (clears on success, kept on failure); a failed tool-input answer re-presents its pending question. The error state is carried across history refetches and turn finalization so evidence never vanishes.
- Tests: `ConversationStoreFailedSendTests` (6)

## #288 — Reopenable pending-question chip
Dismissing the question sheet is now non-destructive: sheet visibility is decoupled from the store-owned pending inputs. When questions exist and the sheet is closed, a count-aware **"N questions waiting"** chip appears above the composer and reopens the same sheet. Questions clear only on answer or turn end, survive navigation, and the `toolInputRequired` append is idempotent by `requestId` (no duplicates on reconnect).
- Tests: `ConversationStorePendingQuestionTests` (5)
- E2E-verified against a mock backend: the interactive question sheet auto-presents when `tool_input_required` arrives.

## #295 — Dynamic Type
- `WhisperFont.mono` now maps each base size to the nearest semantic text style, so its ~30 call sites scale in one edit point; added `WhisperFont.scaled` and migrated the core chat text (user bubble, conversation rows, agent activity, image captions).
- Markdown agent responses scale: the `whisperChat` theme is driven from a `@ScaledMetric` base font with heading/code sizes converted to relative `.em` units.
- Acceptance is a **manual Dynamic Type sweep** across screens (per the PRD). Icon/avatar glyph sizes, the `SelectableMarkdownText` path, and the plan-proposal theme are intentionally left fixed to avoid unverifiable layout regressions — follow-ups if desired.

## #298 — Small polish (5 independent commits)
1. **Hub tab badge** — numeric count of workspaces with a completed turn or unread session, from the monitor's existing tracking; clears as viewed. Tested (`hubBadgeCount`).
2. **List loading skeletons** — shimmer placeholder rows on the empty initial load of the Hub / Brain / workspace conversation lists (never over cached content); reuses the theme shimmer, which already honors Reduce Motion.
3. **VoiceOver streaming label** — the dots + elapsed timer become one accessibility element labeled "Agent working, N minutes" (minute buckets).
4. **Locked-model footer** — the model menu explains provider lock when locked.
5. **Settings guidance** — a 401/403 surfaces as a distinct "Invalid token" status vs "Disconnected"; classification lives in `ConnectionHealth.classify` (tested); plus a connection-fields footer.

## Field feedback fixes (added after review of Lenny's reports)

### Long-press copy now works while the agent is streaming (`8c09f16`)
Root cause: any transcript movement — the programmatic scroll-to-bottom on each delta AND the List's own bottom-anchoring as the streaming cell grows — cancelled the ~0.5s context-menu press, making messages uncopyable during a stream. A finger on the transcript now pauses both the auto-scroll and the streaming delta flush (deltas keep buffering and apply on release). Touch is observed via a zero-duration UIKit long-press recognizer on the List's `UICollectionView` (`cancelsTouchesInView` off) because SwiftUI gestures on a List never fire for stationary touches.
- Test: `uiHoldKeepsBufferingUntilReleased`
- E2E-verified with a mock backend streaming 8 deltas/s: the Copy menu opens on a user bubble mid-stream.

### Collapse/expand toggles never touch the scroll (`97ed0cf`)
The tool-calls group, individual tool rows, the thinking block, activity disclosures, and the tracker sections above the composer now toggle with animations disabled (shared `withoutAnimation` helper; the tracker's spring animation is removed). Animated row-height and safe-area-inset changes made the List re-align its scroll position, which glitched on tall content.
- E2E-verified during an active stream: tracker and tool-group expand/collapse leave the scroll position untouched.


### Airplane mode: failed sends now surface immediately (`2b55d84`)
Field report: airplane mode + send → nothing at all (no error row, no banner) until navigating away. Root cause: the 30s ping hadn't detected the drop and `wsTask.send` hung on TCP retransmissions, so the awaited send never resolved. An `NWPathMonitor` now flips network availability instantly: sends fail fast (error row right away), the banner shows within its 3s debounce (in the chat too), and the connection is re-probed the moment the network returns. Tested (`sendFailsImmediatelyWithoutNetwork`, `networkRestoreProbesTheConnection`) and E2E-verified with the mock: banner in chat → failed send → error row with Retry/discard → Retry after reconnect replays the message and clears the row.


### Optimistic sends with per-bubble delivery status (`61f14a2`)
A sent message now appears in the transcript **instantly** with a *Sending…* status; the backend's `user_message` echo confirms delivery and swaps the local bubble in place (no duplicate). A failed send keeps the bubble marked **Not delivered** with Retry/discard on the bubble itself — the text is never lost and never needs retyping. Pending/failed local messages survive history refetches. `FailedSend` is now tool-input-only. 10 store tests; E2E-verified with the mock (instant bubble → echo → confirmed, single bubble).

## Also done in this pass
Closed #290, #294, #296, #297 — already implemented on `main` via #316; deleted their stale `origin/ios-*` branches (cut from an old main, would have regressed).

## Hardening from the branch review (`85ee220`, `01c27f1`)
A senior-advisor review of this branch surfaced two robustness gaps in the new code, fixed on the branch:

- **Optimistic-send confirmation is now scoped to newly fetched messages** (`85ee220`). The history-refetch merge confirmed a *Sending…* bubble by content equality against the whole history, so an older identical message (a previous "ok"/"yes") could falsely confirm a new in-flight send — and if that send then failed, the message vanished silently with no error row. The merge now only accepts a confirming message whose id is new to the client in that fetch. 2 regression tests.
- **The transcript touch-probe attach retries until the List exists** (`01c27f1`). The zero-duration long-press recognizer was attached to the List's `UICollectionView` on a single async hop after `didMoveToWindow`; if SwiftUI hadn't built the collection view yet, the streaming hold silently never engaged. The attach now retries up to 20× at 100 ms, re-armed on window changes; gesture configuration unchanged.

## Not included
- #277 (streaming-flow remaining work) — dependent follow-up.
- #253 (Workflows PRD) — large standalone backend feature; deserves its own PR.

## Test
`cd ios && swift test` → 238 tests pass. Manual sweeps still needed: Dynamic Type (#295), VoiceOver (#298.3), and hand-feel checks for the failed-send row, question chip, skeletons, long-press-during-stream, and collapse toggles.



