### PR TITLE
iOS streaming render performance: eliminate jank during long streamed replies (#318)

### DIFF
--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -558,7 +558,7 @@ enum TaskStatus: String {
     case declined
 }
 
-struct TrackedTask: Identifiable {
+struct TrackedTask: Identifiable, Equatable {
     let id: String
     var subject: String
     var description: String?
@@ -567,7 +567,7 @@ struct TrackedTask: Identifiable {
     var isCreating: Bool
 }
 
-struct TaskCounts {
+struct TaskCounts: Equatable {
     let total: Int
     let completed: Int
     let inProgress: Int
@@ -584,7 +584,7 @@ enum TaskTrackerStatus: Equatable {
     case unconfirmed
 }
 
-struct TasksState {
+struct TasksState: Equatable {
     let tasks: [TrackedTask]
     let currentTask: TrackedTask?
     let counts: TaskCounts

--- a/ios/HiveMobile/Stores/BackgroundAgentDerivation.swift
+++ b/ios/HiveMobile/Stores/BackgroundAgentDerivation.swift
@@ -4,25 +4,48 @@ import Foundation
 //
 // Pure function port of `frontend/src/hooks/useBackgroundAgents.ts`.
 
+struct BackgroundAgentsHistorySnapshot {
+    fileprivate var toolsById: [String: ToolCall] = [:]
+    fileprivate var order: [String] = []
+
+    static let empty = BackgroundAgentsHistorySnapshot()
+
+    fileprivate mutating func upsert(_ tool: ToolCall) {
+        if toolsById[tool.id] == nil { order.append(tool.id) }
+        toolsById[tool.id] = tool
+    }
+}
+
+/// History pass: de-duplicate the finalized messages' tools by id,
+/// preserving first-seen order (mirrors the JS Map).
+func deriveBackgroundAgentsHistory(from messages: [ChatMessage]) -> BackgroundAgentsHistorySnapshot {
+    var state = BackgroundAgentsHistorySnapshot()
+    for message in messages {
+        for tool in message.toolCalls ?? [] { state.upsert(tool) }
+    }
+    return state
+}
+
 /// Derive background sub-agents (Task/Agent tools with `run_in_background`)
 /// and their running state from history + active (streaming) tool calls.
 func deriveBackgroundAgents(
     from messages: [ChatMessage],
     activeToolCalls: [ToolCall]
 ) -> BackgroundAgentsState {
-    // De-duplicate tools by id, preserving first-seen order (mirrors the JS Map).
-    var toolsById: [String: ToolCall] = [:]
-    var order: [String] = []
-    func upsert(_ tool: ToolCall) {
-        if toolsById[tool.id] == nil { order.append(tool.id) }
-        toolsById[tool.id] = tool
-    }
-    for message in messages {
-        for tool in message.toolCalls ?? [] { upsert(tool) }
-    }
-    for tool in activeToolCalls { upsert(tool) }
+    deriveBackgroundAgents(
+        history: deriveBackgroundAgentsHistory(from: messages),
+        activeToolCalls: activeToolCalls
+    )
+}
 
-    let allTools = order.compactMap { toolsById[$0] }
+func deriveBackgroundAgents(
+    history: BackgroundAgentsHistorySnapshot,
+    activeToolCalls: [ToolCall]
+) -> BackgroundAgentsState {
+    var state = history
+    for tool in activeToolCalls { state.upsert(tool) }
+
+    let allTools = state.order.compactMap { state.toolsById[$0] }
     let childrenMap = buildChildrenMap(allTools)
     let activeToolIds = Set(activeToolCalls.map(\.id))
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -114,27 +114,41 @@ final class ConversationStore {
     /// Store-owned failed send for the focused session, if any.
     var failedSend: FailedSend? { activeStream?.failedSend }
 
-    private(set) var tasksState: TasksState =
-        deriveTasks(from: [], activeToolCalls: [], activeAgentActivities: [])
-    private(set) var goalState: GoalState? =
-        deriveGoalState(from: [], activeAgentActivities: [])
-    private(set) var backgroundAgents: BackgroundAgentsState =
-        deriveBackgroundAgents(from: [], activeToolCalls: [])
+    private(set) var tasksState: TasksState = .empty
+    private(set) var goalState: GoalState?
+    private(set) var backgroundAgents: BackgroundAgentsState = .empty
     private(set) var dismissedToolCallIds: Set<String> = []
     @ObservationIgnored private(set) var derivationRunCount = 0
+    @ObservationIgnored private(set) var historyDerivationRunCount = 0
+
+    @ObservationIgnored private var tasksHistory = TasksHistorySnapshot.empty
+    @ObservationIgnored private var goalHistory: GoalState?
+    @ObservationIgnored private var agentsHistory = BackgroundAgentsHistorySnapshot.empty
 
     private func recomputeDerivations() {
+        historyDerivationRunCount += 1
+        tasksHistory = deriveTasksHistory(from: messages)
+        goalHistory = deriveGoalHistory(from: messages)
+        agentsHistory = deriveBackgroundAgentsHistory(from: messages)
+        let newDismissed = deriveDismissedToolCallIds(from: messages)
+        if dismissedToolCallIds != newDismissed { dismissedToolCallIds = newDismissed }
+        applyActiveDerivations()
+    }
+
+    private func applyActiveDerivations() {
         derivationRunCount += 1
         let toolCalls = activeStream?.activeToolCalls ?? []
         let activities = activeStream?.activeAgentActivities ?? []
-        tasksState = deriveTasks(
-            from: messages,
+        let newTasks = deriveTasks(
+            history: tasksHistory,
             activeToolCalls: toolCalls,
             activeAgentActivities: activities
         )
-        goalState = deriveGoalState(from: messages, activeAgentActivities: activities)
-        backgroundAgents = deriveBackgroundAgents(from: messages, activeToolCalls: toolCalls)
-        dismissedToolCallIds = deriveDismissedToolCallIds(from: messages)
+        if tasksState != newTasks { tasksState = newTasks }
+        let newGoal = deriveGoalState(history: goalHistory, activeAgentActivities: activities)
+        if goalState != newGoal { goalState = newGoal }
+        let newAgents = deriveBackgroundAgents(history: agentsHistory, activeToolCalls: toolCalls)
+        if backgroundAgents != newAgents { backgroundAgents = newAgents }
     }
 
     // MARK: - Streaming delta buffering
@@ -202,7 +216,7 @@ final class ConversationStore {
                 output: nil, parentToolUseId: parentToolUseId
             ))
             if sid == sessionId {
-                recomputeDerivations()
+                applyActiveDerivations()
             }
 
         case .toolResult(let sid, let toolUseId, let output):
@@ -214,7 +228,7 @@ final class ConversationStore {
                 output: output, parentToolUseId: tc.parentToolUseId
             )
             if sid == sessionId {
-                recomputeDerivations()
+                applyActiveDerivations()
             }
 
         case .agentActivity(let sid, let activity):
@@ -238,7 +252,7 @@ final class ConversationStore {
                 sessionId = sid
             }
             if sid == sessionId {
-                recomputeDerivations()
+                applyActiveDerivations()
             }
 
         case .toolInputRequired(let sid, let requestId, let toolName, let toolUseId, let input):
@@ -344,7 +358,7 @@ final class ConversationStore {
                 sessionId = incomingSessionId
             }
             if let incomingSessionId, incomingSessionId == sessionId {
-                recomputeDerivations()
+                applyActiveDerivations()
             }
 
         case .userMessage(let msg):
@@ -368,7 +382,7 @@ final class ConversationStore {
                 }
                 cacheMessages(messages, for: sid)
             } else if isActive {
-                recomputeDerivations()
+                applyActiveDerivations()
             } else {
                 lastHistoryFetchAt.removeValue(forKey: sid)
             }
@@ -654,7 +668,7 @@ final class ConversationStore {
 
     func setFocusedSessionId(_ value: String?) {
         sessionId = value
-        recomputeDerivations()
+        applyActiveDerivations()
     }
 
     func prepareSessionSwitch(_ newSessionId: String) {
@@ -761,7 +775,7 @@ final class ConversationStore {
             stream.activeAgentActivities.append(activity)
         }
         if sid == sessionId {
-            recomputeDerivations()
+            applyActiveDerivations()
         }
     }
 

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -27,7 +27,12 @@ final class ConversationStore {
 
     /// ISO8601 timestamp for the current moment (shared formatter).
     static func timestamp() -> String {
-        outgoingTimestampFormatter.string(from: Date())
+        timestamp(from: Date())
+    }
+
+    /// ISO8601 timestamp for a specific moment (shared formatter).
+    static func timestamp(from date: Date) -> String {
+        outgoingTimestampFormatter.string(from: date)
     }
 
     // MARK: - Public state

--- a/ios/HiveMobile/Stores/GoalDerivation.swift
+++ b/ios/HiveMobile/Stores/GoalDerivation.swift
@@ -5,27 +5,40 @@ import Foundation
 // Pure function that derives the active Codex goal from conversation messages.
 // Direct port of `frontend/src/hooks/useGoalState.ts`.
 
+func deriveGoalHistory(from messages: [ChatMessage]) -> GoalState? {
+    var latest: GoalState?
+    for message in messages {
+        for activity in message.agentActivities ?? [] {
+            fold(activity, into: &latest)
+        }
+    }
+    return latest
+}
+
 /// Derive the latest active goal from history + active (streaming) agent activities.
 /// Returns `nil` when the most recent goal update is inactive (goal cleared).
 func deriveGoalState(
     from messages: [ChatMessage],
     activeAgentActivities: [AgentActivity] = []
 ) -> GoalState? {
-    var latest: GoalState?
+    deriveGoalState(
+        history: deriveGoalHistory(from: messages),
+        activeAgentActivities: activeAgentActivities
+    )
+}
 
-    func read(_ activity: AgentActivity) {
-        guard case .goalUpdate(let goal) = activity else { return }
-        latest = goal.active ? goal : nil
-    }
-
-    for message in messages {
-        for activity in message.agentActivities ?? [] {
-            read(activity)
-        }
-    }
+func deriveGoalState(
+    history: GoalState?,
+    activeAgentActivities: [AgentActivity]
+) -> GoalState? {
+    var latest = history
     for activity in activeAgentActivities {
-        read(activity)
+        fold(activity, into: &latest)
     }
-
     return latest
+}
+
+private func fold(_ activity: AgentActivity, into latest: inout GoalState?) {
+    guard case .goalUpdate(let goal) = activity else { return }
+    latest = goal.active ? goal : nil
 }

--- a/ios/HiveMobile/Stores/MarkdownStructure.swift
+++ b/ios/HiveMobile/Stores/MarkdownStructure.swift
@@ -146,26 +146,23 @@ func markdownNeedsRichRenderer(_ markdown: String) -> Bool {
     return false
 }
 
-/// Boundary = blank line with all ``` fences closed before it, so the stable
+/// Boundary = blank line outside any ``` / ~~~ fenced block, so the stable
 /// prefix never ends inside an open code block.
 func splitStableMarkdownPrefix(_ text: String) -> (stable: String, tail: String) {
-    var fenceCount = 0
+    var insideFence = false
     var lastSafeBoundary: String.Index?
-    var index = text.startIndex
+    var lineStart = text.startIndex
 
-    while index < text.endIndex {
-        if text[index...].hasPrefix("```") {
-            fenceCount += 1
-            index = text.index(index, offsetBy: 3)
-            continue
+    while lineStart < text.endIndex {
+        let lineEnd = text[lineStart...].firstIndex(of: "\n") ?? text.endIndex
+        let line = text[lineStart..<lineEnd].trimmingCharacters(in: .whitespaces)
+        if line.hasPrefix("```") || line.hasPrefix("~~~") {
+            insideFence.toggle()
+        } else if lineStart == lineEnd, !insideFence, lineEnd < text.endIndex {
+            lastSafeBoundary = text.index(after: lineEnd)
         }
-        if text[index] == "\n" {
-            let next = text.index(after: index)
-            if next < text.endIndex, text[next] == "\n", fenceCount.isMultiple(of: 2) {
-                lastSafeBoundary = text.index(after: next)
-            }
-        }
-        index = text.index(after: index)
+        guard lineEnd < text.endIndex else { break }
+        lineStart = text.index(after: lineEnd)
     }
 
     guard let boundary = lastSafeBoundary else { return ("", text) }

--- a/ios/HiveMobile/Stores/MarkdownStructure.swift
+++ b/ios/HiveMobile/Stores/MarkdownStructure.swift
@@ -145,3 +145,29 @@ func markdownNeedsRichRenderer(_ markdown: String) -> Bool {
     }
     return false
 }
+
+/// Boundary = blank line with all ``` fences closed before it, so the stable
+/// prefix never ends inside an open code block.
+func splitStableMarkdownPrefix(_ text: String) -> (stable: String, tail: String) {
+    var fenceCount = 0
+    var lastSafeBoundary: String.Index?
+    var index = text.startIndex
+
+    while index < text.endIndex {
+        if text[index...].hasPrefix("```") {
+            fenceCount += 1
+            index = text.index(index, offsetBy: 3)
+            continue
+        }
+        if text[index] == "\n" {
+            let next = text.index(after: index)
+            if next < text.endIndex, text[next] == "\n", fenceCount.isMultiple(of: 2) {
+                lastSafeBoundary = text.index(after: next)
+            }
+        }
+        index = text.index(after: index)
+    }
+
+    guard let boundary = lastSafeBoundary else { return ("", text) }
+    return (String(text[..<boundary]), String(text[boundary...]))
+}

--- a/ios/HiveMobile/Stores/TaskDerivation.swift
+++ b/ios/HiveMobile/Stores/TaskDerivation.swift
@@ -78,6 +78,31 @@ private func hasOpenPlanTask(_ tasks: [TrackedTask], activityId: String) -> Bool
     }
 }
 
+struct TasksHistorySnapshot {
+    fileprivate var tasks: [(key: String, value: TrackedTask)] = []
+    fileprivate var taskIndex: [String: Int] = [:]
+    fileprivate var createIndex = 0
+    fileprivate var planActivities: [(plan: AgentActivity.PlanUpdate, source: PlanActivitySource)] = []
+    fileprivate var hasTaskTools = false
+
+    static let empty = TasksHistorySnapshot()
+}
+
+func deriveTasksHistory(from messages: [ChatMessage]) -> TasksHistorySnapshot {
+    var state = TasksHistorySnapshot()
+    for msg in messages {
+        for tool in msg.toolCalls ?? [] {
+            applyTaskTool(tool, to: &state)
+        }
+        for activity in msg.agentActivities ?? [] {
+            if case .planUpdate(let plan) = activity {
+                state.planActivities.append((plan: plan, source: .history))
+            }
+        }
+    }
+    return state
+}
+
 /// Derive task tracking state from conversation messages and active (streaming) tool calls.
 /// Mirrors the logic in `frontend/src/hooks/useTasks.ts` exactly.
 func deriveTasks(
@@ -85,127 +110,48 @@ func deriveTasks(
     activeToolCalls: [ToolCall],
     activeAgentActivities: [AgentActivity] = []
 ) -> TasksState {
-    // Collect all tool calls in chronological order
-    var allTools: [ToolCall] = []
-    var planActivities: [(plan: AgentActivity.PlanUpdate, source: PlanActivitySource)] = []
-    for msg in messages {
-        if let tools = msg.toolCalls {
-            allTools.append(contentsOf: tools)
-        }
-        if let activities = msg.agentActivities {
-            for activity in activities {
-                if case .planUpdate(let plan) = activity {
-                    planActivities.append((plan: plan, source: .history))
-                }
-            }
-        }
+    deriveTasks(
+        history: deriveTasksHistory(from: messages),
+        activeToolCalls: activeToolCalls,
+        activeAgentActivities: activeAgentActivities
+    )
+}
+
+func deriveTasks(
+    history: TasksHistorySnapshot,
+    activeToolCalls: [ToolCall],
+    activeAgentActivities: [AgentActivity] = []
+) -> TasksState {
+    var state = history
+    for tool in activeToolCalls {
+        applyTaskTool(tool, to: &state)
     }
-    allTools.append(contentsOf: activeToolCalls)
     for activity in activeAgentActivities {
         if case .planUpdate(let plan) = activity {
-            planActivities.append((plan: plan, source: .active))
+            state.planActivities.append((plan: plan, source: .active))
         }
     }
 
     // Quick bail: no task tools at all
-    let hasTaskTools = allTools.contains { taskToolNames.contains($0.name) }
-    guard hasTaskTools || !planActivities.isEmpty else { return .empty }
-
-    // Ordered storage: array of (key, task) pairs + index lookup
-    var tasks: [(key: String, value: TrackedTask)] = []
-    var taskIndex: [String: Int] = [:]
-    var createIndex = 0
-
-    for tool in allTools {
-        if tool.name == "TaskCreate" {
-            createIndex += 1
-            let input = parseInput(tool)
-            let subject = (input["subject"] as? String) ?? "Task \(createIndex)"
-            let description = input["description"] as? String
-            let activeForm = input["activeForm"] as? String
-
-            let id: String
-            var isCreating = false
-
-            if let output = tool.output {
-                let parsed = parseTaskId(from: output)
-                id = parsed ?? "_idx_\(createIndex)"
-            } else {
-                // Still streaming — use tool_use id as temp key
-                id = "_pending_\(tool.id)"
-                isCreating = true
-            }
-
-            let task = TrackedTask(
-                id: id,
-                subject: subject,
-                description: description,
-                activeForm: activeForm,
-                status: .pending,
-                isCreating: isCreating
-            )
-            taskIndex[id] = tasks.count
-            tasks.append((key: id, value: task))
-
-        } else if tool.name == "TaskUpdate" {
-            let input = parseInput(tool)
-            guard let taskId = input["taskId"] as? String,
-                  let idx = taskIndex[taskId] else { continue }
-
-            let statusStr = input["status"] as? String
-            if statusStr == "deleted" {
-                tasks.remove(at: idx)
-                taskIndex.removeValue(forKey: taskId)
-                // Rebuild indices for items after removed position
-                for i in idx..<tasks.count {
-                    taskIndex[tasks[i].key] = i
-                }
-                continue
-            }
-
-            if let s = input["subject"] as? String { tasks[idx].value.subject = s }
-            if let d = input["description"] as? String { tasks[idx].value.description = d }
-            if let a = input["activeForm"] as? String { tasks[idx].value.activeForm = a }
-            if let status = normalizeTaskStatus(statusStr) {
-                tasks[idx].value.status = status
-            }
-        } else if tool.name == "TodoList" {
-            for (index, item) in parseTodoList(tool).enumerated() {
-                let id = "codex-todo-\(index + 1)"
-                let task = TrackedTask(
-                    id: id,
-                    subject: item.text,
-                    status: item.completed ? .completed : .pending,
-                    isCreating: false
-                )
-
-                if let existingIndex = taskIndex[id] {
-                    tasks[existingIndex].value = task
-                } else {
-                    taskIndex[id] = tasks.count
-                    tasks.append((key: id, value: task))
-                }
-            }
-        }
-    }
+    guard state.hasTaskTools || !state.planActivities.isEmpty else { return .empty }
 
     // Codex app-server emits plan updates as agent activities, not tool calls.
     // The latest plan represents the current turn, so older plans should not
     // accumulate in the global task tracker.
-    let latestPlanEntry = planActivities.last
+    let latestPlanEntry = state.planActivities.last
     if let latestPlanEntry {
         for task in planTasks(from: latestPlanEntry.plan) {
             let key = "plan:\(task.id)"
-            if let existingIndex = taskIndex[key] {
-                tasks[existingIndex].value = task
+            if let existingIndex = state.taskIndex[key] {
+                state.tasks[existingIndex].value = task
             } else {
-                taskIndex[key] = tasks.count
-                tasks.append((key: key, value: task))
+                state.taskIndex[key] = state.tasks.count
+                state.tasks.append((key: key, value: task))
             }
         }
     }
 
-    let taskList = tasks.map(\.value)
+    let taskList = state.tasks.map(\.value)
     let currentTask = taskList.first { $0.status == .inProgress }
     let counts = TaskCounts(
         total: taskList.count,
@@ -213,7 +159,7 @@ func deriveTasks(
         inProgress: taskList.filter { $0.status == .inProgress }.count,
         pending: taskList.filter { $0.status == .pending }.count
     )
-    let trackerSource: TaskTrackerSource? = latestPlanEntry != nil ? .codexPlan : (hasTaskTools ? .taskTools : nil)
+    let trackerSource: TaskTrackerSource? = latestPlanEntry != nil ? .codexPlan : (state.hasTaskTools ? .taskTools : nil)
     // A persisted Codex plan with open steps is only the last reported snapshot,
     // not proof that the finished turn still has work remaining.
     let hasUnconfirmedOpenPlanTasks: Bool
@@ -231,4 +177,80 @@ func deriveTasks(
         trackerSource: trackerSource,
         trackerStatus: trackerStatus
     )
+}
+
+private func applyTaskTool(_ tool: ToolCall, to state: inout TasksHistorySnapshot) {
+    guard taskToolNames.contains(tool.name) else { return }
+    state.hasTaskTools = true
+
+    if tool.name == "TaskCreate" {
+        state.createIndex += 1
+        let input = parseInput(tool)
+        let subject = (input["subject"] as? String) ?? "Task \(state.createIndex)"
+        let description = input["description"] as? String
+        let activeForm = input["activeForm"] as? String
+
+        let id: String
+        var isCreating = false
+
+        if let output = tool.output {
+            let parsed = parseTaskId(from: output)
+            id = parsed ?? "_idx_\(state.createIndex)"
+        } else {
+            // Still streaming — use tool_use id as temp key
+            id = "_pending_\(tool.id)"
+            isCreating = true
+        }
+
+        let task = TrackedTask(
+            id: id,
+            subject: subject,
+            description: description,
+            activeForm: activeForm,
+            status: .pending,
+            isCreating: isCreating
+        )
+        state.taskIndex[id] = state.tasks.count
+        state.tasks.append((key: id, value: task))
+
+    } else if tool.name == "TaskUpdate" {
+        let input = parseInput(tool)
+        guard let taskId = input["taskId"] as? String,
+              let idx = state.taskIndex[taskId] else { return }
+
+        let statusStr = input["status"] as? String
+        if statusStr == "deleted" {
+            state.tasks.remove(at: idx)
+            state.taskIndex.removeValue(forKey: taskId)
+            // Rebuild indices for items after removed position
+            for i in idx..<state.tasks.count {
+                state.taskIndex[state.tasks[i].key] = i
+            }
+            return
+        }
+
+        if let s = input["subject"] as? String { state.tasks[idx].value.subject = s }
+        if let d = input["description"] as? String { state.tasks[idx].value.description = d }
+        if let a = input["activeForm"] as? String { state.tasks[idx].value.activeForm = a }
+        if let status = normalizeTaskStatus(statusStr) {
+            state.tasks[idx].value.status = status
+        }
+    } else if tool.name == "TodoList" {
+        for (index, item) in parseTodoList(tool).enumerated() {
+            let id = "codex-todo-\(index + 1)"
+            let task = TrackedTask(
+                id: id,
+                subject: item.text,
+                status: item.completed ? .completed : .pending,
+                isCreating: false
+            )
+
+            if let existingIndex = state.taskIndex[id] {
+                state.tasks[existingIndex].value = task
+            } else {
+                state.taskIndex[id] = state.tasks.count
+                state.tasks.append((key: id, value: task))
+            }
+        }
+    }
 }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -335,7 +335,7 @@ struct ChatView: View {
             toolCalls: store.activeToolCalls.isEmpty ? nil : store.activeToolCalls,
             agentActivities: store.activeAgentActivities.isEmpty ? nil : store.activeAgentActivities,
             thinkingContent: store.currentThinking.isEmpty ? nil : store.currentThinking,
-            timestamp: ConversationStore.timestamp(),
+            timestamp: store.streamingStartedAt.map(ConversationStore.timestamp(from:)) ?? "",
             cancelled: nil,
             durationMs: nil
         )

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -121,6 +121,7 @@ struct ChatView: View {
                                     onRetrySend: { Task { await store.retryOptimisticSend(message.id) } },
                                     onDiscardSend: { store.discardOptimisticSend(message.id) }
                                 )
+                                .equatable()
                                 .id(message.id)
                                 .chatTranscriptRow()
                             }
@@ -132,6 +133,7 @@ struct ChatView: View {
                                 pendingToolUseIds: pendingToolUseIds,
                                 dismissedToolCallIds: store.dismissedToolCallIds
                             )
+                            .equatable()
                             .id(message.id)
                             .chatTranscriptRow()
                         }

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -1,13 +1,20 @@
 import MarkdownUI
 import SwiftUI
 
-struct MessageBubble: View {
+struct MessageBubble: View, Equatable {
     let message: ChatMessage
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
     var sendState: ConversationStore.UserSendState? = nil
     var onRetrySend: (() -> Void)? = nil
     var onDiscardSend: (() -> Void)? = nil
+
+    static func == (lhs: MessageBubble, rhs: MessageBubble) -> Bool {
+        lhs.message == rhs.message
+            && lhs.pendingToolUseIds == rhs.pendingToolUseIds
+            && lhs.dismissedToolCallIds == rhs.dismissedToolCallIds
+            && lhs.sendState == rhs.sendState
+    }
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
     @State private var copied = false
@@ -164,9 +171,7 @@ struct MessageBubble: View {
                     )
             case .assistant:
                 if message.id == "streaming" {
-                    Markdown(message.content)
-                        .markdownTextStyle { FontSize(markdownBaseSize) }
-                        .markdownTheme(.whisperChat)
+                    StreamingMarkdownView(text: message.content, baseSize: markdownBaseSize)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 } else if markdownNeedsRichRenderer(message.content) {
                     Markdown(message.content)
@@ -1006,7 +1011,7 @@ private struct AskUserQuestionContent: View {
 
 private let whisperLinkColor = Color.accentColor
 
-private extension Theme {
+extension Theme {
     static let whisperChat = Theme.gitHub
         // ── Inline text ──
         .text {

--- a/ios/HiveMobile/Views/Chat/StreamingMarkdownView.swift
+++ b/ios/HiveMobile/Views/Chat/StreamingMarkdownView.swift
@@ -1,0 +1,33 @@
+import MarkdownUI
+import SwiftUI
+
+struct StreamingMarkdownView: View {
+    let text: String
+    let baseSize: CGFloat
+
+    var body: some View {
+        let parts = splitStableMarkdownPrefix(text)
+        VStack(alignment: .leading, spacing: baseSize) {
+            if !parts.stable.isEmpty {
+                StablePrefixMarkdown(text: parts.stable, baseSize: baseSize)
+                    .equatable()
+            }
+            if !parts.tail.isEmpty {
+                Markdown(parts.tail)
+                    .markdownTextStyle { FontSize(baseSize) }
+                    .markdownTheme(.whisperChat)
+            }
+        }
+    }
+}
+
+private struct StablePrefixMarkdown: View, Equatable {
+    let text: String
+    let baseSize: CGFloat
+
+    var body: some View {
+        Markdown(text)
+            .markdownTextStyle { FontSize(baseSize) }
+            .markdownTheme(.whisperChat)
+    }
+}

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
@@ -1,3 +1,4 @@
+import Observation
 import Testing
 @testable import HiveMobileStoresCore
 
@@ -100,5 +101,53 @@ struct ConversationStoreDerivationTests {
 
         store.applyFetchedHistory(history, for: "session-1")
         #expect(store.dismissedToolCallIds == ["ask-1"])
+    }
+}
+
+extension ConversationStoreDerivationTests {
+    @Test @MainActor
+    func toolEventsDoNotRerunHistoryDerivations() {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        store.applyFetchedHistory([
+            ChatMessage(
+                id: "m1", sessionId: "s1", role: .assistant, content: "done",
+                images: nil,
+                toolCalls: [ToolCall(id: "t0", name: "TaskCreate", input: "{\"subject\":\"Old\"}", output: "Task #1 created", parentToolUseId: nil)],
+                thinkingContent: nil,
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+            )
+        ], for: "s1")
+        store.handle(.status(status: .busy, sessionId: "s1", streaming: true, streamingStartedAt: nil, lockedProvider: nil))
+        let base = store.historyDerivationRunCount
+
+        store.handle(.toolUse(sessionId: "s1", id: "t1", name: "TaskCreate", input: "{\"subject\":\"New\"}", parentToolUseId: nil))
+        store.handle(.toolResult(sessionId: "s1", toolUseId: "t1", output: "Task #2 created"))
+        store.handle(.toolUse(sessionId: "s1", id: "t2", name: "Read", input: "{}", parentToolUseId: nil))
+
+        #expect(store.historyDerivationRunCount == base)
+        #expect(store.tasksState.tasks.map(\.subject) == ["Old", "New"])
+
+        store.applyFetchedHistory([], for: "s1")
+        #expect(store.historyDerivationRunCount == base + 1)
+    }
+
+    @Test @MainActor
+    func unchangedDerivationsDoNotNotifyObservers() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        store.handle(.status(status: .busy, sessionId: "s1", streaming: true, streamingStartedAt: nil, lockedProvider: nil))
+
+        var tasksChanged = false
+        withObservationTracking {
+            _ = store.tasksState
+        } onChange: {
+            tasksChanged = true
+        }
+
+        store.handle(.toolUse(sessionId: "s1", id: "t1", name: "Read", input: "{}", parentToolUseId: nil))
+
+        #expect(store.derivationRunCount > 0)
+        #expect(!tasksChanged)
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreDerivationTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Observation
 import Testing
 @testable import HiveMobileStoresCore
@@ -149,5 +150,12 @@ extension ConversationStoreDerivationTests {
 
         #expect(store.derivationRunCount > 0)
         #expect(!tasksChanged)
+    }
+
+    @Test @MainActor
+    func timestampFromDateIsDeterministic() {
+        let date = Date(timeIntervalSince1970: 1_700_000_000)
+        #expect(ConversationStore.timestamp(from: date) == ConversationStore.timestamp(from: date))
+        #expect(ConversationStore.timestamp(from: date) == "2023-11-14T22:13:20.000Z")
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/MarkdownStructureTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MarkdownStructureTests.swift
@@ -141,4 +141,44 @@ struct SplitStableMarkdownPrefixTests {
         let parts = splitStableMarkdownPrefix("\n\n")
         #expect(parts.stable + parts.tail == "\n\n")
     }
+
+    @Test
+    func inlineTripleBackticksInProseDoNotFlipFenceState() {
+        let text = "Wrap it in ``` fences.\n\n```swift\nlet a = 1\n\nlet b = 2\n"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Wrap it in ``` fences.\n\n")
+        #expect(parts.tail == "```swift\nlet a = 1\n\nlet b = 2\n")
+    }
+
+    @Test
+    func neverSplitsInsideAnOpenTildeFence() {
+        let text = "Intro.\n\n~~~\nlet a = 1\n\nlet b = 2\n"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Intro.\n\n")
+        #expect(parts.tail == "~~~\nlet a = 1\n\nlet b = 2\n")
+    }
+
+    @Test
+    func splitsAfterAClosedTildeFence() {
+        let text = "Intro.\n\n~~~\ncode\n~~~\n\nTail"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Intro.\n\n~~~\ncode\n~~~\n\n")
+        #expect(parts.tail == "Tail")
+    }
+
+    @Test
+    func indentedFenceLineTogglesFenceState() {
+        let text = "Intro.\n\n  ```\ncode\n\nmore\n"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Intro.\n\n")
+        #expect(parts.tail == "  ```\ncode\n\nmore\n")
+    }
+
+    @Test
+    func whitespaceOnlyLineIsNotABoundary() {
+        let text = "First.\n \nSecond"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable.isEmpty)
+        #expect(parts.tail == text)
+    }
 }

--- a/ios/Tests/ChatDraftStoreTests/MarkdownStructureTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MarkdownStructureTests.swift
@@ -91,3 +91,54 @@ struct MarkdownStructureTests {
         #expect(context?.indentLevel == 0)
     }
 }
+
+struct SplitStableMarkdownPrefixTests {
+    @Test
+    func plainParagraphsSplitAtLastBlankLine() {
+        let text = "First paragraph.\n\nSecond paragraph.\n\nTail still streaming"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "First paragraph.\n\nSecond paragraph.\n\n")
+        #expect(parts.tail == "Tail still streaming")
+        #expect(parts.stable + parts.tail == text)
+    }
+
+    @Test
+    func noBlankLineMeansEverythingIsTail() {
+        let text = "One long paragraph without any boundary"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable.isEmpty)
+        #expect(parts.tail == text)
+    }
+
+    @Test
+    func neverSplitsInsideAnOpenCodeFence() {
+        let text = "Intro.\n\n```swift\nlet a = 1\n\nlet b = 2\n"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Intro.\n\n")
+        #expect(parts.tail == "```swift\nlet a = 1\n\nlet b = 2\n")
+    }
+
+    @Test
+    func splitsAfterAClosedCodeFence() {
+        let text = "Intro.\n\n```swift\nlet a = 1\n```\n\nTail"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Intro.\n\n```swift\nlet a = 1\n```\n\n")
+        #expect(parts.tail == "Tail")
+    }
+
+    @Test
+    func trailingPartialFenceStaysInTail() {
+        let text = "Done block.\n\nNow code:\n``"
+        let parts = splitStableMarkdownPrefix(text)
+        #expect(parts.stable == "Done block.\n\n")
+        #expect(parts.tail == "Now code:\n``")
+    }
+
+    @Test
+    func emptyAndWhitespaceInputs() {
+        #expect(splitStableMarkdownPrefix("").stable.isEmpty)
+        #expect(splitStableMarkdownPrefix("").tail.isEmpty)
+        let parts = splitStableMarkdownPrefix("\n\n")
+        #expect(parts.stable + parts.tail == "\n\n")
+    }
+}


### PR DESCRIPTION
Closes #318.

Two commits, four workstreams from the issue plan, plus two review-fix commits. Behavior and visuals unchanged — the app just stops dropping frames while an agent streams a long reply.

## A+B — Incremental streaming markdown + equatable rows (`48a4345`)
- The live bubble no longer re-parses the whole document ~20×/s (was O(len²) per turn): `splitStableMarkdownPrefix` cuts the text at the last blank line with all ``` fences closed; the stable prefix renders behind an `Equatable` wrapper (re-parsed only when a new block completes) and only the small volatile tail re-parses per flush (`StreamingMarkdownView`).
- `MessageBubble` is `Equatable` (closures ignored) with `.equatable()` at both transcript sites — visible rows stop re-running their bodies on every flush.
- Finalized messages render exactly as before (paths untouched; `whisperChat` theme made internal for the new view).

## C+D — Memoized derivations + equality guards (`1119503`)
- `deriveTasks` / `deriveGoalState` / `deriveBackgroundAgents` split into a history pass (folded once per `messages` mutation, cached as opaque snapshots) and an active overlay replayed per tool event — tool-heavy turns stop re-walking the full transcript per event (was O(n²)); `dismissedToolCallIds` cached outright.
- Derived states are `Equatable` and only reassigned on change, so unchanged recomputes no longer invalidate `ChatView`/`TaskTrackerView`.
- New `historyDerivationRunCount` hook; `derivationRunCount` semantics preserved.

## Review fixes (`4b64eeb`, `731dec3`)
A branch audit found two gaps in the above and both are fixed on this PR:
- **Stable streaming-bubble timestamp** (`4b64eeb`): the synthetic streaming `ChatMessage` was built with a fresh wall-clock timestamp on every `ChatView` body evaluation, so its synthesized `==` never matched and the `.equatable()` on the streaming row was a no-op — unrelated body re-evals (scroll/touch state flips, `diffStats` pushes) still re-parsed the streaming tail. The timestamp is now derived from `streamingStartedAt` (stable per turn; never displayed — the footer skips the streaming bubble).
- **Line-based fence detection** (`731dec3`): `splitStableMarkdownPrefix` counted ``` ``` ``` anywhere in the text, so an inline mention in prose ("wrap it in ``` fences") flipped fence parity and could place the split inside a real code block; `~~~` fences were invisible to it entirely. It now scans per line (trimmed line starting with ``` ``` ``` or `~~~` toggles fence state), matching `markdownNeedsRichRenderer` in the same file. Blank-line boundary semantics unchanged.

## Tests — 252 pass (+14 vs main)
- `SplitStableMarkdownPrefixTests` (11): plain paragraphs, no boundary, open fence, closed fence, trailing partial fence, empty input, inline-backtick prose, open/closed `~~~` fences, indented fence lines, whitespace-only-line non-boundary.
- `toolEventsDoNotRerunHistoryDerivations`: 3 tool events leave the history counter untouched (combined task state still correct); +1 exactly on a messages mutation.
- `unchangedDerivationsDoNotNotifyObservers`: a non-task tool event runs the overlay without notifying `tasksState` observers (Observation-tracked).
- `timestampFromDateIsDeterministic`: pins the shared-formatter helper backing the stable streaming timestamp.
- All pre-existing derivation/streaming/session suites green — the refactor preserves exact behavior. `xcodebuild` simulator build green for the view-layer changes.

## E2E (mock backend, markdown-rich stream at 60 chars/s)
- Mid-stream screenshot: heading, bold, and a bullet list render live with no visible seam between the stable prefix and the tail; task tracker and tool-call rows update via the overlay.
- Post-`done`: the finalized bubble (incl. code fence) renders identically to before and survives the REST reconcile.

Per the grilled decisions: validation by eye + mock soak (no bench infra); the plain-text-tail fallback wasn't needed — full markdown stays live.
