### PR TITLE
fix: web misses stream started from another client (replay snapshot on view mount)

### DIFF
--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -401,7 +401,8 @@ export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
   | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
-  | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };
+  | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string }
+  | { type: "request_stream_snapshots" };
 
 /** Backend -> Frontend */
 export type WsOutgoing =

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -8,6 +8,7 @@ import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { createProject } from "../projects/project-manager.js";
 import { createWorkspace } from "../workspaces/workspace-manager.js";
 import {
+  getSession,
   getOrCreateSession,
   getSessionById,
   createNewSession,
@@ -2017,5 +2018,83 @@ describe("WS /ws/hub", () => {
     ws.close();
     await local.app.close();
     await endSession(wsId, dataDir).catch(() => {});
+  });
+
+  it("replays the streaming snapshot only for the targeted workspace via request_stream_snapshots", async () => {
+    const fakeClaudePath = join(tempDir, "fake-claude-request-stream-snapshots.sh");
+    await writeFile(fakeClaudePath, "#!/bin/sh\nsleep 5\n", "utf-8");
+    await chmod(fakeClaudePath, 0o755);
+    const slowCmd = { command: fakeClaudePath, systemPrompt: false as const };
+    const local = await startWsApp(undefined, slowCmd);
+
+    const other = await createWorkspace(projectId, dataDir);
+
+    const { session: targetSession } = await getOrCreateSession(wsId, dataDir, slowCmd);
+    targetSession.sendMessage("streaming on target");
+    const targetSnapshotData = targetSession.getStreamingSnapshot();
+    if (!targetSnapshotData) throw new Error("Expected a streaming snapshot on target");
+    vi.spyOn(targetSession, "getStreamingSnapshot").mockReturnValue({
+      ...targetSnapshotData,
+      text: "target snapshot text",
+    });
+
+    const { session: otherSession } = await getOrCreateSession(other.id, dataDir, slowCmd);
+    otherSession.sendMessage("streaming on other");
+    if (!otherSession.getStreamingSnapshot()) throw new Error("Expected a streaming snapshot on other");
+
+    const { wsReady, allEnvelopes } = connectHub([wsId, other.id], {
+      app: local.app,
+      collectAll: true,
+    });
+    const ws = await wsReady;
+
+    const snapshotsFor = (id: string) =>
+      allEnvelopes.filter((e) => e.workspaceId === id && e.event.type === "stream_snapshot");
+
+    // Initial bootstrap ships exactly one snapshot per streaming workspace.
+    await waitForCondition(
+      () => snapshotsFor(wsId).length === 1 && snapshotsFor(other.id).length === 1,
+    );
+
+    const otherEnvelopeCountBefore = allEnvelopes.filter((e) => e.workspaceId === other.id).length;
+
+    ws.send(hubEvent(wsId, { type: "request_stream_snapshots" }));
+
+    await waitForCondition(() => snapshotsFor(wsId).length === 2);
+    const replayed = snapshotsFor(wsId)[1]?.event as Extract<WsOutgoing, { type: "stream_snapshot" }>;
+    expect(replayed.sessionId).toBe(targetSession.sessionId);
+    expect(replayed.text).toBe("target snapshot text");
+
+    // The untargeted workspace must not receive any additional event (snapshot,
+    // status, branch, diff, script, browser, or PR) purely because a sibling
+    // workspace was targeted -- unlike forceBootstrap, this request is scoped
+    // to exactly the addressed workspace.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(allEnvelopes.filter((e) => e.workspaceId === other.id).length).toBe(otherEnvelopeCountBefore);
+    expect(snapshotsFor(wsId).length).toBe(2);
+    expect(ws.readyState).toBe(ws.OPEN);
+
+    ws.close();
+    await local.app.close();
+    await endSession(wsId, dataDir).catch(() => {});
+    await endSession(other.id, dataDir).catch(() => {});
+  });
+
+  it("request_stream_snapshots on an idle workspace emits nothing and does not create or activate a session", async () => {
+    const { wsReady, allEnvelopes } = connectHub([wsId], { collectAll: true });
+    const ws = await wsReady;
+
+    await waitForCondition(() => allEnvelopes.some((e) => e.event.type === "status"));
+    expect(getSession(wsId)).toBeUndefined();
+
+    const countBefore = allEnvelopes.length;
+    ws.send(hubEvent(wsId, { type: "request_stream_snapshots" }));
+
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(allEnvelopes.length).toBe(countBefore);
+    expect(getSession(wsId)).toBeUndefined();
+    expect(ws.readyState).toBe(ws.OPEN);
+
+    ws.close();
   });
 });

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -351,29 +351,40 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
 
   // ── Workspace bootstrap (sent to one hub socket on subscribe) ─────
 
