### PR TITLE
review: install-flow design amendments (round 1)

### DIFF
--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -26,6 +26,12 @@ infrastructure.
    review dropped the planned `/ws/setup` channel (§3.5), no new WS surface
    is added at all. iOS is unaffected until Phase 5 (which only adds a QR
    scanner + Keychain move).
+6. **Pristine servers only.** `provision.sh` refuses servers that already run
+   other services or a manual Hive install (`probe_env` →
+   `SERVER_NOT_PRISTINE` / `EXISTING_INSTALL`) instead of half-applying
+   firewall and unit changes to an inhabited box. No automatic migration from
+   manual installs in v1 — the documented path is: back up `~/.hive`, wipe or
+   recreate the server, run the wizard, restore the data dir.
 
 ---
 
@@ -210,8 +216,10 @@ scripts/provision/
   lib.sh                    # framework: emit/run_step/state/locking/traps (§5.1)
   protocol.schema.json      # frozen contract 3.1
   steps/
-    00-probe-os.sh          10-apt-baseline.sh      20-install-node.sh
-    30-create-user.sh       40-install-tailscale.sh 41-tailscale-up.sh
+    00-probe-os.sh          01-probe-env.sh         10-apt-baseline.sh
+    20-install-node.sh
+    30-create-user.sh       40-install-tailscale.sh
+    41-tailscale-up.sh
     50-configure-ufw.sh     60-fetch-release.sh     61-install-release.sh
     70-write-secrets.sh     71-write-units.sh       72-install-helpers.sh
     80-enable-service.sh    90-health-check.sh      99-cleanup.sh
@@ -279,6 +287,7 @@ The built artifact wraps everything in `main "$@"` called on the last line
 | Step | Guard (skip if…) | Action | Verify (emit `data`) |
 |---|---|---|---|
 | `probe_os` | never skips | parse `/etc/os-release`, check systemd + arch (x64/arm64) | in matrix (Ubuntu 22.04/24.04, Debian 12) else `die UNSUPPORTED_OS` |
+| `probe_env` | never skips | refuse non-pristine servers: running Hive process or busy `HIVE_PORT` → `die EXISTING_INSTALL`; `/opt/hive` present without our state file, or pre-existing non-default ufw rules → `die SERVER_NOT_PRISTINE`. A server previously provisioned by us (state file present) passes — that's a resume, not a conflict | pristine or ours |
 | `apt_baseline` | all pkgs `dpkg -s` ok | `apt_install build-essential python3 python-is-python3 pkg-config libssl-dev unzip xz-utils jq ripgrep fd-find sqlite3 git-delta fzf tree gnupg ca-certificates ufw` + `ln -sf $(command -v fdfind) /usr/local/bin/fd` | `fd --version`, `rg --version` |
 | `install_node` | `node -v` ≥ 22 | NodeSource repo + `apt_install nodejs` | `node -v`, `npm -v` |
 | `create_user` | `id hive` exists | `useradd -m -s /bin/bash hive`; `install -d -o hive /home/hive/.hive` | home exists, owned |
@@ -612,7 +621,8 @@ CHECKSUM_MISMATCH, TS_AUTHKEY_INVALID, TS_DAEMON_DOWN, UFW_FAILURE,
 RELEASE_DOWNLOAD_FAILED, SERVICE_START_FAILED, HEALTH_TIMEOUT,
 SSH_AUTH_FAILED, SSH_HOST_KEY_CHANGED, SSH_UNREACHABLE, SSH_NO_ROOT,
 CLAUDE_PASTEBACK_BROKEN, DEVICE_CODE_EXPIRED, CODEX_DEVICE_AUTH_DISABLED,
-GH_POLL_STUCK, AUTH_EXPIRED, INTERRUPTED, CONCURRENT_RUN, UNKNOWN`
+GH_POLL_STUCK, AUTH_EXPIRED, SERVER_NOT_PRISTINE, EXISTING_INSTALL,
+INTERRUPTED, CONCURRENT_RUN, UNKNOWN`
 
 Each code maps to a user-facing hint (i18n-ready) + a docs anchor. Contract
 test asserts bash/TS lists are identical.
@@ -652,7 +662,9 @@ DoD: `make provision-docker` runs an empty-steps skeleton green. **E: 3**
 
 **PR 1.2 — Core steps** (probe→health, minus tailscale/ufw; `--release-file`).
 T: Tier-1 clean run; double-run all-skip; per-step bats guard tests; wrong-OS
-container (debian:11) → `UNSUPPORTED_OS`; checksum-tamper → `CHECKSUM_MISMATCH`.
+container (debian:11) → `UNSUPPORTED_OS`; dirty container (foreign service on
+the port / pre-existing ufw rules) → `SERVER_NOT_PRISTINE`; checksum-tamper →
+`CHECKSUM_MISMATCH`.
 DoD: container serves authenticated /health on 127.0.0.1. **E: 3**
 
 **PR 1.3 — Chaos harness** (`chaos.sh`, CI wiring).

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -6,6 +6,34 @@ frozen contracts, per-step specs, per-PR test cases, and the feedback-loop
 infrastructure that lets every piece be validated locally before touching real
 infrastructure.
 
+> **Amendments — review round 1 (2026-07-17).** Eight decisions changed from
+> the original draft after design review; each is folded into the sections
+> below and carries its full rationale in the corresponding commit message:
+>
+> 1. **Threat model:** the `hive` user is assumed hostile (agents execute
+>    arbitrary code as this user) — Docker rootless-only, the updater ignores
+>    the `hive`-writable trigger file and refuses downgrades, helpers audited
+>    for escalation by effect (§2, §5.4, §5.6, §6.3).
+> 2. **System OpenSSH sidecar replaces russh:** agent-held keys become the
+>    happy path instead of an excluded population; one whole client less to
+>    maintain (§2, §4, §8-S4, PR 2.1).
+> 3. **Rollback belongs to the updater only** (no `OnFailure=` on
+>    `hive.service`) and the backend binds `0.0.0.0` behind ufw — a slow
+>    tailscaled boot must never trigger a root rollback (§5.3, §5.4).
+> 4. **Claude auth runs locally on the user's machine** (wizard-driven
+>    `setup-token`, token POSTed to the backend); Codex stays device-auth on
+>    the VPS (rotating refresh tokens forbid copying `auth.json`); detection
+>    reports `authenticated`; auth is re-entrant — day 366 is designed
+>    (§3.4, §6.2, §6.4).
+> 5. **`/ws/setup` dropped** — REST polling covers setup progress once no
+>    client PTY input remains (§3.5; PR 3.2 removed).
+> 6. **Auth token is hash-only at rest** on provisioned servers; `shred`
+>    replaced by `rm` (no false guarantees) (§3.3, §5.5).
+> 7. **Pristine-server guard:** `probe_env` refuses inhabited servers; no
+>    migration tool from manual installs in v1 (§1.6, §5.2, §10).
+> 8. **Factual fix:** `deploy/` templates do not exist on `main` yet; both
+>    docs now say so instead of "(exist)".
+
 ---
 
 ## 1. Ground rules
@@ -106,8 +134,8 @@ state file's forces `--reset` behavior (a new script may change step semantics).
 
 ### 3.3 Secrets env file
 
-Uploaded by the app via SFTP to `/var/lib/hive/provision.env` (0600, root),
-**never argv**:
+Streamed by the app over SSH stdin to `/var/lib/hive/provision.env` (0600,
+root), **never argv**:
 
 ```
 HIVE_VERSION=0.3.0
@@ -244,7 +272,7 @@ frontend/src-tauri/src/ssh/
 frontend/src/pages/setup/            # wizard (state machine §9)
 frontend/src/hooks/useAuthToken.ts
 
-deploy/                              # templates; provision steps 71 embed these
+deploy/                              # templates; provision steps 71 embed these (to create — deploy/ does not exist on main yet)
   hive.service  hive.env.example
   hive-updater.service  hive-updater.path
 

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -22,8 +22,10 @@ infrastructure.
    tests in all three languages (bash, Rust, TypeScript). After freezing,
    changing a contract requires bumping its `v` field and updating all three
    test suites in the same PR.
-5. **Nothing in this plan touches the existing hub WS protocol**, so iOS is
-   unaffected until Phase 5 (which only adds a QR scanner + Keychain move).
+5. **Nothing in this plan touches the existing hub WS protocol** — and since
+   review dropped the planned `/ws/setup` channel (§3.5), no new WS surface
+   is added at all. iOS is unaffected until Phase 5 (which only adds a QR
+   scanner + Keychain move).
 
 ---
 
@@ -153,27 +155,31 @@ interface SetupStep {
 }
 ```
 
-### 3.5 Setup WS channel (`/ws/setup`)
+### 3.5 Setup progress transport — REST polling (no new WS channel)
 
-Own mini-protocol (NOT part of `HubOutgoing` — the hub protocol and iOS stay
-untouched). Auth: same bearer/`?token=` as other WS routes.
+Review decision: with Claude auth running locally (§6.4) no client→server
+PTY input remains — gh's Enter keystroke is injected server-side — so the
+originally planned `/ws/setup` channel lost its founding use case. The
+wizard polls instead (setup steps take tens of seconds; 1–2 s latency is
+invisible):
 
