### PR TITLE
Codex: sub-agent activity, multi-agent v2 spawns & context compaction

### DIFF
--- a/backend/src/agents/agent-event-normalizer.ts
+++ b/backend/src/agents/agent-event-normalizer.ts
@@ -66,6 +66,11 @@ export type NormalizedAgentEvent =
       agentPath: string;
     }
   | {
+      type: "context_compaction_updated";
+      id: string;
+      status?: string;
+    }
+  | {
       type: "diagnostic";
       id: string;
       severity: "info" | "warning" | "error";

--- a/backend/src/agents/agent-event-normalizer.ts
+++ b/backend/src/agents/agent-event-normalizer.ts
@@ -5,6 +5,7 @@ import type {
   ContentBlock,
   ServerToolResultType,
 } from "../types.js";
+import type { AgentActivitySubagentActivityKind } from "@hive/shared/agent-activity";
 
 type AssistantEvent = Extract<CliJsonLine, { type: "assistant" }>;
 type UserEvent = Extract<CliJsonLine, { type: "user" }>;
@@ -56,6 +57,13 @@ export type NormalizedAgentEvent =
       timeUsedSeconds?: number;
       createdAt?: number;
       updatedAt?: number;
+    }
+  | {
+      type: "subagent_activity_updated";
+      id: string;
+      activityKind: AgentActivitySubagentActivityKind;
+      agentThreadId: string;
+      agentPath: string;
     }
   | {
       type: "diagnostic";

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -711,6 +711,70 @@ describe("ConversationSession", () => {
     }]);
   });
 
+  it("streams and persists context compaction updates by item id", async () => {
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "context_compaction_updated",
+        id: "compaction-1",
+        status: "inProgress",
+      });
+      fakeRunner.emit("agent_event", {
+        type: "context_compaction_updated",
+        id: "compaction-1",
+        status: "completed",
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-compaction", duration_ms: 1 });
+      fakeRunner.emit("exit", 0, "provider-compaction");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-compaction",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "compaction-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Keep working past the context limit");
+
+    await waitForMessages(messages, "done");
+
+    expect(messages.filter((msg) => msg.type === "agent_activity")).toEqual([
+      {
+        type: "agent_activity",
+        sessionId: "compaction-session",
+        activity: { id: "compaction-1", kind: "context_compaction", status: "inProgress" },
+      },
+      {
+        type: "agent_activity",
+        sessionId: "compaction-session",
+        activity: { id: "compaction-1", kind: "context_compaction", status: "completed" },
+      },
+    ]);
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    expect(assistant?.agentActivities).toEqual([{
+      id: "compaction-1",
+      kind: "context_compaction",
+      status: "completed",
+    }]);
+  });
+
   it("bounds large command outputs before streaming and persistence", async () => {
     const largeOutput = "x".repeat(MAX_AGENT_OUTPUT_CHARS + 2048);
     const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -629,6 +629,88 @@ describe("ConversationSession", () => {
     ]);
   });
 
+  it("streams and persists sub-agent activity updates by item id", async () => {
+    const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;
+    fakeRunner.start = vi.fn(() => {
+      fakeRunner.emit("agent_event", {
+        type: "subagent_activity_updated",
+        id: "subagent-activity",
+        activityKind: "started",
+        agentThreadId: "thread-child",
+        agentPath: "/root/worker",
+      });
+      fakeRunner.emit("agent_event", {
+        type: "subagent_activity_updated",
+        id: "subagent-activity",
+        activityKind: "interrupted",
+        agentThreadId: "thread-child",
+        agentPath: "/root/worker",
+      });
+      fakeRunner.emit("result", { type: "result", session_id: "provider-subagent-activity", duration_ms: 1 });
+      fakeRunner.emit("exit", 0, "provider-subagent-activity");
+    });
+    fakeRunner.stop = vi.fn(() => {});
+
+    const runnerFactory: AgentRunnerFactory = vi.fn(() => ({
+      runner: fakeRunner,
+      protocol: "process" as const,
+      providerId: "codex",
+      modelId: "gpt-5.5",
+      supportsBlockingTools: false,
+      providerSessionId: "provider-subagent-activity",
+      debug: { command: "fake", args: [] },
+      start: fakeRunner.start,
+    }));
+    const session = new ConversationSession({
+      cwd: "/tmp/test",
+      dataDir: tempDir,
+      workspaceId: "ws-test",
+      sessionId: "subagent-activity-session",
+      runnerFactory,
+    });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Inspect with a sub-agent");
+
+    await waitForMessages(messages, "done");
+
+    expect(messages.filter((msg) => msg.type === "agent_activity")).toEqual([
+      {
+        type: "agent_activity",
+        sessionId: "subagent-activity-session",
+        activity: {
+          id: "subagent-activity",
+          kind: "subagent_activity",
+          activityKind: "started",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+      {
+        type: "agent_activity",
+        sessionId: "subagent-activity-session",
+        activity: {
+          id: "subagent-activity",
+          kind: "subagent_activity",
+          activityKind: "interrupted",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    ]);
+
+    const persisted = await session.getMessages();
+    const assistant = persisted.find((msg) => msg.role === "assistant");
+    expect(assistant?.agentActivities).toEqual([{
+      id: "subagent-activity",
+      kind: "subagent_activity",
+      activityKind: "interrupted",
+      agentThreadId: "thread-child",
+      agentPath: "/root/worker",
+    }]);
+  });
+
   it("bounds large command outputs before streaming and persistence", async () => {
     const largeOutput = "x".repeat(MAX_AGENT_OUTPUT_CHARS + 2048);
     const fakeRunner = new EventEmitter<AgentRunnerEvent>() as EventEmitter<AgentRunnerEvent> & AgentRunner;

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -179,6 +179,8 @@ function cloneAgentActivity(activity: AgentActivity): AgentActivity {
       return { ...activity };
     case "subagent_activity":
       return { ...activity };
+    case "context_compaction":
+      return { ...activity };
     case "diagnostic":
       return { ...activity };
   }
@@ -1100,6 +1102,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       case "subagent_activity_updated":
         this.handleSubagentActivityEvent(event);
         break;
+      case "context_compaction_updated":
+        this.handleContextCompactionEvent(event);
+        break;
       case "diagnostic":
         this.handleDiagnosticEvent(event);
         break;
@@ -1429,6 +1434,16 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       activityKind: event.activityKind,
       agentThreadId: event.agentThreadId,
       agentPath: event.agentPath,
+    });
+  }
+
+  private handleContextCompactionEvent(
+    event: Extract<NormalizedAgentEvent, { type: "context_compaction_updated" }>,
+  ): void {
+    this.upsertAgentActivity({
+      id: event.id,
+      kind: "context_compaction",
+      status: event.status,
     });
   }
 

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -177,6 +177,8 @@ function cloneAgentActivity(activity: AgentActivity): AgentActivity {
       return { ...activity };
     case "image_generation":
       return { ...activity };
+    case "subagent_activity":
+      return { ...activity };
     case "diagnostic":
       return { ...activity };
   }
@@ -1095,6 +1097,9 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       case "goal_updated":
         this.handleGoalUpdateEvent(event);
         break;
+      case "subagent_activity_updated":
+        this.handleSubagentActivityEvent(event);
+        break;
       case "diagnostic":
         this.handleDiagnosticEvent(event);
         break;
@@ -1412,6 +1417,18 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       timeUsedSeconds: event.timeUsedSeconds,
       createdAt: event.createdAt,
       updatedAt: event.updatedAt,
+    });
+  }
+
+  private handleSubagentActivityEvent(
+    event: Extract<NormalizedAgentEvent, { type: "subagent_activity_updated" }>,
+  ): void {
+    this.upsertAgentActivity({
+      id: event.id,
+      kind: "subagent_activity",
+      activityKind: event.activityKind,
+      agentThreadId: event.agentThreadId,
+      agentPath: event.agentPath,
     });
   }
 

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -797,6 +797,10 @@ describe("CodexAppServerSession normalized events", () => {
       method: "serverRequest/resolved",
       params: { threadId: "thread-1", requestId: "req-1" },
     }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "thread/compacted",
+      params: { threadId: "thread-1" },
+    }) + "\n");
 
     expect(events).toEqual([]);
   });
