### PR TITLE
iOS: whole-app audit polish — honest states, accessibility, fluidity, visual consistency

### DIFF
--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -92,7 +92,7 @@ struct AccountUser: Codable {
 
 // MARK: - Project & Workspace
 
-struct Project: Codable, Identifiable {
+struct Project: Codable, Identifiable, Equatable {
     let id: String
     let name: String
     let url: String?
@@ -119,13 +119,13 @@ struct Workspace: Codable, Identifiable, Hashable {
 
 // MARK: - UI Preferences
 
-struct SidebarProjectFolder: Codable, Identifiable {
+struct SidebarProjectFolder: Codable, Identifiable, Equatable {
     let id: String
     let name: String
     let projectIds: [String]
 }
 
-struct SidebarProjectFoldersState: Codable {
+struct SidebarProjectFoldersState: Codable, Equatable {
     let folders: [SidebarProjectFolder]
     let folderOpenState: [String: Bool]
 

--- a/ios/HiveMobile/Stores/ComposerAutocomplete.swift
+++ b/ios/HiveMobile/Stores/ComposerAutocomplete.swift
@@ -62,30 +62,51 @@ enum ComposerAutocomplete {
         var id: String { path }
     }
 
+    /// Precomputed lowercased forms for a repository path so per-keystroke
+    /// matching avoids re-lowercasing every candidate.
+    struct FileCandidate {
+        let path: String
+        let basename: String
+        let lowerName: String
+        let lowerPath: String
+    }
+
+    static func prepareFiles(_ files: [String]) -> [FileCandidate] {
+        files.map { path in
+            let name = basename(of: path)
+            return FileCandidate(
+                path: path,
+                basename: name,
+                lowerName: name.lowercased(),
+                lowerPath: path.lowercased()
+            )
+        }
+    }
+
     /// Tiered fuzzy match over repository paths: basename exact > basename
     /// prefix > basename substring > path substring > path subsequence, ties
     /// broken by shorter path. Empty query lists the first files as-is.
     static func matchFiles(_ files: [String], query: String, limit: Int = 15) -> [FileMatch] {
+        matchFiles(prepareFiles(files), query: query, limit: limit)
+    }
+
+    static func matchFiles(_ candidates: [FileCandidate], query: String, limit: Int = 15) -> [FileMatch] {
         if query.isEmpty {
-            return files.prefix(limit).map { FileMatch(path: $0, basename: basename(of: $0)) }
+            return candidates.prefix(limit).map { FileMatch(path: $0.path, basename: $0.basename) }
         }
 
         let q = query.lowercased()
         var scored: [(match: FileMatch, score: Int)] = []
-        for path in files {
-            let name = basename(of: path)
-            let lowerName = name.lowercased()
-            let lowerPath = path.lowercased()
-
+        for candidate in candidates {
             let score: Int
-            if lowerName == q { score = 100 }
-            else if lowerName.hasPrefix(q) { score = 80 }
-            else if lowerName.contains(q) { score = 60 }
-            else if lowerPath.contains(q) { score = 40 }
-            else if isSubsequence(q, of: lowerPath) { score = 20 }
+            if candidate.lowerName == q { score = 100 }
+            else if candidate.lowerName.hasPrefix(q) { score = 80 }
+            else if candidate.lowerName.contains(q) { score = 60 }
+            else if candidate.lowerPath.contains(q) { score = 40 }
+            else if isSubsequence(q, of: candidate.lowerPath) { score = 20 }
             else { continue }
 
-            scored.append((FileMatch(path: path, basename: name), score))
+            scored.append((FileMatch(path: candidate.path, basename: candidate.basename), score))
         }
 
         return scored

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -123,6 +123,7 @@ final class ConversationStore {
     private(set) var goalState: GoalState?
     private(set) var backgroundAgents: BackgroundAgentsState = .empty
     private(set) var dismissedToolCallIds: Set<String> = []
+    private(set) var historyLoadFailedSessionIds: Set<String> = []
     @ObservationIgnored private(set) var derivationRunCount = 0
     @ObservationIgnored private(set) var historyDerivationRunCount = 0
 
@@ -693,6 +694,7 @@ final class ConversationStore {
     func removeSessionState(_ removedSessionId: String, fallbackSessionId: String?) {
         sessionStreams.removeValue(forKey: removedSessionId)
         historyTokenBySession.removeValue(forKey: removedSessionId)
+        historyLoadFailedSessionIds.remove(removedSessionId)
         messagesBySession.removeValue(forKey: removedSessionId)
         serverHistory.removeValue(forKey: removedSessionId)
         lastHistoryFetchAt.removeValue(forKey: removedSessionId)
@@ -887,13 +889,22 @@ final class ConversationStore {
             let msgs = try await fetch(since)
             guard self.sessionId == sessionId,
                   historyToken(for: sessionId) == requestToken else { return }
+            historyLoadFailedSessionIds.remove(sessionId)
             if since != nil {
                 applyIncrementalHistory(msgs, for: sessionId)
             } else {
                 applyFetchedHistory(msgs, for: sessionId)
             }
+        } catch is CancellationError {
         } catch {
+            guard historyToken(for: sessionId) == requestToken else { return }
+            historyLoadFailedSessionIds.insert(sessionId)
         }
+    }
+
+    func historyLoadFailed(for sessionId: String?) -> Bool {
+        guard let sessionId else { return false }
+        return historyLoadFailedSessionIds.contains(sessionId)
     }
 
     func handleMemoryWarning() {

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -111,15 +111,13 @@ final class ProjectStore {
         }
     }
 
-    @discardableResult
-    func createProject(url: String) async -> Bool {
+    func createProject(url: String) async -> String? {
         await createProjectWithWorkspace(displayName: Self.extractRepoName(from: url)) {
             try await api.createProject(url: url)
         }
     }
 
-    @discardableResult
-    func createNewProject(name: String, visibility: String?) async -> Bool {
+    func createNewProject(name: String, visibility: String?) async -> String? {
         await createProjectWithWorkspace(displayName: name) {
             try await api.createNewProject(name: name, visibility: visibility)
         }
@@ -128,8 +126,8 @@ final class ProjectStore {
     private func createProjectWithWorkspace(
         displayName: String,
         apiCall: () async throws -> Project
-    ) async -> Bool {
-        guard !isCreatingProject else { return false }
+    ) async -> String? {
+        guard !isCreatingProject else { return "A project is already being created." }
 
         isCreatingProject = true
         cloningRepoName = displayName
@@ -162,16 +160,15 @@ final class ProjectStore {
             pendingNavigation = workspace
             cloningRepoName = nil
             isCreatingProject = false
-            return true
+            return nil
         } catch is CancellationError {
             cloningRepoName = nil
             isCreatingProject = false
-            return false
+            return nil
         } catch {
-            errorMessage = error.localizedDescription
             cloningRepoName = nil
             isCreatingProject = false
-            return false
+            return error.localizedDescription
         }
     }
 

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -111,13 +111,15 @@ final class ProjectStore {
         }
     }
 
-    func createProject(url: String) async {
+    @discardableResult
+    func createProject(url: String) async -> Bool {
         await createProjectWithWorkspace(displayName: Self.extractRepoName(from: url)) {
             try await api.createProject(url: url)
         }
     }
 
-    func createNewProject(name: String, visibility: String?) async {
+    @discardableResult
+    func createNewProject(name: String, visibility: String?) async -> Bool {
         await createProjectWithWorkspace(displayName: name) {
             try await api.createNewProject(name: name, visibility: visibility)
         }
@@ -126,8 +128,8 @@ final class ProjectStore {
     private func createProjectWithWorkspace(
         displayName: String,
         apiCall: () async throws -> Project
-    ) async {
-        guard !isCreatingProject else { return }
+    ) async -> Bool {
+        guard !isCreatingProject else { return false }
 
         isCreatingProject = true
         cloningRepoName = displayName
@@ -158,14 +160,19 @@ final class ProjectStore {
 
             syncMonitoredWorkspaces()
             pendingNavigation = workspace
+            cloningRepoName = nil
+            isCreatingProject = false
+            return true
         } catch is CancellationError {
-            // Ignore
+            cloningRepoName = nil
+            isCreatingProject = false
+            return false
         } catch {
             errorMessage = error.localizedDescription
+            cloningRepoName = nil
+            isCreatingProject = false
+            return false
         }
-
-        cloningRepoName = nil
-        isCreatingProject = false
     }
 
     func archiveWorkspace(id: String) async {

--- a/ios/HiveMobile/Theme/DesignTokens.swift
+++ b/ios/HiveMobile/Theme/DesignTokens.swift
@@ -108,6 +108,8 @@ enum WhisperColor {
     static let successMuted  = dynamic(light: rgb(22, 163, 74, alpha: 0.12), dark: rgb(34, 197, 94, alpha: 0.12))
     static let successBorder = dynamic(light: rgb(22, 163, 74, alpha: 0.30), dark: rgb(34, 197, 94, alpha: 0.28))
     static let danger        = dynamic(light: rgb(220, 38, 38), dark: rgb(248, 113, 113))
+    static let diffAdded     = success
+    static let diffRemoved   = danger
     static let findMatch     = dynamic(light: rgb(253, 224, 71, alpha: 0.55), dark: rgb(255, 224, 102))
     static let findMatchActive = dynamic(light: rgb(251, 146, 60, alpha: 0.85), dark: rgb(255, 152, 56))
     static let findMatchForeground = dynamic(light: rgb(24, 24, 27), dark: rgb(24, 24, 27))

--- a/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
+++ b/ios/HiveMobile/Views/Brain/BrainConversationsView.swift
@@ -11,6 +11,7 @@ struct BrainConversationsView: View {
     @Environment(ProjectStore.self) private var projectStore
 
     @State private var brainState: BrainState?
+    @State private var stateLoadFailed = false
     @State private var brainStatus: BrainStatusResponse?
     @State private var brainDiff: BrainDiffResponse?
     @State private var statusLoading = true
@@ -56,7 +57,9 @@ struct BrainConversationsView: View {
 
     var body: some View {
         Group {
-            if brainState == nil {
+            if stateLoadFailed && brainState == nil {
+                errorState
+            } else if brainState == nil {
                 loadingPlaceholder
             } else if brainState?.exists == false {
                 emptyState
@@ -117,6 +120,21 @@ struct BrainConversationsView: View {
             .navigationBarTitleDisplayMode(.inline)
     }
 
+    private var errorState: some View {
+        ContentUnavailableView {
+            Label("Couldn't reach the Brain", systemImage: "exclamationmark.triangle")
+        } description: {
+            Text("Check your connection and try again.")
+        } actions: {
+            Button("Retry") { Task { await loadState() } }
+                .buttonStyle(.borderedProminent)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .hiveScreenBackground()
+        .navigationTitle("Brain")
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
     private var emptyState: some View {
         VStack(spacing: HiveSpacing.md) {
             Image(systemName: "brain")
@@ -140,11 +158,11 @@ struct BrainConversationsView: View {
     private func loadState() async {
         do {
             brainState = try await api.fetchBrain()
+            stateLoadFailed = false
         } catch is CancellationError {
             // View disappeared.
         } catch {
-            // Degrade to the empty state if the Brain state can't be fetched.
-            brainState = BrainState(exists: false, repoUrl: nil, createdAt: nil, lastSyncedAt: nil)
+            stateLoadFailed = true
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
+++ b/ios/HiveMobile/Views/Chat/ChatActivityChrome.swift
@@ -73,11 +73,11 @@ struct ChatActivityRowLabel: View {
                     HStack(spacing: 4) {
                         if stats.added > 0 {
                             Text("+\(stats.added)")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(WhisperColor.diffAdded)
                         }
                         if stats.removed > 0 {
                             Text("-\(stats.removed)")
-                                .foregroundStyle(.red)
+                                .foregroundStyle(WhisperColor.diffRemoved)
                         }
                     }
                     .font(WhisperFont.mono(10))

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -330,7 +330,7 @@ struct ChatInputBar: View {
         guard normalized != current else { return }
 
         let restored: [AttachedImage] = attachments.compactMap { attachment in
-            guard attachment.decodedImage != nil else { return nil }
+            guard attachment.hasDecodableImagePayload else { return nil }
             return AttachedImage(attachment: attachment)
         }
         attachedImages = restored + attachedImages.filter { $0.attachment == nil }
@@ -560,15 +560,14 @@ private extension ImageAttachment {
         )
     }
 
-    var decodedImage: UIImage? {
+    var hasDecodableImagePayload: Bool {
         let payload: String
         if let commaIndex = dataUrl.firstIndex(of: ",") {
             payload = String(dataUrl[dataUrl.index(after: commaIndex)...])
         } else {
             payload = dataUrl
         }
-        guard let data = Data(base64Encoded: payload) else { return nil }
-        return UIImage(data: data)
+        return Data(base64Encoded: payload) != nil
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -21,6 +21,7 @@ struct ChatInputBar: View {
     var onStop: (() -> Void)?
 
     @AppStorage("hiveAccent") private var accentId = AccentOption.defaultId
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var attachedImages: [AttachedImage] = []
     @State private var selectedItems: [PhotosPickerItem] = []
     @State private var showAttachmentError = false
@@ -164,7 +165,7 @@ struct ChatInputBar: View {
             HStack(spacing: 8) {
                 ForEach(attachedImages) { item in
                     AttachmentChip(source: item.attachment?.dataUrl, pending: item.attachment == nil) {
-                        withAnimation(.spring(duration: 0.25)) {
+                        animateAttachment {
                             attachedImages.removeAll { $0.id == item.id }
                         }
                         onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
@@ -214,8 +215,9 @@ struct ChatInputBar: View {
                 Image(systemName: "plus")
                     .font(.system(size: 16, weight: .medium))
                     .foregroundStyle(WhisperColor.textSecondary)
-                    .frame(width: 32, height: 32)
+                    .frame(width: 44, height: 44)
             }
+            .accessibilityLabel("Attach image")
 
             TextField("Message", text: $draft, axis: .vertical)
                 .lineLimit(1...10)
@@ -228,8 +230,11 @@ struct ChatInputBar: View {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 28))
                     .foregroundStyle(canSend ? WhisperColor.text : WhisperColor.textMuted)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .disabled(!canSend)
+            .accessibilityLabel("Send message")
 
             if isBusy {
                 Button {
@@ -239,7 +244,10 @@ struct ChatInputBar: View {
                     Image(systemName: "stop.circle.fill")
                         .font(.system(size: 28))
                         .foregroundStyle(.red)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
                 }
+                .accessibilityLabel("Stop response")
             }
         }
         .padding(.horizontal, 16)
@@ -267,6 +275,10 @@ struct ChatInputBar: View {
         return hasContent && !hasPending && !isBusy
     }
 
+    private func animateAttachment(_ body: () -> Void) {
+        if reduceMotion { body() } else { withAnimation(.spring(duration: 0.25), body) }
+    }
+
     private func handleSend() {
         Haptics.impact(.light)
         let imageAttachments = attachedImages.compactMap(\.attachment)
@@ -281,7 +293,7 @@ struct ChatInputBar: View {
         showAttachmentError = false
         for item in items {
             let pending = AttachedImage(attachment: nil)
-            withAnimation(.spring(duration: 0.25)) {
+            animateAttachment {
                 attachedImages.append(pending)
             }
             item.loadTransferable(type: Data.self) { result in
@@ -294,7 +306,7 @@ struct ChatInputBar: View {
                             $0.id != pending.id && $0.attachment?.dataUrl == attachment.dataUrl
                         }
                         if isDuplicate {
-                            withAnimation(.spring(duration: 0.25)) {
+                            animateAttachment {
                                 attachedImages.removeAll { $0.id == pending.id }
                             }
                         } else {
@@ -302,7 +314,7 @@ struct ChatInputBar: View {
                             onDraftAttachmentsChange(attachedImages.compactMap(\.attachment))
                         }
                     } else {
-                        withAnimation(.spring(duration: 0.25)) {
+                        animateAttachment {
                             attachedImages.remove(at: index)
                             showAttachmentError = true
                         }

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -109,7 +109,21 @@ struct ChatView: View {
                 }
             } else if store.messages.isEmpty && streamingMessage == nil && !store.isStreaming {
                 Spacer()
-                if isBrainWorkspaceId(workspace.id) {
+                if store.historyLoadFailed(for: session.sessionId) {
+                    VStack(spacing: 12) {
+                        Text("Couldn't load this conversation")
+                            .font(WhisperFont.scaled(14))
+                            .foregroundStyle(WhisperColor.textSecondary)
+                        Button {
+                            Task { await loadMessages() }
+                        } label: {
+                            Label("Retry", systemImage: "arrow.clockwise")
+                                .font(WhisperFont.scaled(13).weight(.semibold))
+                        }
+                        .buttonStyle(.plain)
+                        .foregroundStyle(WhisperColor.danger)
+                    }
+                } else if isBrainWorkspaceId(workspace.id) {
                     BrainSessionEmptyState()
                 } else {
                     SessionEmptyState(

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -27,6 +27,7 @@ struct ChatView: View {
     @State private var activeAutocomplete: ComposerAutocomplete.Active?
     @State private var draftFileMentions: [FileMention] = []
     @State private var completionFiles: [String]?
+    @State private var preparedFileCandidates: [ComposerAutocomplete.FileCandidate]?
     @State private var completionItems: [CompletionItem]?
     @State private var completionItemsProvider: String?
 
@@ -348,6 +349,7 @@ struct ChatView: View {
         .onChange(of: store.diffStats) {
             guard completionFiles != nil else { return }
             completionFiles = nil
+            preparedFileCandidates = nil
             if activeAutocomplete?.trigger == .file {
                 loadFileCompletionsIfNeeded()
             }
@@ -600,8 +602,8 @@ struct ChatView: View {
         guard let active = activeAutocomplete else { return [] }
         switch active.trigger {
         case .file:
-            guard let files = completionFiles else { return [] }
-            return ComposerAutocomplete.matchFiles(files, query: active.query).map { .file($0) }
+            guard let candidates = preparedFileCandidates else { return [] }
+            return ComposerAutocomplete.matchFiles(candidates, query: active.query).map { .file($0) }
         case .command, .agent:
             guard let items = completionItems else { return [] }
             let type = active.trigger == .command ? "slash_command" : "agent"
@@ -629,12 +631,18 @@ struct ChatView: View {
     private func loadFileCompletionsIfNeeded() {
         guard completionFiles == nil else { return }
         completionFiles = []
+        preparedFileCandidates = []
         Task {
             guard let files = try? await api.fetchFileCompletions(workspaceId: workspace.id) else {
                 completionFiles = nil
+                preparedFileCandidates = nil
                 return
             }
-            withAnimation(.snappy(duration: 0.22)) { completionFiles = files }
+            let prepared = ComposerAutocomplete.prepareFiles(files)
+            withAnimation(.snappy(duration: 0.22)) {
+                completionFiles = files
+                preparedFileCandidates = prepared
+            }
         }
     }
 

--- a/ios/HiveMobile/Views/Chat/ContextRingView.swift
+++ b/ios/HiveMobile/Views/Chat/ContextRingView.swift
@@ -68,7 +68,9 @@ struct ContextRingView: View {
             }
             .frame(width: 16, height: 16)
             .animation(.easeInOut(duration: 0.3), value: fraction)
-            .help(tooltipText)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Context usage")
+            .accessibilityValue(tooltipText)
         }
     }
 }

--- a/ios/HiveMobile/Views/Chat/ConversationRow.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationRow.swift
@@ -2,8 +2,15 @@ import SwiftUI
 
 struct ConversationRow: View {
     let session: SessionMetadata
-    let isStreaming: Bool
-    let isUnread: Bool
+    let monitor: HubStatusMonitor
+    let workspaceId: String
+
+    private var isStreaming: Bool {
+        monitor.isStreaming(workspaceId: workspaceId, sessionId: session.sessionId)
+    }
+    private var isUnread: Bool {
+        monitor.isUnread(workspaceId: workspaceId, sessionId: session.sessionId)
+    }
 
     private var title: String { session.displayTitle }
 
@@ -147,6 +154,7 @@ private struct SessionStatusIndicator: View {
 }
 
 #Preview {
+    let store = ProjectStore(storeCache: ConversationStoreCache())
     List {
         ConversationRow(
             session: SessionMetadata(
@@ -160,8 +168,8 @@ private struct SessionStatusIndicator: View {
                 messageCount: 5,
                 lockedProvider: "claude"
             ),
-            isStreaming: true,
-            isUnread: false
+            monitor: store.statusMonitor,
+            workspaceId: "ws1"
         )
         .listRowBackground(WhisperColor.appBackground)
         .listRowInsets(EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0))

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -138,14 +138,8 @@ struct ConversationsSection<Header: View>: View {
                 } label: {
                     ConversationRow(
                         session: session,
-                        isStreaming: projectStore.statusMonitor.isStreaming(
-                            workspaceId: workspace.id,
-                            sessionId: session.sessionId
-                        ),
-                        isUnread: projectStore.statusMonitor.isUnread(
-                            workspaceId: workspace.id,
-                            sessionId: session.sessionId
-                        )
+                        monitor: projectStore.statusMonitor,
+                        workspaceId: workspace.id
                     )
                 }
                 .buttonStyle(.plain)

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -39,6 +39,7 @@ struct ConversationsSection<Header: View>: View {
     @State private var isLoading = true
     @State private var isCreatingSession = false
     @State private var errorMessage: String?
+    @State private var actionErrorMessage: String?
     @State private var sessionToDelete: SessionMetadata?
     @State private var lastRefreshAt = Date.distantPast
 
@@ -91,6 +92,16 @@ struct ConversationsSection<Header: View>: View {
         } message: {
             if let errorMessage {
                 Text(errorMessage)
+            }
+        }
+        .alert(labels.errorTitle, isPresented: Binding(
+            get: { actionErrorMessage != nil },
+            set: { if !$0 { actionErrorMessage = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            if let actionErrorMessage {
+                Text(actionErrorMessage)
             }
         }
         .alert(
@@ -242,7 +253,7 @@ struct ConversationsSection<Header: View>: View {
             } catch is CancellationError {
                 // View disappeared.
             } catch {
-                errorMessage = error.localizedDescription
+                actionErrorMessage = error.localizedDescription
             }
         }
     }
@@ -263,7 +274,7 @@ struct ConversationsSection<Header: View>: View {
             if outcome.deleted {
                 sessions.removeAll { $0.sessionId == session.sessionId }
             }
-            errorMessage = outcome.errorMessage
+            actionErrorMessage = outcome.errorMessage
         }
     }
 }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -84,7 +84,7 @@ struct ConversationsSection<Header: View>: View {
             }
         }
         .alert(labels.errorTitle, isPresented: Binding(
-            get: { errorMessage != nil },
+            get: { errorMessage != nil && !sessions.isEmpty },
             set: { if !$0 { errorMessage = nil } }
         )) {
             Button("OK", role: .cancel) {}
@@ -168,6 +168,15 @@ struct ConversationsSection<Header: View>: View {
         .overlay {
             if isLoading, sessions.isEmpty {
                 ListLoadingSkeleton()
+            } else if let errorMessage, sessions.isEmpty {
+                ContentUnavailableView {
+                    Label("Couldn't load conversations", systemImage: "exclamationmark.triangle")
+                } description: {
+                    Text(errorMessage)
+                } actions: {
+                    Button("Retry") { Task { await refreshContent(force: true) } }
+                        .buttonStyle(.borderedProminent)
+                }
             } else if !isLoading, sessions.isEmpty {
                 VStack(spacing: HiveSpacing.sm) {
                     Text(labels.emptyTitle)
@@ -177,6 +186,11 @@ struct ConversationsSection<Header: View>: View {
                         .font(.subheadline)
                         .foregroundStyle(WhisperColor.textSecondary)
                         .multilineTextAlignment(.center)
+                    Button("New conversation") {
+                        createSession()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(sessions.count >= maxSessions || isCreatingSession)
                 }
                 .padding(.horizontal, HiveSpacing.xl)
             }

--- a/ios/HiveMobile/Views/Chat/DiffRendering.swift
+++ b/ios/HiveMobile/Views/Chat/DiffRendering.swift
@@ -53,8 +53,8 @@ struct DiffLinesView: View {
     private func backgroundColor(_ kind: DiffLine.Kind) -> Color {
         switch kind {
         case .context: .clear
-        case .added: Color.green.opacity(0.12)
-        case .removed: Color.red.opacity(0.12)
+        case .added: WhisperColor.diffAdded.opacity(0.12)
+        case .removed: WhisperColor.diffRemoved.opacity(0.12)
         case .hunk: .clear
         }
     }

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -263,6 +263,7 @@ struct MessageBubble: View, Equatable {
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
+                    .accessibilityLabel(copied ? "Copied" : "Copy message")
                 }
             }
         }

--- a/ios/HiveMobile/Views/Chat/WorkspaceDiffViews.swift
+++ b/ios/HiveMobile/Views/Chat/WorkspaceDiffViews.swift
@@ -98,11 +98,11 @@ private struct ChangedFileRow: View {
             Spacer(minLength: 8)
             if file.additions > 0 {
                 Text("+\(file.additions)")
-                    .foregroundStyle(.green)
+                    .foregroundStyle(WhisperColor.diffAdded)
             }
             if file.deletions > 0 {
                 Text("-\(file.deletions)")
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WhisperColor.diffRemoved)
             }
             Image(systemName: "chevron.right")
                 .font(.caption2.weight(.semibold))
@@ -362,10 +362,10 @@ struct WorkspaceFileDiffView: View {
                     .truncationMode(.middle)
                 Spacer(minLength: 8)
                 if parsed.added > 0 {
-                    Text("+\(parsed.added)").foregroundStyle(.green)
+                    Text("+\(parsed.added)").foregroundStyle(WhisperColor.diffAdded)
                 }
                 if parsed.removed > 0 {
-                    Text("-\(parsed.removed)").foregroundStyle(.red)
+                    Text("-\(parsed.removed)").foregroundStyle(WhisperColor.diffRemoved)
                 }
             }
             .font(WhisperFont.mono(11))

--- a/ios/HiveMobile/Views/Chat/WorkspaceDiffViews.swift
+++ b/ios/HiveMobile/Views/Chat/WorkspaceDiffViews.swift
@@ -539,16 +539,20 @@ private struct ReviewSummaryBar: View {
                 Image(systemName: "chevron.up")
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(WhisperColor.textSecondary)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Previous comment")
             Button { onJump(1) } label: {
                 Image(systemName: "chevron.down")
                     .font(.footnote.weight(.semibold))
                     .foregroundStyle(WhisperColor.textSecondary)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Next comment")
             Spacer()
             Button("Send review", action: onSend)
                 .font(WhisperFont.scaled(13, weight: .semibold))

--- a/ios/HiveMobile/Views/Components/StatusDot.swift
+++ b/ios/HiveMobile/Views/Components/StatusDot.swift
@@ -14,6 +14,7 @@ struct UnreadDot: View {
     let size: CGFloat
     let shadowRadius: CGFloat
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var appeared = false
     private let color = Color.accentColor
 
@@ -30,8 +31,12 @@ struct UnreadDot: View {
             .scaleEffect(appeared ? 1.0 : 0.3)
             .opacity(appeared ? 1.0 : 0.0)
             .onAppear {
-                withAnimation(.spring(duration: 0.4, bounce: 0.3)) {
+                if reduceMotion {
                     appeared = true
+                } else {
+                    withAnimation(.spring(duration: 0.4, bounce: 0.3)) {
+                        appeared = true
+                    }
                 }
             }
     }

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -8,8 +8,8 @@ enum AddProjectMode: String, CaseIterable {
 struct AddProjectSheet: View {
     @Environment(\.dismiss) private var dismiss
     let api: APIClient
-    let onClone: (String) async -> Bool
-    let onCreate: (_ name: String, _ visibility: String?) async -> Bool
+    let onClone: (String) async -> String?
+    let onCreate: (_ name: String, _ visibility: String?) async -> String?
 
     @State private var mode: AddProjectMode = .clone
 
@@ -98,6 +98,7 @@ struct AddProjectSheet: View {
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
+        .interactiveDismissDisabled(isSubmitting)
         .onChange(of: mode) { _, newMode in
             if newMode == .create && accountStatus == nil {
                 checkAccountStatus()
@@ -189,19 +190,19 @@ struct AddProjectSheet: View {
         isSubmitting = true
         submitError = nil
         Task {
-            let ok: Bool
+            let error: String?
             switch mode {
             case .clone:
-                ok = await onClone(url.trimmingCharacters(in: .whitespacesAndNewlines))
+                error = await onClone(url.trimmingCharacters(in: .whitespacesAndNewlines))
             case .create:
                 let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                ok = await onCreate(trimmed, ghConnected ? visibility : nil)
+                error = await onCreate(trimmed, ghConnected ? visibility : nil)
             }
             isSubmitting = false
-            if ok {
-                dismiss()
+            if let error {
+                submitError = error
             } else {
-                submitError = "Couldn't add the project. Check the URL and your connection, then try again."
+                dismiss()
             }
         }
     }
@@ -231,7 +232,7 @@ struct AddProjectSheet: View {
 #Preview {
     Text("Hub")
         .sheet(isPresented: .constant(true)) {
-            AddProjectSheet(api: APIClient(), onClone: { _ in true }, onCreate: { _, _ in true })
+            AddProjectSheet(api: APIClient(), onClone: { _ in nil }, onCreate: { _, _ in nil })
         }
         .preferredColorScheme(.dark)
 }

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -8,8 +8,8 @@ enum AddProjectMode: String, CaseIterable {
 struct AddProjectSheet: View {
     @Environment(\.dismiss) private var dismiss
     let api: APIClient
-    let onClone: (String) -> Void
-    let onCreate: (_ name: String, _ visibility: String?) -> Void
+    let onClone: (String) async -> Bool
+    let onCreate: (_ name: String, _ visibility: String?) async -> Bool
 
     @State private var mode: AddProjectMode = .clone
 
@@ -21,6 +21,9 @@ struct AddProjectSheet: View {
     @State private var visibility = "private"
     @State private var accountStatus: AccountStatusResponse?
     @State private var loadingAccount = false
+
+    @State private var isSubmitting = false
+    @State private var submitError: String?
 
     private var ghConnected: Bool {
         accountStatus?.authenticated == true
@@ -45,19 +48,41 @@ struct AddProjectSheet: View {
                     }
                 }
                 .pickerStyle(.segmented)
+                .disabled(isSubmitting)
 
-                if mode == .clone {
-                    cloneForm
-                } else {
-                    createForm
+                Group {
+                    if mode == .clone {
+                        cloneForm
+                    } else {
+                        createForm
+                    }
                 }
+                .disabled(isSubmitting)
 
                 Spacer()
 
-                Button(mode == .clone ? "Add Project" : "Create Project") { submit() }
-                    .buttonStyle(.glassProminent)
-                    .disabled(!canSubmit)
-                    .frame(maxWidth: .infinity)
+                if let submitError {
+                    Text(submitError)
+                        .font(.footnote)
+                        .foregroundStyle(WhisperColor.danger)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
+                Button {
+                    submit()
+                } label: {
+                    if isSubmitting {
+                        ProgressView()
+                            .controlSize(.small)
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text(mode == .clone ? "Add Project" : "Create Project")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.glassProminent)
+                .disabled(!canSubmit || isSubmitting)
+                .frame(maxWidth: .infinity)
             }
             .padding()
             .hiveScreenBackground()
@@ -160,17 +185,25 @@ struct AddProjectSheet: View {
     // MARK: - Actions
 
     private func submit() {
-        switch mode {
-        case .clone:
-            let trimmed = url.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !trimmed.isEmpty else { return }
-            onClone(trimmed)
-        case .create:
-            let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            guard !trimmed.isEmpty else { return }
-            onCreate(trimmed, ghConnected ? visibility : nil)
+        guard !isSubmitting else { return }
+        isSubmitting = true
+        submitError = nil
+        Task {
+            let ok: Bool
+            switch mode {
+            case .clone:
+                ok = await onClone(url.trimmingCharacters(in: .whitespacesAndNewlines))
+            case .create:
+                let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                ok = await onCreate(trimmed, ghConnected ? visibility : nil)
+            }
+            isSubmitting = false
+            if ok {
+                dismiss()
+            } else {
+                submitError = "Couldn't add the project. Check the URL and your connection, then try again."
+            }
         }
-        dismiss()
     }
 
     private func checkAccountStatus() {
@@ -198,7 +231,7 @@ struct AddProjectSheet: View {
 #Preview {
     Text("Hub")
         .sheet(isPresented: .constant(true)) {
-            AddProjectSheet(api: APIClient(), onClone: { _ in }, onCreate: { _, _ in })
+            AddProjectSheet(api: APIClient(), onClone: { _ in true }, onCreate: { _, _ in true })
         }
         .preferredColorScheme(.dark)
 }

--- a/ios/HiveMobile/Views/Hub/HubRows.swift
+++ b/ios/HiveMobile/Views/Hub/HubRows.swift
@@ -181,16 +181,20 @@ struct HubWorkspaceRow: View {
         .padding(.vertical, 6)
         .frame(maxWidth: .infinity, minHeight: 42, alignment: .leading)
         .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
     }
 
     @ViewBuilder
     private var workspaceStatus: some View {
         if isStreaming {
             AgentActivityIndicator(dotSize: 3, spacing: 1.5)
+                .accessibilityLabel("Streaming")
         } else if turnCompleted {
             UnreadDot()
+                .accessibilityLabel("Unread activity")
         } else {
             StatusDot()
+                .accessibilityHidden(true)
         }
     }
 }

--- a/ios/HiveMobile/Views/Hub/HubRows.swift
+++ b/ios/HiveMobile/Views/Hub/HubRows.swift
@@ -131,11 +131,15 @@ struct HubProjectRow: View {
 
 struct HubWorkspaceRow: View {
     let workspace: Workspace
-    let isStreaming: Bool
-    let turnCompleted: Bool
-    let diffStats: DiffStatResponse?
-    let prStatus: PrStatusResponse?
-    let isPrStatusLoading: Bool
+    let monitor: HubStatusMonitor
+
+    private var isStreaming: Bool { monitor.isStreaming(workspace.id) }
+    private var turnCompleted: Bool {
+        monitor.isCompleted(workspace.id) || monitor.hasUnreadSessions(workspace.id)
+    }
+    private var diffStats: DiffStatResponse? { monitor.diffStats(for: workspace.id) }
+    private var prStatus: PrStatusResponse? { monitor.prStatus(for: workspace.id) }
+    private var isPrStatusLoading: Bool { monitor.isPrStatusLoading(workspace.id) }
 
     private var diffSummary: HubDiffSummary {
         HubDiffSummary(diffStats: diffStats)

--- a/ios/HiveMobile/Views/Hub/HubRows.swift
+++ b/ios/HiveMobile/Views/Hub/HubRows.swift
@@ -242,15 +242,9 @@ private struct HubActivityDot: View {
     var body: some View {
         switch state {
         case .streaming:
-            ZStack {
-                Circle()
-                    .fill(Color.accentColor.opacity(0.28))
-                    .frame(width: 11, height: 11)
-                Circle()
-                    .fill(Color.accentColor)
-                    .frame(width: 7, height: 7)
-            }
-            .accessibilityLabel("Agent is working")
+            AgentActivityIndicator(dotSize: 2, spacing: 1)
+                .frame(width: 11, height: 11)
+                .accessibilityLabel("Agent is working")
         case .completed:
             UnreadDot(size: 7, shadowRadius: 4)
                 .accessibilityLabel("Unread activity")
@@ -268,11 +262,11 @@ private struct HubDiffBadge: View {
         HStack(spacing: 5) {
             if additions > 0 {
                 Text("+\(additions)")
-                    .foregroundStyle(WhisperColor.success)
+                    .foregroundStyle(WhisperColor.diffAdded)
             }
             if deletions > 0 {
                 Text("-\(deletions)")
-                    .foregroundStyle(.red)
+                    .foregroundStyle(WhisperColor.diffRemoved)
             }
         }
         .font(.caption2.monospacedDigit().weight(.medium))

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -33,6 +33,9 @@ struct HubView: View {
                 VStack(alignment: .leading, spacing: HiveSpacing.md) {
                     if store.projects.isEmpty {
                         emptyState
+                    } else if !searchText.isEmpty, displayedSections.isEmpty {
+                        ContentUnavailableView.search(text: searchText)
+                            .padding(.top, 40)
                     } else {
                         denseHubContent(sections: displayedSections)
                     }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -403,6 +403,7 @@ struct HubView: View {
     }
 
     private func setSection(_ section: HubSection, expanded: Bool) {
+        guard searchText.isEmpty else { return }
         withAnimation(.easeInOut(duration: 0.2)) {
             sectionExpansionOverrides[section.id] = expanded
         }
@@ -410,6 +411,7 @@ struct HubView: View {
     }
 
     private func setProject(_ projectId: String, expanded: Bool) {
+        guard searchText.isEmpty else { return }
         withAnimation(.easeInOut(duration: 0.2)) {
             projectExpansionOverrides[projectId] = expanded
         }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -19,9 +19,11 @@ struct HubView: View {
         key: HubView.projectExpansionKey
     )
     @State private var sections: [HubSection] = []
+    @State private var searchText = ""
 
     var body: some View {
-        let prIds = visiblePrWorkspaceIds(in: sections)
+        let displayedSections = filteredSections(sections)
+        let prIds = visiblePrWorkspaceIds(in: displayedSections)
 
         ZStack {
             WhisperColor.appBackground
@@ -32,7 +34,7 @@ struct HubView: View {
                     if store.projects.isEmpty {
                         emptyState
                     } else {
-                        denseHubContent(sections: sections)
+                        denseHubContent(sections: displayedSections)
                     }
                 }
                 .padding(.horizontal, HiveSpacing.lg)
@@ -41,6 +43,7 @@ struct HubView: View {
             .scrollBounceBehavior(.always)
             .scrollContentBackground(.hidden)
         }
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
         .navigationTitle("Hub")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
@@ -106,12 +109,8 @@ struct HubView: View {
         .sheet(isPresented: $showAddProject) {
             AddProjectSheet(
                 api: APIClient(),
-                onClone: { url in
-                    Task { await store.createProject(url: url) }
-                },
-                onCreate: { name, visibility in
-                    Task { await store.createNewProject(name: name, visibility: visibility) }
-                }
+                onClone: { url in await store.createProject(url: url) },
+                onCreate: { name, visibility in await store.createNewProject(name: name, visibility: visibility) }
             )
         }
         .alert(
@@ -206,6 +205,26 @@ struct HubView: View {
             projects: store.projects,
             preferences: store.uiPreferences.sidebar
         )
+    }
+
+    private func filteredSections(_ sections: [HubSection]) -> [HubSection] {
+        guard !searchText.isEmpty else { return sections }
+        return sections.compactMap { section in
+            let nodes = section.projects.compactMap { node -> HubProjectNode? in
+                let projectMatches = node.project.name.localizedCaseInsensitiveContains(searchText)
+                let workspaces = node.project.workspaces.filter {
+                    $0.name.localizedCaseInsensitiveContains(searchText)
+                        || $0.branch.localizedCaseInsensitiveContains(searchText)
+                }
+                if projectMatches { return node }
+                guard !workspaces.isEmpty else { return nil }
+                var project = node.project
+                project.workspaces = workspaces
+                return HubProjectNode(project: project)
+            }
+            guard !nodes.isEmpty else { return nil }
+            return HubSection(kind: section.kind, projects: nodes, defaultExpanded: true)
+        }
     }
 
     private func visiblePrWorkspaceIds(in sections: [HubSection]) -> [String] {
@@ -373,11 +392,11 @@ struct HubView: View {
     // MARK: - Expansion State
 
     private func isSectionExpanded(_ section: HubSection) -> Bool {
-        return sectionExpansionOverrides[section.id] ?? section.defaultExpanded
+        return !searchText.isEmpty || (sectionExpansionOverrides[section.id] ?? section.defaultExpanded)
     }
 
     private func isProjectExpanded(_ project: Project) -> Bool {
-        return projectExpansionOverrides[project.id] ?? projectHasLiveAttention(project)
+        return !searchText.isEmpty || (projectExpansionOverrides[project.id] ?? projectHasLiveAttention(project))
     }
 
     private func setSection(_ section: HubSection, expanded: Bool) {

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -18,9 +18,9 @@ struct HubView: View {
     @State private var projectExpansionOverrides: [String: Bool] = HubView.loadExpansionOverrides(
         key: HubView.projectExpansionKey
     )
+    @State private var sections: [HubSection] = []
 
     var body: some View {
-        let sections = baseSections
         let prIds = visiblePrWorkspaceIds(in: sections)
 
         ZStack {
@@ -67,6 +67,8 @@ struct HubView: View {
         .task(id: prIds) {
             store.statusMonitor.syncVisiblePrWorkspaces(prIds)
         }
+        .onChange(of: store.projects, initial: true) { _, _ in sections = baseSections }
+        .onChange(of: store.uiPreferences.sidebar) { _, _ in sections = baseSections }
         .overlay {
             if let errorMessage = store.errorMessage {
                 errorBanner(errorMessage)

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -125,7 +125,7 @@ struct HubView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { ws in
-            Text("\"\(ws.name)\" will be archived.")
+            Text("\"\(ws.name)\" will be archived and removed from this list. Archived workspaces can be restored from the desktop app.")
         }
     }
 
@@ -147,11 +147,16 @@ struct HubView: View {
         } else if store.isLoading || !store.hasLoadedSuccessfully {
             loadingState
         } else {
-            ContentUnavailableView(
-                "No Projects",
-                systemImage: "folder",
-                description: Text("Tap + to add your first project, or connect to your Hive server from Settings.")
-            )
+            ContentUnavailableView {
+                Label("No Projects", systemImage: "folder")
+            } description: {
+                Text("Tap + to add your first project, or connect to your Hive server from Settings.")
+            } actions: {
+                Button("Add project") { showAddProject = true }
+                    .buttonStyle(.borderedProminent)
+                Button("Open Settings") { openSettings?() }
+                    .buttonStyle(.bordered)
+            }
             .padding(.top, 40)
         }
     }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -277,12 +277,7 @@ struct HubView: View {
                     NavigationLink(value: workspace) {
                         HubWorkspaceRow(
                             workspace: workspace,
-                            isStreaming: store.statusMonitor.isStreaming(workspace.id),
-                            turnCompleted: store.statusMonitor.isCompleted(workspace.id)
-                                || store.statusMonitor.hasUnreadSessions(workspace.id),
-                            diffStats: store.statusMonitor.diffStats(for: workspace.id),
-                            prStatus: store.statusMonitor.prStatus(for: workspace.id),
-                            isPrStatusLoading: store.statusMonitor.isPrStatusLoading(workspace.id)
+                            monitor: store.statusMonitor
                         )
                     }
                     .buttonStyle(.plain)

--- a/ios/HiveMobile/Views/Settings/AutomationDetailView.swift
+++ b/ios/HiveMobile/Views/Settings/AutomationDetailView.swift
@@ -21,7 +21,11 @@ struct AutomationDetailView: View {
             }
 
             Section {
-                if !isLoading, runs.isEmpty {
+                if isLoading, runs.isEmpty {
+                    ListLoadingSkeleton(rowCount: 3)
+                        .listRowBackground(WhisperColor.appBackground)
+                        .listRowSeparator(.hidden)
+                } else if !isLoading, runs.isEmpty {
                     if let errorMessage {
                         ContentUnavailableView {
                             Label("Couldn't load runs", systemImage: "exclamationmark.triangle")

--- a/ios/HiveMobile/Views/Settings/AutomationsListView.swift
+++ b/ios/HiveMobile/Views/Settings/AutomationsListView.swift
@@ -7,12 +7,18 @@ struct AutomationsListView: View {
     @State private var selectedAutomation: Automation?
     @State private var isLoading = true
     @State private var errorMessage: String?
+    @State private var searchText = ""
 
     private let api = APIClient()
 
+    private var filteredAutomations: [Automation] {
+        guard !searchText.isEmpty else { return automations }
+        return automations.filter { $0.name.localizedCaseInsensitiveContains(searchText) }
+    }
+
     var body: some View {
         List {
-            ForEach(automations) { automation in
+            ForEach(filteredAutomations) { automation in
                 Button {
                     selectedAutomation = automation
                 } label: {
@@ -26,6 +32,7 @@ struct AutomationsListView: View {
         }
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
         .hiveScreenBackground()
         .navigationTitle("Automations")
         .navigationBarTitleDisplayMode(.inline)
@@ -37,7 +44,9 @@ struct AutomationsListView: View {
         .refreshable { await load() }
         .task { await load() }
         .overlay {
-            if isLoading, automations.isEmpty {
+            if !searchText.isEmpty, filteredAutomations.isEmpty, !automations.isEmpty {
+                ContentUnavailableView.search(text: searchText)
+            } else if isLoading, automations.isEmpty {
                 ListLoadingSkeleton()
             } else if let errorMessage, automations.isEmpty {
                 ContentUnavailableView {

--- a/ios/HiveMobile/Views/Settings/SettingsView.swift
+++ b/ios/HiveMobile/Views/Settings/SettingsView.swift
@@ -38,7 +38,10 @@ struct SettingsView: View {
         .onChange(of: host) { _, _ in scheduleConnectionCheck() }
         .onChange(of: port) { _, _ in scheduleConnectionCheck() }
         .onChange(of: token) { _, _ in scheduleConnectionCheck() }
-        .toolbar(.hidden, for: .navigationBar)
+        .navigationTitle("Settings")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
+        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()

--- a/ios/Tests/ChatDraftStoreTests/ComposerAutocompleteTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ComposerAutocompleteTests.swift
@@ -109,6 +109,16 @@ final class ComposerAutocompleteTests: XCTestCase {
         XCTAssertTrue(ComposerAutocomplete.matchFiles(files, query: "zzzzzz").isEmpty)
     }
 
+    func testPreparedCandidatesMatchStringOverload() {
+        let corpus = files + ["a/git.ts.bak", "b/mygit.ts"]
+        let candidates = ComposerAutocomplete.prepareFiles(corpus)
+        for query in ["git.ts", "index", "utils", "fzmt", "", "zzzzzz"] {
+            let viaStrings = ComposerAutocomplete.matchFiles(corpus, query: query)
+            let viaCandidates = ComposerAutocomplete.matchFiles(candidates, query: query)
+            XCTAssertEqual(viaStrings, viaCandidates, "ranking diverged for query \"\(query)\"")
+        }
+    }
+
     // MARK: - Disambiguation
 
     func testUniqueBasenameStaysBasename() {

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreHistoryFailureTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreHistoryFailureTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Observation
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ConversationStoreHistoryFailureTests {
+    private func message(id: String, sessionId: String) -> ChatMessage {
+        ChatMessage(
+            id: id,
+            sessionId: sessionId,
+            role: .assistant,
+            content: "hello",
+            images: nil,
+            toolCalls: nil,
+            thinkingContent: nil,
+            timestamp: "2026-01-01T00:00:00.000Z",
+            cancelled: nil,
+            durationMs: nil
+        )
+    }
+
+    @Test @MainActor
+    func failedFetchMarksSessionAsFailed() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        #expect(store.historyLoadFailed(for: "s1"))
+        #expect(!store.historyLoadFailed(for: "s2"))
+    }
+
+    @Test @MainActor
+    func successfulRetryClearsFailureAndAppliesMessages() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            throw URLError(.timedOut)
+        }
+        #expect(store.historyLoadFailed(for: "s1"))
+
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            [self.message(id: "m1", sessionId: "s1")]
+        }
+        #expect(!store.historyLoadFailed(for: "s1"))
+        #expect(store.cachedMessages(for: "s1")?.isEmpty == false)
+    }
+
+    @Test @MainActor
+    func cancellationDoesNotMarkFailure() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            throw CancellationError()
+        }
+        #expect(!store.historyLoadFailed(for: "s1"))
+    }
+
+    @Test @MainActor
+    func staleRequestDoesNotMarkFailure() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            store.bumpHistoryToken(for: "s1")
+            throw URLError(.notConnectedToInternet)
+        }
+        #expect(!store.historyLoadFailed(for: "s1"))
+    }
+
+    @Test @MainActor
+    func removeSessionStateClearsFailure() async {
+        let store = ConversationStore(streamFlushInterval: nil)
+        store.setFocusedSessionId("s1")
+        await store.loadHistoryIfNeeded(for: "s1") { _ in
+            throw URLError(.notConnectedToInternet)
+        }
+        #expect(store.historyLoadFailed(for: "s1"))
+
+        store.removeSessionState("s1", fallbackSessionId: nil)
+        #expect(!store.historyLoadFailed(for: "s1"))
+    }
+}


### PR DESCRIPTION
## Summary

Global iOS polish batch from the first whole-app audit of the mobile client (UX, accessibility, fluidity, visual consistency). Every change is iOS-only — no backend files touched. 11 commits, each mapping to audit findings.

### Honest error/loading/empty states (UX-01/02/03/04/06/08/09/10)
- A failed Brain fetch no longer renders "No Brain connected" — it shows an error state with Retry, and the empty state is reserved for a genuine `exists: false` response.
- A failed history fetch for a non-empty conversation no longer renders as a brand-new-workspace empty state — `ConversationStore` tracks per-session load failures (5 new store tests) and `ChatView` shows "Couldn't load this conversation" with Retry.
- A failed session-list load shows an error state with Retry instead of "No Conversations"; create/delete failures surface as an alert, kept separate from load errors so a failed "New conversation" can't masquerade as "Couldn't load conversations".
- Automation run history shows a skeleton while loading instead of a blank section.
- "No Projects" gained "Add project" / "Open Settings" buttons; the empty conversations state gained an inline "New conversation" button.
- The archive confirmation now says the workspace is removed from this list and restorable from desktop.
- Settings has a navigation title again instead of a hidden nav bar.

### Accessibility (DESIGN-01/02/03/06/07)
- VoiceOver labels on the composer's send/stop/attach, the message copy button, and the diff review-bar chevrons; all brought to 44pt hit targets.
- The context-usage ring exposes "Nk / Mk tokens · P%" via accessibilityValue (`.help()` is a no-op on touch iOS).
- Hub workspace rows read as one combined element with labeled statuses, matching conversation rows.
- Reduce Motion now covers the unread-dot pop and attachment chip springs.

### Fluidity (PERF-01/02/03/05)
- Hub: the section tree is memoized behind new `Equatable` model conformances and per-workspace status reads moved into the row — a `diff_stats` tick no longer rebuilds the whole Hub hierarchy.
- Chat open with drafted images no longer does a full main-thread `UIImage` decode per attachment just to validate it.
- `#file` autocomplete pre-lowercases candidates once per load instead of per keystroke (ranking-parity test added).
- Conversation rows read their own streaming/unread status.

### Visual consistency & affordances (DESIGN-04/05, UX-05/07)
- New `WhisperColor.diffAdded`/`diffRemoved` tokens replace raw `.green`/`.red` at all diff +/− sites (7 sites, incl. the Hub badge that mixed both styles).
- One streaming-indicator language: the Hub project/folder badge now uses the same animated `AgentActivityIndicator` as rows.
- Search on the Hub (projects/workspaces by name or branch, auto-expanded results, no-results state) and on the automations list. Expansion toggles are ignored while a search is active, so a tap during search can't silently corrupt the persisted expand/collapse state.
- The Add-Project sheet stays open until the clone/create result: inline progress, input preserved on failure, dismisses only on success. It is the single error surface for the flow — `ProjectStore` create methods return the actual error message (`String?`) shown inline, the Hub's red banner no longer double-fires behind the sheet, and swipe-dismiss is blocked while a submit is in flight.

## Audit trail

Findings, evidence and vetting live in the local `plans/` index (run 20, plans 015 + 038–041; post-review branch audit run 21, plans 042–044 — the last three commits).

Deliberately excluded from this PR: notification actions and Live Activities (need backend), automation trigger / provider usage / file browsing (feature-track, separate PRD flow), fixed-size SF Symbols at max Dynamic Type, and the per-image UserDefaults read (both judged not worth it).

## Known notes for review
- View-layer changes are covered by the `xcodebuild` compile gate only (`swift test` excludes `Views/`, known repo gap); CI runs both gates on this PR.

## Testing
- `cd ios && swift test` → 292 swift-testing tests + XCTest suites pass (5 new history-failure tests, 1 new autocomplete parity test).
- `xcodebuild -scheme HiveMobile -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED.
- Both gates re-run by the reviewer on the composed branch tip (`3264000`).