-  const sendWorkspaceBootstrap = async (hub: HubSocket, wsId: string, channel: WorkspaceChannel): Promise<void> => {
-    const sendStreamingBootstraps = (primarySessionId?: string): void => {
-      for (const streamingId of getStreamingSessionIds(wsId)) {
-        if (streamingId === primarySessionId) continue;
-        const streamingSession = getSessionById(wsId, streamingId);
-        if (streamingSession) {
-          attachSessionListeners(wsId, channel, streamingSession);
-        }
-        sendToHub(hub, wsId, {
-          type: "status",
-          status: "busy",
-          sessionId: streamingId,
-          streaming: true,
-          ...(streamingSession?.streamingStartedAt
-            ? { streamingStartedAt: streamingSession.streamingStartedAt }
-            : {}),
-        });
-        if (streamingSession) {
-          sendStreamingSnapshot(hub, wsId, streamingSession);
-        }
+  /**
+   * Replay live status + full snapshot for every currently streaming session in
+   * one workspace (excluding `primarySessionId`, already covered by the caller's
+   * own bootstrap). Shared by full workspace bootstrap and the narrower
+   * `request_stream_snapshots` recovery path.
+   */
+  const sendStreamingBootstraps = (
+    hub: HubSocket,
+    wsId: string,
+    channel: WorkspaceChannel,
+    primarySessionId?: string,
+  ): void => {
+    for (const streamingId of getStreamingSessionIds(wsId)) {
+      if (streamingId === primarySessionId) continue;
+      const streamingSession = getSessionById(wsId, streamingId);
+      if (streamingSession) {
+        attachSessionListeners(wsId, channel, streamingSession);
       }
-    };
+      sendToHub(hub, wsId, {
+        type: "status",
+        status: "busy",
+        sessionId: streamingId,
+        streaming: true,
+        ...(streamingSession?.streamingStartedAt
+          ? { streamingStartedAt: streamingSession.streamingStartedAt }
+          : {}),
+      });
+      if (streamingSession) {
+        sendStreamingSnapshot(hub, wsId, streamingSession);
+      }
+    }
+  };
 
+  const sendWorkspaceBootstrap = async (hub: HubSocket, wsId: string, channel: WorkspaceChannel): Promise<void> => {
     const session = getSession(wsId);
     const sessionIsDefaultCandidate = session
       ? isLoadedDefaultSessionCandidate(wsId, session)
@@ -385,7 +396,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     if (session && (sessionIsDefaultCandidate || !defaultSessionId)) {
       attachSessionListeners(wsId, channel, session);
       await sendSessionBootstrap(hub, wsId, session);
-      sendStreamingBootstraps(session.sessionId);
+      sendStreamingBootstraps(hub, wsId, channel, session.sessionId);
     } else {
       // The in-memory active session is empty/idle, so we steer a fresh client
       // to a different default chat. Still attach the active chat session's
@@ -402,7 +413,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         // sent — a streaming default must not be announced as idle first.
         attachSessionListeners(wsId, channel, defaultSession);
         await sendSessionBootstrap(hub, wsId, defaultSession);
-        sendStreamingBootstraps(defaultSession.sessionId);
+        sendStreamingBootstraps(hub, wsId, channel, defaultSession.sessionId);
       } else {
         // No default-worthy chat is loaded in memory. Tell the client which
         // session to open (persisted active / most-recent non-empty chat) so a
@@ -414,7 +425,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           streaming: false,
           ...(defaultSessionId ? { sessionId: defaultSessionId } : {}),
         });
-        sendStreamingBootstraps();
+        sendStreamingBootstraps(hub, wsId, channel);
       }
     }
 