@@ -911,7 +915,6 @@ describe("CodexAppServerSession normalized events", () => {
   });
 
   it.each([
-    ["started", "item/started"],
     ["interacted", "item/completed"],
     ["interrupted", "item/completed"],
   ] as const)("emits %s sub-agent activity without a diagnostic", async (activityKind, method) => {
@@ -943,6 +946,212 @@ describe("CodexAppServerSession normalized events", () => {
       agentPath: `/root/${activityKind}`,
     }]);
     expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
+  });
+
+  it("renders a v2 sub-agent spawn (\"started\" activity) as an Agent tool call", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    const assistantEvents: unknown[] = [];
+    const userEvents: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    session.on("assistant", (event) => assistantEvents.push(event));
+    session.on("user", (event) => userEvents.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: "spawn-1",
+          kind: "started",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    }) + "\n");
+
+    expect(assistantEvents).toEqual([
+      expect.objectContaining({
+        type: "assistant",
+        message: expect.objectContaining({
+          id: "spawn-1",
+          content: [
+            expect.objectContaining({ type: "tool_use", id: "spawn-1", name: "Agent" }),
+          ],
+        }),
+      }),
+    ]);
+    expect((assistantEvents[0] as {
+      message: { content: Array<{ parentToolUseId?: string }> };
+    }).message.content[0].parentToolUseId).toBeUndefined();
+    expect(userEvents).toEqual([
+      expect.objectContaining({
+        type: "user",
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({ type: "tool_result", tool_use_id: "spawn-1" }),
+          ],
+        }),
+      }),
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "subagent_activity_updated")).toBe(false);
+    expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
+  });
+
+  it("owns child thread items after a v2 sub-agent spawn", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    const assistantEvents: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    session.on("assistant", (event) => assistantEvents.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: "spawn-1",
+          kind: "started",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "inProgress",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "agentMessage",
+          id: "child-msg-1",
+          text: "done",
+        },
+      },
+    }) + "\n");
+
+    expect(assistantEvents).toEqual([
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [expect.objectContaining({ type: "tool_use", id: "spawn-1", name: "Agent" })],
+        }),
+      }),
+      expect.objectContaining({
+        message: expect.objectContaining({
+          content: [
+            expect.objectContaining({
+              type: "tool_use",
+              id: "child-cmd-1",
+              name: "Bash",
+              parentToolUseId: "spawn-1",
+            }),
+          ],
+        }),
+      }),
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "command_execution_updated")).toBe(false);
+    expect(assistantEvents.some((event) => {
+      const content = (event as { message: { content: Array<{ type?: string }> } }).message.content;
+      return content.some((block) => block.type === "text");
+    })).toBe(false);
+  });
+
+  it("replays registered child threads when a v2 wait completes", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: Array<{ message: { content: Array<Record<string, unknown>> } }> = [];
+    session.on("assistant", (event) => assistantEvents.push(event as never));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: "spawn-1",
+          kind: "started",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-wait-1",
+          tool: "wait",
+          status: "completed",
+          receiverThreadIds: [],
+        },
+      },
+    }) + "\n");
+
+    const read = await waitForMethod(proc, "thread/read");
+    expect(parseWrites(proc).find((write) => write.id === read.id)).toEqual(
+      expect.objectContaining({ params: expect.objectContaining({ threadId: "thread-child" }) }),
+    );
+    proc._stdout.push(appServerResponse(read.id, {
+      thread: {
+        id: "thread-child",
+        turns: [{
+          id: "turn-child",
+          items: [{
+            type: "commandExecution",
+            id: "child-cmd-1",
+            command: "npm test",
+            cwd: "/tmp/project",
+            status: "completed",
+            aggregatedOutput: "ok",
+            exitCode: 0,
+          }],
+        }],
+      },
+    }));
+
+    await waitForCondition(() =>
+      assistantEvents.some((event) => event.message.content.some((block) => block.id === "child-cmd-1")),
+    );
+    const blocks = assistantEvents.flatMap((event) => event.message.content);
+    expect(blocks.find((block) => block.id === "child-cmd-1")).toEqual(
+      expect.objectContaining({ parentToolUseId: "spawn-1" }),
+    );
   });
 
   it("emits a diagnostic instead of sub-agent activity for an unknown activity kind", async () => {
@@ -1025,7 +1234,7 @@ describe("CodexAppServerSession normalized events", () => {
     };
     proc._stdout.push(JSON.stringify({
       method: "item/started",
-      params: { item: { ...item, kind: "started" } },
+      params: { item: { ...item, kind: "interacted" } },
     }) + "\n");
     proc._stdout.push(JSON.stringify({
       method: "item/completed",
@@ -1036,7 +1245,7 @@ describe("CodexAppServerSession normalized events", () => {
       {
         type: "subagent_activity_updated",
         id: item.id,
-        activityKind: "started",
+        activityKind: "interacted",
         agentThreadId: item.agentThreadId,
         agentPath: item.agentPath,
       },
@@ -1047,6 +1256,31 @@ describe("CodexAppServerSession normalized events", () => {
         agentThreadId: item.agentThreadId,
         agentPath: item.agentPath,
       },
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
+  });
+
+  it("emits context compaction updates across the item lifecycle without a diagnostic", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    const item = { type: "contextCompaction", id: "compaction-1" };
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: { item },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: { item },
+    }) + "\n");
+
+    expect(events).toEqual([
+      { type: "context_compaction_updated", id: "compaction-1", status: "inProgress" },
+      { type: "context_compaction_updated", id: "compaction-1", status: "completed" },
     ]);
     expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
   });
@@ -1619,7 +1853,7 @@ describe("CodexAppServerSession normalized events", () => {
         item: {
           type: "subAgentActivity",
           id: "child-subagent-1",
-          kind: "started",
+          kind: "interacted",
           agentThreadId: "thread-grandchild",
           agentPath: "/root/worker/nested",
         },
@@ -1632,7 +1866,7 @@ describe("CodexAppServerSession normalized events", () => {
         item: {
           type: "subAgentActivity",
           id: "main-subagent-1",
-          kind: "started",
+          kind: "interacted",
           agentThreadId: "thread-child",
           agentPath: "/root/worker",
         },
@@ -1642,10 +1876,88 @@ describe("CodexAppServerSession normalized events", () => {
     expect(events).toEqual([{
       type: "subagent_activity_updated",
       id: "main-subagent-1",
-      activityKind: "started",
+      activityKind: "interacted",
       agentThreadId: "thread-child",
       agentPath: "/root/worker",
     }]);
+  });
+
+  it("registers grandchild threads from foreign started activities without rendering them", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    const assistantEvents: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    session.on("assistant", (event) => assistantEvents.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    // A v2 spawn observed inside the child thread must stay out of the main
+    // stream but still register the grandchild thread under its spawn call.
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "subAgentActivity",
+          id: "grandchild-spawn-1",
+          kind: "started",
+          agentThreadId: "thread-grandchild",
+          agentPath: "/root/worker/nested",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-grandchild",
+        item: {
+          type: "commandExecution",
+          id: "grandchild-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "inProgress",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: {
+        threadId: "thread-grandchild",
+        item: {
+          type: "commandExecution",
+          id: "grandchild-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        },
+      },
+    }) + "\n");
+
+    const toolUseBlocks = assistantEvents
+      .flatMap((event) => (event as { message: { content: Array<Record<string, unknown>> } }).message.content)
+      .filter((block) => block.type === "tool_use");
+    expect(toolUseBlocks.find((block) => block.id === "grandchild-spawn-1")).toBeUndefined();
+    expect(events.some((event) => (event as { type?: string }).type === "subagent_activity_updated")).toBe(false);
+    expect(toolUseBlocks.find((block) => block.id === "grandchild-cmd-1")).toEqual(
+      expect.objectContaining({ parentToolUseId: "grandchild-spawn-1" }),
+    );
   });
 
   it("parents live receiver-thread tools under documented Codex collab tool calls", async () => {

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -910,6 +910,147 @@ describe("CodexAppServerSession normalized events", () => {
     ]);
   });
 
+  it.each([
+    ["started", "item/started"],
+    ["interacted", "item/completed"],
+    ["interrupted", "item/completed"],
+  ] as const)("emits %s sub-agent activity without a diagnostic", async (activityKind, method) => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method,
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: `subagent-activity-${activityKind}`,
+          kind: activityKind,
+          agentThreadId: "thread-child",
+          agentPath: `/root/${activityKind}`,
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([{
+      type: "subagent_activity_updated",
+      id: `subagent-activity-${activityKind}`,
+      activityKind,
+      agentThreadId: "thread-child",
+      agentPath: `/root/${activityKind}`,
+    }]);
+    expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
+  });
+
+  it("emits a diagnostic instead of sub-agent activity for an unknown activity kind", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-unknown",
+          kind: "delegated",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "diagnostic",
+        severity: "info",
+        title: "Unsupported App Server item",
+        message: "Hive does not render sub-agent activity kind \"delegated\" yet.",
+        method: "item/subAgentActivity",
+      }),
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "subagent_activity_updated")).toBe(false);
+  });
+
+  it("emits a diagnostic instead of sub-agent activity for a malformed payload", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        item: {
+          type: "subAgentActivity",
+          id: "subagent-missing-path",
+          kind: "started",
+          agentThreadId: "thread-child",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([
+      expect.objectContaining({
+        type: "diagnostic",
+        severity: "info",
+        title: "Unsupported App Server item",
+        method: "item/subAgentActivity",
+      }),
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "subagent_activity_updated")).toBe(false);
+  });
+
+  it("updates sub-agent activity on item completion without inferring completion", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    const item = {
+      type: "subAgentActivity",
+      id: "subagent-activity-1",
+      agentThreadId: "thread-child",
+      agentPath: "/root/worker",
+    };
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: { item: { ...item, kind: "started" } },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: { item: { ...item, kind: "interrupted" } },
+    }) + "\n");
+
+    expect(events).toEqual([
+      {
+        type: "subagent_activity_updated",
+        id: item.id,
+        activityKind: "started",
+        agentThreadId: item.agentThreadId,
+        agentPath: item.agentPath,
+      },
+      {
+        type: "subagent_activity_updated",
+        id: item.id,
+        activityKind: "interrupted",
+        agentThreadId: item.agentThreadId,
+        agentPath: item.agentPath,
+      },
+    ]);
+    expect(events.some((event) => (event as { type?: string }).type === "diagnostic")).toBe(false);
+  });
+
   it("emits image view activities with workspace-relative paths", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
@@ -1447,6 +1588,64 @@ describe("CodexAppServerSession normalized events", () => {
         }),
       }),
     ]);
