### PR TITLE
fix: harden config.json against wipe on malformed/unreadable files

### DIFF
--- a/backend/src/state/config.test.ts
+++ b/backend/src/state/config.test.ts
@@ -178,4 +178,33 @@ describe("updateConfig", () => {
     const loaded = await loadConfig(dataDir);
     expect(loaded.defaultModelId).toBe("claude:opus-4-8");
   });
+
+  it("rejects and leaves the file untouched when config.json is corrupt", async () => {
+    await writeFile(join(dataDir, "config.json"), "{invalid", "utf-8");
+
+    await expect(
+      updateConfig((c) => { c.defaultModelId = "claude:opus-4-8"; }, dataDir),
+    ).rejects.toThrow();
+
+    const raw = await readFile(join(dataDir, "config.json"), "utf-8");
+    expect(raw).toBe("{invalid");
+  });
+
+  it("rejects when config.json is not a JSON object", async () => {
+    await writeFile(join(dataDir, "config.json"), "null", "utf-8");
+
+    await expect(
+      updateConfig((c) => { c.defaultModelId = "claude:opus-4-8"; }, dataDir),
+    ).rejects.toThrow("does not contain a JSON object");
+
+    const raw = await readFile(join(dataDir, "config.json"), "utf-8");
+    expect(raw).toBe("null");
+  });
+
+  it("creates the file when it does not exist yet", async () => {
+    await updateConfig((c) => { c.defaultModelId = "claude:opus-4-8"; }, dataDir);
+
+    const loaded = await loadConfig(dataDir);
+    expect(loaded.defaultModelId).toBe("claude:opus-4-8");
+  });
 });

--- a/backend/src/state/config.test.ts
+++ b/backend/src/state/config.test.ts
@@ -201,6 +201,17 @@ describe("updateConfig", () => {
     expect(raw).toBe("null");
   });
 