-```jsonc
-// client → server
-{"type":"subscribe","operationId":"op-1a2b","sinceSeq":0}
-{"type":"pty_input","data":"<base64>"}         // for interactive auth steps
-// server → client
-{"type":"op","op":{/* SetupOperation */}}                    // on every state change
-{"type":"log","seq":17,"stepId":"install_claude","line":"..."}
-{"type":"pty_data","data":"<base64>"}
-{"type":"auth_action","stepId":"auth_codex","kind":"open_url_with_code",
- "url":"https://auth.openai.com/device","code":"ABCD-1234","expiresAt":"..."}
-{"type":"auth_action","stepId":"auth_claude","kind":"open_url","url":"https://claude.ai/oauth/..."}
+- `GET /api/setup/operations/:id` every 1–2 s while an operation runs
+- `GET /api/setup/operations/:id/log?since=<seq>` for incremental log lines
+
+Interactive data rides on the step itself:
+
+```ts
+interface SetupStep {
+  // ...as in 3.4, plus:
+  action?: { kind: "open_url" | "open_url_with_code";
+             url: string; code?: string; expiresAt?: string };
+}
 ```
 
-Reconnect: client re-subscribes with `sinceSeq`; server replays from the
-operation's `log.jsonl` then streams live (same durable-log trick as the
-provision script).
+The hub WS protocol and iOS stay untouched — no new WS surface at all. If a
+truly interactive terminal is ever needed in the wizard, the backend's
+existing session PTY/WS infrastructure is the starting point, not a bespoke
+setup channel.
 
 ### 3.6 Release artifact layout (GitHub Releases)
 
@@ -220,7 +226,6 @@ backend/src/
   services/setup/auth-flows/{claude-token,codex-device,gh-device}.ts   # claude-token: validate/write/verify (captured wizard-side)
   services/setup/runner.ts           # detached child + line-buffered capture
   services/update/updater.ts
-  ws/setup.ts                        # WS 3.5
   utils/auth.ts                      # extended: hashed-token compare (§5.5)
 
 frontend/src-tauri/src/ssh/
@@ -584,7 +589,7 @@ welcome
  → tailnet_handoff        (poll /health via tailnet; timeout → diagnostics screen:
                            is Mac on tailnet? is node visible? keep SSH available)
  → guided_setup           (sub-machine: detect → claude → stacks → codex? → gh? →
-                           verify; each step = SetupOperation via /ws/setup)
+                           verify; each step = SetupOperation polled over REST §3.5)
  → ios_pairing            (QR render; "skip")
  → done                   (summary; where things live; how updates work)
 ```
@@ -686,12 +691,10 @@ mid-op → reaper marks INTERRUPTED + retry works; heartbeat staleness;
 single-op-per-kind 409.
 DoD: durable resumable ops with REST surface. **E: 3**
 
-**PR 3.2 — `/ws/setup`** (channel, subscribe/replay, PTY bridge without
-workspace guard).
-T (injectWS): subscribe+replay from seq; live tail; pty_input round-trip
-against a fake CLI; auth-rejected close 1008; hub protocol contract test
-untouched (regression gate).
-DoD: pre-project streaming works; iOS unaffected. **E: 2**
+**PR 3.2 — removed in review.** The `/ws/setup` channel was dropped: REST
+polling of the operation + log endpoints (§3.5) covers setup progress, and no
+client→server PTY input remains once Claude auth runs locally. Numbering
+kept to avoid renumbering downstream references.
 
 **PR 3.3 — Detection + installers** (`detect.ts`, 6 installers, helper calls).
 T: detect matrix via fixture PATHs; each installer vs fake CLIs (logic) and on
@@ -720,7 +723,7 @@ persistence/restore, back-navigation); component tests. **E: 3**
 provisioning screen on Tauri events, error panel + Retry). T: mocked-Tauri
 component tests per screen; scripted happy path vs Tier-2 VM. **E: 4**
 **PR 4.3 — Guided setup + QR + finish** (detection UI, stack checkboxes, auth
-screens rendering `auth_action` frames, QR render, finish summary).
+screens rendering step `action` data (§3.5), QR render, finish summary).
 T: component tests per auth scenario (driven by fake-CLI backend); full
 scripted E2E: `vm-reset` → wizard → done with fake CLIs.
 DoD: **a non-author completes the full wizard on a pristine VM without a

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -105,15 +105,15 @@ Uploaded by the app via SFTP to `/var/lib/hive/provision.env` (0600, root),
 
 ```
 HIVE_VERSION=0.3.0
-HIVE_AUTH_TOKEN_SHA256=<hex>       # backend stores/compares the hash only
-HIVE_AUTH_TOKEN=<plaintext>        # written into hive.env for the service, then this file is shredded
+HIVE_AUTH_TOKEN_SHA256=<hex>       # the ONLY form of the token that ever lands on server disk (§5.5)
 TS_AUTHKEY=tskey-auth-...
 HIVE_HOST_MODE=tailnet             # or "loopback" (tests)
 HIVE_PORT=3000
 ```
 
 `provision.sh` consumes it, writes `/etc/hive/hive.env` (0600) for the service,
-and `shred -u`s the provision copy in its last step.
+and `rm -f`s the provision copy in its last step (review dropped `shred`: on
+journaling filesystems it adds no real guarantee — don't pretend otherwise).
 
 ### 3.4 Setup REST API (backend)
 
@@ -287,12 +287,12 @@ The built artifact wraps everything in `main "$@"` called on the last line
 | `configure_ufw` | rules already present | `ufw default deny incoming; ufw allow in on tailscale0; ufw allow ssh; ufw --force enable` | `ufw status` matches (ssh stays open — repair channel) |
 | `fetch_release` | tarball present + checksum ok | download `hive-backend-$HIVE_VERSION-linux-$ARCH.tar.gz` (or `--release-file`) | sha256 verified else `die CHECKSUM_MISMATCH` |
 | `install_release` | `current` → this version | unpack `/opt/hive/releases/<v>`; link `shared/data` → `/home/hive/.hive`; scratch-symlink + `mv -T` swap | `readlink current` |
-| `write_secrets` | `/etc/hive/hive.env` content identical | write env (HOST=0.0.0.0 — tailnet-only enforced by ufw; 127.0.0.1 when `HIVE_HOST_MODE=loopback` (tests); PORT, DATA_DIR, HIVE_AUTH_TOKEN, PATH incl. mise shims) 0600 | perms + owner |
+| `write_secrets` | `/etc/hive/hive.env` content identical | write env (HOST=0.0.0.0 — tailnet-only enforced by ufw; 127.0.0.1 when `HIVE_HOST_MODE=loopback` (tests); PORT, DATA_DIR, HIVE_AUTH_TOKEN_SHA256 (hash-only — §5.5), PATH incl. mise shims) 0600 | perms + owner |
 | `write_units` | unit content identical | install `hive.service` + updater pair from embedded templates; `daemon-reload` | `systemd-analyze verify` |
 | `install_helpers` | dir content identical | §5.6 helpers + sudoers drop-in | `visudo -c` |
 | `enable_service` | active | `systemctl enable --now hive` | `systemctl is-active` |
 | `health_check` | — | curl `--retry 10` health with token (tailnet IP; 127.0.0.1 in loopback mode) | 200 + version matches |
-| `cleanup` | — | `shred -u /var/lib/hive/provision.env`; print/emit pairing summary `data:{tailnetIp,port}` | — |
+| `cleanup` | — | `rm -f /var/lib/hive/provision.env`; print/emit pairing summary `data:{tailnetIp,port}` | — |
 
 Every step is independently re-runnable; the chaos harness (§7.2) proves it for
 every kill point.
@@ -346,13 +346,17 @@ enforced by ufw, not by binding the 100.x IP, which races tailscaled at boot.)
   unit and no `OnFailure=` on `hive.service`: rollback can only happen
   inside the updater's window, never from a steady-state crash
 
-### 5.5 Auth token at rest
+### 5.5 Auth token at rest — hash-only
 
-`/etc/hive/hive.env` carries `HIVE_AUTH_TOKEN` (the service must compare
-incoming bearers). Additionally `HIVE_AUTH_TOKEN_SHA256` is supported by
-`utils/auth.ts`: if only the hash is present, the backend hashes incoming
-tokens before `timingSafeEqual` (removes plaintext-at-rest; enabled by
-provision, transparent to clients). Backend change lands in PR 0.3.
+Provisioned installs never store the plaintext token server-side:
+`/etc/hive/hive.env` carries only `HIVE_AUTH_TOKEN_SHA256`, and
+`utils/auth.ts` hashes incoming bearers before `timingSafeEqual`. The app
+generated the token and is the sole holder of the plaintext (it also feeds
+the iOS QR). `HIVE_AUTH_TOKEN` (plaintext) remains accepted for legacy
+manual installs only — one mode per install, never both. Consequence, by
+design: the token is *reset*, never *recovered* — a lost token means SSH in
+and write a new hash (documented one-liner; SSH is the repair channel).
+Backend change lands in PR 0.3.
 
 ### 5.6 Privileged helpers (v1 substitute for a root helper daemon)
 

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -120,7 +120,7 @@ GET  /api/version
      → {"version":"0.3.0","protocolVersion":1,"commit":"abc123"}
 
 GET  /api/setup/status