+  });
+
+  it("suppresses sub-agent activity from receiver threads", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const events: unknown[] = [];
+    session.on("agent_event", (event) => events.push(event));
+    await initializeSession(session, proc);
+
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "collabAgentToolCall",
+          id: "collab-1",
+          tool: "spawnAgent",
+          status: "inProgress",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-child",
+        item: {
+          type: "subAgentActivity",
+          id: "child-subagent-1",
+          kind: "started",
+          agentThreadId: "thread-grandchild",
+          agentPath: "/root/worker/nested",
+        },
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/started",
+      params: {
+        threadId: "thread-1",
+        item: {
+          type: "subAgentActivity",
+          id: "main-subagent-1",
+          kind: "started",
+          agentThreadId: "thread-child",
+          agentPath: "/root/worker",
+        },
+      },
+    }) + "\n");
+
+    expect(events).toEqual([{
+      type: "subagent_activity_updated",
+      id: "main-subagent-1",
+      activityKind: "started",
+      agentThreadId: "thread-child",
+      agentPath: "/root/worker",
+    }]);
   });
 
   it("parents live receiver-thread tools under documented Codex collab tool calls", async () => {

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -154,6 +154,11 @@ type ThreadItem =
       agentThreadId?: unknown;
       agentPath?: unknown;
     }
+  | {
+      type: "contextCompaction";
+      id: string;
+      status?: string;
+    }
   | { type: string; id?: string; [key: string]: unknown };
 
 type CollabToolCallItem = {
@@ -621,6 +626,10 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
       case "thread/settings/updated":
       case "serverRequest/resolved":
         break;
+      case "thread/compacted":
+        // The contextCompaction item already renders the compaction row; the
+        // thread-level notification would only duplicate it.
+        break;
       case "mcpServer/startupStatus/updated":
         if (isNotificationStatus(data, "failed", "cancelled")) {
           this.emitProtocolDiagnostic(method, data, "Codex MCP startup status", "warning");
@@ -971,8 +980,15 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "subAgentActivity": {
-        if (parentToolUseId) break;
         const activityItem = item as Extract<ThreadItem, { type: "subAgentActivity" }>;
+        // Multi-agent v2 spawns emit no collabAgentToolCall and v2 wait items
+        // carry no receiver ids; this item is the only signal mapping the
+        // child thread to its spawn call. Register even foreign-thread
+        // activities so grandchild threads are owned too.
+        if (activityItem.kind === "started" && typeof activityItem.agentThreadId === "string") {
+          this.collabParentByThreadId.set(activityItem.agentThreadId, activityItem.id);
+        }
+        if (parentToolUseId) break;
         if (
           !isAgentActivitySubagentActivityKind(activityItem.kind)
           || typeof activityItem.agentThreadId !== "string"
@@ -989,12 +1005,46 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
           });
           break;
         }
+        if (activityItem.kind === "started") {
+          // v2 spawn: render the same Agent card as a v1 spawnAgent call so
+          // child tools nest under it. Spawn completes at thread creation
+          // (same rationale as the v1 comment on spawnAgent), so emit the
+          // result immediately.
+          this.emitToolUse(activityItem.id, "Agent", JSON.stringify({
+            subagent_type: "agent",
+            description: activityItem.agentPath,
+            run_in_background: true,
+            tool: "spawnAgent",
+            receiver_thread_ids: [activityItem.agentThreadId],
+            agent_path: activityItem.agentPath,
+          }));
+          this.emitToolResult(activityItem.id, JSON.stringify([{
+            type: "text",
+            text: formatUnknown({
+              tool: "spawnAgent",
+              status: "completed",
+              receiverThreadIds: [activityItem.agentThreadId],
+            }),
+          }]));
+          break;
+        }
         this.emit("agent_event", {
           type: "subagent_activity_updated",
           id: activityItem.id,
           activityKind: activityItem.kind,
           agentThreadId: activityItem.agentThreadId,
           agentPath: activityItem.agentPath,
+        });
+        break;
+      }
+      case "contextCompaction": {
+        // A sub-agent compacting its own context is internal to its execution.
+        if (parentToolUseId) break;
+        const compactionItem = item as Extract<ThreadItem, { type: "contextCompaction" }>;
+        this.emit("agent_event", {
+          type: "context_compaction_updated",
+          id: compactionItem.id,
+          status: compactionItem.status ?? (phase === "completed" ? "completed" : "inProgress"),
         });
         break;
       }
@@ -1047,7 +1097,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private queueCollabAgentReplay(item: CollabToolCallItem): void {
-    const threadIds = collabAgentReceiverThreadIds(item);
+    let threadIds = collabAgentReceiverThreadIds(item);
+    if (threadIds.length === 0 && (item.tool === "wait" || item.tool === "closeAgent")) {
+      // Multi-agent v2 wait items never carry receiver ids; replay every
+      // thread learned from subAgentActivity registrations instead.
+      threadIds = [...this.collabParentByThreadId.keys()];
+    }
     if (threadIds.length === 0) return;
     // Catch-up items nest under the spawning Agent card when known; the
     // triggering wait/closeAgent card is only a fallback for threads whose

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "node:events";
 import { isAbsolute, relative, resolve } from "node:path";
 import {
   commandExecutionActivityToToolCall,
+  isAgentActivitySubagentActivityKind,
   normalizeAgentActivityCommandActions,
   type AgentActivityCommandAction,
 } from "@hive/shared/agent-activity";
@@ -145,6 +146,13 @@ type ThreadItem =
       revisedPrompt?: string | null;
       result?: string;
       savedPath?: string | null;
+    }
+  | {
+      type: "subAgentActivity";
+      id: string;
+      kind?: unknown;
+      agentThreadId?: unknown;
+      agentPath?: unknown;
     }
   | { type: string; id?: string; [key: string]: unknown };
 
@@ -959,6 +967,34 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
             ? relativizeWorkspacePath(savedPath, this.currentCwd).relativePath
             : undefined,
           result: result && result.length <= MAX_IMAGE_GENERATION_RESULT_LENGTH ? result : undefined,
+        });
+        break;
+      }
+      case "subAgentActivity": {
+        if (parentToolUseId) break;
+        const activityItem = item as Extract<ThreadItem, { type: "subAgentActivity" }>;
+        if (
+          !isAgentActivitySubagentActivityKind(activityItem.kind)
+          || typeof activityItem.agentThreadId !== "string"
+          || typeof activityItem.agentPath !== "string"
+        ) {
+          this.emitDiagnostic({
+            id: diagnosticId("codex-item", `subAgentActivity-${String(activityItem.kind)}`),
+            severity: "info",
+            title: "Unsupported App Server item",
+            message: `Hive does not render sub-agent activity kind "${String(activityItem.kind)}" yet.`,
+            method: "item/subAgentActivity",
+            details: formatDiagnosticDetails(item),
+            dedupeKey: `item:subAgentActivity:${String(activityItem.kind)}`,
+          });
+          break;
+        }
+        this.emit("agent_event", {
+          type: "subagent_activity_updated",
+          id: activityItem.id,
+          activityKind: activityItem.kind,
+          agentThreadId: activityItem.agentThreadId,
+          agentPath: activityItem.agentPath,
         });
         break;
       }

