### PR TITLE
iOS find-in-conversation, Telegram-style (#320)

### DIFF
--- a/ios/HiveMobile/Stores/ConversationFind.swift
+++ b/ios/HiveMobile/Stores/ConversationFind.swift
@@ -1,13 +1,20 @@
 import Foundation
 
-/// Offsets are UTF-16 code units within the message content (`NSRange` semantics).
+struct FindableMessage: Equatable {
+    let id: String
+    let content: String
+    let rendersMarkdown: Bool
+}
+
+/// Offsets are UTF-16 code units within the message's searchable text (`NSRange` semantics).
 struct ConversationFindMatch: Equatable {
     let messageId: String
     let range: Range<Int>
 }
 
+/// Offsets are UTF-16 code units within the message's searchable text.
 struct MessageFindHighlight: Equatable {
-    let query: String
+    let ranges: [Range<Int>]
     let activeOrdinal: Int?
 }
 
@@ -15,6 +22,12 @@ struct ConversationFindModel: Equatable {
     private(set) var query = ""
     private(set) var matches: [ConversationFindMatch] = []
     private(set) var activeIndex = -1
+    private(set) var highlightsByMessage: [String: MessageFindHighlight] = [:]
+    private var searchableTexts: [String: (source: String, text: String)] = [:]
+
+    static func == (lhs: ConversationFindModel, rhs: ConversationFindModel) -> Bool {
+        lhs.query == rhs.query && lhs.matches == rhs.matches && lhs.activeIndex == rhs.activeIndex
+    }
 
     var matchCount: Int { matches.count }
 
@@ -45,16 +58,32 @@ struct ConversationFindModel: Equatable {
         return ranges
     }
 
+    /// The exact string the renderer paints: joined markdown segments for
+    /// assistant messages, raw content otherwise.
+    static func searchableText(_ content: String, rendersMarkdown: Bool) -> String {
+        guard rendersMarkdown, let segments = markdownRenderSegments(content) else { return content }
+        return segments.map(\.text).joined()
+    }
+
     /// A query change jumps to the newest match; a content-only change keeps
     /// the active position (clamped).
-    mutating func update(messages: [(id: String, content: String)], query: String) {
+    mutating func update(messages: [FindableMessage], query: String) {
         let queryChanged = query != self.query
         self.query = query
-        matches = messages.flatMap { message in
-            Self.matchRanges(in: message.content, query: query).map {
+        var texts: [String: (source: String, text: String)] = [:]
+        matches = messages.flatMap { message -> [ConversationFindMatch] in
+            let text: String
+            if let cached = searchableTexts[message.id], cached.source == message.content {
+                text = cached.text
+            } else {
+                text = Self.searchableText(message.content, rendersMarkdown: message.rendersMarkdown)
+            }
+            texts[message.id] = (message.content, text)
+            return Self.matchRanges(in: text, query: query).map {
                 ConversationFindMatch(messageId: message.id, range: $0)
             }
         }
+        searchableTexts = texts
         if matches.isEmpty {
             activeIndex = -1
         } else if queryChanged || activeIndex < 0 {
@@ -62,6 +91,7 @@ struct ConversationFindModel: Equatable {
         } else {
             activeIndex = min(activeIndex, matches.count - 1)
         }
+        rebuildHighlights()
     }
 
     mutating func next() { step(1) }
@@ -77,25 +107,41 @@ struct ConversationFindModel: Equatable {
         } else {
             activeIndex = (activeIndex + direction + matches.count) % matches.count
         }
+        rebuildHighlights()
     }
 
     mutating func reset() {
         query = ""
         matches = []
         activeIndex = -1
-    }
-
-    func hasMatches(in messageId: String) -> Bool {
-        matches.contains { $0.messageId == messageId }
+        searchableTexts = [:]
+        rebuildHighlights()
     }
 
     /// Nil for unmatched messages so their bubbles keep Equatable identity.
     func highlight(for messageId: String) -> MessageFindHighlight? {
-        guard !query.isEmpty, hasMatches(in: messageId) else { return nil }
-        var activeOrdinal: Int?
-        if let active = activeMatch, active.messageId == messageId {
-            activeOrdinal = matches[..<activeIndex].filter { $0.messageId == messageId }.count
+        highlightsByMessage[messageId]
+    }
+
+    func searchableLength(of messageId: String) -> Int? {
+        searchableTexts[messageId].map { ($0.text as NSString).length }
+    }
+
+    private mutating func rebuildHighlights() {
+        guard !query.isEmpty else {
+            highlightsByMessage = [:]
+            return
         }
-        return MessageFindHighlight(query: query, activeOrdinal: activeOrdinal)
+        var ranges: [String: [Range<Int>]] = [:]
+        var activeOrdinals: [String: Int] = [:]
+        for (index, match) in matches.enumerated() {
+            if index == activeIndex {
+                activeOrdinals[match.messageId] = ranges[match.messageId, default: []].count
+            }
+            ranges[match.messageId, default: []].append(match.range)
+        }
+        highlightsByMessage = Dictionary(uniqueKeysWithValues: ranges.map {
+            ($0.key, MessageFindHighlight(ranges: $0.value, activeOrdinal: activeOrdinals[$0.key]))
+        })
     }
 }

--- a/ios/HiveMobile/Stores/ConversationFind.swift
+++ b/ios/HiveMobile/Stores/ConversationFind.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Offsets are UTF-16 code units within the message content (`NSRange` semantics).
+struct ConversationFindMatch: Equatable {
+    let messageId: String
+    let range: Range<Int>
+}
+
+struct MessageFindHighlight: Equatable {
+    let query: String
+    let activeOrdinal: Int?
+}
+
+struct ConversationFindModel: Equatable {
+    private(set) var query = ""
+    private(set) var matches: [ConversationFindMatch] = []
+    private(set) var activeIndex = -1
+
+    var matchCount: Int { matches.count }
+
+    var activeMatch: ConversationFindMatch? {
+        matches.indices.contains(activeIndex) ? matches[activeIndex] : nil
+    }
+
+    /// Telegram-style counter: the newest (bottom-most) match is "1 of N".
+    var displayIndex: Int {
+        activeIndex >= 0 ? matchCount - activeIndex : 0
+    }
+
+    static func matchRanges(in text: String, query: String) -> [Range<Int>] {
+        guard !query.isEmpty else { return [] }
+        let haystack = text as NSString
+        var ranges: [Range<Int>] = []
+        var from = 0
+        while from < haystack.length {
+            let found = haystack.range(
+                of: query,
+                options: [.caseInsensitive, .diacriticInsensitive],
+                range: NSRange(location: from, length: haystack.length - from)
+            )
+            guard found.location != NSNotFound, found.length > 0 else { break }
+            ranges.append(found.location..<(found.location + found.length))
+            from = found.location + found.length
+        }
+        return ranges
+    }
+
+    /// A query change jumps to the newest match; a content-only change keeps
+    /// the active position (clamped).
+    mutating func update(messages: [(id: String, content: String)], query: String) {
+        let queryChanged = query != self.query
+        self.query = query
+        matches = messages.flatMap { message in
+            Self.matchRanges(in: message.content, query: query).map {
+                ConversationFindMatch(messageId: message.id, range: $0)
+            }
+        }
+        if matches.isEmpty {
+            activeIndex = -1
+        } else if queryChanged || activeIndex < 0 {
+            activeIndex = matches.count - 1
+        } else {
+            activeIndex = min(activeIndex, matches.count - 1)
+        }
+    }
+
+    mutating func next() { step(1) }
+    mutating func previous() { step(-1) }
+
+    private mutating func step(_ direction: Int) {
+        guard !matches.isEmpty else {
+            activeIndex = -1
+            return
+        }
+        if activeIndex < 0 || activeIndex >= matches.count {
+            activeIndex = direction == 1 ? 0 : matches.count - 1
+        } else {
+            activeIndex = (activeIndex + direction + matches.count) % matches.count
+        }
+    }
+
+    mutating func reset() {
+        query = ""
+        matches = []
+        activeIndex = -1
+    }
+
+    func hasMatches(in messageId: String) -> Bool {
+        matches.contains { $0.messageId == messageId }
+    }
+
+    /// Nil for unmatched messages so their bubbles keep Equatable identity.
+    func highlight(for messageId: String) -> MessageFindHighlight? {
+        guard !query.isEmpty, hasMatches(in: messageId) else { return nil }
+        var activeOrdinal: Int?
+        if let active = activeMatch, active.messageId == messageId {
+            activeOrdinal = matches[..<activeIndex].filter { $0.messageId == messageId }.count
+        }
+        return MessageFindHighlight(query: query, activeOrdinal: activeOrdinal)
+    }
+}

--- a/ios/HiveMobile/Theme/DesignTokens.swift
+++ b/ios/HiveMobile/Theme/DesignTokens.swift
@@ -108,6 +108,9 @@ enum WhisperColor {
     static let successMuted  = dynamic(light: rgb(22, 163, 74, alpha: 0.12), dark: rgb(34, 197, 94, alpha: 0.12))
     static let successBorder = dynamic(light: rgb(22, 163, 74, alpha: 0.30), dark: rgb(34, 197, 94, alpha: 0.28))
     static let danger        = dynamic(light: rgb(220, 38, 38), dark: rgb(248, 113, 113))
+    static let findMatch     = dynamic(light: rgb(253, 224, 71, alpha: 0.55), dark: rgb(255, 224, 102))
+    static let findMatchActive = dynamic(light: rgb(251, 146, 60, alpha: 0.85), dark: rgb(255, 152, 56))
+    static let findMatchForeground = dynamic(light: rgb(24, 24, 27), dark: rgb(24, 24, 27))
 
     private static func dynamic(light: UIColor, dark: UIColor) -> Color {
         Color(UIColor { traits in

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -17,6 +17,11 @@ struct ChatView: View {
     @State private var isNearScrollBottom = true
     @State private var isTouchingTranscript = false
     @State private var showQuestionSheet = false
+    @State private var findOpen = false
+    @State private var findQuery = ""
+    @State private var findModel = ConversationFindModel()
+    @State private var transcriptScroller = TranscriptScroller()
+    @FocusState private var findFieldFocused: Bool
 
     @Environment(ModelCatalog.self) private var modelCatalog
     @Environment(ProjectStore.self) private var projectStore
@@ -118,6 +123,7 @@ struct ChatView: View {
                                     pendingToolUseIds: pendingToolUseIds,
                                     dismissedToolCallIds: store.dismissedToolCallIds,
                                     sendState: store.sendState(for: message.id),
+                                    findHighlight: findOpen ? findModel.highlight(for: message.id) : nil,
                                     onRetrySend: { Task { await store.retryOptimisticSend(message.id) } },
                                     onDiscardSend: { store.discardOptimisticSend(message.id) }
                                 )
@@ -172,6 +178,9 @@ struct ChatView: View {
                         TranscriptTouchProbe { touching in
                             isTouchingTranscript = touching
                             store.setStreamingUIHold(touching)
+                            if touching { transcriptScroller.cancelScroll() }
+                        } onCollectionView: { collectionView in
+                            transcriptScroller.collectionView = collectionView
                         }
                     )
                     .onReceive(NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)) { _ in
@@ -197,70 +206,71 @@ struct ChatView: View {
                             scrollToBottomIfNeeded(proxy)
                         }
                     }
+                    .onChange(of: findModel.activeMatch) { _, match in
+                        guard findOpen, let match else { return }
+                        scrollToFindMatch(match, proxy: proxy)
+                    }
                 }
             }
 
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .hiveScreenBackground()
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            VStack(spacing: HiveSpacing.sm) {
-                let tasksState = store.tasksState
-                let goal = store.goalState
-                let agents = store.backgroundAgents
-                if goal != nil || !tasksState.tasks.isEmpty || !agents.agents.isEmpty {
-                    TaskTrackerView(
-                        goal: goal,
-                        tasks: tasksState.tasks,
-                        currentTask: tasksState.currentTask,
-                        counts: tasksState.counts,
-                        trackerStatus: tasksState.trackerStatus,
-                        backgroundAgents: agents.agents,
-                        backgroundRunningCount: agents.runningCount,
-                        isStreaming: store.isStreaming
-                    )
-                }
-                if !store.pendingToolInputs.isEmpty, !showQuestionSheet {
-                    PendingQuestionChip(count: store.pendingToolInputs.count) {
-                        showQuestionSheet = true
-                    }
-                }
-                if let failed = store.failedSend {
-                    FailedSendRow(
-                        failed: failed,
-                        onRetry: { Task { await store.retryFailedSend(for: failed.sessionId) } },
-                        onDiscard: { store.discardFailedSend(for: failed.sessionId) }
-                    )
-                }
-                ChatInputBar(
-                    draft: $draft,
-                    draftAttachments: draftAttachments,
-                    isBusy: store.isBusy,
-                    planModeEnabled: $planModeEnabled,
-                    thinkingLevel: $thinkingLevel,
-                    fastModeEnabled: $fastModeEnabled,
-                    models: modelCatalog.models,
-                    groupedModels: modelCatalog.groupedByProvider,
-                    selectedModelId: selectedModelId,
-                    defaultModelId: modelCatalog.defaultModelId,
-                    lockedProvider: lockedProvider,
-                    capabilities: selectedCapabilities,
-                    onModelSelect: { selectedModelId = $0 },
-                    contextUsage: contextUsage,
-                    onDraftAttachmentsChange: { draftAttachments = $0 },
-                    onSend: sendMessage,
-                    onStop: { Task { _ = await store.send?(.stop(sessionId: session.sessionId)) } }
+        .overlay(alignment: .bottomTrailing) {
+            if findOpen {
+                ConversationFindNavigator(
+                    enabled: findModel.matchCount > 0,
+                    onPrevious: { findModel.previous() },
+                    onNext: { findModel.next() }
                 )
-                .padding(.horizontal, 12)
+                .padding(.trailing, HiveSpacing.lg)
+                .padding(.bottom, HiveSpacing.lg)
+                .transition(.scale(scale: 0.85, anchor: .bottomTrailing).combined(with: .opacity))
             }
-            .padding(.top, HiveSpacing.sm)
-            .padding(.bottom, HiveSpacing.sm)
+        }
+        .overlay(alignment: .bottomLeading) {
+            if findOpen, !findQuery.isEmpty {
+                ConversationFindCounter(
+                    matchCount: findModel.matchCount,
+                    displayIndex: findModel.displayIndex,
+                    noResults: findModel.query == findQuery && findModel.matchCount == 0
+                )
+                .padding(.leading, HiveSpacing.lg)
+                .padding(.bottom, HiveSpacing.lg)
+                .transition(.scale(scale: 0.85, anchor: .bottomLeading).combined(with: .opacity))
+            }
+        }
+        .safeAreaInset(edge: .top, spacing: 0) {
+            if findOpen {
+                ConversationFindBar(
+                    query: $findQuery,
+                    focused: $findFieldFocused,
+                    onSubmit: { findModel.update(messages: findableMessages, query: findQuery) },
+                    onClose: closeFind
+                )
+                .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            if !findOpen {
+                composerStack
+            }
         }
         .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .navigationTitle(navigationTitle)
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button(action: openFind) {
+                    Image(systemName: "magnifyingglass")
+                }
+                .accessibilityLabel("Search in conversation")
+                .disabled(isLoading || store.messages.isEmpty)
+            }
+        }
+        .toolbar(findOpen ? .hidden : .automatic, for: .navigationBar)
         .sensoryFeedback(.success, trigger: store.visibleCompletionCount)
         .sheet(isPresented: $showQuestionSheet) {
             ToolInputSheet(pendingInputs: store.pendingToolInputs) { pending, result in
@@ -279,6 +289,18 @@ struct ChatView: View {
         }
         .task { await setup() }
         .task { await modelCatalog.loadIfNeeded() }
+        .task(id: findQuery) {
+            guard findOpen else { return }
+            try? await Task.sleep(for: .milliseconds(200))
+            if !Task.isCancelled {
+                findModel.update(messages: findableMessages, query: findQuery)
+            }
+        }
+        .onChange(of: store.messages) {
+            if findOpen, !findModel.query.isEmpty {
+                findModel.update(messages: findableMessages, query: findModel.query)
+            }
+        }
         .task(id: isLoading) {
             guard isLoading else {
                 showSkeleton = false
@@ -314,6 +336,111 @@ struct ChatView: View {
             store.onTurnCompleted = nil
             projectStore.statusMonitor.clearViewingSession(workspaceId: workspace.id, sessionId: session.sessionId)
         }
+    }
+
+    // MARK: - Find in Conversation
+
+    private var findableMessages: [(id: String, content: String)] {
+        store.messages.compactMap { message -> (id: String, content: String)? in
+            if message.role == .user && message.content == "Question dismissed." { return nil }
+            if message.role == .assistant && message.cancelled == true { return nil }
+            return (id: message.id, content: message.content)
+        }
+    }
+
+    private func openFind() {
+        withAnimation(.snappy(duration: 0.25)) { findOpen = true }
+        Task {
+            try? await Task.sleep(for: .milliseconds(50))
+            findFieldFocused = true
+        }
+    }
+
+    private func closeFind() {
+        findFieldFocused = false
+        findQuery = ""
+        findModel.reset()
+        withAnimation(.snappy(duration: 0.25)) { findOpen = false }
+    }
+
+    /// Anchor the match's message proportionally to where the match sits in it,
+    /// so a hit deep inside a long message still lands on screen. Prefers the
+    /// UIKit scroller (smooth, distance-scaled animation on the List's backing
+    /// collection view); SwiftUI's animated `scrollTo` stutters on rows whose
+    /// heights are still estimated.
+    private func scrollToFindMatch(_ match: ConversationFindMatch, proxy: ScrollViewProxy) {
+        let displayed = store.messages.filter { !($0.role == .user && $0.content == "Question dismissed.") }
+        guard let row = displayed.firstIndex(where: { $0.id == match.messageId }) else { return }
+
+        let length = max(1, (displayed[row].content as NSString).length)
+        let ratio = min(0.85, max(0.15, Double(match.range.lowerBound) / Double(length)))
+
+        var expectedRows = displayed.count + 1
+        if streamingMessage != nil { expectedRows += 1 }
+        if store.isStreaming { expectedRows += 1 }
+
+        if transcriptScroller.scrollToItem(row, expectedItemCount: expectedRows, anchorRatio: ratio) {
+            return
+        }
+        withAnimation(.easeInOut(duration: 0.25)) {
+            proxy.scrollTo(match.messageId, anchor: UnitPoint(x: 0.5, y: ratio))
+        }
+    }
+
+    // MARK: - Composer
+
+    private var composerStack: some View {
+        VStack(spacing: HiveSpacing.sm) {
+            let tasksState = store.tasksState
+            let goal = store.goalState
+            let agents = store.backgroundAgents
+            if goal != nil || !tasksState.tasks.isEmpty || !agents.agents.isEmpty {
+                TaskTrackerView(
+                    goal: goal,
+                    tasks: tasksState.tasks,
+                    currentTask: tasksState.currentTask,
+                    counts: tasksState.counts,
+                    trackerStatus: tasksState.trackerStatus,
+                    backgroundAgents: agents.agents,
+                    backgroundRunningCount: agents.runningCount,
+                    isStreaming: store.isStreaming
+                )
+            }
+            if !store.pendingToolInputs.isEmpty, !showQuestionSheet {
+                PendingQuestionChip(count: store.pendingToolInputs.count) {
+                    showQuestionSheet = true
+                }
+            }
+            if let failed = store.failedSend {
+                FailedSendRow(
+                    failed: failed,
+                    onRetry: { Task { await store.retryFailedSend(for: failed.sessionId) } },
+                    onDiscard: { store.discardFailedSend(for: failed.sessionId) }
+                )
+            }
+            ChatInputBar(
+                draft: $draft,
+                draftAttachments: draftAttachments,
+                isBusy: store.isBusy,
+                planModeEnabled: $planModeEnabled,
+                thinkingLevel: $thinkingLevel,
+                fastModeEnabled: $fastModeEnabled,
+                models: modelCatalog.models,
+                groupedModels: modelCatalog.groupedByProvider,
+                selectedModelId: selectedModelId,
+                defaultModelId: modelCatalog.defaultModelId,
+                lockedProvider: lockedProvider,
+                capabilities: selectedCapabilities,
+                onModelSelect: { selectedModelId = $0 },
+                contextUsage: contextUsage,
+                onDraftAttachmentsChange: { draftAttachments = $0 },
+                onSend: sendMessage,
+                onStop: { Task { _ = await store.send?(.stop(sessionId: session.sessionId)) } }
+            )
+            .padding(.horizontal, 12)
+        }
+        .padding(.top, HiveSpacing.sm)
+        .padding(.bottom, HiveSpacing.sm)
     }
 
     // MARK: - Streaming Activity
@@ -547,7 +674,7 @@ struct ChatView: View {
     }
 
     private func scrollToBottom(_ proxy: ScrollViewProxy, force: Bool) {
-        guard force || (isNearScrollBottom && !isTouchingTranscript) else { return }
+        guard force || (isNearScrollBottom && !isTouchingTranscript && !findOpen) else { return }
         proxy.scrollTo(bottomAnchorID, anchor: .bottom)
     }
 
@@ -597,21 +724,107 @@ struct ChatView: View {
 /// Reports whether a finger is currently down on the transcript List, via a
 /// zero-duration UIKit long-press attached to the List's UICollectionView
 /// (SwiftUI gestures on a List never fire for stationary touches).
+/// Smooth find-navigation scrolling on the List's backing UICollectionView.
+/// Estimated row heights can drift while the animation runs, so a completion
+/// pass re-measures and settles with a short follow-up animation.
+@MainActor
+final class TranscriptScroller {
+    weak var collectionView: UICollectionView?
+    private var animator: UIViewPropertyAnimator?
+
+    func cancelScroll() {
+        animator?.stopAnimation(true)
+        animator = nil
+    }
+
+    func scrollToItem(_ flatIndex: Int, expectedItemCount: Int, anchorRatio: Double) -> Bool {
+        guard let cv = collectionView,
+              totalItems(in: cv) == expectedItemCount,
+              let indexPath = indexPath(forFlatIndex: flatIndex, in: cv),
+              let target = targetOffset(in: cv, indexPath: indexPath, anchorRatio: anchorRatio)
+        else { return false }
+        cancelScroll()
+        animate(cv, to: target, indexPath: indexPath, anchorRatio: anchorRatio, allowCorrection: true)
+        return true
+    }
+
+    private func totalItems(in cv: UICollectionView) -> Int {
+        (0..<cv.numberOfSections).reduce(0) { $0 + cv.numberOfItems(inSection: $1) }
+    }
+
+    private func indexPath(forFlatIndex flatIndex: Int, in cv: UICollectionView) -> IndexPath? {
+        var remaining = flatIndex
+        for section in 0..<cv.numberOfSections {
+            let count = cv.numberOfItems(inSection: section)
+            if remaining < count { return IndexPath(item: remaining, section: section) }
+            remaining -= count
+        }
+        return nil
+    }
+
+    private func targetOffset(in cv: UICollectionView, indexPath: IndexPath, anchorRatio: Double) -> CGFloat? {
+        guard let attrs = cv.layoutAttributesForItem(at: indexPath) else { return nil }
+        let insets = cv.adjustedContentInset
+        let visibleHeight = cv.bounds.height - insets.top - insets.bottom
+        guard visibleHeight > 0 else { return nil }
+        let anchorInContent = attrs.frame.minY + attrs.frame.height * CGFloat(anchorRatio)
+        let raw = anchorInContent - insets.top - visibleHeight * CGFloat(anchorRatio)
+        let minY = -insets.top
+        let maxY = max(minY, cv.contentSize.height + insets.bottom - cv.bounds.height)
+        return min(max(raw, minY), maxY)
+    }
+
+    private func animate(
+        _ cv: UICollectionView,
+        to target: CGFloat,
+        indexPath: IndexPath,
+        anchorRatio: Double,
+        allowCorrection: Bool
+    ) {
+        let distance = abs(target - cv.contentOffset.y)
+        guard distance > 1 else { return }
+        let duration = min(0.55, 0.3 + Double(distance) / 6000)
+        let animator = UIViewPropertyAnimator(
+            duration: duration,
+            controlPoint1: CGPoint(x: 0.3, y: 0),
+            controlPoint2: CGPoint(x: 0.2, y: 1)
+        )
+        animator.addAnimations {
+            cv.contentOffset = CGPoint(x: cv.contentOffset.x, y: target)
+        }
+        animator.addCompletion { [weak self, weak cv] position in
+            guard position == .end, allowCorrection, let self, let cv else { return }
+            MainActor.assumeIsolated {
+                if let corrected = self.targetOffset(in: cv, indexPath: indexPath, anchorRatio: anchorRatio),
+                   abs(corrected - cv.contentOffset.y) > 24 {
+                    self.animate(cv, to: corrected, indexPath: indexPath, anchorRatio: anchorRatio, allowCorrection: false)
+                }
+            }
+        }
+        self.animator = animator
+        animator.startAnimation()
+    }
+}
+
 private struct TranscriptTouchProbe: UIViewRepresentable {
     let onChange: (Bool) -> Void
+    var onCollectionView: ((UICollectionView) -> Void)? = nil
 
     func makeUIView(context: Context) -> ProbeView {
         let view = ProbeView()
         view.onChange = onChange
+        view.onCollectionView = onCollectionView
         return view
     }
 
     func updateUIView(_ uiView: ProbeView, context: Context) {
         uiView.onChange = onChange
+        uiView.onCollectionView = onCollectionView
     }
 
     final class ProbeView: UIView, UIGestureRecognizerDelegate {
         var onChange: ((Bool) -> Void)?
+        var onCollectionView: ((UICollectionView) -> Void)?
         private weak var attachedTo: UIView?
         private var attachAttemptsRemaining = 0
 
@@ -639,6 +852,7 @@ private struct TranscriptTouchProbe: UIViewRepresentable {
             press.delegate = self
             target.addGestureRecognizer(press)
             attachedTo = target
+            onCollectionView?(target)
         }
 
         private func findCollectionView() -> UICollectionView? {

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -340,11 +340,12 @@ struct ChatView: View {
 
     // MARK: - Find in Conversation
 
-    private var findableMessages: [(id: String, content: String)] {
-        store.messages.compactMap { message -> (id: String, content: String)? in
+    private var findableMessages: [FindableMessage] {
+        store.messages.compactMap { message in
             if message.role == .user && message.content == "Question dismissed." { return nil }
             if message.role == .assistant && message.cancelled == true { return nil }
-            return (id: message.id, content: message.content)
+            return FindableMessage(id: message.id, content: message.content,
+                                   rendersMarkdown: message.role == .assistant)
         }
     }
 
@@ -372,7 +373,7 @@ struct ChatView: View {
         let displayed = store.messages.filter { !($0.role == .user && $0.content == "Question dismissed.") }
         guard let row = displayed.firstIndex(where: { $0.id == match.messageId }) else { return }
 
-        let length = max(1, (displayed[row].content as NSString).length)
+        let length = max(1, findModel.searchableLength(of: match.messageId) ?? 1)
         let ratio = min(0.85, max(0.15, Double(match.range.lowerBound) / Double(length)))
 
         var expectedRows = displayed.count + 1

--- a/ios/HiveMobile/Views/Chat/ConversationFindBar.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationFindBar.swift
@@ -155,30 +155,23 @@ struct ConversationFindNavigator: View {
 
 enum FindHighlighting {
     static func apply(to attributed: NSMutableAttributedString, highlight: MessageFindHighlight) {
-        let ranges = ConversationFindModel.matchRanges(in: attributed.string, query: highlight.query)
-        for (ordinal, range) in ranges.enumerated() {
+        for (ordinal, range) in highlight.ranges.enumerated() {
+            guard range.upperBound <= attributed.length else { continue }
             let isActive = ordinal == highlight.activeOrdinal
-            let nsRange = NSRange(location: range.lowerBound, length: range.count)
             attributed.addAttributes([
                 .backgroundColor: UIColor(isActive ? WhisperColor.findMatchActive : WhisperColor.findMatch),
                 .foregroundColor: UIColor(WhisperColor.findMatchForeground)
-            ], range: nsRange)
+            ], range: NSRange(location: range.lowerBound, length: range.count))
         }
     }
 
     static func apply(to attributed: inout AttributedString, highlight: MessageFindHighlight) {
-        var searchStart = attributed.startIndex
-        var ordinal = 0
-        while searchStart < attributed.endIndex,
-              let range = attributed[searchStart...].range(
-                  of: highlight.query,
-                  options: [.caseInsensitive, .diacriticInsensitive]
-              ) {
+        for (ordinal, range) in highlight.ranges.enumerated() {
+            let nsRange = NSRange(location: range.lowerBound, length: range.count)
+            guard let swiftRange = Range(nsRange, in: attributed) else { continue }
             let isActive = ordinal == highlight.activeOrdinal
-            attributed[range].backgroundColor = isActive ? WhisperColor.findMatchActive : WhisperColor.findMatch
-            attributed[range].foregroundColor = WhisperColor.findMatchForeground
-            searchStart = range.upperBound
-            ordinal += 1
+            attributed[swiftRange].backgroundColor = isActive ? WhisperColor.findMatchActive : WhisperColor.findMatch
+            attributed[swiftRange].foregroundColor = WhisperColor.findMatchForeground
         }
     }
 }

--- a/ios/HiveMobile/Views/Chat/ConversationFindBar.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationFindBar.swift
@@ -1,0 +1,184 @@
+import SwiftUI
+import UIKit
+
+struct ConversationFindBar: View {
+    @Binding var query: String
+    var focused: FocusState<Bool>.Binding
+    let onSubmit: () -> Void
+    let onClose: () -> Void
+
+    var body: some View {
+        HStack(spacing: HiveSpacing.md) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 15, weight: .medium))
+                    .foregroundStyle(WhisperColor.textMuted)
+
+                TextField("Search", text: $query)
+                    .focused(focused)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .submitLabel(.search)
+                    .onSubmit(onSubmit)
+                    .font(.body)
+                    .foregroundStyle(WhisperColor.text)
+
+                if !query.isEmpty {
+                    Button {
+                        query = ""
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 16))
+                            .foregroundStyle(WhisperColor.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Clear search")
+                }
+            }
+            .padding(.horizontal, 14)
+            .frame(height: 44)
+            .glassPill()
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 15, weight: .semibold))
+                    .foregroundStyle(WhisperColor.text)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .glassEffect(.regular.interactive(), in: Circle())
+            .accessibilityLabel("Close search")
+        }
+        .padding(.horizontal, HiveSpacing.lg)
+        .padding(.top, HiveSpacing.xs)
+        .padding(.bottom, HiveSpacing.md)
+        .background {
+            ProgressiveTopBlur()
+                .padding(.bottom, -40)
+                .ignoresSafeArea(edges: .top)
+                .allowsHitTesting(false)
+        }
+    }
+}
+
+/// Approximates Telegram's variable blur above the search bar: stacked
+/// materials whose gradient masks fade out toward the transcript, so content
+/// scrolling underneath blurs more the closer it gets to the top edge.
+private struct ProgressiveTopBlur: View {
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .fill(.ultraThinMaterial)
+                .mask(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white, location: 0),
+                            .init(color: .white, location: 0.55),
+                            .init(color: .clear, location: 1)
+                        ],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+            Rectangle()
+                .fill(.regularMaterial)
+                .mask(
+                    LinearGradient(
+                        stops: [
+                            .init(color: .white, location: 0),
+                            .init(color: .clear, location: 0.55)
+                        ],
+                        startPoint: .top, endPoint: .bottom
+                    )
+                )
+        }
+    }
+}
+
+struct ConversationFindCounter: View {
+    let matchCount: Int
+    let displayIndex: Int
+    let noResults: Bool
+
+    var body: some View {
+        Group {
+            if noResults {
+                Text("No results")
+                    .font(WhisperFont.scaled(14, weight: .medium))
+                    .foregroundStyle(WhisperColor.textSecondary)
+            } else if matchCount > 0 {
+                Text("\(displayIndex) of \(matchCount)")
+                    .font(WhisperFont.scaled(14, weight: .medium))
+                    .foregroundStyle(WhisperColor.text)
+                    .monospacedDigit()
+                    .contentTransition(.numericText())
+                    .animation(.snappy(duration: 0.2), value: displayIndex)
+                    .accessibilityLabel("Match \(displayIndex) of \(matchCount)")
+            }
+        }
+        .padding(.horizontal, 14)
+        .frame(height: 38)
+        .glassPill()
+    }
+}
+
+struct ConversationFindNavigator: View {
+    let enabled: Bool
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+
+    var body: some View {
+        VStack(spacing: 10) {
+            navButton(icon: "chevron.up", label: "Previous match", action: onPrevious)
+            navButton(icon: "chevron.down", label: "Next match", action: onNext)
+        }
+        .opacity(enabled ? 1 : 0.4)
+        .disabled(!enabled)
+    }
+
+    private func navButton(icon: String, label: String, action: @escaping () -> Void) -> some View {
+        Button {
+            action()
+            Haptics.selection()
+        } label: {
+            Image(systemName: icon)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundStyle(enabled ? WhisperColor.text : WhisperColor.textMuted)
+                .frame(width: 44, height: 44)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .glassEffect(.regular.interactive(), in: Circle())
+        .accessibilityLabel(label)
+    }
+}
+
+enum FindHighlighting {
+    static func apply(to attributed: NSMutableAttributedString, highlight: MessageFindHighlight) {
+        let ranges = ConversationFindModel.matchRanges(in: attributed.string, query: highlight.query)
+        for (ordinal, range) in ranges.enumerated() {
+            let isActive = ordinal == highlight.activeOrdinal
+            let nsRange = NSRange(location: range.lowerBound, length: range.count)
+            attributed.addAttributes([
+                .backgroundColor: UIColor(isActive ? WhisperColor.findMatchActive : WhisperColor.findMatch),
+                .foregroundColor: UIColor(WhisperColor.findMatchForeground)
+            ], range: nsRange)
+        }
+    }
+
+    static func apply(to attributed: inout AttributedString, highlight: MessageFindHighlight) {
+        var searchStart = attributed.startIndex
+        var ordinal = 0
+        while searchStart < attributed.endIndex,
+              let range = attributed[searchStart...].range(
+                  of: highlight.query,
+                  options: [.caseInsensitive, .diacriticInsensitive]
+              ) {
+            let isActive = ordinal == highlight.activeOrdinal
+            attributed[range].backgroundColor = isActive ? WhisperColor.findMatchActive : WhisperColor.findMatch
+            attributed[range].foregroundColor = WhisperColor.findMatchForeground
+            searchStart = range.upperBound
+            ordinal += 1
+        }
+    }
+}

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -6,6 +6,7 @@ struct MessageBubble: View, Equatable {
     var pendingToolUseIds: Set<String> = []
     var dismissedToolCallIds: Set<String> = []
     var sendState: ConversationStore.UserSendState? = nil
+    var findHighlight: MessageFindHighlight? = nil
     var onRetrySend: (() -> Void)? = nil
     var onDiscardSend: (() -> Void)? = nil
 
@@ -14,6 +15,7 @@ struct MessageBubble: View, Equatable {
             && lhs.pendingToolUseIds == rhs.pendingToolUseIds
             && lhs.dismissedToolCallIds == rhs.dismissedToolCallIds
             && lhs.sendState == rhs.sendState
+            && lhs.findHighlight == rhs.findHighlight
     }
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
@@ -173,14 +175,17 @@ struct MessageBubble: View, Equatable {
                 if message.id == "streaming" {
                     StreamingMarkdownView(text: message.content, baseSize: markdownBaseSize)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                } else if markdownNeedsRichRenderer(message.content) {
+                } else if findHighlight == nil, markdownNeedsRichRenderer(message.content) {
+                    // MarkdownUI cannot paint arbitrary ranges; while this
+                    // message has find matches it falls back to the selectable
+                    // renderer so highlights stay visible.
                     Markdown(message.content)
                         .markdownTextStyle { FontSize(markdownBaseSize) }
                         .markdownTheme(.whisperChat)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
                 } else {
-                    SelectableMarkdownText(markdown: message.content)
+                    SelectableMarkdownText(markdown: message.content, findHighlight: findHighlight)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
@@ -303,6 +308,10 @@ struct MessageBubble: View, Equatable {
                 result[range].foregroundColor = fgColor
                 atCursor = range.upperBound
             }
+        }
+
+        if let findHighlight {
+            FindHighlighting.apply(to: &result, highlight: findHighlight)
         }
 
         return result

--- a/ios/HiveMobile/Views/Chat/SelectableMarkdownText.swift
+++ b/ios/HiveMobile/Views/Chat/SelectableMarkdownText.swift
@@ -3,6 +3,7 @@ import UIKit
 
 struct SelectableMarkdownText: UIViewRepresentable {
     let markdown: String
+    var findHighlight: MessageFindHighlight? = nil
 
     @Environment(\.colorScheme) private var colorScheme
 
@@ -10,6 +11,8 @@ struct SelectableMarkdownText: UIViewRepresentable {
 
     final class Coordinator {
         var lastMarkdown: String?
+        var lastFindHighlight: MessageFindHighlight?
+        var baseRendered: NSAttributedString?
     }
 
     func makeUIView(context: Context) -> UITextView {
@@ -28,9 +31,23 @@ struct SelectableMarkdownText: UIViewRepresentable {
 
     func updateUIView(_ uiView: UITextView, context: Context) {
         uiView.overrideUserInterfaceStyle = colorScheme == .dark ? .dark : .light
-        guard context.coordinator.lastMarkdown != markdown else { return }
-        context.coordinator.lastMarkdown = markdown
-        uiView.attributedText = renderMarkdown(markdown)
+        let coordinator = context.coordinator
+        guard coordinator.lastMarkdown != markdown || coordinator.lastFindHighlight != findHighlight else {
+            return
+        }
+        if coordinator.lastMarkdown != markdown || coordinator.baseRendered == nil {
+            coordinator.baseRendered = renderMarkdown(markdown)
+            coordinator.lastMarkdown = markdown
+        }
+        coordinator.lastFindHighlight = findHighlight
+        guard let base = coordinator.baseRendered else { return }
+        if let findHighlight {
+            let highlighted = NSMutableAttributedString(attributedString: base)
+            FindHighlighting.apply(to: highlighted, highlight: findHighlight)
+            uiView.attributedText = highlighted
+        } else {
+            uiView.attributedText = base
+        }
     }
 
     func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {

--- a/ios/Package.swift
+++ b/ios/Package.swift
@@ -32,6 +32,7 @@ let package = Package(
                 "Services/HiveHTTP.swift",
                 "Stores/BackgroundAgentDerivation.swift",
                 "Stores/ChatDraftStore.swift",
+                "Stores/ConversationFind.swift",
                 "Stores/ConversationStoreCache.swift",
                 "Stores/ConversationStore.swift",
                 "Stores/GoalDerivation.swift",

--- a/ios/Tests/ChatDraftStoreTests/ConversationFindTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationFindTests.swift
@@ -2,8 +2,10 @@ import XCTest
 @testable import HiveMobileStoresCore
 
 final class ConversationFindTests: XCTestCase {
-    private func messages(_ contents: [String]) -> [(id: String, content: String)] {
-        contents.enumerated().map { (id: "m\($0.offset)", content: $0.element) }
+    private func messages(_ contents: [String]) -> [FindableMessage] {
+        contents.enumerated().map {
+            FindableMessage(id: "m\($0.offset)", content: $0.element, rendersMarkdown: false)
+        }
     }
 
     // MARK: - Matching
@@ -118,13 +120,18 @@ final class ConversationFindTests: XCTestCase {
         var model = ConversationFindModel()
         model.update(messages: messages(["a a", "a a"]), query: "a")
         // Fresh query: active is the newest global match = second occurrence in m1.
-        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: 1))
-        XCTAssertEqual(model.highlight(for: "m0"), MessageFindHighlight(query: "a", activeOrdinal: nil))
+        XCTAssertEqual(model.highlight(for: "m1"),
+                       MessageFindHighlight(ranges: [0..<1, 2..<3], activeOrdinal: 1))
+        XCTAssertEqual(model.highlight(for: "m0"),
+                       MessageFindHighlight(ranges: [0..<1, 2..<3], activeOrdinal: nil))
         model.previous()
-        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: 0))
+        XCTAssertEqual(model.highlight(for: "m1"),
+                       MessageFindHighlight(ranges: [0..<1, 2..<3], activeOrdinal: 0))
         model.previous()
-        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: nil))
-        XCTAssertEqual(model.highlight(for: "m0"), MessageFindHighlight(query: "a", activeOrdinal: 1))
+        XCTAssertEqual(model.highlight(for: "m1"),
+                       MessageFindHighlight(ranges: [0..<1, 2..<3], activeOrdinal: nil))
+        XCTAssertEqual(model.highlight(for: "m0"),
+                       MessageFindHighlight(ranges: [0..<1, 2..<3], activeOrdinal: 1))
     }
 
     func testResetClearsEverything() {
@@ -134,5 +141,40 @@ final class ConversationFindTests: XCTestCase {
         XCTAssertEqual(model.query, "")
         XCTAssertEqual(model.matchCount, 0)
         XCTAssertEqual(model.activeIndex, -1)
+        XCTAssertNil(model.highlight(for: "m0"))
+    }
+
+    // MARK: - Rendered-text matching
+
+    private func markdownMessage(_ content: String) -> [FindableMessage] {
+        [FindableMessage(id: "m0", content: content, rendersMarkdown: true)]
+    }
+
+    func testMarkdownMatchesIgnoreLinkURLs() {
+        var model = ConversationFindModel()
+        model.update(messages: markdownMessage("see [docs](https://example.com/query-hit) now"),
+                     query: "query-hit")
+        XCTAssertEqual(model.matchCount, 0)
+    }
+
+    func testMarkdownMatchOffsetsAreInRenderedText() {
+        var model = ConversationFindModel()
+        model.update(messages: markdownMessage("`foo` bar"), query: "foo")
+        XCTAssertEqual(model.matches.map(\.range), [0..<3])
+    }
+
+    func testMarkdownOrdinalsCountRenderedOccurrencesOnly() {
+        var model = ConversationFindModel()
+        model.update(messages: markdownMessage("foo then [foo](https://foo.example) end"),
+                     query: "foo")
+        XCTAssertEqual(model.matchCount, 2)
+        model.previous()
+        XCTAssertEqual(model.highlight(for: "m0")?.activeOrdinal, 0)
+    }
+
+    func testSearchableTextFallsBackToRawContentWhenNotMarkdown() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["foo then [foo](https://foo.example) end"]), query: "foo")
+        XCTAssertEqual(model.matchCount, 3)
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/ConversationFindTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationFindTests.swift
@@ -1,0 +1,138 @@
+import XCTest
+@testable import HiveMobileStoresCore
+
+final class ConversationFindTests: XCTestCase {
+    private func messages(_ contents: [String]) -> [(id: String, content: String)] {
+        contents.enumerated().map { (id: "m\($0.offset)", content: $0.element) }
+    }
+
+    // MARK: - Matching
+
+    func testMatchRangesFindsAllOccurrencesLeftToRight() {
+        let ranges = ConversationFindModel.matchRanges(in: "abc abc abc", query: "abc")
+        XCTAssertEqual(ranges, [0..<3, 4..<7, 8..<11])
+    }
+
+    func testMatchRangesIsCaseInsensitive() {
+        let ranges = ConversationFindModel.matchRanges(in: "Hello HELLO hello", query: "hello")
+        XCTAssertEqual(ranges.count, 3)
+    }
+
+    func testMatchRangesIsDiacriticInsensitive() {
+        XCTAssertEqual(ConversationFindModel.matchRanges(in: "café", query: "cafe"), [0..<4])
+        XCTAssertEqual(ConversationFindModel.matchRanges(in: "cafe", query: "café"), [0..<4])
+    }
+
+    func testMatchRangesDoesNotOverlap() {
+        XCTAssertEqual(ConversationFindModel.matchRanges(in: "aaaa", query: "aa"), [0..<2, 2..<4])
+    }
+
+    func testMatchRangesEmptyQueryReturnsNothing() {
+        XCTAssertTrue(ConversationFindModel.matchRanges(in: "anything", query: "").isEmpty)
+    }
+
+    func testMatchRangesUsesUTF16Offsets() {
+        // The emoji is 2 UTF-16 code units, so "fix" starts at offset 3.
+        let ranges = ConversationFindModel.matchRanges(in: "🚀 fix", query: "fix")
+        XCTAssertEqual(ranges, [3..<6])
+    }
+
+    // MARK: - Update / ordering
+
+    func testUpdateOrdersMatchesByMessageThenPosition() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["b then b", "nothing", "b"]), query: "b")
+        XCTAssertEqual(model.matches.map(\.messageId), ["m0", "m0", "m2"])
+        XCTAssertEqual(model.matches.map(\.range), [0..<1, 7..<8, 0..<1])
+        // A fresh query activates the newest (bottom-most) match, shown as "1 of N".
+        XCTAssertEqual(model.activeIndex, 2)
+        XCTAssertEqual(model.displayIndex, 1)
+    }
+
+    func testUpdateWithNoMatchesClearsActiveIndex() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["hello"]), query: "zzz")
+        XCTAssertEqual(model.matchCount, 0)
+        XCTAssertEqual(model.activeIndex, -1)
+        XCTAssertNil(model.activeMatch)
+    }
+
+    func testQueryChangeResetsActiveToNewestMatch() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["a a a"]), query: "a")
+        model.previous()
+        XCTAssertEqual(model.activeIndex, 1)
+        model.update(messages: messages(["a a a"]), query: "a ")
+        XCTAssertEqual(model.activeIndex, 1)
+        XCTAssertEqual(model.matchCount, 2)
+        XCTAssertEqual(model.displayIndex, 1)
+    }
+
+    func testContentChangeKeepsActivePositionAndClamps() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["a a a"]), query: "a")
+        model.previous()
+        XCTAssertEqual(model.activeIndex, 1)
+        // Same query, more content: position kept.
+        model.update(messages: messages(["a a a", "a"]), query: "a")
+        XCTAssertEqual(model.activeIndex, 1)
+        // Same query, less content: clamped to the last match.
+        model.update(messages: messages(["a"]), query: "a")
+        XCTAssertEqual(model.activeIndex, 0)
+    }
+
+    // MARK: - Navigation
+
+    func testNextAndPreviousWrapAround() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["x x x"]), query: "x")
+        XCTAssertEqual(model.activeIndex, 2)
+        model.previous()
+        model.previous()
+        XCTAssertEqual(model.activeIndex, 0)
+        model.previous()
+        XCTAssertEqual(model.activeIndex, 2)
+        model.next()
+        XCTAssertEqual(model.activeIndex, 0)
+    }
+
+    func testNavigationWithNoMatchesStaysInactive() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["hello"]), query: "nope")
+        model.next()
+        XCTAssertEqual(model.activeIndex, -1)
+        model.previous()
+        XCTAssertEqual(model.activeIndex, -1)
+    }
+
+    // MARK: - Per-message highlight payload
+
+    func testHighlightIsNilForUnmatchedMessages() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["match here", "nothing"]), query: "match")
+        XCTAssertNotNil(model.highlight(for: "m0"))
+        XCTAssertNil(model.highlight(for: "m1"))
+    }
+
+    func testHighlightCarriesActiveOrdinalWithinMessage() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["a a", "a a"]), query: "a")
+        // Fresh query: active is the newest global match = second occurrence in m1.
+        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: 1))
+        XCTAssertEqual(model.highlight(for: "m0"), MessageFindHighlight(query: "a", activeOrdinal: nil))
+        model.previous()
+        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: 0))
+        model.previous()
+        XCTAssertEqual(model.highlight(for: "m1"), MessageFindHighlight(query: "a", activeOrdinal: nil))
+        XCTAssertEqual(model.highlight(for: "m0"), MessageFindHighlight(query: "a", activeOrdinal: 1))
+    }
+
+    func testResetClearsEverything() {
+        var model = ConversationFindModel()
+        model.update(messages: messages(["a"]), query: "a")
+        model.reset()
+        XCTAssertEqual(model.query, "")
+        XCTAssertEqual(model.matchCount, 0)
+        XCTAssertEqual(model.activeIndex, -1)
+    }
+}