-     → {"detected":{"claude":{"installed":true,"version":"2.1.53"},
+     → {"detected":{"claude":{"installed":true,"version":"2.1.53","authenticated":true},
                     "codex":{"installed":false},"gh":{...},"tailscale":{...},
                     "mise":{...},"uv":{...},"docker":{...}},
         "operations":[SetupOperation, ...]}
@@ -131,7 +131,7 @@ POST /api/setup/run           body {"steps":["install_claude","auth_claude"],"op
 GET  /api/setup/operations/:id            → SetupOperation
 GET  /api/setup/operations/:id/log?since=<seq>  → NDJSON lines (backfill)
 POST /api/setup/operations/:id/retry      → re-runs from the failed step
-POST /api/setup/auth/claude/token         body {"token":"sk-ant-oat01-..."}   // Mac-side fallback
+POST /api/setup/auth/claude/token         body {"token":"sk-ant-oat01-..."}   // PRIMARY path: token captured locally by the wizard
 POST /api/system/update                   → {"operationId":...}               // Phase 6
 ```
 
@@ -217,7 +217,7 @@ backend/src/
   services/setup/operations.ts       # durable op engine (§8, PR 3.1)
   services/setup/detect.ts
   services/setup/installers/{claude,codex,gh,mise,uv,docker}.ts
-  services/setup/auth-flows/{claude-setup-token,codex-device,gh-device}.ts
+  services/setup/auth-flows/{claude-token,codex-device,gh-device}.ts   # claude-token: validate/write/verify (captured wizard-side)
   services/setup/runner.ts           # detached child + line-buffered capture
   services/update/updater.ts
   ws/setup.ts                        # WS 3.5
@@ -406,6 +406,12 @@ timeout, all run in parallel; result cached 30 s. Adds: tailscale (+
 `status --json` state), mise, uv, docker (+ compose plugin), and per-CLI
 `latestVersion` reuse from `agents-settings.ts`.
 
+Each agent CLI probe also reports `authenticated` (gh: `gh auth status`;
+codex: `~hive/.codex/auth.json` present + parseable; claude:
+`CLAUDE_CODE_OAUTH_TOKEN` present in the service env, verified by a cheap
+`claude -p` smoke on demand). Guided setup skips auth steps already green —
+a logged-in CLI is never asked to log in again.
+
 ### 6.3 Installers
 
 Each installer = ordered SetupSteps with the same guard/action/verify shape as
@@ -416,16 +422,26 @@ group is root equivalence for a user that runs arbitrary agent code).
 
 ### 6.4 Auth-flow drivers (`auth-flows/*`)
 
-Common shape: spawn CLI in a PTY (`spawnPtyProcess`), scan output with
-**versioned regex sets keyed by CLI version** (from Spike S2 transcripts), emit
-`auth_action` frames, handle: URL lift, code lift, paste-back injection,
+Codex and gh: spawn the CLI in a PTY (`spawnPtyProcess`), scan output with
+**versioned regex sets keyed by CLI version** (from Spike S2 transcripts),
+expose `action` data on the step (§3.5), handle: URL lift, code lift,
 **gh Enter-keystroke injection** (cli/cli #12925), 15-min code expiry →
-auto-regenerate (max 3), and typed errors (`CODEX_DEVICE_AUTH_DISABLED`,
-`CLAUDE_PASTEBACK_BROKEN` → surface the Mac fallback).
-Post-auth: claude → write `CLAUDE_CODE_OAUTH_TOKEN` into `/etc/hive/hive.env`
-via helper + pre-seed `~hive/.claude.json` (`hasCompletedOnboarding`,
-per-project trust) + assert `ANTHROPIC_API_KEY` absent; codex → verify
-`~hive/.codex/auth.json` exists 0600.
+auto-regenerate (max 3), and typed errors (`CODEX_DEVICE_AUTH_DISABLED`).
+Codex post-auth: verify `~hive/.codex/auth.json` exists 0600.
+
+Claude never runs interactively on the VPS (review decision — the wizard
+captures the token locally, see design doc): `claude-token.ts` backs
+`POST /api/setup/auth/claude/token` — validate token format, write
+`CLAUDE_CODE_OAUTH_TOKEN` into `/etc/hive/hive.env` via helper, pre-seed
+`~hive/.claude.json` (`hasCompletedOnboarding`, per-project trust), assert
+`ANTHROPIC_API_KEY` absent, verify with a `claude -p` smoke call. Install
+channel: official native installer (no Anthropic apt repo exists) with
+`DISABLE_AUTOUPDATER=1` — Hive owns updates.
+
+Auth is re-entrant after install (day 366): detection exposes per-CLI
+`authenticated`, token expiry/revocation surfaces in `/api/setup/status` and
+the health payload (`AUTH_EXPIRED`), and Settings offers "Reconnect <CLI>"
+re-running the same operations.
 
 ---
 
@@ -474,7 +490,7 @@ of the real tools** (captured in Spike S2 with `test/tools/record-cli.sh`,
 which wraps the CLI in `script -q` on the VM). Scenario selection via env:
 
 ```
-FAKE_CLAUDE_SCENARIO=happy | paste_back_broken | slow_user | code_expired
+FAKE_CLAUDE_SCENARIO=happy | paste_back_broken | slow_user | code_expired   # consumed by wizard-side tests (local setup-token capture)
 FAKE_CODEX_SCENARIO=happy | device_auth_disabled | url_variant_2
 FAKE_GH_SCENARIO=happy | waits_for_enter | timeout
 ```
@@ -524,14 +540,14 @@ make e2e-nightly-local          # run the nightly script against your own Hetzne
 expiry" click. Output: decision recorded in install-flow.md + the exact wizard
 deep-link URLs.
 
-**S2 — CLI transcripts.** On a pristine Multipass VM: run
-`claude setup-token`, `claude` first-run, `codex login --device-auth`,
-`gh auth login --web` under `test/tools/record-cli.sh`; capture happy path +
-every reachable error (wrong code, expiry, codex admin-gate). Verify the
-claude paste-back state on the current CLI version (issues #42965/#48048).
-Output: `test/fixtures/transcripts/*`, parser spec per CLI+version, and a
-go/no-go on PTY-first vs Mac-fallback-first for Claude (plan assumes PTY-first
-per the design doc; the fallback ships either way).
+**S2 — CLI transcripts.** Codex + gh on a pristine Multipass VM; claude
+**locally** on macOS/Windows/Linux (its capture lives in the wizard now): run
+`codex login --device-auth`, `gh auth login --web`, and local
+`claude setup-token` + `claude` first-run under `test/tools/record-cli.sh`;
+capture happy path + every reachable error (wrong code, expiry, codex
+admin-gate, claude paste-back state on the current version — issues
+#42965/#48048). Output: `test/fixtures/transcripts/*`, parser spec per
+CLI+version.
 
 **S3 — tailnet in CI.** Throwaway workflow: (a) tailscale up with an ephemeral
 key on a GitHub runner; (b) Headscale container + client. Assert a runner ↔ VM
@@ -587,7 +603,7 @@ CHECKSUM_MISMATCH, TS_AUTHKEY_INVALID, TS_DAEMON_DOWN, UFW_FAILURE,
 RELEASE_DOWNLOAD_FAILED, SERVICE_START_FAILED, HEALTH_TIMEOUT,
 SSH_AUTH_FAILED, SSH_HOST_KEY_CHANGED, SSH_UNREACHABLE, SSH_NO_ROOT,
 CLAUDE_PASTEBACK_BROKEN, DEVICE_CODE_EXPIRED, CODEX_DEVICE_AUTH_DISABLED,
-GH_POLL_STUCK, INTERRUPTED, CONCURRENT_RUN, UNKNOWN`
+GH_POLL_STUCK, AUTH_EXPIRED, INTERRUPTED, CONCURRENT_RUN, UNKNOWN`
 
 Each code maps to a user-facing hint (i18n-ready) + a docs anchor. Contract
 test asserts bash/TS lists are identical.
@@ -684,12 +700,14 @@ service PATH after install (unit env asserted); docker group/rootless per
 design flag.
 DoD: pristine VM → all installers green twice. **E: 4**
 
-**PR 3.4 — Auth-flow drivers** (3 drivers + regex sets keyed by CLI version +
-Mac-fallback endpoint).
-T: snapshot tests across every S2 transcript scenario (happy/broken/expired/
-gated/slow); gh Enter-injection case; code-expiry regenerate (max 3);
-`CLAUDE_PASTEBACK_BROKEN` → fallback surfaced; fallback endpoint validates
-token format + writes env via helper + verifies with a `claude -p` smoke call.
+**PR 3.4 — Auth-flow drivers** (codex/gh PTY drivers + regex sets keyed by
+CLI version + the claude token endpoint — primary path, wizard-captured).
+T: snapshot tests across every S2 transcript scenario (happy/expired/gated/
+slow); gh Enter-injection case; code-expiry regenerate (max 3); token
+endpoint validates format + writes env via helper + verifies with a
+`claude -p` smoke call; `authenticated` detection short-circuits
+already-logged-in CLIs; day-366 path: expired token → `AUTH_EXPIRED` in
+status/health → Reconnect re-runs the flow.
 DoD: every fixture variant → correct wizard instruction or typed error; real
 flows deferred to §12. **E: 4**
 
@@ -743,8 +761,9 @@ disk-space warning UI using existing /health metrics, fixture-drift CI job).
 
 ## 12. Manual release checklist (the non-automatable)
 
-1. Real Claude Pro/Max auth via wizard on a fresh VM — PTY path **and** Mac
-   fallback; assert subscription (not API) billing in the Claude console.
+1. Real Claude Pro/Max auth via wizard on a fresh VM — local wizard-driven
+   path **and** manual paste fallback; assert subscription (not API) billing
+   in the Claude console.
 2. Real Codex device-auth incl. the admin-gate error path.
 3. Real gh device flow incl. Enter-poll behavior on the current gh version.
 4. Brand-new Tailscale account onboarding following only wizard instructions
@@ -781,7 +800,7 @@ checklist §12.
 
 | Risk | Exposure | Mitigation |
 |---|---|---|
-| Claude PTY auth regresses upstream | wizard's flagship step fails | version-keyed regex sets; fixture-drift nightly job; Mac fallback is first-class (PR 3.4); CLI version pinned by installer |
+| Claude local setup-token output changes upstream | flagship auth step fails | the flow runs locally — no SSH/remote PTY in the loop; version-keyed capture patterns; fixture-drift nightly job; manual paste fallback is first-class; CLI version pinned by installer |
 | Tailscale-in-CI flaky | nightly noise | S3 decides strategy before Phase 1.4; ephemeral keys self-clean; retry-once policy on network steps only |
 | system `ssh` output/version variance across OSes | brittle error mapping | map only coarse error classes from exit codes/stderr; version floor check at wizard start; S4 validates askpass/agent/Windows before 2.1; v1 scope = stock Ubuntu/Debian sshd, root+key (typed errors otherwise) |
 | Contract drift bash/Rust/TS | subtle integration bugs | single schema files + tri-language contract tests; `v` field bump policy |

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -41,6 +41,11 @@ The `hive` user model (vs. running as the login user like the manual setup)
 is what allows unit hardening. All agent credentials, mise shims, and repos
 live under `/home/hive`.
 
+Threat model: the `hive` user is **assumed hostile** — Hive's product runs LLM
+agents that execute arbitrary code as this user. Every helper and unit is
+audited against one criterion: compromise of `hive` may yield agent
+credentials and repos, never root.
+
 ---
 
 ## 3. Frozen contracts (write these first, test them everywhere)
@@ -320,7 +325,10 @@ this hardened variant. Single source: both generated from one template at
 ### 5.4 Updater units (installed in Phase 1, used in Phase 6)
 
 - `hive-updater.path`: `PathExists=/opt/hive/shared/.update-requested`
-- `hive-updater.service`: `Type=oneshot`, root; reads requested version, runs
+- `hive-updater.service`: `Type=oneshot`, root; the request file is a pure
+  trigger — its **content is ignored** (it is writable by the hostile `hive`
+  user); the updater resolves the latest release from GitHub itself and
+  refuses any version ≤ the installed one (downgrade protection), then runs
   `helpers/update-hive.sh` (§5.6)
 - `hive-rollback.service`: `Type=oneshot`, root; `mv -T` current → previous
   generation + restart + emit a marker file the API surfaces
@@ -353,6 +361,9 @@ hive ALL=(root) NOPASSWD: /usr/lib/hive/helpers/install-claude.sh, /usr/lib/hive
 
 Explicit file list, **no wildcards, never `apt-get` or `tailscale` directly**
 (GTFOBins). mise/uv/rustup run as `hive` directly — no helper needed.
+Helpers are audited for escalation by *effect*, not only argument injection:
+`install-docker.sh` sets up **rootless Docker only** — `hive` never joins the
+`docker` group (instant root equivalence for a user running agent code).
 
 ### 5.7 Uninstall
 
@@ -392,8 +403,8 @@ timeout, all run in parallel; result cached 30 s. Adds: tailscale (+
 Each installer = ordered SetupSteps with the same guard/action/verify shape as
 provision steps. Privileged actions call helpers (§5.6); user-space ones run as
 `hive` (mise shims mode + `mise trust -a`; uv installer; corepack note for
-Node ≥ 25). Docker installer ends with the rootless-vs-group decision encoded
-per the design doc.
+Node ≥ 25). Docker installer is rootless-only (review decision: the `docker`
+group is root equivalence for a user that runs arbitrary agent code).
 
 ### 6.4 Auth-flow drivers (`auth-flows/*`)
 

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -232,8 +232,8 @@ frontend/src/pages/setup/            # wizard (state machine §9)
 frontend/src/hooks/useAuthToken.ts
 
 deploy/                              # templates; provision steps 71 embed these
-  hive.service  hive.env.example     # (exist)
-  hive-updater.service  hive-updater.path  hive-rollback.service
+  hive.service  hive.env.example
+  hive-updater.service  hive-updater.path
 
 test/
   images/ubuntu-systemd.Dockerfile   # Tier-1
@@ -282,11 +282,11 @@ The built artifact wraps everything in `main "$@"` called on the last line
 | `configure_ufw` | rules already present | `ufw default deny incoming; ufw allow in on tailscale0; ufw allow ssh; ufw --force enable` | `ufw status` matches (ssh stays open — repair channel) |
 | `fetch_release` | tarball present + checksum ok | download `hive-backend-$HIVE_VERSION-linux-$ARCH.tar.gz` (or `--release-file`) | sha256 verified else `die CHECKSUM_MISMATCH` |
 | `install_release` | `current` → this version | unpack `/opt/hive/releases/<v>`; link `shared/data` → `/home/hive/.hive`; scratch-symlink + `mv -T` swap | `readlink current` |
-| `write_secrets` | `/etc/hive/hive.env` content identical | write env (HOST=tailnet IP or per `HIVE_HOST_MODE`, PORT, DATA_DIR, HIVE_AUTH_TOKEN, PATH incl. mise shims) 0600 | perms + owner |
-| `write_units` | unit content identical | install `hive.service`, updater trio from embedded templates; `daemon-reload` | `systemd-analyze verify` |
+| `write_secrets` | `/etc/hive/hive.env` content identical | write env (HOST=0.0.0.0 — tailnet-only enforced by ufw; 127.0.0.1 when `HIVE_HOST_MODE=loopback` (tests); PORT, DATA_DIR, HIVE_AUTH_TOKEN, PATH incl. mise shims) 0600 | perms + owner |
+| `write_units` | unit content identical | install `hive.service` + updater pair from embedded templates; `daemon-reload` | `systemd-analyze verify` |
 | `install_helpers` | dir content identical | §5.6 helpers + sudoers drop-in | `visudo -c` |
 | `enable_service` | active | `systemctl enable --now hive` | `systemctl is-active` |
-| `health_check` | — | curl `--retry 10` health on bound IP with token | 200 + version matches |
+| `health_check` | — | curl `--retry 10` health with token (tailnet IP; 127.0.0.1 in loopback mode) | 200 + version matches |
 | `cleanup` | — | `shred -u /var/lib/hive/provision.env`; print/emit pairing summary `data:{tailnetIp,port}` | — |
 
 Every step is independently re-runnable; the chaos harness (§7.2) proves it for
@@ -309,7 +309,6 @@ Restart=on-failure
 RestartSec=5
 StartLimitIntervalSec=60
 StartLimitBurst=3
-OnFailure=hive-rollback.service
 MemoryMax=3G
 NoNewPrivileges=true
 ProtectSystem=strict
@@ -322,7 +321,11 @@ WantedBy=multi-user.target
 
 (`deploy/hive.service` — the manual-install template — stays; step 71 embeds
 this hardened variant. Single source: both generated from one template at
-`build.sh` time to prevent drift.)
+`build.sh` time to prevent drift. No `OnFailure=` rollback hook by review
+decision: rollback is owned by the updater within its update window (§5.4) —
+a steady-state crash, e.g. slow tailscaled at boot or a full disk, must never
+swap releases. The backend binds `0.0.0.0`; tailnet-only reachability is
+enforced by ufw, not by binding the 100.x IP, which races tailscaled at boot.)
 
 ### 5.4 Updater units (installed in Phase 1, used in Phase 6)
 
@@ -332,8 +335,11 @@ this hardened variant. Single source: both generated from one template at
   user); the updater resolves the latest release from GitHub itself and
   refuses any version ≤ the installed one (downgrade protection), then runs
   `helpers/update-hive.sh` (§5.6)
-- `hive-rollback.service`: `Type=oneshot`, root; `mv -T` current → previous
-  generation + restart + emit a marker file the API surfaces
+- After the swap the updater itself health-checks the restarted service and,
+  on failure, rolls back (`mv -T` current → previous generation + restart +
+  a marker file the API surfaces). There is no separate `hive-rollback`
+  unit and no `OnFailure=` on `hive.service`: rollback can only happen
+  inside the updater's window, never from a steady-state crash
 
 ### 5.5 Auth token at rest
 

--- a/docs/install-flow-implementation-plan.md
+++ b/docs/install-flow-implementation-plan.md
@@ -11,8 +11,9 @@ infrastructure.
 ## 1. Ground rules
 
 1. **Build order follows risk.** The four genuine unknowns (Tailscale tagged-key
-   friction, Claude PTY auth behavior, Tailscale-in-CI, russh vs stock sshd) are
-   resolved by timeboxed spikes in week 1 — before any contract is frozen.
+   friction, Claude local-auth capture, Tailscale-in-CI, system-ssh sidecar
+   portability) are resolved by timeboxed spikes in week 1 — before any
+   contract is frozen.
 2. **Everything is testable without a cloud account by default.** Real VPS +
    real tailnet appear only in the nightly E2E and the manual release checklist.
 3. **`provision.sh` is safely re-runnable at any interruption point.** This is
@@ -35,7 +36,7 @@ infrastructure.
 | Privileged helpers | root via sudoers | `/usr/lib/hive/helpers/*.sh` | fixed, argument-free wrappers (§5.6); the v1 substitute for a helper daemon |
 | `hive-updater.service` | root (oneshot) | VPS, triggered by path unit | separate cgroup → survives hive restart |
 | Agent CLIs (claude/codex/gh) + mise/uv | `hive` user | `/home/hive` | credentials live in the service user's home |
-| Tauri app + embedded SSH | user | desktop | russh; app-owned or user-selected key |
+| Tauri app + system `ssh` sidecar | user | desktop | spawns OpenSSH (present by default on macOS/Linux/Win10+); user's key/agent, or app-generated fallback key |
 
 The `hive` user model (vs. running as the login user like the manual setup)
 is what allows unit hardening. All agent credentials, mise shims, and repos
@@ -223,8 +224,9 @@ backend/src/
   utils/auth.ts                      # extended: hashed-token compare (§5.5)
 
 frontend/src-tauri/src/ssh/
-  mod.rs  keys.rs  known_hosts.rs  provision.rs
-  bin/hive-ssh.rs                    # CLI over the same crate; used by CI E2E only
+  mod.rs                             # sidecar driver: spawn system ssh/ssh-keyscan, stream output
+  keys.rs  known_hosts.rs  provision.rs
+                                     # CI E2E drives the plain `ssh` binary — no separate CLI to maintain
 
 frontend/src/pages/setup/            # wizard (state machine §9)
 frontend/src/hooks/useAuthToken.ts
@@ -235,7 +237,7 @@ deploy/                              # templates; provision steps 71 embed these
 
 test/
   images/ubuntu-systemd.Dockerfile   # Tier-1
-  images/sshd.Dockerfile             # Rust SSH integration target
+  images/sshd.Dockerfile             # ssh sidecar-driver integration target
   fixtures/fake-clis/{claude,codex,gh,tailscale}      # scenario-driven stubs (§7.4)
   fixtures/transcripts/*.txt         # recorded real-CLI output (Spike S2)
   tools/record-cli.sh                # PTY recorder used on the spike VM
@@ -453,7 +455,7 @@ make vm-reset       # multipass restore hive-test.pristine    (~5 s "new VPS")
 make vm-provision   # full provision incl. tailscale (real test tailnet key from .env.local)
 make vm-setup-steps # drive /api/setup against the VM with fake or real CLIs
 make vm-update-e2e  # Phase 6 scenario (local release server, good + broken release)
-make vm-ssh-e2e     # Rust crate integration vs the VM's stock sshd
+make vm-ssh-e2e     # ssh sidecar-driver integration vs the VM's stock sshd
 ```
 
 Snapshots make "fresh VPS" a 5-second operation — this is the everyday manual
@@ -497,8 +499,8 @@ make e2e-nightly-local          # run the nightly script against your own Hetzne
 ### 7.7 CI wiring
 
 - **PR CI (additions):** shellcheck + bats; Tier-1 provision run; chaos (3 kill
-  points); Rust ssh tests vs sshd container; vitest incl. contract tests +
-  fake-CLI driver tests; frontend tests.
+  points); ssh sidecar-driver tests vs sshd container; vitest incl. contract
+  tests + fake-CLI driver tests; frontend tests.
 - **Nightly:** full chaos matrix; Tier-3 E2E; fixture-drift job (installs
   latest real CLIs in a container, re-records `--help`/version banners, fails
   if parsers' version key is unknown → early warning of upstream changes).
@@ -529,10 +531,13 @@ per the design doc; the fallback ships either way).
 key on a GitHub runner; (b) Headscale container + client. Assert a runner ↔ VM
 tailnet connection both ways. Output: Tier-3 network choice.
 
-**S4 — russh vs stock sshd.** `hive-ssh` prototype: connect/exec/sftp/tail
-against Multipass (stock Ubuntu sshd) and a Hetzner default image, with
-ed25519 + RSA + passphrase keys. Output: confirmed auth matrix + any sshd
-config edge (e.g., `PubkeyAcceptedAlgorithms`) folded into error taxonomy.
+**S4 — system-ssh sidecar portability.** Prototype the sidecar driver: spawn
+the OS `ssh`/`ssh-keyscan` for connect/exec/stdin-upload/detached-run/
+tail-resume against Multipass (stock Ubuntu sshd) and a Hetzner default image.
+Validate: presence + version floor on macOS/Windows 10+/Linux, `SSH_ASKPASS`
+behavior from a GUI-spawned process on all three, agent-held keys (1Password),
+coarse error mapping from exit codes/stderr. Output: confirmed support matrix
+folded into the error taxonomy.
 
 ---
 
@@ -633,12 +638,14 @@ DoD: fresh VM → tailnet-only Hive, idempotent, uninstallable. **E: 3**
 
 ### Phase 2 — Tauri SSH
 
-**PR 2.1 — russh core** (`mod.rs, keys.rs, known_hosts.rs`, sshd test image).
-T (Rust, CI): auth ok (ed25519/RSA), encrypted key + passphrase, wrong key →
-`SSH_AUTH_FAILED`, host-key change → `SSH_HOST_KEY_CHANGED`, exec exit codes,
-sftp write + mode, timeout behavior; key discovery on the 3 OS dir layouts
-(fixture homes).
-DoD: matrix green in CI; `hive-ssh exec uname -a` works vs Tier-2 VM. **E: 4**
+**PR 2.1 — ssh sidecar driver** (`mod.rs, keys.rs, known_hosts.rs`, sshd test
+image).
+T (Rust, CI): auth ok (file key + agent), encrypted key via `SSH_ASKPASS`,
+wrong key → `SSH_AUTH_FAILED`, `ssh-keyscan` fingerprint + host-key change →
+`SSH_HOST_KEY_CHANGED` (app-owned `UserKnownHostsFile`), exec exit codes,
+stdin upload + mode 0600, timeout behavior, missing `ssh` binary → typed
+error; key discovery on the 3 OS dir layouts (fixture homes).
+DoD: matrix green in CI; sidecar `exec uname -a` works vs Tier-2 VM. **E: 4**
 
 **PR 2.2 — Provision driver + Tauri commands** (`provision.rs`, events,
 commands `ssh_list_keys/test_connection/start_provision/resume_provision`).
@@ -716,7 +723,7 @@ DoD: success and rollback paths green in one make target. **E: 3**
 ### Phase 7 — E2E + release hardening
 
 **PR 7.1 — Nightly E2E** (`e2e-nightly.yml`, `test/e2e/nightly.sh` driving
-`hive-ssh` + REST with fake CLIs on a real Hetzner VM + S3-decided tailnet).
+plain `ssh` + REST with fake CLIs on a real Hetzner VM + S3-decided tailnet).
 T: the script *is* the test; junit summary; VM always destroyed (trap).
 DoD: nightly reproduces a full "new user" install on real infra. **E: 3**
 **PR 7.2 — Docs + polish** (GETTING_STARTED rewrite around the wizard,
@@ -756,7 +763,7 @@ Join: 4.2 needs 1.x artifacts + 2.2; 4.3 needs 3.x; 7.x needs all.
 
 Contracts (§3) are frozen end of week 1 after S1/S2 land their corrections;
 both tracks code against the schemas + fake implementations from day one
-(wizard against a fixture backend, backend against the `hive-ssh` CLI).
+(wizard against a fixture backend, backend against scripted plain `ssh`).
 
 Critical path: **S2 → 0.1 → 1.1–1.3 → 2.2 → 4.2/4.3**. First full demo
 (fake CLIs, Tier-2 VM): end of Phase 4. Ship gate: Phase 6 + nightly green +
@@ -770,7 +777,7 @@ checklist §12.
 |---|---|---|
 | Claude PTY auth regresses upstream | wizard's flagship step fails | version-keyed regex sets; fixture-drift nightly job; Mac fallback is first-class (PR 3.4); CLI version pinned by installer |
 | Tailscale-in-CI flaky | nightly noise | S3 decides strategy before Phase 1.4; ephemeral keys self-clean; retry-once policy on network steps only |
-| russh edge cases on user sshd configs | support tickets | v1 scope = stock Ubuntu/Debian sshd, root+key (typed errors otherwise); S4 validates before 2.1 |
+| system `ssh` output/version variance across OSes | brittle error mapping | map only coarse error classes from exit codes/stderr; version floor check at wizard start; S4 validates askpass/agent/Windows before 2.1; v1 scope = stock Ubuntu/Debian sshd, root+key (typed errors otherwise) |
 | Contract drift bash/Rust/TS | subtle integration bugs | single schema files + tri-language contract tests; `v` field bump policy |
 | Chaos matrix too slow for PR CI | devs skip it | 3 kill points on PR, full matrix nightly; container layer caching |
 | apt lock on fresh VPS (unattended-upgrades) | first-run failures in the wild | `DPkg::Lock::Timeout=300` in `apt_install` + dedicated chaos case |

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -226,10 +226,14 @@ flows. Day 366 is a designed path.
   the root updater never consumes `hive`-writable input (it resolves the
   latest release itself and refuses downgrades). Every helper is audited
   against this criterion.
-- **Secrets at rest:** token in a `0600` EnvironmentFile; auth token stored
-  hashed server-side; the app persists only a path reference to the user's SSH
-  key (generated-key fallback: `0600` file in the app data dir); iOS token to
-  move from UserDefaults to Keychain.
+- **Secrets at rest:** the server stores only the SHA-256 of the auth token —
+  the app, which generated it, is the sole holder of the plaintext (a lost
+  token is *reset* over SSH, not recovered). Agent CLI tokens live in `0600`
+  files under the service user's home — readable by agent-run code, an
+  accepted v1 trade-off (see the hostile-`hive` threat model above). The app
+  persists only a path reference to the user's SSH key (generated-key
+  fallback: `0600` file in the app data dir); iOS token to move from
+  UserDefaults to Keychain.
 
 ## Updates
 

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -2,7 +2,8 @@
 
 **Status: design proposal, not yet implemented.** This document describes the target
 installation and configuration flow for open-source Hive. Today's manual setup is
-documented in [GETTING_STARTED.md](../GETTING_STARTED.md) and [deploy/README.md](../deploy/README.md).
+documented in [GETTING_STARTED.md](../GETTING_STARTED.md). (A `deploy/` directory
+with unit templates does not exist on `main` yet; this design introduces it.)
 
 ## Goals
 

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -293,8 +293,9 @@ No terminal, no shell command, no manual server configuration, no VPN setup.
    is the natural monetization path.
 6. **Backend work not covered here** (tracked separately): runtime-issued auth
    tokens instead of the build-time `VITE_HIVE_AUTH_TOKEN`, a backend version
-   endpoint + WS protocol version, a workspace-less WS channel for setup
-   progress, QR scanning + deep links in iOS, tagged release CI.
+   endpoint + WS protocol version, setup progress served over REST polling
+   (review decision: no new WS channel), QR scanning + deep links in iOS,
+   tagged release CI.
 
 ## Alternatives considered and rejected
 

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -199,6 +199,14 @@ patterns are snapshot-tested (no login flow has a `--json` mode).
   `NoNewPrivileges=true`; root is only used by the one-shot provision script and
   the narrow update/restart path. No sudoers command whitelist for `apt`/
   `tailscale` (GTFOBins-style escapes make those un-whitelistable).
+- **The `hive` user is assumed hostile.** Hive's core product runs LLM agents
+  that execute arbitrary code as the service user, so compromise of `hive`
+  yields agent credentials and cloned repos by design — but must never yield
+  root: Docker is rootless-only (`docker` group membership is instant root
+  equivalence), no privileged helper may escalate through its *effect*, and
+  the root updater never consumes `hive`-writable input (it resolves the
+  latest release itself and refuses downgrades). Every helper is audited
+  against this criterion.
 - **Secrets at rest:** token in a `0600` EnvironmentFile; auth token stored
   hashed server-side; the app persists only a path reference to the user's SSH
   key (generated-key fallback: `0600` file in the app data dir); iOS token to

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -27,21 +27,26 @@ documented in [GETTING_STARTED.md](../GETTING_STARTED.md) and [deploy/README.md]
 | Tag | Actor | Runs where |
 |---|---|---|
 | `[U]` | User | Mac/PC, iPhone, browser |
-| `[W]` | Hive desktop app (wizard, embedded SSH client) | user's computer |
+| `[W]` | Hive desktop app (wizard, drives the system OpenSSH client) | user's computer |
 | `[S]` | `provision.sh` (root, one-shot, idempotent) | VPS |
 | `[H]` | Hive backend (systemd service; acts as installer after handoff) | VPS |
 
 Key implementation choices for `[W]`:
 
-- SSH client is **embedded** (`russh`, pure Rust) — no dependency on a system
-  `ssh` binary, identical behavior on macOS/Linux/Windows.
+- SSH client is the **system OpenSSH binary** (`ssh`, spawned as a Tauri
+  sidecar) — present by default on macOS, Linux, and Windows 10+. This buys,
+  for free: agent-held keys (1Password, YubiKey, macOS keychain),
+  `~/.ssh/config`, and two decades of sshd compatibility. If no `ssh` binary
+  is found (rare), the wizard shows a clear error. *(Review change: an
+  embedded Rust client — russh — was originally planned; see Alternatives.)*
 - The app uses the **user's existing SSH key** — the one that has access to the
   server. The wizard auto-detects candidate keys in `~/.ssh`
   (`%USERPROFILE%\.ssh` on Windows) and offers a file picker for non-standard
-  paths. Passphrase-protected keys get an in-app prompt (decrypted in-process,
-  never persisted). The app stores only the file *path*; the private key is read
-  locally at connection time and never copied or transmitted. Supported: OpenSSH
-  format (ed25519, ECDSA, RSA); PuTTY `.ppk` is not.
+  paths. Keys held only in an agent (1Password, YubiKey, macOS keychain) work
+  natively — the system `ssh` talks to the agent; Hive never reads or copies
+  key material. Passphrase-protected key files get an in-app prompt via
+  `SSH_ASKPASS`. The app stores only the file *path*. Supported: whatever the
+  local OpenSSH supports; PuTTY `.ppk` is not.
   **Fallback for users with no SSH key:** the app generates an ed25519 keypair
   (stored `0600` in the app data dir) and shows the public key to paste into the
   provider's "SSH keys" field when creating the VPS.
@@ -69,9 +74,9 @@ flowchart TD
     end
 
     subgraph P3["3 · Install over SSH (~3 min, watched from the wizard)"]
-        C1["[W] connects via SSH (russh + the user's key)<br/>host-key trust dialog (TOFU)"]
+        C1["[W] connects via SSH (system ssh + the user's key/agent)<br/>host-key trust dialog (TOFU)"]
         C2["[W] probes OS: /etc/os-release + systemd<br/>clean refusal if unsupported"]
-        C3["[W] uploads provision.sh + secrets via SFTP<br/>(nothing in shell history or console)"]
+        C3["[W] streams provision.sh + secrets over stdin<br/>(nothing in argv, shell history, or console)"]
         C4["[S] runs DETACHED (setsid + logfile)<br/>survives app close; NDJSON progress streamed to the checklist"]
         C1 --> C2 --> C3 --> C4
     end
@@ -129,7 +134,7 @@ sequenceDiagram
     U->>W: select SSH key (passphrase prompt if encrypted)
     U->>W: paste server IP
     W->>V: SSH connect (user's key), TOFU dialog
-    W->>V: SFTP upload provision.sh + secrets
+    W->>V: stream provision.sh + secrets over stdin
     W->>V: run detached, tail NDJSON progress
     V->>T: tailscale up --auth-key (node joins tailnet)
     V->>V: install node, ufw, Hive release, systemd units
@@ -189,10 +194,10 @@ patterns are snapshot-tested (no login flow has a `--json` mode).
   pairing window, no self-signed certificate pinning, no commit-confirm rebind —
   that entire threat surface is designed out rather than mitigated.
 - **Trust chain:** the app generates the auth token locally; secrets reach the
-  server over SFTP inside SSH (never in a command line, console, or shell
-  history). The user's private key is read locally at connection time and never
-  copied or transmitted. First API contact happens over the encrypted tailnet
-  with a token the app already holds.
+  server over stdin inside SSH (never in a command line, console, or shell
+  history). The user's private key never leaves their machine — Hive does not
+  even read it; the system `ssh`/agent handles it. First API contact happens
+  over the encrypted tailnet with a token the app already holds.
 - **Host key TOFU:** first SSH connection shows the server fingerprint in a
   native dialog; accepted keys are remembered.
 - **Least privilege at runtime:** `hive.service` runs as a dedicated user with
@@ -255,11 +260,12 @@ No terminal, no shell command, no manual server configuration, no VPN setup.
 2. **Non-root servers** (AWS uses `ubuntu` + sudo): v1 targets root login
    (Hetzner/DO/OVH default); sudo support later. Hardened servers with
    `PermitRootLogin no` get a clear error and a documented fallback.
-3. **SSH key edge cases:** keys that live only in an agent (1Password, YubiKey,
-   macOS keychain) have no on-disk file the app can read — v1 does not talk to
-   agents; those users take the generated-key fallback. PuTTY `.ppk` files are
-   not supported (convert or fall back). Passphrase-protected keys are supported
-   via an in-app prompt.
+3. **SSH key edge cases:** agent-held keys (1Password, YubiKey, macOS
+   keychain) work natively through the system `ssh`. PuTTY `.ppk` files are
+   not supported (convert or use the generated-key fallback).
+   Passphrase-protected key files are supported via an in-app `SSH_ASKPASS`
+   prompt — its behavior from a GUI-spawned process is validated per-OS in
+   spike S4.
 4. **OS matrix:** Ubuntu 22.04/24.04 + Debian 12 (systemd required) at launch;
    the probe refuses anything else cleanly.
 5. **Hard dependency on Tailscale** (account required). Accepted: remote access
@@ -280,4 +286,4 @@ No terminal, no shell command, no manual server configuration, no VPN setup.
 | Provider API + cloud-init (app creates the VPS) | excellent, but adds a second account/token paste; deferred — natural v2 on top of the same script, and the basis for a future "Hive Cloud" |
 | Docker as primary distribution | fights the product: git worktrees, host PTYs, agent CLIs and their host credentials |
 | App-generated dedicated key as the default | adds a public-key paste step at the provider that key-owning users find redundant; kept as the fallback for users with no SSH key |
-| Deep SSH-agent integration (1Password, YubiKey, macOS keychain, `~/.ssh/config`) | the largest per-user variability surface; v1 reads key files only (passphrase prompt included), agent-only users take the generated-key fallback |
+| Embedded Rust SSH client (`russh`) | original choice, replaced in review: strictly less capable than the system `ssh` it ships next to (no agent-held keys — excluding 1Password/YubiKey users, common among developers — no `~/.ssh/config`), plus an entire SSH client to maintain and re-validate against sshd variants. The system OpenSSH binary is present by default on macOS/Linux/Windows 10+ and makes agent keys the happy path |

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -76,7 +76,7 @@ flowchart TD
 
     subgraph P3["3 · Install over SSH (~3 min, watched from the wizard)"]
         C1["[W] connects via SSH (system ssh + the user's key/agent)<br/>host-key trust dialog (TOFU)"]
-        C2["[W] probes OS: /etc/os-release + systemd<br/>clean refusal if unsupported"]
+        C2["[W] probes OS + pristine state<br/>clean refusal if unsupported or already occupied"]
         C3["[W] streams provision.sh + secrets over stdin<br/>(nothing in argv, shell history, or console)"]
         C4["[S] runs DETACHED (setsid + logfile)<br/>survives app close; NDJSON progress streamed to the checklist"]
         C1 --> C2 --> C3 --> C4
@@ -295,7 +295,13 @@ No terminal, no shell command, no manual server configuration, no VPN setup.
    required it in every considered design; the free tier suffices. A hosted
    relay ("Hive Connect", Nabu-Casa-style) could remove the dependency later and
    is the natural monetization path.
-6. **Backend work not covered here** (tracked separately): runtime-issued auth
+6. **Pristine servers only.** The wizard refuses servers that already run
+   other services or a manual Hive install (explicit `SERVER_NOT_PRISTINE` /
+   `EXISTING_INSTALL` errors) rather than half-applying firewall and unit
+   changes to an inhabited box. Existing manual installs keep the
+   GETTING_STARTED path; migration = documented backup/wipe/restore, no tool
+   in v1.
+7. **Backend work not covered here** (tracked separately): runtime-issued auth
    tokens instead of the build-time `VITE_HIVE_AUTH_TOKEN`, a backend version
    endpoint + WS protocol version, setup progress served over REST polling
    (review decision: no new WS channel), QR scanning + deep links in iOS,

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -98,8 +98,8 @@ flowchart TD
     end
 
     subgraph P5["5 · Guided setup (backend = installer, resumable jobs)"]
-        E1["detect: claude / codex / gh<br/>only missing pieces are shown"]
-        E2["Claude: install CLI (apt), auth with SUBSCRIPTION:<br/>claude setup-token in a PTY → URL shown in wizard →<br/>[U] approves in browser (fallback: token generated on the Mac)"]
+        E1["detect: claude / codex / gh<br/>(installed + authenticated)<br/>only missing pieces are shown"]
+        E2["Claude: auth with SUBSCRIPTION, LOCALLY:<br/>wizard runs claude setup-token on the user's computer<br/>(downloads standalone binary if absent) → browser opens →<br/>token captured and POSTed to the backend"]
         E3["Codex (optional): codex login --device-auth<br/>URL + code shown in wizard"]
         E4["GitHub (optional, private HTTPS repos):<br/>gh device flow, one-time code in wizard"]
         E5["preflight ✓ · health ✓ · 'Your Hive is ready'"]
@@ -142,7 +142,9 @@ sequenceDiagram
     V->>H: start hive.service (tailnet-only via ufw)
     W->>H: GET /health over tailnet (token) — first API contact
     W--xV: close SSH (repair channel only)
-    W->>H: guided setup: claude / codex / gh (PTY device flows)
+    W->>W: claude setup-token runs locally, browser approval on the same machine
+    W->>H: POST captured Claude token
+    W->>H: guided setup: codex / gh device flows (VPS PTY)
     U->>H: approves OAuth pages in browser (subscription auth)
 ```
 
@@ -154,7 +156,7 @@ sequenceDiagram
 | 2 | node 22, git, ufw | script (root) | NodeSource apt / apt | ufw: default-deny, `allow in on tailscale0` |
 | 3 | Hive backend | script (root) | GitHub Release tarball, checksum-verified | `/opt/hive/releases/N`, `current` symlink, `shared/` data dir |
 | 4 | systemd units | script (root) | files | `hive.service` (dedicated user, hardened) + `hive-updater` |
-| 5 | claude CLI | backend | Anthropic apt repo | no background auto-update; Hive owns updates |
+| 5 | claude CLI | backend | official native installer (standalone binary — no Anthropic apt repo exists) | auto-updater disabled (`DISABLE_AUTOUPDATER=1`); Hive owns updates |
 | 6 | codex CLI (opt.) | backend | npm/binary release | device-auth on the VPS |
 | 7 | gh CLI (opt.) | backend | official apt repo | only needed for HTTPS cloning of private repos |
 | — | Tailscale app | user | App Store / MSI | on the Mac (step 1) and iPhone (step 6) |
@@ -184,13 +186,21 @@ sequenceDiagram
 
 | CLI | Flow | Fallback | Known pitfalls encoded in the design |
 |---|---|---|---|
-| claude | `claude setup-token` in a PTY on the VPS; wizard lifts the OAuth URL; user approves in browser; 1-year `CLAUDE_CODE_OAUTH_TOKEN` written to a `0600` EnvironmentFile | run `setup-token` on the user's computer, paste the token | paste-back over SSH has known regressions (anthropics/claude-code #42965, #48048) → fallback is mandatory. Never set `ANTHROPIC_API_KEY` alongside (it silently wins and bills API credits). Pre-seed `~/.claude.json` (onboarding + workspace trust; `--dangerously-skip-permissions` does NOT bypass the trust dialog) |
+| claude | the wizard runs `claude setup-token` **locally on the user's computer** (downloading the standalone native binary into app data if absent); the browser opens on the same machine; the wizard captures the 1-year `CLAUDE_CODE_OAUTH_TOKEN` and POSTs it to the backend, which writes it to a `0600` EnvironmentFile | manual: the user runs `setup-token` themselves and pastes the token into the wizard | running locally keeps SSH and remote PTYs out of the most fragile flow (paste-back regressions anthropics/claude-code #42965, #48048 — originally the #1 project risk). Never set `ANTHROPIC_API_KEY` alongside (it silently wins and bills API credits). Pre-seed `~/.claude.json` (onboarding + workspace trust; `--dangerously-skip-permissions` does NOT bypass the trust dialog) |
 | codex | `codex login --device-auth` in a PTY; wizard shows URL + code; tokens auto-refresh in `~/.codex/auth.json` on the VPS | SSH port-forward of the login callback | requires "Allow device code login" enabled in ChatGPT settings (detect the error, guide the user). Never copy `auth.json` between machines (single-use rotating refresh tokens) |
 | gh | device flow; wizard shows the one-time code | personal access token | the CLI does not poll until Enter is pressed (cli/cli #12925) → inject the keystroke into the PTY. Step is optional: SSH-key/public-repo users skip it |
 
-All flows run on the VPS inside a PTY owned by the backend; the wizard renders
-extracted URLs/codes and streams output. CLI versions are pinned and the scrape
-patterns are snapshot-tested (no login flow has a `--json` mode).
+Codex and gh flows run on the VPS inside a PTY owned by the backend; the
+wizard renders extracted URLs/codes. Claude never runs interactively on the
+VPS — the token is generated on the user's machine and POSTed to the backend.
+CLI versions are pinned and the scrape patterns are snapshot-tested (no login
+flow has a `--json` mode).
+
+Auth is a permanent service, not an install step: detection reports
+`authenticated` per CLI (already-logged-in binaries are never asked again),
+expiry or revocation — the Claude token lasts one year — surfaces as a
+visible health warning, and Settings offers "Reconnect" re-running the same
+flows. Day 366 is a designed path.
 
 ## Security model
 
@@ -261,9 +271,11 @@ No terminal, no shell command, no manual server configuration, no VPN setup.
 
 ## Known risks and open questions
 
-1. **Claude subscription auth on a headless box is the #1 project risk** (buggy
-   paste-back flow, no device-code mode). Prototype first; the on-computer
-   fallback must ship from day one.
+1. **Claude subscription auth was the #1 project risk** while it ran in a
+   remote PTY on the VPS (buggy paste-back, no device-code mode). Review moved
+   it local: the wizard drives `claude setup-token` on the user's machine and
+   POSTs the token — SSH and remote terminals are out of the flow. Residual
+   risk: local CLI output capture still needs version-keyed patterns.
 2. **Non-root servers** (AWS uses `ubuntu` + sudo): v1 targets root login
    (Hetzner/DO/OVH default); sudo support later. Hardened servers with
    `PermitRootLogin no` get a clear error and a documented fallback.

--- a/docs/install-flow.md
+++ b/docs/install-flow.md
@@ -14,8 +14,9 @@ documented in [GETTING_STARTED.md](../GETTING_STARTED.md) and [deploy/README.md]
 3. **Subscriptions, not API keys.** Claude and Codex authenticate with the user's
    existing consumer subscription (Claude Pro/Max, ChatGPT Plus/Pro). Hive never
    asks for a pay-per-use API key.
-4. **Never publicly exposed.** The backend binds to the Tailscale interface from
-   its first second. No port is ever reachable from the public internet, so there
+4. **Never publicly exposed.** The backend is reachable only over the Tailscale
+   interface from its first second (ufw default-deny enforces this).
+   No port is ever reachable from the public internet, so there
    is no setup-window attack surface (the class of bug behind the Portainer
    first-run takeover CVE and the OpenClaw mass-exposure incident).
 5. **One script, simple tech.** A single idempotent `provision.sh` does all
@@ -86,7 +87,7 @@ flowchart TD
         S2["node 22 (NodeSource) · git<br/>ufw default-deny + allow in on tailscale0"]
         S3["/opt/hive/releases/N ← release tarball (checksum)<br/>current → N symlink · shared/ for data"]
         S4["HIVE_AUTH_TOKEN → EnvironmentFile (0600)<br/>systemd units: hive.service + hive-updater"]
-        S5["start Hive — bound to the TAILNET IP only,<br/>never on a public interface"]
+        S5["start Hive — reachable over the tailnet only<br/>(ufw default-deny; no public port ever open)"]
         S1 --> S2 --> S3 --> S4 --> S5
     end
 
@@ -138,7 +139,7 @@ sequenceDiagram
     W->>V: run detached, tail NDJSON progress
     V->>T: tailscale up --auth-key (node joins tailnet)
     V->>V: install node, ufw, Hive release, systemd units
-    V->>H: start hive.service bound to tailnet IP
+    V->>H: start hive.service (tailnet-only via ufw)
     W->>H: GET /health over tailnet (token) — first API contact
     W--xV: close SSH (repair channel only)
     W->>H: guided setup: claude / codex / gh (PTY device flows)
@@ -166,8 +167,11 @@ sequenceDiagram
   after 180 days" failure.
 - The script installs Tailscale from the official apt repo and runs
   `tailscale up --auth-key=…` — fully non-interactive, no login URL to lift.
-- The backend binds to the Tailscale IP (100.x.y.z). `ufw` is default-deny with
-  `allow in on tailscale0`; no public port is ever opened.
+- The backend listens on `0.0.0.0`; reachability is enforced by `ufw`
+  (default-deny, `allow in on tailscale0`) — no public port is ever opened.
+  Binding the 100.x IP directly was dropped in review: it races tailscaled at
+  boot (the IP may not be assigned yet → crash loop on every slow reboot);
+  the firewall alone carries the guarantee.
 - Optional (guided later, for clean iOS HTTPS): enabling **MagicDNS + HTTPS** on
   the tailnet gives `https://<host>.<tailnet>.ts.net` with a real Let's Encrypt
   certificate. This is a one-time manual toggle in the admin console and publishes
@@ -235,7 +239,10 @@ flowchart LR
 - The updater is a separate systemd unit triggered by a path unit, so restarting
   Hive never kills the update mid-flight.
 - Keep 2–3 release generations; rollback is a second symlink swap.
-- `StartLimitBurst` + `OnFailure=hive-rollback.service` protect against boot loops.
+- Rollback logic lives only inside the updater's window: after the swap, the
+  updater health-checks and rolls back itself. `hive.service` has no
+  `OnFailure=` hook — a steady-state crash (full disk, slow tailscale at
+  boot) must never trigger a root rollback of a healthy release.
 - If an update is requested while agent sessions are running, the UI warns first.
 - If the backend is ever unreachable, the desktop app still holds a working SSH
   key: SSH is the out-of-band repair channel (tail logs, roll back, restart).


### PR DESCRIPTION
Stacked on #336 — eight design decisions changed after a review pass, one commit per decision so each can be discussed, cherry-picked, or rejected independently. Full rationale lives in each commit message; the plan doc now opens with an "Amendments — review round 1" summary block.

## The eight decisions

1. **Threat model: the `hive` user is assumed hostile.** Hive's product runs LLM agents executing arbitrary code as the service user. Consequences: Docker rootless-only (never the `docker` group = instant root), the root updater ignores the content of the `hive`-writable trigger file and refuses downgrades, every helper audited for escalation *by effect*.
2. **System OpenSSH sidecar replaces russh.** The embedded client was less capable than the `ssh` already on the user's machine: no agent-held keys (1Password/YubiKey/keychain — common among our audience), no `~/.ssh/config`, plus a whole client to maintain. Agent keys become the happy path. TOFU kept via `ssh-keyscan` + app-owned known_hosts; secrets go over stdin (same no-argv guarantee).
3. **Rollback belongs to the updater; bind `0.0.0.0` behind ufw.** `OnFailure=hive-rollback` on the main unit + binding the 100.x IP meant every slow tailscaled boot could trigger a root rollback of a healthy release. Rollback now only happens inside the updater's health-gated window; tailnet-only reachability is carried by ufw (already the load-bearing defense).
4. **Claude auth runs locally on the user's machine.** The wizard spawns `claude setup-token` locally (downloads the standalone binary if absent), browser opens on the same machine, token POSTed to the existing endpoint — SSH/remote PTYs leave the most fragile flow. Codex intentionally stays device-auth on the VPS (rotating refresh tokens forbid copying `auth.json` — your own pitfall table). Also: per-CLI `authenticated` detection (never re-ask a logged-in CLI), re-entrant auth for day 366 (`AUTH_EXPIRED` + Settings Reconnect), and install-channel fix (no Anthropic apt repo exists; native installer + `DISABLE_AUTOUPDATER=1`).
5. **`/ws/setup` dropped.** With Claude local, no client→server PTY input remains (gh's Enter is injected server-side). REST polling of the already-specified operation/log endpoints covers progress; `auth_action` becomes an `action` field on `SetupStep`. PR 3.2 removed.
6. **Auth token hash-only at rest.** Resolves the §3.3/§5.5 contradiction: provisioned installs store only the SHA-256 (the app holds the plaintext it generated); plaintext accepted for legacy manual installs only; lost token = documented SSH reset, not recovery. `shred` → `rm` (no false guarantees on journaling filesystems).
7. **Pristine-server guard.** New `probe_env` step refuses inhabited servers (`SERVER_NOT_PRISTINE` / `EXISTING_INSTALL`) instead of half-applying ufw/units to a box running something else; resume on our own installs stays legitimate via the state file. No migration tool from manual installs in v1 (documented backup/wipe/restore).
8. **Factual fix:** `deploy/` templates were marked "(exist)" but the directory does not exist on `main`.

Not touched on purpose: sequencing, estimates, and phase/track structure (§11/§13) — owner's call; the removals above (russh PR 2.1 scope, PR 3.2, spike S2/S4 shrinkage) will mechanically lighten them.