### PR TITLE
fix: ignore Claude tool progress events

### DIFF
--- a/backend/src/agents/stream-parser.test.ts
+++ b/backend/src/agents/stream-parser.test.ts
@@ -199,6 +199,24 @@ describe("StreamParser", () => {
     expect(errors[0].message).toContain("Unknown message type");
   });
 
+  it("silently ignores tool_progress from Claude CLI", () => {
+    const parser = new StreamParser();
+    const errors: Error[] = [];
+    parser.on("error", (e) => errors.push(e));
+
+    parser.write(JSON.stringify({
+      type: "tool_progress",
+      tool_use_id: "toolu_abc",
+      tool_name: "Bash",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 30,
+      uuid: "5ceca816-9afd-4d1a-a57f-7bc7e117ca0e",
+      session_id: "test-session",
+    }) + "\n");
+
+    expect(errors).toHaveLength(0);
+  });
+
   it("silently ignores rate_limit_event from Claude CLI", () => {
     const parser = new StreamParser();
     const errors: Error[] = [];

--- a/backend/src/agents/stream-parser.ts
+++ b/backend/src/agents/stream-parser.ts
@@ -56,7 +56,11 @@ export class StreamParser extends EventEmitter<StreamParserEvent> {
       return;
     }
 
-    // Handle CLI-internal events before narrowing to CliJsonLine
+    // Handle non-conversation events before narrowing to CliJsonLine
+    if (raw.type === "tool_progress") {
+      return;
+    }
+
     if (raw.type === "rate_limit_event") {
       const info = raw.rate_limit_info as {
         status?: string;


### PR DESCRIPTION
## Summary
- ignore periodic `tool_progress` heartbeats from Claude Code
- preserve errors for genuinely unknown stream message types
- add regression coverage using the documented event shape

## Testing
- `npm test --workspace @hive/backend -- --run src/agents/stream-parser.test.ts`
- `npm run lint --workspace @hive/backend`
- `npm run typecheck --workspace @hive/backend`
- `npm run test --workspace @hive/backend` (1,614 tests)