+  it("rejects and leaves the file untouched when config.json has an array root", async () => {
+    await writeFile(join(dataDir, "config.json"), "[]", "utf-8");
+
+    await expect(
+      updateConfig((c) => { c.defaultModelId = "claude:opus-4-8"; }, dataDir),
+    ).rejects.toThrow("does not contain a JSON object");
+
+    const raw = await readFile(join(dataDir, "config.json"), "utf-8");
+    expect(raw).toBe("[]");
+  });
+
   it("creates the file when it does not exist yet", async () => {
     await updateConfig((c) => { c.defaultModelId = "claude:opus-4-8"; }, dataDir);
 

--- a/backend/src/state/config.ts
+++ b/backend/src/state/config.ts
@@ -51,35 +51,59 @@ function configFilePath(dataDir: string): string {
   return join(dataDir, "config.json");
 }
 
-export async function loadConfig(dataDir = getDataDir()): Promise<AppConfig> {
-  try {
-    const raw = await readFile(configFilePath(dataDir), "utf-8");
-    const parsed = JSON.parse(raw) as Partial<AppConfig>;
-    const apns = parsed.notifications?.apns;
-    return {
-      notifications: {
-        telegram: {
-          enabled: parsed.notifications?.telegram?.enabled ?? DEFAULT_CONFIG.notifications.telegram.enabled,
-          botToken: parsed.notifications?.telegram?.botToken ?? DEFAULT_CONFIG.notifications.telegram.botToken,
-          chatId: parsed.notifications?.telegram?.chatId ?? DEFAULT_CONFIG.notifications.telegram.chatId,
-        },
-        apns: {
-          enabled: apns?.enabled ?? DEFAULT_APNS.enabled,
-          teamId: apns?.teamId ?? DEFAULT_APNS.teamId,
-          keyId: apns?.keyId ?? DEFAULT_APNS.keyId,
-          keyContent: apns?.keyContent ?? DEFAULT_APNS.keyContent,
-          bundleId: apns?.bundleId ?? DEFAULT_APNS.bundleId,
-          sandbox: apns?.sandbox ?? DEFAULT_APNS.sandbox,
-          deviceTokens: apns?.deviceTokens ?? DEFAULT_APNS.deviceTokens,
-        },
+function withDefaults(parsed: Partial<AppConfig>): AppConfig {
+  const apns = parsed.notifications?.apns;
+  return {
+    notifications: {
+      telegram: {
+        enabled: parsed.notifications?.telegram?.enabled ?? DEFAULT_CONFIG.notifications.telegram.enabled,
+        botToken: parsed.notifications?.telegram?.botToken ?? DEFAULT_CONFIG.notifications.telegram.botToken,
+        chatId: parsed.notifications?.telegram?.chatId ?? DEFAULT_CONFIG.notifications.telegram.chatId,
       },
-      defaultModelId: typeof parsed.defaultModelId === "string" && parsed.defaultModelId
-        ? parsed.defaultModelId
-        : undefined,
-    };
-  } catch {
-    return structuredClone(DEFAULT_CONFIG);
+      apns: {
+        enabled: apns?.enabled ?? DEFAULT_APNS.enabled,
+        teamId: apns?.teamId ?? DEFAULT_APNS.teamId,
+        keyId: apns?.keyId ?? DEFAULT_APNS.keyId,
+        keyContent: apns?.keyContent ?? DEFAULT_APNS.keyContent,
+        bundleId: apns?.bundleId ?? DEFAULT_APNS.bundleId,
+        sandbox: apns?.sandbox ?? DEFAULT_APNS.sandbox,
+        deviceTokens: apns?.deviceTokens ?? [],
+      },
+    },
+    defaultModelId: typeof parsed.defaultModelId === "string" && parsed.defaultModelId
+      ? parsed.defaultModelId
+      : undefined,
+  };
+}
+
+/** Read and parse config.json. Returns null when the file does not exist
+ *  (first run); throws when it exists but cannot be read or parsed. */
+async function readConfigFile(dataDir: string): Promise<Partial<AppConfig> | null> {
+  let raw: string;
+  try {
+    raw = await readFile(configFilePath(dataDir), "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
   }
+  const parsed: unknown = JSON.parse(raw);
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`${configFilePath(dataDir)} does not contain a JSON object`);
+  }
+  return parsed as Partial<AppConfig>;
+}
+
+export async function loadConfig(dataDir = getDataDir()): Promise<AppConfig> {
+  let parsed: Partial<AppConfig> | null;
+  try {
+    parsed = await readConfigFile(dataDir);
+  } catch (err) {
+    // Degrade reads to defaults so the server keeps running, but never persist
+    // this fallback — updateConfig re-reads strictly before writing.
+    console.error("[config] failed to read config.json, using defaults:", err);
+    parsed = null;
+  }
+  return parsed ? withDefaults(parsed) : structuredClone(DEFAULT_CONFIG);
 }
 
 export async function saveConfig(config: AppConfig, dataDir = getDataDir()): Promise<void> {
@@ -100,7 +124,10 @@ export function updateConfig(
   dataDir = getDataDir(),
 ): Promise<AppConfig> {
   const task = updateQueue.then(async () => {
-    const config = await loadConfig(dataDir);
+    // Strict read: if config.json exists but is unreadable or corrupt, fail the
+    // update instead of silently overwriting saved settings with defaults.
+    const parsed = await readConfigFile(dataDir);
+    const config = parsed ? withDefaults(parsed) : structuredClone(DEFAULT_CONFIG);
     mutate(config);
     await saveConfig(config, dataDir);
     return config;

--- a/backend/src/state/config.ts
+++ b/backend/src/state/config.ts
@@ -87,7 +87,7 @@ async function readConfigFile(dataDir: string): Promise<Partial<AppConfig> | nul
     throw err;
   }
   const parsed: unknown = JSON.parse(raw);
-  if (typeof parsed !== "object" || parsed === null) {
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
     throw new Error(`${configFilePath(dataDir)} does not contain a JSON object`);
   }
   return parsed as Partial<AppConfig>;


### PR DESCRIPTION
## Context

Audit of the latest `main` commit (#339, configurable default model) surfaced a latent risk in `config.json` persistence. That commit routed all writers through a new `updateConfig` read-modify-write cycle, which amplified a pre-existing weakness: `loadConfig` swallowed *every* read error and returned defaults. Combined, a transient read failure or a corrupt file followed by any settings write would silently rewrite `config.json` with defaults — wiping notification settings and APNs device tokens.

## Changes

**`fix: never overwrite config.json with defaults on read errors`**
- Split read vs. write concerns. `loadConfig` still degrades to defaults so the server keeps running (now logged), but `updateConfig` re-reads strictly and **rejects** when the file exists but cannot be read or parsed. `ENOENT` remains the only case treated as a fresh start.
- Stop aliasing `DEFAULT_APNS.deviceTokens` into loaded configs — a `push` on a config missing that field previously mutated the module-level default for the process lifetime.

**`fix: reject array-root config.json before overwriting`**
- `readConfigFile` guarded against `null`/primitive JSON roots but not arrays (`typeof [] === "object"`). A `config.json` containing `[]` passed the strict read and got overwritten. Now every non-object root fails before any mutation.

## Testing

- `npm test --workspace @hive/backend -- --run src/state/config.test.ts` — all pass (new regression cases for corrupt JSON, `null` root, array root, and first-run creation).
- Backend `typecheck` and `lint` clean.

## Notes

- `package-lock.json` has unrelated lockfile drift in the working tree; deliberately **not** included.