### PR DESCRIPTION
Closes #320.

## What

In-conversation search on iOS, mirroring the Telegram reference approved in the issue: a magnifier at the right of the chat title opens a floating glass search field that replaces the nav bar, with a progressive blur fading the transcript above it. Typing (200ms debounce, no submit step) highlights every match in the transcript; the active match is visually distinct (orange vs yellow, web color parity). A floating "N of M" pill sits bottom-left and two floating chevrons bottom-right jump between occurrences with wrap-around. No "Show as list" (out of scope per the issue).

## How

- **Match model** (`ConversationFind.swift`, in the SPM stores target): pure state over `(messageId, UTF-16 range)` pairs, case- and diacritic-insensitive (`café` ↔ `cafe`), transcript-ordered. Telegram numbering: a fresh query activates the newest (bottom-most) match as "1 of N"; ↑ walks to older matches, content-only updates keep the active position clamped.
- **Search scope**: user + assistant message bodies only — tool calls, thinking content, hidden "Question dismissed." rows and cancelled turns are excluded, per the issue decisions.
- **Highlighting**: `AttributedString` ranges on the user bubble, `NSAttributedString` post-pass in `SelectableMarkdownText` for assistant messages. Only matched messages receive a non-nil highlight payload, so unmatched rows keep their Equatable identity and skip re-rendering (preserves the #318 row work). Messages that need the MarkdownUI rich renderer (tables/images) fall back to the selectable renderer *only while they have matches*, since MarkdownUI cannot paint arbitrary ranges.
- **Smooth match navigation**: `ScrollViewProxy.scrollTo` stutters on Lists with estimated row heights, so a `TranscriptScroller` animates the backing `UICollectionView`'s `contentOffset` directly — distance-scaled duration (0.3–0.55s), proportional anchor so a match deep in a long message lands on screen, a settle-correction pass after estimated heights resolve, and cancellation on touch. Falls back to SwiftUI `scrollTo` if the collection view shape doesn't match.
- **Streaming**: search is a browsing mode — auto-scroll-to-bottom pauses while the bar is open, and the match set reindexes when messages change, keeping the active position (verified live: counter went "6 of 26" → "9 of 29" with no scroll jump while a simulated turn streamed in).

## Testing

- `cd ios && swift test`: 287 tests pass, including 16 new `ConversationFindTests` (ordering, UTF-16 ranges, case/diacritic-insensitivity, wrap-around navigation, active-ordinal payloads, reset).
- Verified end-to-end in the simulator against a mocked backend (REST + WS hub, simulated streaming turn): open/close flow, live highlighting, counter, "No results", cross-message jumps, wrap-around, accent-insensitive matching, dark and light mode, and frame-by-frame analysis of a screen recording to confirm the match-to-match scroll is a continuous eased animation with no single-frame teleports.

## Follow-up: rendered-text match alignment (7fe1693)

A branch review caught a source-vs-rendered mismatch in the original implementation: matches were computed on the raw markdown **source**, while highlights were painted by re-searching the **rendered** text (link URLs stripped, backticks/bold markers removed, list prefixes synthesized). A query intersecting markdown syntax — e.g. `swift` in `[docs](https://docs.swift.org)` — was counted and navigable but invisible once rendered, and the source-derived active ordinal could paint the orange "active" highlight on the wrong occurrence within a message.

Fixed by aligning both sides by construction:

- The model now searches each message's **searchable text** — the exact string the renderer paints (joined `markdownRenderSegments` output for assistant messages, raw content for user messages), cached per message id since markdown parsing is too expensive to redo per keystroke.
- `MessageFindHighlight` carries **explicit UTF-16 ranges** instead of the query; `FindHighlighting` applies them directly (with out-of-bounds skip guards) instead of re-searching, so counter, navigation, and painted highlights can no longer disagree.
- Per-message highlights are precomputed into a dictionary on each update/step instead of scanning all matches per visible row per body evaluation.
- The scroll-anchor ratio now uses the searchable text's length, consistent with the new range offsets.

Testing: `cd ios && swift test` — 287 tests pass, `ConversationFindTests` now has 19 tests including 4 new rendered-text alignment cases (link URLs excluded from matches, offsets in rendered coordinates, ordinals counting rendered occurrences only, raw-content fallback for non-markdown messages). `xcodebuild` (iOS Simulator) build succeeded.