--- a/frontend/src/components/chat/ActivityShell.tsx
+++ b/frontend/src/components/chat/ActivityShell.tsx
@@ -6,6 +6,8 @@ import { ToolExpandedContent } from "@/components/ChatToolUse";
 
 interface ActivityShellProps {
   title: string;
+  /** Native tooltip shown when hovering the row. */
+  tooltip?: string;
   icon?: ReactNode;
   detail?: ReactNode;
   trailingIcon?: ReactNode;
@@ -28,6 +30,7 @@ interface ActivityShellProps {
  */
 export function ActivityShell({
   title,
+  tooltip,
   icon,
   detail,
   trailingIcon,
@@ -52,6 +55,7 @@ export function ActivityShell({
           )}
           onClick={() => canOpen && setOpen(!open)}
           aria-expanded={canOpen ? open : undefined}
+          title={tooltip}
         >
           {icon ? <span className="shrink-0">{icon}</span> : canOpen && (
             <ChevronRightIcon className={cn("size-3.5 shrink-0 transition-transform", open && "rotate-90")} />

--- a/frontend/src/components/chat/AgentActivityList.tsx
+++ b/frontend/src/components/chat/AgentActivityList.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { AlertTriangleIcon, BotIcon, CirclePauseIcon, MessageCircleIcon, XCircleIcon } from "lucide-react";
+import { AlertTriangleIcon, BotIcon, CirclePauseIcon, FoldVerticalIcon, MessageCircleIcon, XCircleIcon } from "lucide-react";
 import { commandExecutionActivityToToolCall } from "@hive/shared/agent-activity";
 import type { AgentActivity, QuestionAnswer, ToolCall } from "@/types";
 import ChatToolUse from "@/components/ChatToolUse";
@@ -9,6 +9,7 @@ import { ImageViewActivity, ImageGenerationActivity } from "@/components/chat/Im
 import type { PlanStatus } from "@/components/chat/PlanProposal";
 
 type SubagentActivity = Extract<AgentActivity, { kind: "subagent_activity" }>;
+type ContextCompactionActivity = Extract<AgentActivity, { kind: "context_compaction" }>;
 type InlineAgentActivity = Exclude<AgentActivity, { kind: "plan_update" } | { kind: "goal_update" }>;
 
 interface AgentActivityListProps {
@@ -99,6 +100,7 @@ function activityToToolCalls(activity: InlineAgentActivity): ToolCall[] {
     case "image_generation":
     case "diagnostic":
     case "subagent_activity":
+    case "context_compaction":
       return [];
   }
 }
@@ -134,8 +136,31 @@ const AgentActivityItem = memo(function AgentActivityItem({
       return <DiagnosticActivity activity={activity} />;
     case "subagent_activity":
       return <SubagentActivityItem activity={activity} />;
+    case "context_compaction":
+      return <ContextCompactionActivityItem activity={activity} showExecutingState={showExecutingState} />;
   }
 });
+
+function ContextCompactionActivityItem({
+  activity,
+  showExecutingState,
+}: {
+  activity: ContextCompactionActivity;
+  showExecutingState?: boolean;
+}) {
+  // Only animate while the turn is live so a stale in-progress record
+  // (e.g. a turn that died mid-compaction) never shimmers forever.
+  const compacting = Boolean(showExecutingState) && activity.status !== "completed";
+
+  return (
+    <ActivityShell
+      title={compacting ? "Compacting context…" : "Context compacted"}
+      tooltip="Older messages were summarized to free up context"
+      icon={<FoldVerticalIcon className="size-3.5" aria-label="Context compaction" />}
+      executing={compacting}
+    />
+  );
+}
 
 function SubagentActivityItem({ activity }: { activity: SubagentActivity }) {
   return (

--- a/frontend/src/components/chat/AgentActivityList.tsx
+++ b/frontend/src/components/chat/AgentActivityList.tsx
@@ -1,5 +1,5 @@
 import { memo } from "react";
-import { AlertTriangleIcon, XCircleIcon } from "lucide-react";
+import { AlertTriangleIcon, BotIcon, CirclePauseIcon, MessageCircleIcon, XCircleIcon } from "lucide-react";
 import { commandExecutionActivityToToolCall } from "@hive/shared/agent-activity";
 import type { AgentActivity, QuestionAnswer, ToolCall } from "@/types";
 import ChatToolUse from "@/components/ChatToolUse";
@@ -8,6 +8,7 @@ import { ActivityShell, ActivityDetailChip } from "@/components/chat/ActivityShe
 import { ImageViewActivity, ImageGenerationActivity } from "@/components/chat/ImageActivity";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
 
+type SubagentActivity = Extract<AgentActivity, { kind: "subagent_activity" }>;
 type InlineAgentActivity = Exclude<AgentActivity, { kind: "plan_update" } | { kind: "goal_update" }>;
 
 interface AgentActivityListProps {
@@ -97,6 +98,7 @@ function activityToToolCalls(activity: InlineAgentActivity): ToolCall[] {
     case "image_view":
     case "image_generation":
     case "diagnostic":
+    case "subagent_activity":
       return [];
   }
 }
@@ -130,8 +132,55 @@ const AgentActivityItem = memo(function AgentActivityItem({
       return <ImageGenerationActivity activity={activity} showExecutingState={showExecutingState} />;
     case "diagnostic":
       return <DiagnosticActivity activity={activity} />;
+    case "subagent_activity":
+      return <SubagentActivityItem activity={activity} />;
   }
 });
+
+function SubagentActivityItem({ activity }: { activity: SubagentActivity }) {
+  return (
+    <ActivityShell
+      title={subagentActivityTitle(activity.activityKind)}
+      icon={subagentActivityIcon(activity.activityKind)}
+      detail={<AgentPathChip path={activity.agentPath} />}
+    />
+  );
+}
+
+function AgentPathChip({ path }: { path: string }) {
+  return (
+    <span
+      className="min-w-0 max-w-[min(28rem,60vw)] truncate"
+      title={path}
+      aria-label={`Agent path: ${path}`}
+    >
+      <ActivityDetailChip text={path} />
+    </span>
+  );
+}
+
+function subagentActivityTitle(activityKind: SubagentActivity["activityKind"]): string {
+  switch (activityKind) {
+    case "started":
+      return "Started sub-agent";
+    case "interacted":
+      return "Interacted with sub-agent";
+    case "interrupted":
+      return "Interrupted sub-agent";
+  }
+}
+
+function subagentActivityIcon(activityKind: SubagentActivity["activityKind"]) {
+  if (activityKind === "interrupted") {
+    return <CirclePauseIcon className="size-3.5 text-muted-foreground" aria-label="Sub-agent interrupted" />;
+  }
+
+  if (activityKind === "interacted") {
+    return <MessageCircleIcon className="size-3.5" aria-label="Sub-agent interaction" />;
+  }
+
+  return <BotIcon className="size-3.5" aria-label="Sub-agent started" />;
+}
 
 function DiagnosticActivity({ activity }: { activity: Extract<AgentActivity, { kind: "diagnostic" }> }) {
   const detail = activity.method ? <ActivityDetailChip text={activity.method} /> : undefined;

--- a/frontend/tests/components/AgentActivityList.test.tsx
+++ b/frontend/tests/components/AgentActivityList.test.tsx
@@ -14,6 +14,32 @@ function tool(overrides: Partial<ToolCall>): ToolCall {
 }
 
 describe("AgentActivityList", () => {
+  it.each([
+    ["started", "Started sub-agent"],
+    ["interacted", "Interacted with sub-agent"],
+    ["interrupted", "Interrupted sub-agent"],
+  ] as const)("renders %s sub-agent activity with an accessible path chip", (activityKind, title) => {
+    const agentPath = "/workspace/agents/research/very/long/sub-agent/thread/path";
+
+    render(
+      <AgentActivityList
+        activities={[{
+          id: `subagent-${activityKind}`,
+          kind: "subagent_activity",
+          activityKind,
+          agentThreadId: "thread-1",
+          agentPath,
+        }]}
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: new RegExp(title) });
+    expect(row).toBeInTheDocument();
+    expect(row).not.toHaveAttribute("aria-expanded");
+    expect(screen.getByTitle(agentPath)).toHaveAttribute("aria-label", `Agent path: ${agentPath}`);
+    expect(screen.queryByText("Unsupported App Server event")).not.toBeInTheDocument();
+  });
+
   it("renders command activity with streaming output", async () => {
     const user = userEvent.setup();
     const activities: AgentActivity[] = [{

--- a/frontend/tests/components/AgentActivityList.test.tsx
+++ b/frontend/tests/components/AgentActivityList.test.tsx
@@ -40,6 +40,33 @@ describe("AgentActivityList", () => {
     expect(screen.queryByText("Unsupported App Server event")).not.toBeInTheDocument();
   });
 
+  it("renders an in-progress context compaction while the turn is live", () => {
+    render(
+      <AgentActivityList
+        activities={[{ id: "compaction-1", kind: "context_compaction", status: "inProgress" }]}
+        showExecutingState
+      />,
+    );
+
+    const row = screen.getByRole("button", { name: /Compacting context…/ });
+    expect(row).not.toHaveAttribute("aria-expanded");
+    expect(row).toHaveAttribute("title", "Older messages were summarized to free up context");
+  });
+
+  it.each([
+    ["a completed compaction in a live turn", "completed", true],
+    ["a stale in-progress compaction after the turn ended", "inProgress", false],
+  ] as const)("renders %s as compacted", (_label, status, showExecutingState) => {
+    render(
+      <AgentActivityList
+        activities={[{ id: "compaction-1", kind: "context_compaction", status }]}
+        showExecutingState={showExecutingState}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: /Context compacted/ })).toBeInTheDocument();
+  });
+
   it("renders command activity with streaming output", async () => {
     const user = userEvent.setup();
     const activities: AgentActivity[] = [{

--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -28,6 +28,12 @@ enum AgentActivitySeverity: String, Codable, Equatable {
     case error
 }
 
+enum AgentActivitySubagentActivityKind: String, Codable, Equatable, CaseIterable {
+    case started
+    case interacted
+    case interrupted
+}
+
 enum AgentActivity: Codable, Equatable, Identifiable {
     case commandExecution(CommandExecution)
     case fileChange(FileChange)
@@ -35,6 +41,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
     case goalUpdate(GoalUpdate)
     case imageView(ImageView)
     case imageGeneration(ImageGeneration)
+    case subagentActivity(SubagentActivity)
     case diagnostic(Diagnostic)
     case unknown(Unknown)
 
@@ -111,6 +118,29 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         let imageUrl: String?
     }
 
+    struct SubagentActivity: Codable, Equatable, Identifiable {
+        let id: String
+        let activityKind: AgentActivitySubagentActivityKind
+        let agentThreadId: String
+        let agentPath: String
+
+        var displayTitle: String {
+            switch activityKind {
+            case .started: "Started sub-agent"
+            case .interacted: "Interacted with sub-agent"
+            case .interrupted: "Interrupted sub-agent"
+            }
+        }
+
+        var iconName: String {
+            switch activityKind {
+            case .started: "arrow.triangle.branch"
+            case .interacted: "bubble.left"
+            case .interrupted: "xmark.circle"
+            }
+        }
+    }
+
     struct Diagnostic: Codable, Equatable, Identifiable {
         let id: String
         let severity: AgentActivitySeverity
@@ -134,6 +164,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         case .goalUpdate(let activity): activity.id
         case .imageView(let activity): activity.id
         case .imageGeneration(let activity): activity.id
+        case .subagentActivity(let activity): activity.id
         case .diagnostic(let activity): activity.id
         case .unknown(let activity): activity.id
         }
@@ -147,6 +178,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         case .goalUpdate: "goal_update"
         case .imageView: "image_view"
         case .imageGeneration: "image_generation"
+        case .subagentActivity: "subagent_activity"
         case .diagnostic: "diagnostic"
         case .unknown(let activity): activity.kind
         }
@@ -159,6 +191,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         case steps
         case active, threadId, objective, tokenBudget, tokensUsed, timeUsedSeconds, createdAt, updatedAt
         case path, relativePath, imageUrl, outsideWorkspace, revisedPrompt, result, savedPath
+        case activityKind, agentThreadId, agentPath
         case severity, title, message, source, method, details
     }
 
@@ -166,25 +199,36 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let kind = try container.decode(String.self, forKey: .kind)
 
-        switch kind {
-        case "command_execution":
-            self = .commandExecution(try CommandExecution(from: decoder))
-        case "file_change":
-            self = .fileChange(try FileChange(from: decoder))
-        case "plan_update":
-            self = .planUpdate(try PlanUpdate(from: decoder))
-        case "goal_update":
-            self = .goalUpdate(try GoalUpdate(from: decoder))
-        case "image_view":
-            self = .imageView(try ImageView(from: decoder))
-        case "image_generation":
-            self = .imageGeneration(try ImageGeneration(from: decoder))
-        case "diagnostic":
-            self = .diagnostic(try Diagnostic(from: decoder))
-        default:
-            let id = (try? container.decode(String.self, forKey: .id)) ?? "unknown-\(kind)"
-            self = .unknown(Unknown(id: id, kind: kind))
+        do {
+            switch kind {
+            case "command_execution":
+                self = .commandExecution(try CommandExecution(from: decoder))
+            case "file_change":
+                self = .fileChange(try FileChange(from: decoder))
+            case "plan_update":
+                self = .planUpdate(try PlanUpdate(from: decoder))
+            case "goal_update":
+                self = .goalUpdate(try GoalUpdate(from: decoder))
+            case "image_view":
+                self = .imageView(try ImageView(from: decoder))
+            case "image_generation":
+                self = .imageGeneration(try ImageGeneration(from: decoder))
+            case "subagent_activity":
+                self = .subagentActivity(try SubagentActivity(from: decoder))
+            case "diagnostic":
+                self = .diagnostic(try Diagnostic(from: decoder))
+            default:
+                self = try Self.decodeUnknown(from: decoder, kind: kind)
+            }
+        } catch {
+            self = try Self.decodeUnknown(from: decoder, kind: kind)
         }
+    }
+
+    private static func decodeUnknown(from decoder: Decoder, kind: String) throws -> AgentActivity {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let id = (try? container.decode(String.self, forKey: .id)) ?? "unknown-\(kind)"
+        return .unknown(Unknown(id: id, kind: kind))
     }
 
     func encode(to encoder: Encoder) throws {
@@ -233,6 +277,11 @@ enum AgentActivity: Codable, Equatable, Identifiable {
             try container.encodeIfPresent(activity.savedPath, forKey: .savedPath)
             try container.encodeIfPresent(activity.relativePath, forKey: .relativePath)
             try container.encodeIfPresent(activity.imageUrl, forKey: .imageUrl)
+        case .subagentActivity(let activity):
+            try container.encode(activity.id, forKey: .id)
+            try container.encode(activity.activityKind, forKey: .activityKind)
+            try container.encode(activity.agentThreadId, forKey: .agentThreadId)
+            try container.encode(activity.agentPath, forKey: .agentPath)
         case .diagnostic(let activity):
             try container.encode(activity.id, forKey: .id)
             try container.encode(activity.severity, forKey: .severity)
@@ -267,7 +316,7 @@ private let activityToolCallsCache: NSCache<NSString, CachedActivityToolCalls> =
 extension AgentActivity {
     var toolCalls: [ToolCall] {
         switch self {
-        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .diagnostic, .unknown:
+        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .diagnostic, .unknown:
             return []
         case .commandExecution, .fileChange:
             break
@@ -321,7 +370,7 @@ extension AgentActivity {
                     parentToolUseId: nil
                 )
             }
-        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .diagnostic, .unknown:
+        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .diagnostic, .unknown:
             return []
         }
     }
@@ -342,6 +391,7 @@ private func activityToolCallsCacheCost(_ toolCalls: [ToolCall]) -> Int {
 enum VisibleAgentActivity: Equatable, Identifiable {
     case imageView(AgentActivity.ImageView)
     case imageGeneration(AgentActivity.ImageGeneration)
+    case subagentActivity(AgentActivity.SubagentActivity)
     case diagnostic(AgentActivity.Diagnostic)
     case unknown(AgentActivity.Unknown)
 
@@ -352,6 +402,8 @@ enum VisibleAgentActivity: Equatable, Identifiable {
             self = .imageView(image)
         case .imageGeneration(let image):
             self = .imageGeneration(image)
+        case .subagentActivity(let subagent):
+            self = .subagentActivity(subagent)
         case .diagnostic(let diagnostic):
             self = .diagnostic(diagnostic)
         case .unknown(let unknown):
@@ -367,6 +419,7 @@ enum VisibleAgentActivity: Equatable, Identifiable {
         switch self {
         case .imageView(let activity): activity.id
         case .imageGeneration(let activity): activity.id
+        case .subagentActivity(let activity): activity.id
         case .diagnostic(let activity): activity.id
         case .unknown(let activity): activity.id
         }

--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -42,6 +42,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
     case imageView(ImageView)
     case imageGeneration(ImageGeneration)
     case subagentActivity(SubagentActivity)
+    case contextCompaction(ContextCompaction)
     case diagnostic(Diagnostic)
     case unknown(Unknown)
 
@@ -141,6 +142,22 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         }
     }
 
+    struct ContextCompaction: Codable, Equatable, Identifiable {
+        let id: String
+        let status: String?
+
+        /// A compaction is pending while a turn is live (`showExecutingState`)
+        /// and the record has not reached its terminal status, so stale
+        /// in-progress records never animate after a turn ends.
+        func isPending(showExecutingState: Bool) -> Bool {
+            showExecutingState && status != "completed"
+        }
+
+        func displayTitle(showExecutingState: Bool) -> String {
+            isPending(showExecutingState: showExecutingState) ? "Compacting context…" : "Context compacted"
+        }
+    }
+
     struct Diagnostic: Codable, Equatable, Identifiable {
         let id: String
         let severity: AgentActivitySeverity
@@ -165,6 +182,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         case .imageView(let activity): activity.id
         case .imageGeneration(let activity): activity.id
         case .subagentActivity(let activity): activity.id
+        case .contextCompaction(let activity): activity.id
         case .diagnostic(let activity): activity.id
         case .unknown(let activity): activity.id
         }
@@ -179,6 +197,7 @@ enum AgentActivity: Codable, Equatable, Identifiable {
         case .imageView: "image_view"
         case .imageGeneration: "image_generation"
         case .subagentActivity: "subagent_activity"
+        case .contextCompaction: "context_compaction"
         case .diagnostic: "diagnostic"
         case .unknown(let activity): activity.kind
         }
@@ -215,6 +234,8 @@ enum AgentActivity: Codable, Equatable, Identifiable {
                 self = .imageGeneration(try ImageGeneration(from: decoder))
             case "subagent_activity":
                 self = .subagentActivity(try SubagentActivity(from: decoder))
+            case "context_compaction":
+                self = .contextCompaction(try ContextCompaction(from: decoder))
             case "diagnostic":
                 self = .diagnostic(try Diagnostic(from: decoder))
             default:
@@ -282,6 +303,9 @@ enum AgentActivity: Codable, Equatable, Identifiable {
             try container.encode(activity.activityKind, forKey: .activityKind)
             try container.encode(activity.agentThreadId, forKey: .agentThreadId)
             try container.encode(activity.agentPath, forKey: .agentPath)
+        case .contextCompaction(let activity):
+            try container.encode(activity.id, forKey: .id)
+            try container.encodeIfPresent(activity.status, forKey: .status)
         case .diagnostic(let activity):
             try container.encode(activity.id, forKey: .id)
             try container.encode(activity.severity, forKey: .severity)
@@ -316,7 +340,7 @@ private let activityToolCallsCache: NSCache<NSString, CachedActivityToolCalls> =
 extension AgentActivity {
     var toolCalls: [ToolCall] {
         switch self {
-        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .diagnostic, .unknown:
+        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .contextCompaction, .diagnostic, .unknown:
             return []
         case .commandExecution, .fileChange:
             break
@@ -370,7 +394,7 @@ extension AgentActivity {
                     parentToolUseId: nil
                 )
             }
-        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .diagnostic, .unknown:
+        case .planUpdate, .goalUpdate, .imageView, .imageGeneration, .subagentActivity, .contextCompaction, .diagnostic, .unknown:
             return []
         }
     }
@@ -392,6 +416,7 @@ enum VisibleAgentActivity: Equatable, Identifiable {
     case imageView(AgentActivity.ImageView)
     case imageGeneration(AgentActivity.ImageGeneration)
     case subagentActivity(AgentActivity.SubagentActivity)
+    case contextCompaction(AgentActivity.ContextCompaction)
     case diagnostic(AgentActivity.Diagnostic)
     case unknown(AgentActivity.Unknown)
 
@@ -404,6 +429,8 @@ enum VisibleAgentActivity: Equatable, Identifiable {
             self = .imageGeneration(image)
         case .subagentActivity(let subagent):
             self = .subagentActivity(subagent)
+        case .contextCompaction(let compaction):
+            self = .contextCompaction(compaction)
         case .diagnostic(let diagnostic):
             self = .diagnostic(diagnostic)
         case .unknown(let unknown):
@@ -420,6 +447,7 @@ enum VisibleAgentActivity: Equatable, Identifiable {
         case .imageView(let activity): activity.id
         case .imageGeneration(let activity): activity.id
         case .subagentActivity(let activity): activity.id
+        case .contextCompaction(let activity): activity.id
         case .diagnostic(let activity): activity.id
         case .unknown(let activity): activity.id
         }

--- a/ios/HiveMobile/Views/Chat/AgentActivityList.swift
+++ b/ios/HiveMobile/Views/Chat/AgentActivityList.swift
@@ -26,11 +26,27 @@ private struct AgentActivityRow: View {
             ImageViewActivityRow(activity: image)
         case .imageGeneration(let image):
             ImageGenerationActivityRow(activity: image, showExecutingState: showExecutingState)
+        case .subagentActivity(let subagent):
+            SubagentActivityRow(activity: subagent)
         case .diagnostic(let diagnostic):
             DiagnosticActivityRow(activity: diagnostic)
         case .unknown(let unknown):
             UnknownActivityRow(activity: unknown)
         }
+    }
+}
+
+private struct SubagentActivityRow: View {
+    let activity: AgentActivity.SubagentActivity
+
+    var body: some View {
+        ActivityDisclosureRow(
+            icon: activity.iconName,
+            title: activity.displayTitle,
+            detail: activity.agentPath
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(activity.displayTitle), Agent path: \(activity.agentPath)")
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/AgentActivityList.swift
+++ b/ios/HiveMobile/Views/Chat/AgentActivityList.swift
@@ -28,6 +28,8 @@ private struct AgentActivityRow: View {
             ImageGenerationActivityRow(activity: image, showExecutingState: showExecutingState)
         case .subagentActivity(let subagent):
             SubagentActivityRow(activity: subagent)
+        case .contextCompaction(let compaction):
+            ContextCompactionActivityRow(activity: compaction, showExecutingState: showExecutingState)
         case .diagnostic(let diagnostic):
             DiagnosticActivityRow(activity: diagnostic)
         case .unknown(let unknown):
@@ -47,6 +49,24 @@ private struct SubagentActivityRow: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(activity.displayTitle), Agent path: \(activity.agentPath)")
+    }
+}
+
+private struct ContextCompactionActivityRow: View {
+    let activity: AgentActivity.ContextCompaction
+    var showExecutingState = false
+
+    private var title: String { activity.displayTitle(showExecutingState: showExecutingState) }
+
+    var body: some View {
+        ActivityDisclosureRow(
+            icon: "rectangle.compress.vertical",
+            title: title,
+            executing: activity.isPending(showExecutingState: showExecutingState)
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(title)
+        .accessibilityHint("Older messages were summarized to free up context.")
     }
 }
 

--- a/ios/Tests/ChatDraftStoreTests/AgentActivityDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/AgentActivityDecodingTests.swift
@@ -3,6 +3,180 @@ import Testing
 @testable import HiveMobileStoresCore
 
 struct AgentActivityDecodingTests {
+    @Test(arguments: AgentActivitySubagentActivityKind.allCases)
+    func decodesSubagentActivityVariants(_ activityKind: AgentActivitySubagentActivityKind) throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "subagent-\(activityKind.rawValue)",
+              "kind": "subagent_activity",
+              "activityKind": "\(activityKind.rawValue)",
+              "agentThreadId": "thread-1",
+              "agentPath": "/workspace/agents/research/sub-agent/thread"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .subagentActivity(let subagent) = activity else {
+            Issue.record("Expected subagent activity")
+            return
+        }
+        #expect(subagent.activityKind == activityKind)
+        #expect(subagent.agentThreadId == "thread-1")
+        #expect(subagent.agentPath == "/workspace/agents/research/sub-agent/thread")
+        #expect(subagent.displayTitle == expectedSubagentTitle(for: activityKind))
+        #expect(subagent.iconName == expectedSubagentIcon(for: activityKind))
+        #expect(activity.toolCalls.isEmpty)
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["subagent-\(activityKind.rawValue)"])
+    }
+
+    @Test
+    func keepsUnknownActivityDecodingAndVisibleFiltering() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "future-1",
+              "kind": "future_activity"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .unknown(let unknown) = activity else {
+            Issue.record("Expected unknown activity")
+            return
+        }
+        #expect(unknown.id == "future-1")
+        #expect(unknown.kind == "future_activity")
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["future-1"])
+    }
+
+    @Test
+    func knownActivityWithUnknownSubagentActivityKindDecodesAsUnknown() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "subagent-future",
+              "kind": "subagent_activity",
+              "activityKind": "delegated",
+              "agentThreadId": "thread-1",
+              "agentPath": "/workspace/agents/research"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .unknown(let unknown) = activity else {
+            Issue.record("Expected unknown activity")
+            return
+        }
+        #expect(unknown.id == "subagent-future")
+        #expect(unknown.kind == "subagent_activity")
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["subagent-future"])
+    }
+
+    @Test
+    func knownDiagnosticWithUnknownSeverityDecodesAsUnknown() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "diag-future",
+              "kind": "diagnostic",
+              "severity": "catastrophic",
+              "title": "Future diagnostic",
+              "message": "Future severity",
+              "source": "codex_app_server",
+              "method": "item/subAgentActivity"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .unknown(let unknown) = activity else {
+            Issue.record("Expected unknown activity")
+            return
+        }
+        #expect(unknown.id == "diag-future")
+        #expect(unknown.kind == "diagnostic")
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["diag-future"])
+    }
+
+    @Test
+    func mixedValidAndMalformedActivitiesBothSurviveDecoding() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "subagent-started",
+              "kind": "subagent_activity",
+              "activityKind": "started",
+              "agentThreadId": "thread-1",
+              "agentPath": "/workspace/agents/research"
+            },
+            {
+              "id": "subagent-future",
+              "kind": "subagent_activity",
+              "activityKind": "delegated",
+              "agentThreadId": "thread-2",
+              "agentPath": "/workspace/agents/future"
+            }
+          ]
+        }
+        """)
+
+        let activities = try #require(message.agentActivities)
+        #expect(activities.count == 2)
+
+        guard case .subagentActivity(let valid) = activities[0] else {
+            Issue.record("Expected valid subagent activity")
+            return
+        }
+        #expect(valid.id == "subagent-started")
+        #expect(valid.activityKind == .started)
+
+        guard case .unknown(let unknown) = activities[1] else {
+            Issue.record("Expected unknown activity")
+            return
+        }
+        #expect(unknown.id == "subagent-future")
+        #expect(unknown.kind == "subagent_activity")
+        #expect(visibleAgentActivities(activities).map(\.id) == ["subagent-started", "subagent-future"])
+    }
+
     @Test
     func decodesCommandExecutionWebSocketEvent() throws {
         let envelope = try decodeHubEnvelope("""
@@ -457,5 +631,21 @@ struct AgentActivityDecodingTests {
     private func decodeMessage(_ json: String) throws -> ChatMessage {
         let data = try #require(json.data(using: .utf8))
         return try JSONDecoder().decode(ChatMessage.self, from: data)
+    }
+
+    private func expectedSubagentTitle(for activityKind: AgentActivitySubagentActivityKind) -> String {
+        switch activityKind {
+        case .started: "Started sub-agent"
+        case .interacted: "Interacted with sub-agent"
+        case .interrupted: "Interrupted sub-agent"
+        }
+    }
+
+    private func expectedSubagentIcon(for activityKind: AgentActivitySubagentActivityKind) -> String {
+        switch activityKind {
+        case .started: "arrow.triangle.branch"
+        case .interacted: "bubble.left"
+        case .interrupted: "xmark.circle"
+        }
     }
 }

--- a/ios/Tests/ChatDraftStoreTests/AgentActivityDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/AgentActivityDecodingTests.swift
@@ -178,6 +178,99 @@ struct AgentActivityDecodingTests {
     }
 
     @Test
+    func decodesContextCompactionInProgress() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "compaction-1",
+              "kind": "context_compaction",
+              "status": "inProgress"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .contextCompaction(let compaction) = activity else {
+            Issue.record("Expected context compaction activity")
+            return
+        }
+        #expect(compaction.status == "inProgress")
+        #expect(compaction.isPending(showExecutingState: true))
+        #expect(!compaction.isPending(showExecutingState: false))
+        #expect(compaction.displayTitle(showExecutingState: true) == "Compacting context…")
+        #expect(compaction.displayTitle(showExecutingState: false) == "Context compacted")
+        #expect(activity.toolCalls.isEmpty)
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["compaction-1"])
+    }
+
+    @Test
+    func decodesContextCompactionCompleted() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "compaction-1",
+              "kind": "context_compaction",
+              "status": "completed"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .contextCompaction(let compaction) = activity else {
+            Issue.record("Expected context compaction activity")
+            return
+        }
+        #expect(compaction.status == "completed")
+        #expect(!compaction.isPending(showExecutingState: true))
+        #expect(compaction.displayTitle(showExecutingState: true) == "Context compacted")
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["compaction-1"])
+    }
+
+    @Test
+    func decodesContextCompactionWithoutStatus() throws {
+        let message = try decodeMessage("""
+        {
+          "id": "msg-1",
+          "sessionId": "session-1",
+          "role": "assistant",
+          "content": "",
+          "timestamp": "2026-01-01T00:00:00Z",
+          "agentActivities": [
+            {
+              "id": "compaction-1",
+              "kind": "context_compaction"
+            }
+          ]
+        }
+        """)
+
+        let activity = try #require(message.agentActivities?.first)
+        guard case .contextCompaction(let compaction) = activity else {
+            Issue.record("Expected context compaction activity")
+            return
+        }
+        #expect(compaction.status == nil)
+        #expect(compaction.isPending(showExecutingState: true))
+        #expect(compaction.displayTitle(showExecutingState: true) == "Compacting context…")
+        #expect(compaction.displayTitle(showExecutingState: false) == "Context compacted")
+        #expect(visibleAgentActivities([activity]).map(\.id) == ["compaction-1"])
+    }
+
+    @Test
     func decodesCommandExecutionWebSocketEvent() throws {
         let envelope = try decodeHubEnvelope("""
         {

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -105,6 +105,11 @@ export type AgentActivity =
     }
   | {
       id: string;
+      kind: "context_compaction";
+      status?: string;
+    }
+  | {
+      id: string;
       kind: "diagnostic";
       severity: "info" | "warning" | "error";
       title: string;

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -19,6 +19,17 @@ export interface AgentActivityToolCall {
   parentToolUseId?: string;
 }
 
+export const AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS = ["started", "interacted", "interrupted"] as const;
+
+export type AgentActivitySubagentActivityKind = (typeof AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS)[number];
+
+export function isAgentActivitySubagentActivityKind(value: unknown): value is AgentActivitySubagentActivityKind {
+  return (
+    typeof value === "string"
+    && (AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS as readonly string[]).includes(value)
+  );
+}
+
 export interface CommandExecutionToolSource {
   id: string;
   command?: string;
@@ -84,6 +95,13 @@ export type AgentActivity =
       savedPath?: string;
       relativePath?: string;
       imageUrl?: string;
+    }
+  | {
+      id: string;
+      kind: "subagent_activity";
+      activityKind: AgentActivitySubagentActivityKind;
+      agentThreadId: string;
+      agentPath: string;
     }
   | {
       id: string;


### PR DESCRIPTION
## Summary

Normalize and render Codex App Server activity items that previously fell through as unsupported raw JSON, covering both multi-agent v1 and v2, plus context compaction — across shared types, backend persistence, web UI, and iOS.

## What's new

- **Sub-agent activity (`subAgentActivity`)** — new `subagent_activity` activity with kinds `started`, `interacted`, `interrupted`, threaded from the shared types (`AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS`) through the backend normalizer, `ConversationSession` persistence, and both clients.
- **Multi-agent v2 spawns** — v2 emits no `collabAgentToolCall` and its `wait` items carry no receiver ids. The `started` item is now the sole signal mapping a child thread to its spawn: the backend synthesizes the same `Agent` tool card as a v1 `spawnAgent` (so child tools nest under it via `parentToolUseId`) and registers `collabParentByThreadId`, including foreign/grandchild threads. `interacted`/`interrupted` render as compact activity rows.
- **Context compaction (`contextCompaction`)** — new `context_compaction` activity with a live (shimmer) vs. settled state; a sub-agent compacting its own context is kept internal to its execution.
- **Hardened boundary** — receiver-thread activity is guarded from leaking into the parent stream, and unknown/malformed payloads degrade to an info diagnostic at the backend boundary instead of breaking the turn.
- **iOS resilience** — malformed known-activity payloads decode to `.unknown` so one bad activity no longer blocks history loading.

## UI

- Web (`AgentActivityList` / `SubAgentNode` / `ToolCallList`) and iOS (`AgentActivityList.swift` / `MessageBubble.swift`) render identically: spawn = collapsible `Agent` card with nested child tools and the shared `N tool calls, M subagents` summary (collapse threshold 3); `subagent_activity` / `context_compaction` / `diagnostic` as flat always-visible rows.

## Tests

- Backend: `codex-app-server.test.ts` and `conversation-session.test.ts` cover v1/v2 normalization, receiver-thread guarding, and malformed payloads.
- Frontend: `AgentActivityList.test.tsx`.
- iOS: `AgentActivityDecodingTests` cover decoding and the `.unknown` degradation path.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npx vitest run src/agents/providers/codex-app-server.test.ts`
- `swift test --filter AgentActivityDecodingTests` could not run because `swift` is not installed in this environment.
