### PR TITLE
fix: keep sidebar PR status in sync

### DIFF
--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -1771,6 +1771,109 @@ describe("WS /ws/hub", () => {
     ws.close();
   });
 
+  it("processes overlapping sync_workspaces messages in send order", async () => {
+    const otherWorkspace = await createWorkspace(projectId, dataDir);
+
+    const { wsReady } = connectHub([wsId]);
+    const ws = await wsReady;
+
+    // The first sync awaits the new workspace bootstrap. The second sync must
+    // wait for it instead of undoing its state changes mid-bootstrap.
+    syncWorkspaces(ws, [wsId, otherWorkspace.id]);
+    syncWorkspaces(ws, [wsId]);
+
+    await waitForCondition(() => {
+      const channel = _getChannelsForTests().get(otherWorkspace.id);
+      return !channel || channel.hubSockets.size === 0;
+    });
+
+    expect(_getChannelsForTests().get(wsId)?.hubSockets.size).toBe(1);
+    expect(_getChannelsForTests().get(otherWorkspace.id)?.hubSockets.size ?? 0).toBe(0);
+
+    ws.close();
+  });
+
+  it("authorizes a user_message racing a sync queued behind a slow PR refresh", async () => {
+    let resolvePr!: (value: { pr: null }) => void;
+    const deferred = new Promise<{ pr: null }>((resolve) => { resolvePr = resolve; });
+    const prStatusProvider = {
+      getCachedStatus: vi.fn(() => undefined),
+      getStatus: vi.fn(() => deferred),
+    };
+    const local = await startWsApp(undefined, CONV_CMD, undefined, prStatusProvider);
+    const otherWorkspace = await createWorkspace(projectId, dataDir);
+
+    const { wsReady, allEnvelopes } = connectHub([wsId], {
+      app: local.app,
+      collectAll: true,
+      prWorkspaces: [wsId],
+    });
+    const ws = await wsReady;
+    await waitForCondition(() => allEnvelopes.some((e) => e.event.type === "status"));
+
+    // The PR refresh above is still pending. A follow-up sync adding a
+    // workspace plus an immediate message to it must be authorized:
+    // subscription intent is recorded at receipt, not when the queued sync
+    // finally runs.
+    syncWorkspaces(ws, [wsId, otherWorkspace.id], undefined, [wsId]);
+    ws.send(hubEvent(otherWorkspace.id, { type: "user_message", content: "race" }));
+
+    await waitForCondition(() =>
+      allEnvelopes.some((e) =>
+        e.workspaceId === otherWorkspace.id &&
+        e.event.type === "status" &&
+        e.event.streaming === true,
+      ),
+    );
+    expect(
+      allEnvelopes.some(
+        (e) => e.event.type === "error" && e.event.message.includes("Not subscribed"),
+      ),
+    ).toBe(false);
+
+    resolvePr({ pr: null });
+    ws.close();
+    await endSession(otherWorkspace.id, dataDir).catch(() => {});
+    await local.app.close();
+  });
+
+  it("drops a queued sync when the socket closes before it runs", async () => {
+    let resolvePr!: (value: { pr: null }) => void;
+    const deferred = new Promise<{ pr: null }>((resolve) => { resolvePr = resolve; });
+    const prStatusProvider = {
+      getCachedStatus: vi.fn(() => undefined),
+      getStatus: vi.fn(() => deferred),
+    };
+    const local = await startWsApp(undefined, CONV_CMD, undefined, prStatusProvider);
+    const otherWorkspace = await createWorkspace(projectId, dataDir);
+
+    const { wsReady, allEnvelopes } = connectHub([wsId], {
+      app: local.app,
+      collectAll: true,
+      prWorkspaces: [wsId],
+    });
+    const ws = await wsReady;
+    await waitForCondition(() => allEnvelopes.some((e) => e.event.type === "status"));
+
+    // Queue a sync behind the pending PR refresh, then drop the socket
+    // server-side (client-initiated close does not propagate under injectWS).
+    // The queued sync must not run after close and re-create channels for a
+    // dead socket.
+    syncWorkspaces(ws, [wsId, otherWorkspace.id], undefined, [wsId]);
+    // Let the frame reach the server so the sync is actually queued.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const hub = [..._getHubSocketsForTests()].find((h) => h.subscribedWorkspaces.has(wsId));
+    hub!.ws.terminate();
+    await waitForCondition(() => !_getHubSocketsForTests().has(hub!));
+
+    resolvePr({ pr: null });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(_getChannelsForTests().get(otherWorkspace.id)).toBeUndefined();
+    expect(_getChannelsForTests().get(wsId)).toBeUndefined();
+    await local.app.close();
+  });
+
   it("delivers high-frequency events only to focused workspaces (C13)", async () => {
     const unfocused = (await createWorkspace(projectId, dataDir)).id;
 

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -1504,6 +1504,37 @@ describe("WS /ws/hub", () => {
     await local.app.close();
   });
 
+  it("sends PR status when a PR-flagged workspace later becomes subscribed", async () => {
+    const prStatusProvider = {
+      getCachedStatus: vi.fn(() => undefined),
+      getStatus: vi.fn(async () => ({ pr: null })),
+    };
+    const local = await startWsApp(undefined, CONV_CMD, undefined, prStatusProvider);
+    // Sidebar effects can flag PR interest before the app-level sync sends the
+    // full subscription list: the first sync carries prWorkspaces while the
+    // workspace is still missing from workspaceIds, so nothing is sent yet.
+    const { wsReady, messages, allEnvelopes } = connectHub([], {
+      app: local.app,
+      collectAll: true,
+      prWorkspaces: [wsId],
+    });
+    const ws = await wsReady;
+
+    await new Promise((r) => setTimeout(r, 100));
+    expect(allEnvelopes.some((e) => e.event.type === "pr_status")).toBe(false);
+
+    // The follow-up sync subscribes the workspace; prWorkspaces is unchanged.
+    // The initial status must be delivered now, not skipped as already-flagged.
+    syncWorkspaces(ws, [wsId], undefined, [wsId]);
+
+    await waitForMessage(messages, (msgs) => msgs.some((m) => m.type === "pr_status"));
+    expect(prStatusProvider.getStatus).toHaveBeenCalledWith(wsId);
+    expect(messages).toContainEqual({ type: "pr_status", status: { pr: null } });
+
+    ws.close();
+    await local.app.close();
+  });
+
   it("broadcasts PR status only to hubs interested in that workspace", async () => {
     const interested = connectHub([wsId], { collectAll: true, prWorkspaces: [wsId] });
     const uninterested = connectHub([wsId], { collectAll: true });

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -534,10 +534,17 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
     }
 
+    // A PR status was actually delivered only when the workspace was both
+    // subscribed AND PR-flagged on a previous sync. Clients can flag
+    // prWorkspaces before the full subscription list arrives (sidebar effects
+    // run before the app-level workspace sync), so PR interest recorded while
+    // the workspace was outside `workspaceIds` sent nothing — treat those as
+    // new and send the initial status now.
     const prRefreshes = [...hub.prWorkspaces]
       .filter((wsId) =>
         desired.has(wsId) &&
-        (forceBootstrap || !previousPrWorkspaces.has(wsId))
+        (forceBootstrap ||
+          !(previouslySubscribed.has(wsId) && previousPrWorkspaces.has(wsId)))
       )
       .map((wsId) => sendWorkspacePrStatus(hub, wsId));
     await Promise.all(prRefreshes);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -50,6 +50,11 @@ interface HubSocket {
   isAlive: boolean;
   focusWorkspaces?: Set<string>;
   prWorkspaces: Set<string>;
+  /**
+   * Latest workspaceIds requested via sync_workspaces, recorded synchronously
+   * at receipt so a workspace message racing a queued sync is authorized.
+   */
+  requestedWorkspaces?: Set<string>;
 }
 
 const HIGH_FREQUENCY_EVENTS: ReadonlySet<WsOutgoing["type"]> = new Set([
@@ -498,11 +503,11 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
     }
 
-    // Subscribe to new workspaces and bootstrap. Subscription intent is recorded
-    // synchronously (the channel is created now and hub.subscribedWorkspaces is
-    // updated below, both before the first bootstrap `await`) so that a workspace
-    // message racing the async bootstrap on this same socket is authorized rather
-    // than rejected as "Not subscribed".
+    // Subscribe to new workspaces and bootstrap. Syncs are serialized per
+    // socket and subscription intent is already recorded at message receipt
+    // (hub.requestedWorkspaces plus channel creation), so a workspace message
+    // racing a queued sync or an async bootstrap is authorized rather than
+    // rejected as "Not subscribed".
     //
     // The hub socket is added to channel.hubSockets only AFTER each bootstrap
     // completes so that live events broadcast during the async bootstrap don't
@@ -519,7 +524,9 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
     for (const [wsId, channel] of newlySubscribed) {
       await sendWorkspaceBootstrap(hub, wsId, channel);
-      channel.hubSockets.add(hub);
+      // The socket may close while a bootstrap awaits; adding it then would
+      // resurrect membership the close handler already cleaned up.
+      if (hub.ws.readyState === hub.ws.OPEN) channel.hubSockets.add(hub);
     }
 
     // Resend full bootstrap for workspaces the client was already subscribed
@@ -540,6 +547,11 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     // run before the app-level workspace sync), so PR interest recorded while
     // the workspace was outside `workspaceIds` sent nothing — treat those as
     // new and send the initial status now.
+    //
+    // The refreshes can hit the network (gh takes up to 8s), so let them
+    // finish in the background instead of holding the per-socket sync queue.
+    // sendToHub re-checks PR interest at send time, which suppresses the send
+    // if a later sync drops the workspace; sendWorkspacePrStatus never rejects.
     const prRefreshes = [...hub.prWorkspaces]
       .filter((wsId) =>
         desired.has(wsId) &&
@@ -547,14 +559,16 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           !(previouslySubscribed.has(wsId) && previousPrWorkspaces.has(wsId)))
       )
       .map((wsId) => sendWorkspacePrStatus(hub, wsId));
-    await Promise.all(prRefreshes);
+    void Promise.all(prRefreshes);
   };
 
   // ── Workspace message handler ─────────────────────────────────────
 
   const handleWorkspaceMessage = async (hub: HubSocket, wsId: string, incoming: WsIncoming): Promise<void> => {
     const channel = channels.get(wsId);
-    if (!channel || !hub.subscribedWorkspaces.has(wsId)) {
+    const subscriptionKnown =
+      hub.subscribedWorkspaces.has(wsId) || hub.requestedWorkspaces?.has(wsId) === true;
+    if (!channel || !subscriptionKnown) {
       sendToHub(hub, wsId, { type: "error", message: `Not subscribed to workspace ${wsId}` });
       return;
     }
@@ -740,12 +754,23 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       const pingTimer = setInterval(() => tickHubLiveness(hub), PING_INTERVAL_MS);
       hubPingTimers.set(hub, pingTimer);
 
+      // WebSocket message callbacks can overlap while an async workspace
+      // bootstrap is in flight. Serialize syncs so their final state follows
+      // the order sent by the client.
+      let syncQueue: Promise<void> | null = null;
+      let closed = false;
+
       socket.on("close", () => {
+        closed = true;
         const timer = hubPingTimers.get(hub);
         if (timer) { clearInterval(timer); hubPingTimers.delete(hub); }
 
-        // Unsubscribe from all workspace channels
-        for (const wsId of hub.subscribedWorkspaces) {
+        // Unsubscribe from all workspace channels, including channels created
+        // at sync receipt whose queued sync never got to run.
+        for (const wsId of new Set([
+          ...hub.subscribedWorkspaces,
+          ...(hub.requestedWorkspaces ?? []),
+        ])) {
           const channel = channels.get(wsId);
           if (channel) {
             channel.hubSockets.delete(hub);
@@ -776,17 +801,26 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             socket.send(JSON.stringify({ type: "pong" }));
           }
         } else if ("type" in parsed && parsed.type === "sync_workspaces") {
-          try {
+          // Record subscription intent synchronously — requested set plus
+          // channel creation — so a workspace message sent right behind this
+          // frame is authorized even while the sync waits in the queue.
+          const workspaceIds = parsed.workspaceIds ?? [];
+          hub.requestedWorkspaces = new Set(workspaceIds);
+          for (const wsId of workspaceIds) getOrCreateChannel(wsId);
+          const runSync = async () => {
+            if (closed) return;
             await handleSyncWorkspaces(
               hub,
-              parsed.workspaceIds,
+              workspaceIds,
               parsed.focusWorkspaces,
               parsed.prWorkspaces,
               parsed.forceBootstrap === true,
             );
-          } catch (err) {
-            app.log.error({ err }, "sync_workspaces handler failed");
-          }
+          };
+          syncQueue = (syncQueue ? syncQueue.then(runSync) : runSync())
+            .catch((err) => {
+              app.log.error({ err }, "sync_workspaces handler failed");
+            });
         } else if ("workspaceId" in parsed && "event" in parsed) {
           await handleWorkspaceMessage(hub, parsed.workspaceId, parsed.event);
         }

--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -3,7 +3,6 @@ import {
   useQuery,
   useQueries,
   useQueryClient,
-  keepPreviousData,
 } from "@tanstack/react-query";
 import { wsTransport } from "@/lib/ws-transport";
 import type { PrStatusResponse } from "@/types";
@@ -49,7 +48,6 @@ export function usePrStatus(wsId: string | undefined) {
     enabled: false,
     staleTime: Number.POSITIVE_INFINITY,
     gcTime: PR_GC_TIME,
-    placeholderData: keepPreviousData,
   });
 
   const hasData = query.data !== undefined;
@@ -72,7 +70,6 @@ export function usePrStatusMap(wsIds: string[]) {
       enabled: false,
       staleTime: Number.POSITIVE_INFINITY,
       gcTime: PR_GC_TIME,
-      placeholderData: keepPreviousData,
     })),
   });
 

--- a/frontend/src/hooks/useWsCacheInvalidation.ts
+++ b/frontend/src/hooks/useWsCacheInvalidation.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { wsTransport } from "@/lib/ws-transport";
 import { invalidateSessionMessages } from "@/hooks/useSessionMessages";
+import { prStatusKey } from "@/hooks/usePrStatus";
 
 /**
  * Subscribe to WS messages for the given workspace IDs and invalidate
@@ -14,6 +15,20 @@ import { invalidateSessionMessages } from "@/hooks/useSessionMessages";
  */
 export function useWsCacheInvalidation(workspaceIds: string[]): void {
   const queryClient = useQueryClient();
+
+  // pr_status is cached via the global listener, not the per-workspace
+  // handlers below: those only cover workspaces already loaded from the
+  // projects list, and an event arriving before that load would be consumed
+  // by another handler (e.g. the conversation's) and never buffered.
+  useEffect(
+    () =>
+      wsTransport.onGlobalMessage((wsId, msg) => {
+        if (msg.type === "pr_status") {
+          queryClient.setQueryData(prStatusKey(wsId), msg.status);
+        }
+      }),
+    [queryClient],
+  );
 
   useEffect(() => {
     const unsubscribers = workspaceIds.map((wsId) =>
@@ -33,10 +48,6 @@ export function useWsCacheInvalidation(workspaceIds: string[]): void {
             void queryClient.invalidateQueries({ queryKey: ["files", wsId] });
             void queryClient.invalidateQueries({ queryKey: ["diff-stat", wsId] });
             void queryClient.invalidateQueries({ queryKey: ["file-completions", wsId] });
-            break;
-
-          case "pr_status":
-            queryClient.setQueryData(["pr-status", wsId], msg.status);
             break;
 
           case "status":

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -61,6 +61,7 @@ vi.mock("react-resizable-panels", () => {
 
 vi.mock("@/lib/ws-transport", () => {
   const messageHandlers = new Map<string, Set<(msg: WsOutgoing) => void>>();
+  const globalHandlers = new Set<(workspaceId: string, msg: WsOutgoing) => void>();
 
   const getSet = (workspaceId: string) => {
     const existing = messageHandlers.get(workspaceId);
@@ -78,17 +79,24 @@ vi.mock("@/lib/ws-transport", () => {
         hadBufferedMessages: false,
       };
     }),
+    onGlobalMessage: vi.fn((handler: (workspaceId: string, msg: WsOutgoing) => void) => {
+      globalHandlers.add(handler);
+      return () => { globalHandlers.delete(handler); };
+    }),
     onReconnect: vi.fn(() => () => {}),
     syncPrWorkspaces: vi.fn(),
   };
 
   const __wsMock = {
     emit: (workspaceId: string, msg: WsOutgoing) => {
+      for (const handler of globalHandlers) handler(workspaceId, msg);
       for (const handler of messageHandlers.get(workspaceId) ?? []) handler(msg);
     },
     reset: () => {
       messageHandlers.clear();
+      globalHandlers.clear();
       wsTransport.onMessage.mockClear();
+      wsTransport.onGlobalMessage.mockClear();
       wsTransport.syncPrWorkspaces.mockClear();
     },
   };

--- a/frontend/tests/hooks/usePrStatus.test.ts
+++ b/frontend/tests/hooks/usePrStatus.test.ts
@@ -111,6 +111,34 @@ describe("usePrStatus", () => {
       expect(result.current.pr?.number).toBe(2);
     });
   });
+
+  it("does not leak the previous workspace's status when switching to an uncached one", async () => {
+    const { wrapper, queryClient } = createWrapper();
+    renderHook(() => useSyncPrWorkspaces(["ws-1", "ws-2"]), { wrapper });
+    queryClient.setQueryData(prStatusKey("ws-1"), {
+      pr: makePr({ number: 1 }),
+    } satisfies PrStatusResponse);
+
+    const { result, rerender } = renderHook(
+      ({ wsId }: { wsId: string | undefined }) => usePrStatus(wsId),
+      {
+        initialProps: { wsId: "ws-1" },
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.pr?.number).toBe(1);
+    });
+
+    rerender({ wsId: "ws-2" });
+
+    // ws-2 has no cached status yet: show loading, never ws-1's PR.
+    await waitFor(() => {
+      expect(result.current.loading).toBe(true);
+    });
+    expect(result.current.pr).toBeNull();
+  });
 });
 
 describe("usePrStatusMap", () => {

--- a/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
+++ b/frontend/tests/hooks/useWsCacheInvalidation.test.tsx
@@ -2,12 +2,14 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
 import { sessionMessagesKey } from "@/hooks/useSessionMessages";
+import { prStatusKey } from "@/hooks/usePrStatus";
 import { createWrapper } from "../test-utils";
 
 interface Message {
   type: string;
   sessionId?: string;
   streaming?: boolean;
+  status?: unknown;
 }
 
 interface Listener {
@@ -18,16 +20,20 @@ interface Listener {
 
 const mocks = vi.hoisted(() => ({
   onMessage: vi.fn(),
+  onGlobalMessage: vi.fn(),
 }));
 
 vi.mock("@/lib/ws-transport", () => ({
   wsTransport: {
     onMessage: mocks.onMessage,
+    onGlobalMessage: mocks.onGlobalMessage,
     onReconnect: vi.fn(() => () => {}),
   },
 }));
 
 const listeners: Listener[] = [];
+let globalHandler: ((wsId: string, msg: Message) => void) | null = null;
+let globalUnsubscribe: ReturnType<typeof vi.fn>;
 
 function emit(wsId: string, msg: Message) {
   const listener = listeners.find((entry) => entry.wsId === wsId);
@@ -43,6 +49,12 @@ describe("useWsCacheInvalidation", () => {
       const unsubscribe = vi.fn();
       listeners.push({ wsId, handler, unsubscribe });
       return { unsubscribe, hadBufferedMessages: false };
+    });
+    globalHandler = null;
+    globalUnsubscribe = vi.fn();
+    mocks.onGlobalMessage.mockImplementation((handler: (wsId: string, msg: Message) => void) => {
+      globalHandler = handler;
+      return globalUnsubscribe;
     });
   });
 
@@ -100,6 +112,26 @@ describe("useWsCacheInvalidation", () => {
 
     expect(invalidateSpy).toHaveBeenNthCalledWith(1, { queryKey: ["workspace", "ws-1"] });
     expect(invalidateSpy).toHaveBeenNthCalledWith(2, { queryKey: ["sessions", "ws-1"] });
+  });
+
+  it("caches pr_status from the global listener, even for workspaces outside the list", () => {
+    const { wrapper, queryClient } = createWrapper();
+    renderHook(() => useWsCacheInvalidation(["ws-1"]), { wrapper });
+
+    // pr_status can arrive before the projects list populates workspaceIds;
+    // the global listener must cache it regardless of per-workspace handlers.
+    globalHandler?.("ws-2", { type: "pr_status", status: { pr: null } });
+
+    expect(queryClient.getQueryData(prStatusKey("ws-2"))).toEqual({ pr: null });
+  });
+
+  it("unsubscribes the global listener on unmount", () => {
+    const { wrapper } = createWrapper();
+    const { unmount } = renderHook(() => useWsCacheInvalidation(["ws-1"]), { wrapper });
+
+    unmount();
+
+    expect(globalUnsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("ignores unsupported message types", () => {


### PR DESCRIPTION
## Summary
- keep PR status delivery correct when subscription and PR interest syncs arrive in different orders
- cache PR status globally so early events are not lost
- remove stale placeholder PR data when switching workspaces

## Verification
- backend WS targeted tests
- frontend PR status, cache invalidation, and Sidebar tests
- lint
- typecheck