@@ -720,6 +731,14 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         } catch (err: unknown) {
           sendToHub(hub, wsId, { type: "error", message: errorMessage(err, "Failed to respond to tool input") });
         }
+        break;
+      }
+      case "request_stream_snapshots": {
+        // Narrow web-view recovery path: replay every currently streaming
+        // session's live status + snapshot for this workspace only. Unlike
+        // forceBootstrap, this never touches subscriptions, focus, or PR
+        // interest, and never re-runs the full workspace bootstrap.
+        sendStreamingBootstraps(hub, wsId, channel);
         break;
       }
     }

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -632,12 +632,13 @@ export function useConversation(workspaceId: string | undefined) {
       wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
     }
 
-    // Replay in-progress streaming snapshots for a view that mounts mid-turn.
-    // Stream frames delivered while this view was unmounted were consumed by
-    // the app-level cache hooks (never buffered), so without this a turn
-    // started from another client (e.g. iOS) shows only the frames that arrive
-    // after mount — tool calls without the already-streamed text.
-    wsTransport.requestBootstrap();
+    // Replay in-progress streaming snapshots for this workspace only, for a
+    // view that mounts mid-turn. Stream frames delivered while this view was
+    // unmounted were consumed by the app-level cache hooks (never buffered),
+    // so without this a turn started from another client (e.g. iOS) shows
+    // only the frames that arrive after mount — tool calls without the
+    // already-streamed text.
+    wsTransport.requestStreamSnapshots(workspaceId);
 
     return () => {
       if (workspaceId && sessionIdRef.current) {

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -632,6 +632,13 @@ export function useConversation(workspaceId: string | undefined) {
       wsTransport.send(workspaceId, { type: "switch_session", sessionId: savedSession });
     }
 
+    // Replay in-progress streaming snapshots for a view that mounts mid-turn.
+    // Stream frames delivered while this view was unmounted were consumed by
+    // the app-level cache hooks (never buffered), so without this a turn
+    // started from another client (e.g. iOS) shows only the frames that arrive
+    // after mount — tool calls without the already-streamed text.
+    wsTransport.requestBootstrap();
+
     return () => {
       if (workspaceId && sessionIdRef.current) {
         savedSessionByWorkspace.set(workspaceId, sessionIdRef.current);

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -98,25 +98,20 @@ class WsTransport {
   }
 
   /**
-   * Ask the backend to resend the full bootstrap (status + in-progress
-   * stream snapshots) for every subscribed workspace on the live socket.
+   * Ask the backend to replay the live status + in-progress stream snapshots
+   * of currently streaming sessions for a single workspace.
    *
    * Stream frames that arrive while a workspace's conversation view is
    * unmounted are consumed by the app-level cache hooks (which keep
    * `messageHandlers` non-empty, so nothing is buffered) and are gone for the
    * chat UI. A conversation view that mounts mid-stream must therefore ask for
-   * the snapshot replay explicitly — same mechanism as the iOS foreground
-   * refresh. No-op when the socket is not open: a (re)connecting socket gets
-   * the full bootstrap from the backend anyway.
+   * the snapshot replay explicitly, scoped to just the workspace it opened —
+   * unlike iOS foreground `forceBootstrap`, this must not refresh every
+   * subscribed workspace. No-op when the socket is not open: a (re)connecting
+   * socket gets the full bootstrap from the backend anyway.
    */
-  requestBootstrap(): void {
-    if (!this.hub.ws || this.hub.ws.readyState !== WebSocket.OPEN) return;
-    this.hub.ws.send(JSON.stringify({
-      type: "sync_workspaces",
-      workspaceIds: [...this.subscribedWorkspaceIds],
-      prWorkspaces: [...this.prWorkspaceIds],
-      forceBootstrap: true,
-    }));
+  requestStreamSnapshots(workspaceId: string): void {
+    this.send(workspaceId, { type: "request_stream_snapshots" });
   }
 
   syncPrWorkspaces(workspaceIds: string[]): void {

--- a/frontend/src/lib/ws-transport.ts
+++ b/frontend/src/lib/ws-transport.ts
@@ -97,6 +97,28 @@ class WsTransport {
     this.sendSyncWorkspaces();
   }
 
+  /**
+   * Ask the backend to resend the full bootstrap (status + in-progress
+   * stream snapshots) for every subscribed workspace on the live socket.
+   *
+   * Stream frames that arrive while a workspace's conversation view is
+   * unmounted are consumed by the app-level cache hooks (which keep
+   * `messageHandlers` non-empty, so nothing is buffered) and are gone for the
+   * chat UI. A conversation view that mounts mid-stream must therefore ask for
+   * the snapshot replay explicitly — same mechanism as the iOS foreground
+   * refresh. No-op when the socket is not open: a (re)connecting socket gets
+   * the full bootstrap from the backend anyway.
+   */
+  requestBootstrap(): void {
+    if (!this.hub.ws || this.hub.ws.readyState !== WebSocket.OPEN) return;
+    this.hub.ws.send(JSON.stringify({
+      type: "sync_workspaces",
+      workspaceIds: [...this.subscribedWorkspaceIds],
+      prWorkspaces: [...this.prWorkspaceIds],
+      forceBootstrap: true,
+    }));
+  }
+
   syncPrWorkspaces(workspaceIds: string[]): void {
     this.prWorkspaceIds = new Set(workspaceIds);
     this.ensureHubConnected();

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -390,7 +390,8 @@ export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
   | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
   | { type: "stop"; sessionId?: string }
-  | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string };
+  | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string }
+  | { type: "request_stream_snapshots" };
 
 /** Backend -> Frontend */
 export type WsOutgoing =

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -69,6 +69,7 @@ vi.mock("@/lib/ws-transport", () => {
       statusListeners.clear();
     }),
     send: vi.fn(() => true),
+    requestBootstrap: vi.fn(),
     onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
       getSet(messageHandlers, workspaceId).add(handler);
       for (const msg of replayMessages.get(workspaceId) ?? []) {
@@ -110,6 +111,7 @@ vi.mock("@/lib/ws-transport", () => {
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
+      wsTransport.requestBootstrap.mockClear();
       wsTransport.onMessage.mockClear();
       wsTransport.clearCachedData.mockClear();
     },
@@ -122,6 +124,7 @@ vi.mock("@/lib/ws-transport", () => {
     sendMock: wsTransport.send,
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
+    requestBootstrapMock: wsTransport.requestBootstrap,
   };
 
   return { wsTransport, __wsMock };
@@ -137,6 +140,7 @@ const getWsMock = async () =>
       sendMock: ReturnType<typeof vi.fn>;
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
+      requestBootstrapMock: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -205,6 +209,44 @@ describe("useConversation", () => {
     unmount();
 
     expect(__wsMock.disconnectMock).not.toHaveBeenCalled();
+  });
+
+  it("requests a bootstrap replay on mount so a mid-stream turn is recovered", async () => {
+    const { __wsMock } = await getWsMock();
+    const { rerender } = renderConversation("ws-1");
+
+    // Frames streamed while this view was unmounted are unrecoverable (the
+    // app-level cache hooks consume them), so mounting must ask the backend
+    // to replay the streaming snapshot.
+    expect(__wsMock.requestBootstrapMock).toHaveBeenCalledTimes(1);
+
+    rerender({ wsId: "ws-2" });
+
+    expect(__wsMock.requestBootstrapMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("applies a stream_snapshot arriving after mount to the live stream state", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderConversation("ws-1");
+
+    act(() => {
+      __wsMock.emit("ws-1", {
+        type: "stream_snapshot",
+        sessionId: "sess-1",
+        text: "already streamed text",
+        thinking: "",
+        toolCalls: [
+          { id: "t1", name: "Read", input: "{}" },
+          { id: "t2", name: "Bash", input: "{}" },
+        ],
+        agentActivities: [],
+        agentPlanMode: false,
+      });
+    });
+
+    expect(result.current.isStreaming).toBe(true);
+    expect(result.current.currentStreamingText).toBe("already streamed text");
+    expect(result.current.activeToolCalls).toHaveLength(2);
   });
 
   it("sends user messages through transport without optimistic local append", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -69,7 +69,7 @@ vi.mock("@/lib/ws-transport", () => {
       statusListeners.clear();
     }),
     send: vi.fn(() => true),
-    requestBootstrap: vi.fn(),
+    requestStreamSnapshots: vi.fn(),
     onMessage: vi.fn((workspaceId: string, handler: (msg: WsOutgoing) => void) => {
       getSet(messageHandlers, workspaceId).add(handler);
       for (const msg of replayMessages.get(workspaceId) ?? []) {
@@ -111,7 +111,7 @@ vi.mock("@/lib/ws-transport", () => {
       wsTransport.syncWorkspaces.mockClear();
       wsTransport.disconnectAll.mockClear();
       wsTransport.send.mockClear();
-      wsTransport.requestBootstrap.mockClear();
+      wsTransport.requestStreamSnapshots.mockClear();
       wsTransport.onMessage.mockClear();
       wsTransport.clearCachedData.mockClear();
     },
@@ -124,7 +124,7 @@ vi.mock("@/lib/ws-transport", () => {
     sendMock: wsTransport.send,
     connectMock: wsTransport.connect,
     disconnectMock: wsTransport.disconnect,
-    requestBootstrapMock: wsTransport.requestBootstrap,
+    requestStreamSnapshotsMock: wsTransport.requestStreamSnapshots,
   };
 
   return { wsTransport, __wsMock };
@@ -140,7 +140,7 @@ const getWsMock = async () =>
       sendMock: ReturnType<typeof vi.fn>;
       connectMock: ReturnType<typeof vi.fn>;
       disconnectMock: ReturnType<typeof vi.fn>;
-      requestBootstrapMock: ReturnType<typeof vi.fn>;
+      requestStreamSnapshotsMock: ReturnType<typeof vi.fn>;
     };
   };
 
@@ -211,18 +211,20 @@ describe("useConversation", () => {
     expect(__wsMock.disconnectMock).not.toHaveBeenCalled();
   });
 
-  it("requests a bootstrap replay on mount so a mid-stream turn is recovered", async () => {
+  it("requests a targeted stream-snapshot replay for the mounted workspace so a mid-stream turn is recovered", async () => {
     const { __wsMock } = await getWsMock();
     const { rerender } = renderConversation("ws-1");
 
     // Frames streamed while this view was unmounted are unrecoverable (the
     // app-level cache hooks consume them), so mounting must ask the backend
-    // to replay the streaming snapshot.
-    expect(__wsMock.requestBootstrapMock).toHaveBeenCalledTimes(1);
+    // to replay the streaming snapshot -- scoped to just the opened workspace.
+    expect(__wsMock.requestStreamSnapshotsMock).toHaveBeenCalledTimes(1);
+    expect(__wsMock.requestStreamSnapshotsMock).toHaveBeenNthCalledWith(1, "ws-1");
 
     rerender({ wsId: "ws-2" });
 
-    expect(__wsMock.requestBootstrapMock).toHaveBeenCalledTimes(2);
+    expect(__wsMock.requestStreamSnapshotsMock).toHaveBeenCalledTimes(2);
+    expect(__wsMock.requestStreamSnapshotsMock).toHaveBeenNthCalledWith(2, "ws-2");
   });
 
   it("applies a stream_snapshot arriving after mount to the live stream state", async () => {

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -104,6 +104,32 @@ describe("wsTransport", () => {
     expect(syncs).toEqual([["ws-1"]]);
   });
 
+  it("requestBootstrap resends sync_workspaces with forceBootstrap on an open socket", () => {
+    wsTransport.connect("ws-1");
+    wsTransport.connect("ws-2");
+    const socket = MockWebSocket.instances[0]!;
+    socket.open();
+
+    wsTransport.requestBootstrap();
+
+    const parsed = socket.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+    const forced = parsed.filter((m) => m.type === "sync_workspaces" && m.forceBootstrap === true);
+    expect(forced).toHaveLength(1);
+    expect(forced[0]!.workspaceIds).toEqual(expect.arrayContaining(["ws-1", "ws-2"]));
+  });
+
+  it("requestBootstrap is a no-op while the socket is not open (connect bootstrap covers it)", () => {
+    wsTransport.connect("ws-1");
+    const socket = MockWebSocket.instances[0]!;
+
+    wsTransport.requestBootstrap();
+    expect(socket.sent).toHaveLength(0);
+
+    socket.open();
+    const parsed = socket.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
+    expect(parsed.filter((m) => m.forceBootstrap === true)).toHaveLength(0);
+  });
+
   it("uses a single hub socket for multiple workspaces", () => {
     wsTransport.connect("ws-1");
     wsTransport.connect("ws-2");

--- a/frontend/tests/lib/ws-transport.test.ts
+++ b/frontend/tests/lib/ws-transport.test.ts
@@ -104,25 +104,32 @@ describe("wsTransport", () => {
     expect(syncs).toEqual([["ws-1"]]);
   });
 
-  it("requestBootstrap resends sync_workspaces with forceBootstrap on an open socket", () => {
+  it("requestStreamSnapshots sends a single workspace-scoped envelope, not a forced sync", () => {
     wsTransport.connect("ws-1");
     wsTransport.connect("ws-2");
     const socket = MockWebSocket.instances[0]!;
     socket.open();
+    const sentBeforeRequest = socket.sent.length;
 
-    wsTransport.requestBootstrap();
+    wsTransport.requestStreamSnapshots("ws-2");
 
-    const parsed = socket.sent.map((s) => JSON.parse(s) as Record<string, unknown>);
-    const forced = parsed.filter((m) => m.type === "sync_workspaces" && m.forceBootstrap === true);
-    expect(forced).toHaveLength(1);
-    expect(forced[0]!.workspaceIds).toEqual(expect.arrayContaining(["ws-1", "ws-2"]));
+    const newEnvelopes = socket.sent
+      .slice(sentBeforeRequest)
+      .map((s) => JSON.parse(s) as Record<string, unknown>);
+    expect(newEnvelopes).toEqual([
+      { workspaceId: "ws-2", event: { type: "request_stream_snapshots" } },
+    ]);
+
+    const forced = newEnvelopes.filter((m) => m.type === "sync_workspaces" && m.forceBootstrap === true);
+    expect(forced).toHaveLength(0);
+    expect(newEnvelopes.some((m) => m.workspaceId === "ws-1")).toBe(false);
   });
 
-  it("requestBootstrap is a no-op while the socket is not open (connect bootstrap covers it)", () => {
+  it("requestStreamSnapshots is a no-op while the socket is not open (connect bootstrap covers it)", () => {
     wsTransport.connect("ws-1");
     const socket = MockWebSocket.instances[0]!;
 
-    wsTransport.requestBootstrap();
+    wsTransport.requestStreamSnapshots("ws-1");
     expect(socket.sent).toHaveLength(0);
 
     socket.open();

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -84,6 +84,11 @@ enum WsIncoming: Encodable {
     case userMessage(content: String, images: [ImageAttachment]?, fileMentions: [FileMention]?, options: MessageOptions?, sessionId: String?)
     case stop(sessionId: String?)
     case toolInputResponse(requestId: String, toolName: String, result: ToolInputResult, sessionId: String?)
+    /// Ask the backend to replay live status + full snapshot for every currently
+    /// streaming session in the addressed workspace (no session id: every
+    /// streaming session in that workspace is replayed). Narrow web/mobile-view
+    /// recovery path; does not run full workspace bootstrap or touch subscriptions.
+    case requestStreamSnapshots
 
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -107,6 +112,8 @@ enum WsIncoming: Encodable {
             try container.encode(toolName, forKey: .toolName)
             try container.encode(result, forKey: .result)
             try container.encodeIfPresent(sessionId, forKey: .sessionId)
+        case .requestStreamSnapshots:
+            try container.encode("request_stream_snapshots", forKey: .type)
         }
     }
 

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreSessionTests.swift
@@ -731,6 +731,21 @@ struct ConversationStoreSessionTests {
     }
 
     @Test @MainActor
+    func requestStreamSnapshotsEncodesTypeOnly() throws {
+        let message = WsIncoming.requestStreamSnapshots
+        let data = try JSONEncoder().encode(message)
+        let object = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+
+        #expect(object?["type"] as? String == "request_stream_snapshots")
+        // No session id: every currently streaming session in the addressed
+        // workspace is replayed, and this must not carry any sync_workspaces
+        // fields when wrapped in the { workspaceId, event } envelope.
+        #expect(object?["sessionId"] == nil)
+        #expect(object?["workspaceIds"] == nil)
+        #expect(object?["forceBootstrap"] == nil)
+    }
+
+    @Test @MainActor
     func toolInputResolvedClearsPendingToolInputs() throws {
         let store = ConversationStore()
         store.handle(.status(


### PR DESCRIPTION
## Problem

Launching a prompt from iOS while the desktop web app is open on another view (or freshly launched) leaves the desktop conversation permanently desynced: it shows the user bubble and the tool calls received after the view mounted, but not the already-streamed assistant text or earlier tool calls.

Root cause (web only):

- `useWsCacheInvalidation` and `useWorkspaceLiveData` register app-wide `onMessage` handlers for every workspace, so the transport's `messageBuffer` never buffers (it only buffers when zero handlers are attached). Stream frames that arrive while a workspace's conversation view is unmounted are consumed by those hooks and are gone for the chat UI.
- When the view then mounts, the workspace is already subscribed, so no bootstrap is re-sent; recovery only happened through `switch_session` (needs a saved session) or a socket reconnect. Mid-turn `status busy` broadcasts (`stream.ts` on user_message / tool-input response) make the reducer adopt the session and create an **empty** live slot, and `handleActivateSession` early-returns on the already-active session — so clicking the tab never healed it.

The backend catch-up itself is healthy: verified live with a two-client WS harness that a mid-stream subscriber, a mid-stream `switch_session`, and a mid-stream `forceBootstrap` all return the full `stream_snapshot` (accumulated text + tool calls).

## Fix

On conversation view mount, ask the backend to resend the full bootstrap: `wsTransport.requestBootstrap()` sends `sync_workspaces` with `forceBootstrap: true` — the same mechanism iOS uses for foreground refresh, and a no-op when the socket is not open (a (re)connecting socket gets the full bootstrap anyway). Snapshot replay uses replace semantics, so duplicate bootstraps cannot duplicate content.

No backend or protocol changes; iOS untouched.

## Verification

- Live end-to-end against an isolated backend with a real Claude turn: client subscribed on a healthy socket sends `forceBootstrap` mid-stream → receives `status busy` + full `stream_snapshot` (text + tools), then live frames continue seamlessly.
- New tests: `requestBootstrap` wire behavior (open / not-open socket) and `useConversation` mount requesting the replay + applying a post-mount `stream_snapshot`.
- `npm run lint`, `npm run typecheck`, full frontend suite: 130 files / 1551 tests green.