### PR TITLE
feat: optimistic user message sends with delivery states (web)

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { EventEmitter } from "node:events";
-import { rm, readFile } from "node:fs/promises";
+import { mkdir, rm, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type { ChildProcess } from "node:child_process";
 import type { AgentActivity, WsOutgoing } from "../types.js";
@@ -2781,7 +2781,7 @@ describe("ConversationSession", () => {
     const messages: WsOutgoing[] = [];
     session.on("message", (msg) => messages.push(msg));
 
-    session.sendMessage("Hello from user");
+    session.sendMessage("Hello from user", undefined, undefined, undefined, undefined, "local-abc123");
 
     const userEvents = messages.filter((m) => m.type === "user_message");
     expect(userEvents).toHaveLength(1);
@@ -2790,6 +2790,7 @@ describe("ConversationSession", () => {
         sessionId: "sess-user-evt",
         role: "user",
         content: "Hello from user",
+        clientMessageId: "local-abc123",
       });
     }
   });
@@ -3555,6 +3556,35 @@ describe("ConversationSession", () => {
       expect(userEvents[0].message.images![0].name).toBe("screenshot.png");
       expect(userEvents[0].message.images![0].mediaType).toBe("image/png");
     }
+  });
+
+  it("correlates an attachment failure that happens before the user-message echo", async () => {
+    const sessionId = "img-save-failure";
+    const sessionDir = join(tempDir, "sessions", sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, "attachments"), "not a directory");
+
+    const session = createSession({ sessionId });
+    const messages: WsOutgoing[] = [];
+    const errors: Array<{ error: Error; clientMessageId?: string }> = [];
+    session.on("message", (message) => messages.push(message));
+    session.on("error", (error: Error, clientMessageId?: string) => {
+      errors.push({ error, clientMessageId });
+    });
+
+    session.sendMessage(
+      "Analyze this",
+      undefined,
+      [{ name: "shot.png", mediaType: "image/png", dataUrl: "data:image/png;base64,AAAA" }],
+      undefined,
+      undefined,
+      "local-image-failure",
+    );
+
+    await waitForCondition(() => errors.some((entry) => entry.clientMessageId === "local-image-failure"));
+
+    expect(errors.find((entry) => entry.clientMessageId === "local-image-failure")?.error).toBeInstanceOf(Error);
+    expect(messages.some((message) => message.type === "user_message")).toBe(false);
   });
 
   it("does not include images field when no images are provided", () => {

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -232,7 +232,7 @@ export interface ConversationSessionConfig {
 export type ConversationSessionEvent = {
   message: [msg: WsOutgoing];
   exit: [code: number];
-  error: [err: Error];
+  error: [err: Error, clientMessageId?: string];
   first_message: [content: string];
 };
 
@@ -427,7 +427,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
   /** Send a user message. Spawns a CLI process for this turn.
    *  When `cliContent` is provided, it is sent to the CLI instead of `content`
    *  while the displayed/persisted message remains `content`. */
-  sendMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[], cliContent?: string, fileMentions?: FileMention[]): void {
+  sendMessage(content: string, msgOptions?: MessageOptions, images?: ImageAttachment[], cliContent?: string, fileMentions?: FileMention[], clientMessageId?: string): void {
     // Terminal sessions host a shell PTY, not an agent. Never spawn a runner.
     // Defensive: the UI does not call this for terminal tabs.
     if (this.sessionKind === "terminal") {
@@ -459,7 +459,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       this._streamingStartedAt = Date.now();
       this.stopReason = null;
       this._lastPlanMode = false;
-      this.emitUserMessage(content, undefined, fileMentions, true);
+      this.emitUserMessage(content, undefined, fileMentions, true, clientMessageId);
       this.startCodexGoalCommand(goalCommand, msgOptions, resolved);
       return;
     }
@@ -481,7 +481,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
           !this.testCommand &&
           resolved?.provider.id === "codex" &&
           isInteractiveSessionKind(this.sessionKind);
-        this.emitUserMessage(content, urlImages, fileMentions);
+        this.emitUserMessage(content, urlImages, fileMentions, undefined, clientMessageId);
         this.startAgentTurn(
           useNativeCodexImages ? promptContent : this.buildPromptWithImages(promptContent, imagePaths),
           msgOptions,
@@ -491,10 +491,10 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       }).catch((err) => {
         this._status = "error";
         this._streamingStartedAt = null;
-        this.emit("error", err instanceof Error ? err : new Error(String(err)));
+        this.emit("error", err instanceof Error ? err : new Error(String(err)), clientMessageId);
       });
     } else {
-      this.emitUserMessage(content, undefined, fileMentions);
+      this.emitUserMessage(content, undefined, fileMentions, undefined, clientMessageId);
       this.startAgentTurn(promptContent, msgOptions, resolved);
     }
   }
@@ -504,6 +504,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     images?: ImageAttachment[],
     fileMentions?: FileMention[],
     goalCommand?: boolean,
+    clientMessageId?: string,
   ): void {
     const userMsg: ChatMessage = {
       id: nanoid(12),
@@ -513,6 +514,7 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
       images: images?.length ? images : undefined,
       fileMentions: fileMentions?.length ? fileMentions : undefined,
       goalCommand: goalCommand || undefined,
+      clientMessageId,
       timestamp: new Date().toISOString(),
     };
     if (!this._metadata.title) {

--- a/backend/src/api/workspace-create-from.test.ts
+++ b/backend/src/api/workspace-create-from.test.ts
@@ -41,6 +41,25 @@ async function createFromSource(source: unknown) {
   });
 }
 
+async function createCommit(message: string, repoDir: string): Promise<string> {
+  const { stdout } = await git(
+    [
+      "-c",
+      "user.email=test@hive.dev",
+      "-c",
+      "user.name=Hive Test",
+      "commit-tree",
+      "HEAD^{tree}",
+      "-p",
+      "HEAD",
+      "-m",
+      message,
+    ],
+    repoDir,
+  );
+  return stdout.trim();
+}
+
 beforeEach(async () => {
   vi.mocked(fetchPrDetail).mockReset();
   vi.mocked(fetchIssueDetail).mockReset();
@@ -183,11 +202,8 @@ describe("POST /api/projects/:id/workspaces with source kind 'pr'", () => {
     // Fork's PR head must be a strict descendant of main: if it were the same
     // sha as main, the old buggy fast-forward would write an identical value
     // and the assertions below would pass vacuously either way.
-    const { stdout: prHeadSha } = await git(
-      ["commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "fork commit on top of main"],
-      fixtureRepoUrl,
-    );
-    await git(["update-ref", "refs/pull/9/head", prHeadSha.trim()], fixtureRepoUrl);
+    const prHeadSha = await createCommit("fork commit on top of main", fixtureRepoUrl);
+    await git(["update-ref", "refs/pull/9/head", prHeadSha], fixtureRepoUrl);
     vi.mocked(fetchPrDetail).mockResolvedValue({
       number: 9,
       title: "Fork reuses main",
@@ -207,7 +223,7 @@ describe("POST /api/projects/:id/workspaces with source kind 'pr'", () => {
 
     const wsPath = join(dataDir, projectId, "workspaces", ws.name);
     const { stdout: wsHeadSha } = await git(["rev-parse", "HEAD"], wsPath);
-    expect(wsHeadSha).toBe(prHeadSha.trim());
+    expect(wsHeadSha).toBe(prHeadSha);
   });
 
   it("deletes the pr/<n> branch when the workspace is deleted", async () => {
@@ -241,11 +257,8 @@ describe("POST /api/projects/:id/workspaces with source kind 'pr'", () => {
     // Stale branch at main; the PR head moved one commit ahead of it.
     const { stdout: mainSha } = await git(["rev-parse", "refs/heads/main"], bare);
     await git(["branch", "pr/21", mainSha], bare);
-    const { stdout: prHeadSha } = await git(
-      ["commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "newer fork commit"],
-      fixtureRepoUrl,
-    );
-    await git(["update-ref", "refs/pull/21/head", prHeadSha.trim()], fixtureRepoUrl);
+    const prHeadSha = await createCommit("newer fork commit", fixtureRepoUrl);
+    await git(["update-ref", "refs/pull/21/head", prHeadSha], fixtureRepoUrl);
     vi.mocked(fetchPrDetail).mockResolvedValue({
       number: 21,
       title: "Fork contribution",
@@ -259,18 +272,15 @@ describe("POST /api/projects/:id/workspaces with source kind 'pr'", () => {
     expect(res.statusCode).toBe(201);
     const wsPath = join(dataDir, projectId, "workspaces", res.json().name);
     const { stdout: headSha } = await git(["rev-parse", "HEAD"], wsPath);
-    expect(headSha).toBe(prHeadSha.trim());
+    expect(headSha).toBe(prHeadSha);
   });
 
   it("refuses to delete a stale pr/<n> branch holding commits not on the PR head", async () => {
     await setProjectGitHubUrl();
     const bare = join(dataDir, projectId, "repo.git");
     // Local pr/22 has a commit (e.g. archived workspace work) unknown to the PR.
-    const { stdout: localSha } = await git(
-      ["commit-tree", "HEAD^{tree}", "-p", "HEAD", "-m", "archived local work"],
-      bare,
-    );
-    await git(["branch", "pr/22", localSha.trim()], bare);
+    const localSha = await createCommit("archived local work", bare);
+    await git(["branch", "pr/22", localSha], bare);
     const { stdout: prHeadSha } = await git(["rev-parse", "main"], fixtureRepoUrl);
     await git(["update-ref", "refs/pull/22/head", prHeadSha], fixtureRepoUrl);
     vi.mocked(fetchPrDetail).mockResolvedValue({
@@ -288,7 +298,7 @@ describe("POST /api/projects/:id/workspaces with source kind 'pr'", () => {
 
     // The stale branch and its commits are untouched.
     const { stdout: after } = await git(["rev-parse", "refs/heads/pr/22"], bare);
-    expect(after).toBe(localSha.trim());
+    expect(after).toBe(localSha);
   });
 
   it("returns 400 when the project has no GitHub remote", async () => {

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -294,6 +294,8 @@ export interface ChatMessage {
   sessionId: string;
   role: "user" | "assistant";
   content: string;
+  /** Client-generated id of the optimistic send this message confirms, if any. */
+  clientMessageId?: string;
   images?: ImageAttachment[];
   fileMentions?: FileMention[];
   toolCalls?: ToolCall[];
@@ -478,7 +480,7 @@ export interface BrowserStatusPayload {
 /** Frontend -> Backend */
 export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
-  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
+  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string; clientMessageId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string }
   | { type: "request_stream_snapshots" };
@@ -518,7 +520,7 @@ export type WsOutgoing =
       contextWindowTokens?: number;
       pendingToolName?: string;
     }
-  | { type: "error"; message: string; sessionId?: string }
+  | { type: "error"; message: string; sessionId?: string; clientMessageId?: string }
   | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: WorkspaceStatus; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
   | { type: "user_message"; message: ChatMessage }

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -668,6 +668,7 @@ describe("WS /ws/hub", () => {
       type: "user_message",
       content: "should fail",
       sessionId: deletedSessionId,
+      clientMessageId: "local-rejected-1",
     }));
 
     await waitForMessage(
@@ -681,6 +682,14 @@ describe("WS /ws/hub", () => {
     );
 
     expect(getSessionById(wsId, deletedSessionId)).toBeUndefined();
+    const errorEvent = messages.find(
+      (message) => message.type === "error" && message.message.includes(`Session ${deletedSessionId} not found`),
+    );
+    expect(errorEvent).toMatchObject({
+      type: "error",
+      sessionId: deletedSessionId,
+      clientMessageId: "local-rejected-1",
+    });
     const busyForDeleted = messages
       .slice(marker)
       .some(
@@ -951,7 +960,7 @@ describe("WS /ws/hub", () => {
     await waitForMessage(first.messages, (msgs) => msgs.length >= 1);
     await waitForMessage(second.messages, (msgs) => msgs.length >= 1);
 
-    ws1.send(hubEvent(wsId, { type: "user_message", content: "cross-client-sync" }));
+    ws1.send(hubEvent(wsId, { type: "user_message", content: "cross-client-sync", clientMessageId: "local-xyz789" }));
 
     await waitForMessage(
       first.messages,
@@ -970,10 +979,12 @@ describe("WS /ws/hub", () => {
     if (firstUserEvent?.type === "user_message") {
       expect(firstUserEvent.message.role).toBe("user");
       expect(firstUserEvent.message.content).toBe("cross-client-sync");
+      expect(firstUserEvent.message.clientMessageId).toBe("local-xyz789");
     }
     if (secondUserEvent?.type === "user_message") {
       expect(secondUserEvent.message.role).toBe("user");
       expect(secondUserEvent.message.content).toBe("cross-client-sync");
+      expect(secondUserEvent.message.clientMessageId).toBe("local-xyz789");
     }
 
     ws1.close();

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -301,8 +301,13 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       }
       broadcastToChannel(channel, workspaceId, msg);
     };
-    const onError = (err: Error) => {
-      broadcastToChannel(channel, workspaceId, { type: "error", message: err.message, sessionId: session.sessionId });
+    const onError = (err: Error, clientMessageId?: string) => {
+      broadcastToChannel(channel, workspaceId, {
+        type: "error",
+        message: err.message,
+        sessionId: session.sessionId,
+        clientMessageId,
+      });
     };
     const onExit = (_code: number) => {
       broadcastToChannel(channel, workspaceId, {
@@ -603,6 +608,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         break;
       }
       case "user_message": {
+        let targetSessionId = incoming.sessionId;
         try {
           let targetSession: ActiveSession | undefined;
           if (incoming.sessionId) {
@@ -621,6 +627,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
               targetSession = result.session;
             }
           }
+          targetSessionId = targetSession.sessionId;
 
           attachSessionListeners(wsId, channel, targetSession);
 
@@ -650,7 +657,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             }
           }
 
-          targetSession.sendMessage(incoming.content, incoming.options, incoming.images, cliContent, incoming.fileMentions);
+          targetSession.sendMessage(incoming.content, incoming.options, incoming.images, cliContent, incoming.fileMentions, incoming.clientMessageId);
           broadcastToChannel(channel, wsId, {
             type: "status",
             status: "busy",
@@ -660,7 +667,12 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
             lockedProvider: targetSession.metadata.lockedProvider,
           });
         } catch (err: unknown) {
-          sendToHub(hub, wsId, { type: "error", message: errorMessage(err, "Failed to send message") });
+          sendToHub(hub, wsId, {
+            type: "error",
+            message: errorMessage(err, "Failed to send message"),
+            sessionId: targetSessionId,
+            clientMessageId: incoming.clientMessageId,
+          });
         }
         break;
       }

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -20,6 +20,7 @@ import { Trash2Icon } from "lucide-react";
 import type { AgentActivity, ChatMessage as ChatMessageType, QueuedMessage, ReasoningSegment, ToolCall, QuestionAnswer } from "@/types";
 import type { PendingToolInput } from "@/hooks/useConversation";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
+import type { SendState } from "@/lib/optimistic-sends";
 
 interface ChatConversationProps {
   messages: ChatMessageType[];
@@ -37,6 +38,10 @@ interface ChatConversationProps {
   activeToolCalls: ToolCall[];
   activeAgentActivities: AgentActivity[];
   pendingToolInputs?: PendingToolInput[];
+  /** Delivery state of optimistically-sent user messages, keyed by message id. */
+  sendStates?: Record<string, SendState>;
+  onRetrySend?: (messageId: string) => void;
+  onDiscardSend?: (messageId: string) => void;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
   /** When set, the workspace welcome offers a button to open a terminal tab. */
@@ -71,6 +76,9 @@ export default function ChatConversation({
   activeToolCalls,
   activeAgentActivities = [],
   pendingToolInputs = [],
+  sendStates,
+  onRetrySend,
+  onDiscardSend,
   onQuestionAnswer,
   onFileMentionClick,
   onStartTerminal,
@@ -258,6 +266,9 @@ export default function ChatConversation({
               dismissedToolCallIds={dismissedToolCallIds}
               onQuestionAnswer={onQuestionAnswer}
               onFileMentionClick={onFileMentionClick}
+              sendState={sendStates?.[msg.id]}
+              onRetrySend={onRetrySend}
+              onDiscardSend={onDiscardSend}
             />
           );
         })}

--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -41,7 +41,6 @@ interface ChatConversationProps {
   /** Delivery state of optimistically-sent user messages, keyed by message id. */
   sendStates?: Record<string, SendState>;
   onRetrySend?: (messageId: string) => void;
-  onDiscardSend?: (messageId: string) => void;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
   /** When set, the workspace welcome offers a button to open a terminal tab. */
@@ -78,7 +77,6 @@ export default function ChatConversation({
   pendingToolInputs = [],
   sendStates,
   onRetrySend,
-  onDiscardSend,
   onQuestionAnswer,
   onFileMentionClick,
   onStartTerminal,
@@ -268,7 +266,6 @@ export default function ChatConversation({
               onFileMentionClick={onFileMentionClick}
               sendState={sendStates?.[msg.id]}
               onRetrySend={onRetrySend}
-              onDiscardSend={onDiscardSend}
             />
           );
         })}

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -8,8 +8,9 @@ import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
 import { AgentActivityList, getInlineAgentActivities } from "@/components/chat/AgentActivityList";
 import { CopyButton } from "@/components/chat/CopyButton";
 import { ImageLightbox } from "@/components/chat/ImageLightbox";
-import { FileIcon, TargetIcon } from "lucide-react";
+import { FileIcon, RotateCwIcon, TargetIcon, XIcon } from "lucide-react";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
+import type { SendState } from "@/lib/optimistic-sends";
 import { AT_MENTION_RE, splitByAllMentions } from "@/lib/file-mentions";
 
 function renderContentWithMentions(
@@ -60,6 +61,10 @@ interface ChatMessageProps {
   dismissedToolCallIds?: Set<string>;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
+  /** Delivery state when this is an optimistically-appended user message. */
+  sendState?: SendState;
+  onRetrySend?: (messageId: string) => void;
+  onDiscardSend?: (messageId: string) => void;
 }
 
 const ChatMessage = memo(function ChatMessage({
@@ -69,6 +74,9 @@ const ChatMessage = memo(function ChatMessage({
   dismissedToolCallIds,
   onQuestionAnswer,
   onFileMentionClick,
+  sendState,
+  onRetrySend,
+  onDiscardSend,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
@@ -125,6 +133,39 @@ const ChatMessage = memo(function ChatMessage({
                 className="absolute -top-2 -right-2 opacity-0 transition-opacity group-hover/user-msg:opacity-100"
               />
               {renderContentWithMentions(message.content, message.fileMentions, onFileMentionClick)}
+            </div>
+          )}
+          {sendState === "sending" && (
+            <span className="mt-1 text-[10px] text-muted-foreground" data-testid="send-state-sending">
+              Sending…
+            </span>
+          )}
+          {sendState === "failed" && (
+            <div
+              className="mt-1 flex items-center gap-2 text-[10px] font-medium"
+              data-testid="send-state-failed"
+            >
+              <span className="text-destructive">Not delivered</span>
+              {onRetrySend && (
+                <button
+                  type="button"
+                  onClick={() => onRetrySend(message.id)}
+                  className="inline-flex items-center gap-1 text-destructive hover:underline"
+                >
+                  <RotateCwIcon className="size-3" />
+                  Retry
+                </button>
+              )}
+              {onDiscardSend && (
+                <button
+                  type="button"
+                  onClick={() => onDiscardSend(message.id)}
+                  className="text-muted-foreground hover:text-destructive"
+                  aria-label="Discard message"
+                >
+                  <XIcon className="size-3" />
+                </button>
+              )}
             </div>
           )}
           {message.goalCommand && (

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -8,7 +8,7 @@ import { ThinkingBlock } from "@/components/chat/ThinkingBlock";
 import { AgentActivityList, getInlineAgentActivities } from "@/components/chat/AgentActivityList";
 import { CopyButton } from "@/components/chat/CopyButton";
 import { ImageLightbox } from "@/components/chat/ImageLightbox";
-import { FileIcon, RotateCwIcon, TargetIcon, XIcon } from "lucide-react";
+import { FileIcon, RotateCwIcon, TargetIcon } from "lucide-react";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
 import type { SendState } from "@/lib/optimistic-sends";
 import { AT_MENTION_RE, splitByAllMentions } from "@/lib/file-mentions";
@@ -85,7 +85,6 @@ interface ChatMessageProps {
   /** Delivery state when this is an optimistically-appended user message. */
   sendState?: SendState;
   onRetrySend?: (messageId: string) => void;
-  onDiscardSend?: (messageId: string) => void;
 }
 
 const ChatMessage = memo(function ChatMessage({
@@ -97,7 +96,6 @@ const ChatMessage = memo(function ChatMessage({
   onFileMentionClick,
   sendState,
   onRetrySend,
-  onDiscardSend,
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
@@ -158,6 +156,14 @@ const ChatMessage = memo(function ChatMessage({
               {renderContentWithMentions(message.content, message.fileMentions, onFileMentionClick)}
             </div>
           )}
+          {message.goalCommand && (
+            <div className="mt-1 flex justify-end">
+              <span className="inline-flex items-center gap-1 rounded-full border border-primary/15 bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm">
+                <TargetIcon className="size-3" />
+                Sent with goal
+              </span>
+            </div>
+          )}
           {sendState === "sending" && showSendingIndicator && (
             <span className="mt-1 text-[10px] text-muted-foreground" data-testid="send-state-sending">
               Sending…
@@ -181,24 +187,6 @@ const ChatMessage = memo(function ChatMessage({
                   Retry
                 </button>
               )}
-              {onDiscardSend && (
-                <button
-                  type="button"
-                  onClick={() => onDiscardSend(message.id)}
-                  className="text-muted-foreground hover:text-destructive"
-                  aria-label="Discard message"
-                >
-                  <XIcon className="size-3" />
-                </button>
-              )}
-            </div>
-          )}
-          {message.goalCommand && (
-            <div className="mt-1 flex justify-end">
-              <span className="inline-flex items-center gap-1 rounded-full border border-primary/15 bg-background px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground shadow-sm">
-                <TargetIcon className="size-3" />
-                Sent with goal
-              </span>
             </div>
           )}
         </div>

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -102,6 +102,7 @@ const ChatMessage = memo(function ChatMessage({
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
   const showSendingIndicator = useShowSendingIndicator(sendState);
+  const hasDeliveryIssue = sendState === "failed" || sendState === "unconfirmed";
   const inlineAgentActivities = getInlineAgentActivities(message.agentActivities ?? []);
   const showAssistantActions = !isUser && (message.durationMs != null || Boolean(message.content));
 
@@ -162,13 +163,15 @@ const ChatMessage = memo(function ChatMessage({
               Sending…
             </span>
           )}
-          {sendState === "failed" && (
+          {hasDeliveryIssue && (
             <div
               className="mt-1 flex items-center gap-2 text-[10px] font-medium"
-              data-testid="send-state-failed"
+              data-testid={`send-state-${sendState}`}
             >
-              <span className="text-destructive">Not delivered</span>
-              {onRetrySend && (
+              <span className={sendState === "failed" ? "text-destructive" : "text-muted-foreground"}>
+                {sendState === "failed" ? "Not delivered" : "Delivery unconfirmed"}
+              </span>
+              {sendState === "failed" && onRetrySend && (
                 <button
                   type="button"
                   onClick={() => onRetrySend(message.id)}

--- a/frontend/src/components/ChatMessage.tsx
+++ b/frontend/src/components/ChatMessage.tsx
@@ -1,4 +1,4 @@
-import { memo, useState, type ReactNode } from "react";
+import { memo, useEffect, useState, type ReactNode } from "react";
 import type { ChatMessage as ChatMessageType, FileMention, QuestionAnswer } from "@/types";
 import { cn } from "@/lib/utils";
 import { formatElapsed } from "@/lib/time";
@@ -54,6 +54,27 @@ function renderContentWithMentions(
   return <p className="whitespace-pre-wrap wrap-anywhere" data-find-content="">{segments}</p>;
 }
 
+/**
+ * Grace delay before showing "Sending…" under an optimistic user message.
+ * A healthy echo confirms in well under this, so the label only appears for
+ * genuinely slow/unconfirmed sends instead of flashing on every message.
+ */
+export const SENDING_INDICATOR_DELAY_MS = 2_000;
+
+/** True only when `sendState` has been "sending" for the grace delay. */
+function useShowSendingIndicator(sendState: SendState | undefined): boolean {
+  const [show, setShow] = useState(false);
+  useEffect(() => {
+    if (sendState !== "sending") {
+      setShow(false);
+      return;
+    }
+    const timer = setTimeout(() => setShow(true), SENDING_INDICATOR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [sendState]);
+  return show;
+}
+
 interface ChatMessageProps {
   message: ChatMessageType;
   isInteractive?: boolean;
@@ -80,6 +101,7 @@ const ChatMessage = memo(function ChatMessage({
 }: ChatMessageProps) {
   const isUser = message.role === "user";
   const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+  const showSendingIndicator = useShowSendingIndicator(sendState);
   const inlineAgentActivities = getInlineAgentActivities(message.agentActivities ?? []);
   const showAssistantActions = !isUser && (message.durationMs != null || Boolean(message.content));
 
@@ -135,7 +157,7 @@ const ChatMessage = memo(function ChatMessage({
               {renderContentWithMentions(message.content, message.fileMentions, onFileMentionClick)}
             </div>
           )}
-          {sendState === "sending" && (
+          {sendState === "sending" && showSendingIndicator && (
             <span className="mt-1 text-[10px] text-muted-foreground" data-testid="send-state-sending">
               Sending…
             </span>

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -8,6 +8,7 @@ import type { FileViewMode } from "@/hooks/useTabs";
 import type { TaskCounts, TaskTrackerStatus, TrackedTask } from "@/hooks/useTasks";
 import type { BackgroundAgent } from "@/hooks/useBackgroundAgents";
 import type { PendingToolInput } from "@/hooks/useConversation";
+import type { SendState } from "@/lib/optimistic-sends";
 import type {
   AgentActivity,
   ChatMessage,
@@ -63,6 +64,10 @@ export interface ConversationPaneProps {
   activeToolCalls: ToolCall[];
   activeAgentActivities: AgentActivity[];
   pendingToolInputs: PendingToolInput[];
+  /** Delivery state of optimistically-sent user messages, keyed by message id. */
+  sendStates?: Record<string, SendState>;
+  onRetrySend?: (messageId: string) => void;
+  onDiscardSend?: (messageId: string) => void;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
   switchCounter: number;
@@ -130,6 +135,9 @@ export function ConversationPane({
   activeToolCalls,
   activeAgentActivities,
   pendingToolInputs,
+  sendStates,
+  onRetrySend,
+  onDiscardSend,
   onQuestionAnswer,
   onFileMentionClick,
   switchCounter,
@@ -197,6 +205,9 @@ export function ConversationPane({
               activeToolCalls={activeToolCalls}
               activeAgentActivities={activeAgentActivities}
               pendingToolInputs={pendingToolInputs}
+              sendStates={sendStates}
+              onRetrySend={onRetrySend}
+              onDiscardSend={onDiscardSend}
               onQuestionAnswer={onQuestionAnswer}
               onFileMentionClick={onFileMentionClick}
               onStartTerminal={onStartTerminal}

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -67,7 +67,6 @@ export interface ConversationPaneProps {
   /** Delivery state of optimistically-sent user messages, keyed by message id. */
   sendStates?: Record<string, SendState>;
   onRetrySend?: (messageId: string) => void;
-  onDiscardSend?: (messageId: string) => void;
   onQuestionAnswer?: (toolCallId: string, answers: QuestionAnswer[]) => void;
   onFileMentionClick?: (relativePath: string) => void;
   switchCounter: number;
@@ -137,7 +136,6 @@ export function ConversationPane({
   pendingToolInputs,
   sendStates,
   onRetrySend,
-  onDiscardSend,
   onQuestionAnswer,
   onFileMentionClick,
   switchCounter,
@@ -207,7 +205,6 @@ export function ConversationPane({
               pendingToolInputs={pendingToolInputs}
               sendStates={sendStates}
               onRetrySend={onRetrySend}
-              onDiscardSend={onDiscardSend}
               onQuestionAnswer={onQuestionAnswer}
               onFileMentionClick={onFileMentionClick}
               onStartTerminal={onStartTerminal}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -14,6 +14,7 @@ import {
   trackOptimisticSend,
   markOptimisticSendFailed,
   getOptimisticSendPayload,
+  getSendState,
   resolveOptimisticSend,
   subscribeSendStates,
   getSendStates,
@@ -666,6 +667,11 @@ export function useConversation(workspaceId: string | undefined) {
         }
       }
 
+      // A correlated backend rejection is a definite delivery failure.
+      if (msg.type === "error" && msg.clientMessageId && getSendState(msg.clientMessageId) !== undefined) {
+        markOptimisticSendFailed(msg.clientMessageId);
+      }
+
       dispatch(msg);
     });
     replayingBuffer = false;
@@ -749,6 +755,7 @@ export function useConversation(workspaceId: string | undefined) {
       images: normalizedImages,
       fileMentions: normalizedMentions,
       options,
+      clientMessageId: localId,
       ...sessionIdField(targetSessionId),
     });
     if (!sent) {
@@ -764,13 +771,13 @@ export function useConversation(workspaceId: string | undefined) {
     return true;
   }, [workspaceId, state.sessionId, queryClient]);
 
-  /** Resend a failed optimistic message through the normal send path; delivery
-   * is re-confirmed by the server echo, like the original send. */
+  /** Retry only definite failures; an unconfirmed send may already be accepted. */
   const retrySend = useCallback((messageId: string) => {
     if (!workspaceId) return;
+    if (getSendState(messageId) !== "failed") return;
     const payload = getOptimisticSendPayload(messageId);
     if (!payload) return;
-    trackOptimisticSend(messageId, payload); // back to "sending"
+    trackOptimisticSend(messageId, payload);
     const sent = wsTransport.send(workspaceId, {
       type: "user_message",
       content: payload.content,
@@ -778,6 +785,7 @@ export function useConversation(workspaceId: string | undefined) {
       fileMentions: payload.fileMentions,
       options: payload.options,
       sessionId: payload.sessionId,
+      clientMessageId: messageId,
     });
     if (!sent) markOptimisticSendFailed(messageId);
   }, [workspaceId]);

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -8,14 +8,12 @@ import {
   appendCachedSessionMessage,
   invalidateSessionMessages,
   resolveCachedOptimisticEcho,
-  removeCachedSessionMessage,
 } from "@/hooks/useSessionMessages";
 import {
   trackOptimisticSend,
   markOptimisticSendFailed,
   getOptimisticSendPayload,
   getSendState,
-  resolveOptimisticSend,
   subscribeSendStates,
   getSendStates,
 } from "@/lib/optimistic-sends";
@@ -790,14 +788,6 @@ export function useConversation(workspaceId: string | undefined) {
     if (!sent) markOptimisticSendFailed(messageId);
   }, [workspaceId]);
 
-  /** Remove a failed local message the user no longer wants to deliver. */
-  const discardSend = useCallback((messageId: string) => {
-    const payload = getOptimisticSendPayload(messageId);
-    if (!payload) return;
-    resolveOptimisticSend(messageId);
-    removeCachedSessionMessage(queryClient, workspaceId, payload.sessionId, messageId);
-  }, [workspaceId, queryClient]);
-
   const stopStreaming = useCallback(() => {
     if (!workspaceId) return;
     wsTransport.send(workspaceId, {
@@ -932,7 +922,6 @@ export function useConversation(workspaceId: string | undefined) {
     sendStates,
     sendMessage,
     retrySend,
-    discardSend,
     stopStreaming,
     clearChat,
     switchSession,

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -7,7 +7,17 @@ import {
   getCachedSessionMessages,
   appendCachedSessionMessage,
   invalidateSessionMessages,
+  resolveCachedOptimisticEcho,
+  removeCachedSessionMessage,
 } from "@/hooks/useSessionMessages";
+import {
+  trackOptimisticSend,
+  markOptimisticSendFailed,
+  getOptimisticSendPayload,
+  resolveOptimisticSend,
+  subscribeSendStates,
+  getSendStates,
+} from "@/lib/optimistic-sends";
 
 export interface PendingToolInput {
   requestId: string;
@@ -580,6 +590,10 @@ export function useConversation(workspaceId: string | undefined) {
     () => (workspaceId ? wsTransport.getStatus(workspaceId) : "disconnected"),
   );
 
+  // Per-message delivery state for optimistic sends. Module-level store so a
+  // pending/failed send survives workspace navigation (see lib/optimistic-sends).
+  const sendStates = useSyncExternalStore(subscribeSendStates, getSendStates);
+
   useEffect(() => {
     if (!workspaceId) {
       dispatch({ type: "reset" });
@@ -645,7 +659,11 @@ export function useConversation(workspaceId: string | undefined) {
 
       if (msg.type === "user_message") {
         const sid = msg.message.sessionId ?? stateRef.current.sessionId;
-        appendCachedSessionMessage(queryClient, workspaceId, sid, msg.message);
+        // The echo confirms delivery of an optimistically-appended message:
+        // swap it in place instead of appending a duplicate.
+        if (!resolveCachedOptimisticEcho(queryClient, workspaceId, sid, msg.message)) {
+          appendCachedSessionMessage(queryClient, workspaceId, sid, msg.message);
+        }
       }
 
       dispatch(msg);
@@ -697,20 +715,80 @@ export function useConversation(workspaceId: string | undefined) {
       return false;
     }
     const targetSessionId = sessionId ?? state.sessionId;
+    const normalizedImages = images?.length ? images : undefined;
+    const normalizedMentions = fileMentions?.length ? fileMentions : undefined;
+
+    // Append the message to the transcript immediately (before the server
+    // echo) so sending feels instant. Requires a known target session — the
+    // messages cache is keyed by session — otherwise fall back to echo-only
+    // rendering (first message of a brand-new conversation).
+    let localId: string | undefined;
+    if (targetSessionId) {
+      localId = `local-${newMessageId()}`;
+      trackOptimisticSend(localId, {
+        content,
+        images: normalizedImages,
+        fileMentions: normalizedMentions,
+        options,
+        sessionId: targetSessionId,
+      });
+      appendCachedSessionMessage(queryClient, workspaceId, targetSessionId, {
+        id: localId,
+        sessionId: targetSessionId,
+        role: "user",
+        content,
+        images: normalizedImages,
+        fileMentions: normalizedMentions,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
     const sent = wsTransport.send(workspaceId, {
       type: "user_message",
       content,
-      images: images?.length ? images : undefined,
-      fileMentions: fileMentions?.length ? fileMentions : undefined,
+      images: normalizedImages,
+      fileMentions: normalizedMentions,
       options,
       ...sessionIdField(targetSessionId),
     });
     if (!sent) {
+      if (localId) {
+        // The message stays in the transcript as "Not delivered" with a retry
+        // affordance, so the composer/queue can treat it as handled.
+        markOptimisticSendFailed(localId);
+        return true;
+      }
       dispatch({ type: "error", message: "Message not sent: disconnected from server." });
       return false;
     }
     return true;
-  }, [workspaceId, state.sessionId]);
+  }, [workspaceId, state.sessionId, queryClient]);
+
+  /** Resend a failed optimistic message through the normal send path; delivery
+   * is re-confirmed by the server echo, like the original send. */
+  const retrySend = useCallback((messageId: string) => {
+    if (!workspaceId) return;
+    const payload = getOptimisticSendPayload(messageId);
+    if (!payload) return;
+    trackOptimisticSend(messageId, payload); // back to "sending"
+    const sent = wsTransport.send(workspaceId, {
+      type: "user_message",
+      content: payload.content,
+      images: payload.images,
+      fileMentions: payload.fileMentions,
+      options: payload.options,
+      sessionId: payload.sessionId,
+    });
+    if (!sent) markOptimisticSendFailed(messageId);
+  }, [workspaceId]);
+
+  /** Remove a failed local message the user no longer wants to deliver. */
+  const discardSend = useCallback((messageId: string) => {
+    const payload = getOptimisticSendPayload(messageId);
+    if (!payload) return;
+    resolveOptimisticSend(messageId);
+    removeCachedSessionMessage(queryClient, workspaceId, payload.sessionId, messageId);
+  }, [workspaceId, queryClient]);
 
   const stopStreaming = useCallback(() => {
     if (!workspaceId) return;
@@ -843,7 +921,10 @@ export function useConversation(workspaceId: string | undefined) {
     agentPlanMode: activeStream?.agentPlanMode,
     lockedProvider: state.lockedProvider,
     switchCounter: state.switchCounter,
+    sendStates,
     sendMessage,
+    retrySend,
+    discardSend,
     stopStreaming,
     clearChat,
     switchSession,

--- a/frontend/src/hooks/useConversationColumn.ts
+++ b/frontend/src/hooks/useConversationColumn.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
-import { prefetchSessionMessages } from "@/hooks/useSessionMessages";
+import { prefetchSessionMessages, removeCachedSessionMessages } from "@/hooks/useSessionMessages";
 import { useConversation } from "@/hooks/useConversation";
 import { useSessions } from "@/hooks/useSessions";
 import { useTabs, type UseTabsReturn } from "@/hooks/useTabs";
@@ -9,6 +9,7 @@ import { useTasks, type TasksState } from "@/hooks/useTasks";
 import { useBackgroundAgents, type BackgroundAgentsState } from "@/hooks/useBackgroundAgents";
 import { useGoalState, type GoalState } from "@/hooks/useGoalState";
 import { useAppCommand } from "@/hooks/useAppCommand";
+import { clearTrackedSends } from "@/lib/optimistic-sends";
 import { tabId, type QueuedMessage, type SessionMetadata } from "@/types";
 
 type ConversationApi = ReturnType<typeof useConversation>;
@@ -277,6 +278,12 @@ export function useConversationColumn(
       const isActive = targetSessionId === sessionId;
       const success = await deleteSession(targetSessionId);
       if (!success) return;
+
+      clearTrackedSends(targetSessionId);
+      if (wsId) {
+        removeCachedSessionMessages(queryClient, wsId, targetSessionId);
+      }
+
       if (!isActive) return;
 
       const next = sessions.find((s) => s.sessionId !== targetSessionId);
@@ -287,7 +294,7 @@ export function useConversationColumn(
         onLastSessionDeleted?.();
       }
     },
-    [deleteSession, sessionId, sessions, handleActivateSession, clearChat, onLastSessionDeleted],
+    [deleteSession, sessionId, sessions, handleActivateSession, clearChat, onLastSessionDeleted, wsId, queryClient],
   );
 
   const handleStartTerminal = useCallback(async () => {

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -183,19 +183,6 @@ export function resolveCachedOptimisticEcho(
   return swapped;
 }
 
-/** Remove a single message (e.g. a discarded failed send) from a session's cache. */
-export function removeCachedSessionMessage(
-  queryClient: QueryClient,
-  workspaceId: string | undefined,
-  sessionId: string | undefined,
-  messageId: string,
-): void {
-  if (!workspaceId || !sessionId) return;
-  queryClient.setQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId), (prev) =>
-    prev?.filter((message) => message.id !== messageId),
-  );
-}
-
 /** Mark a session's messages stale so the authoritative server copy is refetched. */
 export function invalidateSessionMessages(
   queryClient: QueryClient,

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -63,9 +63,12 @@ function mergeFetchedMessagesWithCachedUserEchoes(
     ) {
       continue;
     }
-    if (getSendState(message.id) === "sending" && newServerUserContents.has(message.content)) {
+    if (getSendState(message.id) !== undefined && newServerUserContents.has(message.content)) {
       // Delivery confirmed by a newly-appeared server copy: drop the local
-      // echo so it doesn't duplicate the fetched message.
+      // echo so it doesn't duplicate the fetched message. This also resolves
+      // a send that timed out to "failed" locally but actually reached the
+      // server — otherwise it would render twice (server copy + a stale
+      // "Not delivered" local copy) after this refetch.
       resolveOptimisticSend(message.id);
       continue;
     }

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -1,5 +1,10 @@
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
+import {
+  findOptimisticSend,
+  getSendState,
+  resolveOptimisticSend,
+} from "@/lib/optimistic-sends";
 import type { ChatMessage } from "@/types";
 
 /**
@@ -35,13 +40,39 @@ function mergeFetchedMessagesWithCachedUserEchoes(
 ): ChatMessage[] {
   if (!cached?.length) return fetched;
 
+  const cachedIds = new Set(cached.map((message) => message.id));
   const fetchedIds = new Set(fetched.map((message) => message.id));
-  const missingUserMessages = cached.filter((message) =>
-    message.role === "user" &&
-    message.sessionId === sessionId &&
-    message.id &&
-    !fetchedIds.has(message.id)
+  // Server user messages absent from the previous cache state. Each can confirm
+  // delivery of an optimistic send with the same content whose WS echo was
+  // missed (backgrounded tab, zombie socket) — mirroring the iOS history
+  // reconciliation. Only NEW messages confirm, so an older identical message
+  // already in the cache never falsely resolves a pending send.
+  const newServerUserContents = new Set(
+    fetched
+      .filter((message) => message.role === "user" && !cachedIds.has(message.id))
+      .map((message) => message.content),
   );
+
+  const missingUserMessages: ChatMessage[] = [];
+  for (const message of cached) {
+    if (
+      message.role !== "user" ||
+      message.sessionId !== sessionId ||
+      !message.id ||
+      fetchedIds.has(message.id)
+    ) {
+      continue;
+    }
+    if (getSendState(message.id) === "sending" && newServerUserContents.has(message.content)) {
+      // Delivery confirmed by a newly-appeared server copy: drop the local
+      // echo so it doesn't duplicate the fetched message.
+      resolveOptimisticSend(message.id);
+      continue;
+    }
+    // Unconfirmed (pending/failed) sends and plain user echoes are carried
+    // across the refetch so a message never silently vanishes.
+    missingUserMessages.push(message);
+  }
 
   return missingUserMessages.length > 0 ? [...fetched, ...missingUserMessages] : fetched;
 }
@@ -131,6 +162,45 @@ export function appendCachedSessionMessage(
     if (message.id && list.some((m) => m.id === message.id)) return list;
     return [...list, message];
   });
+}
+
+/**
+ * Swap an optimistic local user message for its server echo, in place. Returns
+ * true when a swap happened — the caller must then skip its own append. The
+ * echo carries no client id, so the match is by session + content (like iOS).
+ */
+export function resolveCachedOptimisticEcho(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+  serverMessage: ChatMessage,
+): boolean {
+  if (!workspaceId || !sessionId || serverMessage.role !== "user") return false;
+  const localId = findOptimisticSend(sessionId, serverMessage.content);
+  if (!localId) return false;
+  resolveOptimisticSend(localId);
+  let swapped = false;
+  queryClient.setQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId), (prev) => {
+    const list = prev ?? [];
+    const idx = list.findIndex((message) => message.id === localId);
+    if (idx < 0) return list;
+    swapped = true;
+    return [...list.slice(0, idx), serverMessage, ...list.slice(idx + 1)];
+  });
+  return swapped;
+}
+
+/** Remove a single message (e.g. a discarded failed send) from a session's cache. */
+export function removeCachedSessionMessage(
+  queryClient: QueryClient,
+  workspaceId: string | undefined,
+  sessionId: string | undefined,
+  messageId: string,
+): void {
+  if (!workspaceId || !sessionId) return;
+  queryClient.setQueryData<ChatMessage[]>(sessionMessagesKey(workspaceId, sessionId), (prev) =>
+    prev?.filter((message) => message.id !== messageId),
+  );
 }
 
 /** Mark a session's messages stale so the authoritative server copy is refetched. */

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -1,8 +1,8 @@
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import {
-  findOptimisticSend,
   getSendState,
+  resolveEchoedSend,
   resolveOptimisticSend,
 } from "@/lib/optimistic-sends";
 import type { ChatMessage } from "@/types";
@@ -40,17 +40,15 @@ function mergeFetchedMessagesWithCachedUserEchoes(
 ): ChatMessage[] {
   if (!cached?.length) return fetched;
 
-  const cachedIds = new Set(cached.map((message) => message.id));
   const fetchedIds = new Set(fetched.map((message) => message.id));
-  // Server user messages absent from the previous cache state. Each can confirm
-  // delivery of an optimistic send with the same content whose WS echo was
-  // missed (backgrounded tab, zombie socket) — mirroring the iOS history
-  // reconciliation. Only NEW messages confirm, so an older identical message
-  // already in the cache never falsely resolves a pending send.
-  const newServerUserContents = new Set(
-    fetched
-      .filter((message) => message.role === "user" && !cachedIds.has(message.id))
-      .map((message) => message.content),
+  const cachedIds = new Set(cached.map((message) => message.id));
+  const newServerUserMessages = fetched.filter(
+    (message) => message.role === "user" && !cachedIds.has(message.id),
+  );
+  const confirmedByClientId = new Set(
+    newServerUserMessages
+      .map((message) => message.clientMessageId)
+      .filter((id): id is string => !!id),
   );
 
   const missingUserMessages: ChatMessage[] = [];
@@ -63,17 +61,10 @@ function mergeFetchedMessagesWithCachedUserEchoes(
     ) {
       continue;
     }
-    if (getSendState(message.id) !== undefined && newServerUserContents.has(message.content)) {
-      // Delivery confirmed by a newly-appeared server copy: drop the local
-      // echo so it doesn't duplicate the fetched message. This also resolves
-      // a send that timed out to "failed" locally but actually reached the
-      // server — otherwise it would render twice (server copy + a stale
-      // "Not delivered" local copy) after this refetch.
+    if (getSendState(message.id) !== undefined && confirmedByClientId.has(message.id)) {
       resolveOptimisticSend(message.id);
       continue;
     }
-    // Unconfirmed (pending/failed) sends and plain user echoes are carried
-    // across the refetch so a message never silently vanishes.
     missingUserMessages.push(message);
   }
 
@@ -169,8 +160,7 @@ export function appendCachedSessionMessage(
 
 /**
  * Swap an optimistic local user message for its server echo, in place. Returns
- * true when a swap happened — the caller must then skip its own append. The
- * echo carries no client id, so the match is by session + content (like iOS).
+ * true when a swap happened — the caller must then skip its own append.
  */
 export function resolveCachedOptimisticEcho(
   queryClient: QueryClient,
@@ -179,7 +169,7 @@ export function resolveCachedOptimisticEcho(
   serverMessage: ChatMessage,
 ): boolean {
   if (!workspaceId || !sessionId || serverMessage.role !== "user") return false;
-  const localId = findOptimisticSend(sessionId, serverMessage.content);
+  const localId = resolveEchoedSend(sessionId, serverMessage);
   if (!localId) return false;
   resolveOptimisticSend(localId);
   let swapped = false;

--- a/frontend/src/lib/optimistic-sends.ts
+++ b/frontend/src/lib/optimistic-sends.ts
@@ -1,0 +1,94 @@
+import type { FileMention, ImageAttachment, MessageOptions } from "@/types";
+
+/**
+ * Delivery tracking for user messages appended to the transcript before the
+ * server confirms them, mirroring the iOS ConversationStore optimistic sends.
+ * A message id absent from the map means the message is server-confirmed.
+ *
+ * Module-level (like `savedSessionByWorkspace` in useConversation) so delivery
+ * state survives hook re-mounts on workspace/session navigation — a pending or
+ * failed send must not silently render as delivered after navigating away and
+ * back.
+ */
+
+export type SendState = "sending" | "failed";
+
+export interface OptimisticSendPayload {
+  content: string;
+  images?: ImageAttachment[];
+  fileMentions?: FileMention[];
+  options?: MessageOptions;
+  sessionId: string;
+}
+
+interface OptimisticSend {
+  state: SendState;
+  payload: OptimisticSendPayload;
+}
+
+const sends = new Map<string, OptimisticSend>();
+const listeners = new Set<() => void>();
+let snapshot: Record<string, SendState> = {};
+
+function notify(): void {
+  snapshot = {};
+  for (const [id, send] of sends) snapshot[id] = send.state;
+  for (const listener of listeners) listener();
+}
+
+export function subscribeSendStates(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+/** Per-message delivery state, keyed by local message id. Referentially stable between mutations. */
+export function getSendStates(): Record<string, SendState> {
+  return snapshot;
+}
+
+/** Delivery state for a message, if it is a tracked optimistic send. */
+export function getSendState(messageId: string): SendState | undefined {
+  return sends.get(messageId)?.state;
+}
+
+/** Track a locally-appended user message as sending. Also re-marks a retry. */
+export function trackOptimisticSend(messageId: string, payload: OptimisticSendPayload): void {
+  sends.set(messageId, { state: "sending", payload });
+  notify();
+}
+
+/** Mark a tracked send as failed (kept in the transcript with a retry affordance). */
+export function markOptimisticSendFailed(messageId: string): void {
+  const send = sends.get(messageId);
+  if (!send || send.state === "failed") return;
+  send.state = "failed";
+  notify();
+}
+
+/** Original send payload, kept so a failed message can be resent verbatim. */
+export function getOptimisticSendPayload(messageId: string): OptimisticSendPayload | undefined {
+  return sends.get(messageId)?.payload;
+}
+
+/** Stop tracking a message (delivery confirmed, or the user discarded it). */
+export function resolveOptimisticSend(messageId: string): void {
+  if (sends.delete(messageId)) notify();
+}
+
+/**
+ * Oldest tracked send in a session matching the given content. Server echoes
+ * carry no client-generated id, so delivery is matched by content — the same
+ * trade-off the iOS client makes.
+ */
+export function findOptimisticSend(sessionId: string, content: string): string | undefined {
+  for (const [id, send] of sends) {
+    if (send.payload.sessionId === sessionId && send.payload.content === content) return id;
+  }
+  return undefined;
+}
+
+/** @internal Test-only: clear all tracked sends between tests. */
+export function _resetOptimisticSends(): void {
+  sends.clear();
+  snapshot = {};
+}

--- a/frontend/src/lib/optimistic-sends.ts
+++ b/frontend/src/lib/optimistic-sends.ts
@@ -21,9 +21,17 @@ export interface OptimisticSendPayload {
   sessionId: string;
 }
 
+/**
+ * A send unconfirmed after this long is marked failed so the user gets the
+ * Retry affordance instead of a permanent "Sending…". Generous because the
+ * echo can lag behind cold-session activation and image persistence.
+ */
+export const SEND_CONFIRM_TIMEOUT_MS = 15_000;
+
 interface OptimisticSend {
   state: SendState;
   payload: OptimisticSendPayload;
+  timer?: ReturnType<typeof setTimeout>;
 }
 
 const sends = new Map<string, OptimisticSend>();
@@ -53,7 +61,9 @@ export function getSendState(messageId: string): SendState | undefined {
 
 /** Track a locally-appended user message as sending. Also re-marks a retry. */
 export function trackOptimisticSend(messageId: string, payload: OptimisticSendPayload): void {
-  sends.set(messageId, { state: "sending", payload });
+  clearTimeout(sends.get(messageId)?.timer);
+  const timer = setTimeout(() => markOptimisticSendFailed(messageId), SEND_CONFIRM_TIMEOUT_MS);
+  sends.set(messageId, { state: "sending", payload, timer });
   notify();
 }
 
@@ -61,6 +71,8 @@ export function trackOptimisticSend(messageId: string, payload: OptimisticSendPa
 export function markOptimisticSendFailed(messageId: string): void {
   const send = sends.get(messageId);
   if (!send || send.state === "failed") return;
+  clearTimeout(send.timer);
+  send.timer = undefined;
   send.state = "failed";
   notify();
 }
@@ -72,6 +84,7 @@ export function getOptimisticSendPayload(messageId: string): OptimisticSendPaylo
 
 /** Stop tracking a message (delivery confirmed, or the user discarded it). */
 export function resolveOptimisticSend(messageId: string): void {
+  clearTimeout(sends.get(messageId)?.timer);
   if (sends.delete(messageId)) notify();
 }
 
@@ -89,6 +102,7 @@ export function findOptimisticSend(sessionId: string, content: string): string |
 
 /** @internal Test-only: clear all tracked sends between tests. */
 export function _resetOptimisticSends(): void {
+  for (const send of sends.values()) clearTimeout(send.timer);
   sends.clear();
   snapshot = {};
 }

--- a/frontend/src/lib/optimistic-sends.ts
+++ b/frontend/src/lib/optimistic-sends.ts
@@ -1,17 +1,6 @@
 import type { FileMention, ImageAttachment, MessageOptions } from "@/types";
 
-/**
- * Delivery tracking for user messages appended to the transcript before the
- * server confirms them, mirroring the iOS ConversationStore optimistic sends.
- * A message id absent from the map means the message is server-confirmed.
- *
- * Module-level (like `savedSessionByWorkspace` in useConversation) so delivery
- * state survives hook re-mounts on workspace/session navigation — a pending or
- * failed send must not silently render as delivered after navigating away and
- * back.
- */
-
-export type SendState = "sending" | "failed";
+export type SendState = "sending" | "unconfirmed" | "failed";
 
 export interface OptimisticSendPayload {
   content: string;
@@ -21,11 +10,6 @@ export interface OptimisticSendPayload {
   sessionId: string;
 }
 
-/**
- * A send unconfirmed after this long is marked failed so the user gets the
- * Retry affordance instead of a permanent "Sending…". Generous because the
- * echo can lag behind cold-session activation and image persistence.
- */
 export const SEND_CONFIRM_TIMEOUT_MS = 15_000;
 
 interface OptimisticSend {
@@ -49,25 +33,30 @@ export function subscribeSendStates(listener: () => void): () => void {
   return () => listeners.delete(listener);
 }
 
-/** Per-message delivery state, keyed by local message id. Referentially stable between mutations. */
 export function getSendStates(): Record<string, SendState> {
   return snapshot;
 }
 
-/** Delivery state for a message, if it is a tracked optimistic send. */
 export function getSendState(messageId: string): SendState | undefined {
   return sends.get(messageId)?.state;
 }
 
-/** Track a locally-appended user message as sending. Also re-marks a retry. */
 export function trackOptimisticSend(messageId: string, payload: OptimisticSendPayload): void {
   clearTimeout(sends.get(messageId)?.timer);
-  const timer = setTimeout(() => markOptimisticSendFailed(messageId), SEND_CONFIRM_TIMEOUT_MS);
+  const timer = setTimeout(() => markOptimisticSendUnconfirmed(messageId), SEND_CONFIRM_TIMEOUT_MS);
   sends.set(messageId, { state: "sending", payload, timer });
   notify();
 }
 
-/** Mark a tracked send as failed (kept in the transcript with a retry affordance). */
+export function markOptimisticSendUnconfirmed(messageId: string): void {
+  const send = sends.get(messageId);
+  if (!send || send.state !== "sending") return;
+  clearTimeout(send.timer);
+  send.timer = undefined;
+  send.state = "unconfirmed";
+  notify();
+}
+
 export function markOptimisticSendFailed(messageId: string): void {
   const send = sends.get(messageId);
   if (!send || send.state === "failed") return;
@@ -77,30 +66,35 @@ export function markOptimisticSendFailed(messageId: string): void {
   notify();
 }
 
-/** Original send payload, kept so a failed message can be resent verbatim. */
 export function getOptimisticSendPayload(messageId: string): OptimisticSendPayload | undefined {
   return sends.get(messageId)?.payload;
 }
 
-/** Stop tracking a message (delivery confirmed, or the user discarded it). */
+export function clearTrackedSends(sessionId: string): void {
+  let changed = false;
+  for (const [id, send] of sends) {
+    if (send.payload.sessionId !== sessionId) continue;
+    clearTimeout(send.timer);
+    sends.delete(id);
+    changed = true;
+  }
+  if (changed) notify();
+}
+
 export function resolveOptimisticSend(messageId: string): void {
   clearTimeout(sends.get(messageId)?.timer);
   if (sends.delete(messageId)) notify();
 }
 
-/**
- * Oldest tracked send in a session matching the given content. Server echoes
- * carry no client-generated id, so delivery is matched by content — the same
- * trade-off the iOS client makes.
- */
-export function findOptimisticSend(sessionId: string, content: string): string | undefined {
-  for (const [id, send] of sends) {
-    if (send.payload.sessionId === sessionId && send.payload.content === content) return id;
-  }
-  return undefined;
+export function resolveEchoedSend(
+  sessionId: string,
+  serverMessage: { clientMessageId?: string },
+): string | undefined {
+  if (!serverMessage.clientMessageId) return undefined;
+  const send = sends.get(serverMessage.clientMessageId);
+  return send?.payload.sessionId === sessionId ? serverMessage.clientMessageId : undefined;
 }
 
-/** @internal Test-only: clear all tracked sends between tests. */
 export function _resetOptimisticSends(): void {
   for (const send of sends.values()) clearTimeout(send.timer);
   sends.clear();

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -134,7 +134,10 @@ export default function BrainView() {
     connectionStatus,
     error,
     sessionId,
+    sendStates,
     sendMessage,
+    retrySend,
+    discardSend,
     stopStreaming,
     answerQuestion,
     batchAnswerQuestions,
@@ -390,6 +393,9 @@ export default function BrainView() {
               activeToolCalls={activeToolCalls}
               activeAgentActivities={activeAgentActivities}
               pendingToolInputs={pendingToolInputs}
+              sendStates={sendStates}
+              onRetrySend={retrySend}
+              onDiscardSend={discardSend}
               onQuestionAnswer={answerQuestion}
               onFileMentionClick={handleSelect}
               activeProvider={effectiveLockedProvider}

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -137,7 +137,6 @@ export default function BrainView() {
     sendStates,
     sendMessage,
     retrySend,
-    discardSend,
     stopStreaming,
     answerQuestion,
     batchAnswerQuestions,
@@ -395,7 +394,6 @@ export default function BrainView() {
               pendingToolInputs={pendingToolInputs}
               sendStates={sendStates}
               onRetrySend={retrySend}
-              onDiscardSend={discardSend}
               onQuestionAnswer={answerQuestion}
               onFileMentionClick={handleSelect}
               activeProvider={effectiveLockedProvider}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -172,7 +172,10 @@ export default function WorkspaceView() {
     connectionStatus,
     error,
     sessionId,
+    sendStates,
     sendMessage,
+    retrySend,
+    discardSend,
     stopStreaming,
     switchSession,
     answerQuestion,
@@ -506,6 +509,9 @@ export default function WorkspaceView() {
             activeToolCalls={activeToolCalls}
             activeAgentActivities={activeAgentActivities}
             pendingToolInputs={pendingToolInputs}
+            sendStates={sendStates}
+            onRetrySend={retrySend}
+            onDiscardSend={discardSend}
             onQuestionAnswer={answerQuestion}
             onFileMentionClick={handleFileTreeSelect}
             activeProvider={effectiveLockedProvider}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -175,7 +175,6 @@ export default function WorkspaceView() {
     sendStates,
     sendMessage,
     retrySend,
-    discardSend,
     stopStreaming,
     switchSession,
     answerQuestion,
@@ -511,7 +510,6 @@ export default function WorkspaceView() {
             pendingToolInputs={pendingToolInputs}
             sendStates={sendStates}
             onRetrySend={retrySend}
-            onDiscardSend={discardSend}
             onQuestionAnswer={answerQuestion}
             onFileMentionClick={handleFileTreeSelect}
             activeProvider={effectiveLockedProvider}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -296,6 +296,8 @@ export interface ChatMessage {
   sessionId: string;
   role: "user" | "assistant";
   content: string;
+  /** Client-generated id of the optimistic send this message confirms, if any. */
+  clientMessageId?: string;
   images?: ImageAttachment[];
   fileMentions?: FileMention[];
   toolCalls?: ToolCall[];
@@ -456,7 +458,7 @@ export interface ModelCatalogResponse {
 /** Frontend -> Backend */
 export type WsIncoming =
   | { type: "switch_session"; sessionId: string }
-  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string }
+  | { type: "user_message"; content: string; images?: ImageAttachment[]; fileMentions?: FileMention[]; options?: MessageOptions; sessionId?: string; clientMessageId?: string }
   | { type: "stop"; sessionId?: string }
   | { type: "tool_input_response"; requestId: string; toolName: string; result: ToolInputResult; sessionId?: string }
   | { type: "request_stream_snapshots" };
@@ -496,7 +498,7 @@ export type WsOutgoing =
       contextWindowTokens?: number;
       pendingToolName?: string;
     }
-  | { type: "error"; message: string; sessionId?: string }
+  | { type: "error"; message: string; sessionId?: string; clientMessageId?: string }
   | { type: "cancelled"; sessionId: string; errorDetail?: string; userInitiated?: boolean; durationMs?: number }
   | { type: "status"; status: "idle" | "busy"; sessionId?: string; streaming?: boolean; streamingStartedAt?: number; lockedProvider?: string }
   | { type: "user_message"; message: ChatMessage }

--- a/frontend/tests/components/ChatMessage.sendState.test.tsx
+++ b/frontend/tests/components/ChatMessage.sendState.test.tsx
@@ -1,75 +1,73 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import ChatMessage, { SENDING_INDICATOR_DELAY_MS } from "@/components/ChatMessage";
 import type { ChatMessage as ChatMessageType } from "@/types";
 
-function userMessage(overrides: Partial<ChatMessageType> = {}): ChatMessageType {
-  return {
-    id: "msg-1",
-    sessionId: "session-1",
-    role: "user",
-    content: "hello world",
-    timestamp: new Date().toISOString(),
-    ...overrides,
-  };
-}
+const message: ChatMessageType = {
+  id: "msg-1",
+  sessionId: "session-1",
+  role: "user",
+  content: "hello world",
+  timestamp: "2026-07-23T00:00:00.000Z",
+};
 
-describe("ChatMessage sendState indicator", () => {
+describe("ChatMessage send state", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
 
-  it("does not show 'Sending…' immediately, only after the grace delay", () => {
+  it("delays the sending indicator", () => {
     vi.useFakeTimers();
-    render(<ChatMessage message={userMessage()} sendState="sending" />);
+    render(<ChatMessage message={message} sendState="sending" />);
 
     expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
-
-    act(() => {
-      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
-    });
-
+    act(() => vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS));
     expect(screen.getByTestId("send-state-sending")).toBeInTheDocument();
   });
 
-  it("never shows the label when the echo confirms before the delay elapses", () => {
+  it("cancels the indicator when delivery is confirmed before the delay", () => {
     vi.useFakeTimers();
-    const { rerender } = render(<ChatMessage message={userMessage()} sendState="sending" />);
+    const { rerender } = render(<ChatMessage message={message} sendState="sending" />);
 
-    act(() => {
-      vi.advanceTimersByTime(1_000);
-    });
-    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
-
-    rerender(<ChatMessage message={userMessage()} sendState={undefined} />);
-
-    act(() => {
-      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
-    });
+    rerender(<ChatMessage message={message} />);
+    act(() => vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS));
 
     expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
   });
 
-  it("shows 'Not delivered' immediately with no timer advance needed", () => {
-    render(<ChatMessage message={userMessage()} sendState="failed" />);
+  it("shows retry and discard for a failed send", () => {
+    const onRetrySend = vi.fn();
+    const onDiscardSend = vi.fn();
+    render(
+      <ChatMessage
+        message={message}
+        sendState="failed"
+        onRetrySend={onRetrySend}
+        onDiscardSend={onDiscardSend}
+      />,
+    );
 
-    expect(screen.getByTestId("send-state-failed")).toBeInTheDocument();
+    expect(screen.getByText("Not delivered")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /retry/i }));
+    fireEvent.click(screen.getByRole("button", { name: /discard message/i }));
+    expect(onRetrySend).toHaveBeenCalledWith("msg-1");
+    expect(onDiscardSend).toHaveBeenCalledWith("msg-1");
   });
 
-  it("on retry, hides the failed state immediately and re-arms the delay", () => {
-    vi.useFakeTimers();
-    const { rerender } = render(<ChatMessage message={userMessage()} sendState="failed" />);
-    expect(screen.getByTestId("send-state-failed")).toBeInTheDocument();
+  it("allows discard but not retry when delivery is unconfirmed", () => {
+    const onDiscardSend = vi.fn();
+    render(
+      <ChatMessage
+        message={message}
+        sendState="unconfirmed"
+        onRetrySend={vi.fn()}
+        onDiscardSend={onDiscardSend}
+      />,
+    );
 
-    rerender(<ChatMessage message={userMessage()} sendState="sending" />);
-
-    expect(screen.queryByTestId("send-state-failed")).not.toBeInTheDocument();
-    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
-
-    act(() => {
-      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
-    });
-
-    expect(screen.getByTestId("send-state-sending")).toBeInTheDocument();
+    expect(screen.getByText("Delivery unconfirmed")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /discard message/i }));
+    expect(onDiscardSend).toHaveBeenCalledWith("msg-1");
   });
 });

--- a/frontend/tests/components/ChatMessage.sendState.test.tsx
+++ b/frontend/tests/components/ChatMessage.sendState.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import ChatMessage, { SENDING_INDICATOR_DELAY_MS } from "@/components/ChatMessage";
+import type { ChatMessage as ChatMessageType } from "@/types";
+
+function userMessage(overrides: Partial<ChatMessageType> = {}): ChatMessageType {
+  return {
+    id: "msg-1",
+    sessionId: "session-1",
+    role: "user",
+    content: "hello world",
+    timestamp: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe("ChatMessage sendState indicator", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not show 'Sending…' immediately, only after the grace delay", () => {
+    vi.useFakeTimers();
+    render(<ChatMessage message={userMessage()} sendState="sending" />);
+
+    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("send-state-sending")).toBeInTheDocument();
+  });
+
+  it("never shows the label when the echo confirms before the delay elapses", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<ChatMessage message={userMessage()} sendState="sending" />);
+
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
+    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
+
+    rerender(<ChatMessage message={userMessage()} sendState={undefined} />);
+
+    act(() => {
+      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
+    });
+
+    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Not delivered' immediately with no timer advance needed", () => {
+    render(<ChatMessage message={userMessage()} sendState="failed" />);
+
+    expect(screen.getByTestId("send-state-failed")).toBeInTheDocument();
+  });
+
+  it("on retry, hides the failed state immediately and re-arms the delay", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(<ChatMessage message={userMessage()} sendState="failed" />);
+    expect(screen.getByTestId("send-state-failed")).toBeInTheDocument();
+
+    rerender(<ChatMessage message={userMessage()} sendState="sending" />);
+
+    expect(screen.queryByTestId("send-state-failed")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(SENDING_INDICATOR_DELAY_MS);
+    });
+
+    expect(screen.getByTestId("send-state-sending")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/ChatMessage.sendState.test.tsx
+++ b/frontend/tests/components/ChatMessage.sendState.test.tsx
@@ -35,39 +35,31 @@ describe("ChatMessage send state", () => {
     expect(screen.queryByTestId("send-state-sending")).not.toBeInTheDocument();
   });
 
-  it("shows retry and discard for a failed send", () => {
+  it("shows retry for a failed send", () => {
     const onRetrySend = vi.fn();
-    const onDiscardSend = vi.fn();
     render(
       <ChatMessage
         message={message}
         sendState="failed"
         onRetrySend={onRetrySend}
-        onDiscardSend={onDiscardSend}
       />,
     );
 
     expect(screen.getByText("Not delivered")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /retry/i }));
-    fireEvent.click(screen.getByRole("button", { name: /discard message/i }));
     expect(onRetrySend).toHaveBeenCalledWith("msg-1");
-    expect(onDiscardSend).toHaveBeenCalledWith("msg-1");
   });
 
-  it("allows discard but not retry when delivery is unconfirmed", () => {
-    const onDiscardSend = vi.fn();
+  it("shows no retry when delivery is unconfirmed", () => {
     render(
       <ChatMessage
         message={message}
         sendState="unconfirmed"
         onRetrySend={vi.fn()}
-        onDiscardSend={onDiscardSend}
       />,
     );
 
     expect(screen.getByText("Delivery unconfirmed")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /retry/i })).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: /discard message/i }));
-    expect(onDiscardSend).toHaveBeenCalledWith("msg-1");
   });
 });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useConversation, _resetSavedSessions, setSavedSession } from "@/hooks/useConversation";
 import { sessionMessagesKey, getCachedSessionMessages } from "@/hooks/useSessionMessages";
+import { _resetOptimisticSends } from "@/lib/optimistic-sends";
 import type { ChatMessage, WsOutgoing } from "@/types";
 
 vi.mock("@/hooks/useApi", () => {
@@ -198,6 +199,7 @@ describe("useConversation", () => {
     __wsMock.reset();
     __apiMock.reset();
     _resetSavedSessions();
+    _resetOptimisticSends();
   });
 
   it("connects on mount and keeps connection alive on unmount", async () => {
@@ -251,7 +253,7 @@ describe("useConversation", () => {
     expect(result.current.activeToolCalls).toHaveLength(2);
   });
 
-  it("sends user messages through transport without optimistic local append", async () => {
+  it("sends user messages through transport without optimistic append when no session is active", async () => {
     const { __wsMock } = await getWsMock();
     const { result } = renderConversation("ws-1");
 
@@ -369,6 +371,186 @@ describe("useConversation", () => {
     expect(result.current.messages).toHaveLength(0);
     expect(result.current.isStreaming).toBe(false);
     expect(result.current.error).toContain("Message not sent");
+  });
+
+  describe("optimistic sends", () => {
+    it("appends the user message immediately with a sending state when a session is active", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      act(() => {
+        expect(result.current.sendMessage("hello")).toBe(true);
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      const local = result.current.messages[0]!;
+      expect(local.role).toBe("user");
+      expect(local.content).toBe("hello");
+      expect(local.id.startsWith("local-")).toBe(true);
+      expect(result.current.sendStates[local.id]).toBe("sending");
+      expect(__wsMock.sendMock).toHaveBeenCalledWith("ws-1", {
+        type: "user_message",
+        content: "hello",
+        sessionId: "sess-1",
+      });
+    });
+
+    it("swaps the local message for the server echo and clears the send state", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      act(() => {
+        result.current.sendMessage("hello");
+      });
+      const localId = result.current.messages[0]!.id;
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: {
+            id: "u1",
+            sessionId: "sess-1",
+            role: "user",
+            content: "hello",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+        });
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      expect(result.current.messages[0]?.id).toBe("u1");
+      expect(result.current.sendStates[localId]).toBeUndefined();
+    });
+
+    it("keeps the message in the transcript as failed when the transport send fails", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+      __wsMock.sendMock.mockReturnValueOnce(false);
+
+      act(() => {
+        // The message is handled by the transcript (failed + retry), so the
+        // composer/queue must treat the send as consumed.
+        expect(result.current.sendMessage("hello")).toBe(true);
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      const local = result.current.messages[0]!;
+      expect(result.current.sendStates[local.id]).toBe("failed");
+      expect(result.current.error).toBeUndefined();
+    });
+
+    it("retries a failed send through the transport and resolves on the echo", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+      __wsMock.sendMock.mockReturnValueOnce(false);
+
+      act(() => {
+        result.current.sendMessage("hello", undefined, { planMode: true });
+      });
+      const localId = result.current.messages[0]!.id;
+      expect(result.current.sendStates[localId]).toBe("failed");
+
+      act(() => {
+        result.current.retrySend(localId);
+      });
+
+      expect(result.current.sendStates[localId]).toBe("sending");
+      expect(__wsMock.sendMock).toHaveBeenLastCalledWith("ws-1", {
+        type: "user_message",
+        content: "hello",
+        images: undefined,
+        fileMentions: undefined,
+        options: { planMode: true },
+        sessionId: "sess-1",
+      });
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: {
+            id: "u1",
+            sessionId: "sess-1",
+            role: "user",
+            content: "hello",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+        });
+      });
+
+      expect(result.current.messages).toEqual([expect.objectContaining({ id: "u1" })]);
+      expect(result.current.sendStates[localId]).toBeUndefined();
+    });
+
+    it("stays failed when the retry send fails again", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+      __wsMock.sendMock.mockReturnValue(false);
+
+      act(() => {
+        result.current.sendMessage("hello");
+      });
+      const localId = result.current.messages[0]!.id;
+
+      act(() => {
+        result.current.retrySend(localId);
+      });
+
+      expect(result.current.sendStates[localId]).toBe("failed");
+      expect(result.current.messages).toHaveLength(1);
+      __wsMock.sendMock.mockReturnValue(true);
+    });
+
+    it("discards a failed send, removing it from the transcript", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+      __wsMock.sendMock.mockReturnValueOnce(false);
+
+      act(() => {
+        result.current.sendMessage("hello");
+      });
+      const localId = result.current.messages[0]!.id;
+
+      act(() => {
+        result.current.discardSend(localId);
+      });
+
+      expect(result.current.messages).toHaveLength(0);
+      expect(result.current.sendStates[localId]).toBeUndefined();
+    });
+
+    it("appends a non-matching echo without touching a pending send", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      act(() => {
+        result.current.sendMessage("mine");
+      });
+      const localId = result.current.messages[0]!.id;
+
+      // Echo from another client with different content must not resolve ours.
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: {
+            id: "u-other",
+            sessionId: "sess-1",
+            role: "user",
+            content: "someone else's message",
+            timestamp: "2026-02-12T00:00:00.000Z",
+          },
+        });
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.sendStates[localId]).toBe("sending");
+    });
   });
 
   it("builds assistant message from stream deltas and done event", async () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useConversation, _resetSavedSessions, setSavedSession } from "@/hooks/useConversation";
 import { sessionMessagesKey, getCachedSessionMessages } from "@/hooks/useSessionMessages";
-import { _resetOptimisticSends } from "@/lib/optimistic-sends";
+import { SEND_CONFIRM_TIMEOUT_MS, _resetOptimisticSends } from "@/lib/optimistic-sends";
 import type { ChatMessage, WsOutgoing } from "@/types";
 
 vi.mock("@/hooks/useApi", () => {
@@ -550,6 +550,28 @@ describe("useConversation", () => {
 
       expect(result.current.messages).toHaveLength(2);
       expect(result.current.sendStates[localId]).toBe("sending");
+    });
+
+    it("times out to failed when no echo arrives within SEND_CONFIRM_TIMEOUT_MS", async () => {
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        act(() => {
+          expect(result.current.sendMessage("hello")).toBe(true);
+        });
+        const localId = result.current.messages[0]!.id;
+        expect(result.current.sendStates[localId]).toBe("sending");
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(SEND_CONFIRM_TIMEOUT_MS);
+        });
+
+        expect(result.current.sendStates[localId]).toBe("failed");
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -295,6 +295,7 @@ describe("useConversation", () => {
       type: "user_message",
       content: "run in target",
       sessionId: "sess-target",
+      clientMessageId: expect.any(String),
     });
   });
 
@@ -393,6 +394,7 @@ describe("useConversation", () => {
         type: "user_message",
         content: "hello",
         sessionId: "sess-1",
+        clientMessageId: local.id,
       });
     });
 
@@ -415,6 +417,7 @@ describe("useConversation", () => {
             role: "user",
             content: "hello",
             timestamp: "2026-02-12T00:00:00.000Z",
+            clientMessageId: localId,
           },
         });
       });
@@ -422,6 +425,40 @@ describe("useConversation", () => {
       expect(result.current.messages).toHaveLength(1);
       expect(result.current.messages[0]?.id).toBe("u1");
       expect(result.current.sendStates[localId]).toBeUndefined();
+    });
+
+    it("resolves the exact local send by clientMessageId when two identical sends are pending", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      act(() => {
+        result.current.sendMessage("continue");
+      });
+      act(() => {
+        result.current.sendMessage("continue");
+      });
+      expect(result.current.messages).toHaveLength(2);
+      const [firstLocalId, secondLocalId] = result.current.messages.map((m) => m.id);
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "user_message",
+          message: {
+            id: "u1",
+            sessionId: "sess-1",
+            role: "user",
+            content: "continue",
+            timestamp: "2026-02-12T00:00:00.000Z",
+            clientMessageId: secondLocalId,
+          },
+        });
+      });
+
+      // Only the message the echo names by id resolves; the other stays pending.
+      expect(result.current.messages.map((m) => m.id)).toEqual([firstLocalId, "u1"]);
+      expect(result.current.sendStates[firstLocalId]).toBe("sending");
+      expect(result.current.sendStates[secondLocalId]).toBeUndefined();
     });
 
     it("keeps the message in the transcript as failed when the transport send fails", async () => {
@@ -442,31 +479,38 @@ describe("useConversation", () => {
       expect(result.current.error).toBeUndefined();
     });
 
-    it("retries a failed send through the transport and resolves on the echo", async () => {
+    it("retries a failed send with its full payload and resolves on the echo", async () => {
       const { __wsMock } = await getWsMock();
       const { result } = renderConversation("ws-1");
       await activateSession("ws-1", "sess-1");
       __wsMock.sendMock.mockReturnValueOnce(false);
 
+      const images = [{ name: "shot.png", mediaType: "image/png", dataUrl: "data:image/png;base64,AAAA" }];
+      const fileMentions = [{ relativePath: "src/App.tsx", displayName: "App.tsx" }];
+      const options = { model: "opus", planMode: true };
+
       act(() => {
-        result.current.sendMessage("hello", undefined, { planMode: true });
+        result.current.sendMessage("", images, options, undefined, fileMentions);
       });
       const localId = result.current.messages[0]!.id;
       expect(result.current.sendStates[localId]).toBe("failed");
+      expect(result.current.messages[0]!.images).toEqual(images);
 
+      __wsMock.sendMock.mockClear();
       act(() => {
         result.current.retrySend(localId);
       });
 
-      expect(result.current.sendStates[localId]).toBe("sending");
       expect(__wsMock.sendMock).toHaveBeenLastCalledWith("ws-1", {
         type: "user_message",
-        content: "hello",
-        images: undefined,
-        fileMentions: undefined,
-        options: { planMode: true },
+        content: "",
+        images,
+        fileMentions,
+        options,
         sessionId: "sess-1",
+        clientMessageId: localId,
       });
+      expect(result.current.sendStates[localId]).toBe("sending");
 
       act(() => {
         __wsMock.emit("ws-1", {
@@ -475,8 +519,9 @@ describe("useConversation", () => {
             id: "u1",
             sessionId: "sess-1",
             role: "user",
-            content: "hello",
+            content: "",
             timestamp: "2026-02-12T00:00:00.000Z",
+            clientMessageId: localId,
           },
         });
       });
@@ -534,7 +579,6 @@ describe("useConversation", () => {
       });
       const localId = result.current.messages[0]!.id;
 
-      // Echo from another client with different content must not resolve ours.
       act(() => {
         __wsMock.emit("ws-1", {
           type: "user_message",
@@ -542,8 +586,9 @@ describe("useConversation", () => {
             id: "u-other",
             sessionId: "sess-1",
             role: "user",
-            content: "someone else's message",
+            content: "mine",
             timestamp: "2026-02-12T00:00:00.000Z",
+            clientMessageId: "other-client-id",
           },
         });
       });
@@ -552,7 +597,7 @@ describe("useConversation", () => {
       expect(result.current.sendStates[localId]).toBe("sending");
     });
 
-    it("times out to failed when no echo arrives within SEND_CONFIRM_TIMEOUT_MS", async () => {
+    it("times out to unconfirmed (not failed) when no echo arrives within SEND_CONFIRM_TIMEOUT_MS", async () => {
       const { result } = renderConversation("ws-1");
       await activateSession("ws-1", "sess-1");
 
@@ -568,7 +613,60 @@ describe("useConversation", () => {
           await vi.advanceTimersByTimeAsync(SEND_CONFIRM_TIMEOUT_MS);
         });
 
-        expect(result.current.sendStates[localId]).toBe("failed");
+        // Elapsed time alone is not proof of rejection: unconfirmed, not failed.
+        expect(result.current.sendStates[localId]).toBe("unconfirmed");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("marks the exact bubble failed when a correlated backend rejection arrives", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      act(() => {
+        result.current.sendMessage("hello");
+      });
+      const localId = result.current.messages[0]!.id;
+      expect(result.current.sendStates[localId]).toBe("sending");
+
+      act(() => {
+        __wsMock.emit("ws-1", {
+          type: "error",
+          message: "Session not found",
+          clientMessageId: localId,
+        });
+      });
+
+      expect(result.current.sendStates[localId]).toBe("failed");
+    });
+
+    it("retrySend is a no-op for an unconfirmed send (only failed sends may retry)", async () => {
+      const { __wsMock } = await getWsMock();
+      const { result } = renderConversation("ws-1");
+      await activateSession("ws-1", "sess-1");
+
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      try {
+        act(() => {
+          result.current.sendMessage("hello");
+        });
+        const localId = result.current.messages[0]!.id;
+
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(SEND_CONFIRM_TIMEOUT_MS);
+        });
+        expect(result.current.sendStates[localId]).toBe("unconfirmed");
+        __wsMock.sendMock.mockClear();
+
+        act(() => {
+          result.current.retrySend(localId);
+        });
+
+        // The guard rejects retry outright: no resend, state unchanged.
+        expect(__wsMock.sendMock).not.toHaveBeenCalled();
+        expect(result.current.sendStates[localId]).toBe("unconfirmed");
       } finally {
         vi.useRealTimers();
       }
@@ -1474,6 +1572,9 @@ describe("useConversation", () => {
 
     act(() => {
       result.current.sendMessage("hello");
+    });
+    const localId = result.current.messages[0]!.id;
+    act(() => {
       __wsMock.emit("ws-1", {
         type: "user_message",
         message: {
@@ -1482,6 +1583,7 @@ describe("useConversation", () => {
           role: "user",
           content: "hello",
           timestamp: "2026-02-12T00:00:00.000Z",
+          clientMessageId: localId,
         },
       });
     });

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -550,25 +550,6 @@ describe("useConversation", () => {
       __wsMock.sendMock.mockReturnValue(true);
     });
 
-    it("discards a failed send, removing it from the transcript", async () => {
-      const { __wsMock } = await getWsMock();
-      const { result } = renderConversation("ws-1");
-      await activateSession("ws-1", "sess-1");
-      __wsMock.sendMock.mockReturnValueOnce(false);
-
-      act(() => {
-        result.current.sendMessage("hello");
-      });
-      const localId = result.current.messages[0]!.id;
-
-      act(() => {
-        result.current.discardSend(localId);
-      });
-
-      expect(result.current.messages).toHaveLength(0);
-      expect(result.current.sendStates[localId]).toBeUndefined();
-    });
-
     it("appends a non-matching echo without touching a pending send", async () => {
       const { __wsMock } = await getWsMock();
       const { result } = renderConversation("ws-1");

--- a/frontend/tests/hooks/useConversationColumn.test.tsx
+++ b/frontend/tests/hooks/useConversationColumn.test.tsx
@@ -5,7 +5,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { useConversationColumn } from "@/hooks/useConversationColumn";
 import { _resetSnapshotCache } from "@/hooks/useTabs";
 import * as sessionMessages from "@/hooks/useSessionMessages";
-import type { QueuedMessage } from "@/types";
+import { getCachedSessionMessages, sessionMessagesKey } from "@/hooks/useSessionMessages";
+import { _resetOptimisticSends, getSendState, trackOptimisticSend } from "@/lib/optimistic-sends";
+import type { ChatMessage, QueuedMessage } from "@/types";
 import { dispatchAppCommand } from "@/lib/app-commands";
 
 const mocks = vi.hoisted(() => ({
@@ -32,13 +34,26 @@ function wrapperFor(queryClient: QueryClient) {
 function renderColumn(
   wsId: string | undefined,
   opts?: Parameters<typeof useConversationColumn>[1],
-) {
-  const queryClient = new QueryClient({
+  queryClient: QueryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: Infinity } },
-  });
-  return renderHook(() => useConversationColumn(wsId, opts), {
+  }),
+) {
+  const rendered = renderHook(() => useConversationColumn(wsId, opts), {
     wrapper: wrapperFor(queryClient),
   });
+  return { ...rendered, queryClient };
+}
+
+function trackedMessage(id: string, sessionId: string, overrides: Partial<ChatMessage> = {}): ChatMessage {
+  return {
+    id,
+    sessionId,
+    role: "user",
+    content: "pending",
+    timestamp: "2024-01-01T00:00:00Z",
+    clientMessageId: id,
+    ...overrides,
+  };
 }
 
 // Shared mutable conversation state so we can re-render with different values.
@@ -87,6 +102,7 @@ let refresh: ReturnType<typeof vi.fn>;
 beforeEach(() => {
   vi.clearAllMocks();
   _resetSnapshotCache();
+  _resetOptimisticSends();
   conversation = makeConversation();
   mocks.useConversation.mockImplementation(() => conversation);
   createSession = vi.fn().mockResolvedValue({ sessionId: "s3", title: "New", createdAt: "2024-01-03T00:00:00Z" });
@@ -168,7 +184,10 @@ describe("useConversationColumn — session handlers", () => {
 
   it("handleDeleteSession on a non-last active session activates the next one", async () => {
     const onLastSessionDeleted = vi.fn();
-    const { result } = renderColumn("ws1", { onLastSessionDeleted });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+    queryClient.setQueryData(sessionMessagesKey("ws1", "s1"), [trackedMessage("m1", "s1")]);
+    trackOptimisticSend("local-1", { content: "pending", sessionId: "s1" });
+    const { result } = renderColumn("ws1", { onLastSessionDeleted }, queryClient);
     await act(async () => {
       await result.current.handleDeleteSession("s1"); // active, sibling s2 remains
     });
@@ -176,6 +195,8 @@ describe("useConversationColumn — session handlers", () => {
     expect(conversation.switchSession).toHaveBeenCalledWith("s2");
     expect(conversation.clearChat).not.toHaveBeenCalled();
     expect(onLastSessionDeleted).not.toHaveBeenCalled();
+    expect(getCachedSessionMessages(queryClient, "ws1", "s1")).toBeUndefined();
+    expect(getSendState("local-1")).toBeUndefined();
   });
 
   it("handleDeleteSession on the last session clears chat and runs onLastSessionDeleted", async () => {
@@ -197,13 +218,39 @@ describe("useConversationColumn — session handlers", () => {
   it("handleDeleteSession does nothing when delete fails", async () => {
     deleteSession.mockResolvedValue(false);
     const onLastSessionDeleted = vi.fn();
-    const { result } = renderColumn("ws1", { onLastSessionDeleted });
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+    queryClient.setQueryData(sessionMessagesKey("ws1", "s1"), [trackedMessage("m1", "s1")]);
+    trackOptimisticSend("local-1", { content: "pending", sessionId: "s1" });
+    const { result } = renderColumn("ws1", { onLastSessionDeleted }, queryClient);
     await act(async () => {
       await result.current.handleDeleteSession("s1");
     });
     expect(conversation.clearChat).not.toHaveBeenCalled();
     expect(onLastSessionDeleted).not.toHaveBeenCalled();
     expect(conversation.switchSession).not.toHaveBeenCalled();
+    expect(getCachedSessionMessages(queryClient, "ws1", "s1")).toBeDefined();
+    expect(getSendState("local-1")).toBe("sending");
+  });
+});
+
+describe("useConversationColumn — inactive session deletion", () => {
+  it("successful inactive-session deletion also clears its REST cache and tracked sends", async () => {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: Infinity } } });
+    queryClient.setQueryData(sessionMessagesKey("ws1", "s2"), [trackedMessage("m2", "s2")]);
+    trackOptimisticSend("local-2", { content: "pending", sessionId: "s2" });
+
+    const { result } = renderColumn("ws1", undefined, queryClient); // active session is s1
+
+    await act(async () => {
+      await result.current.handleDeleteSession("s2"); // inactive session
+    });
+
+    expect(deleteSession).toHaveBeenCalledWith("s2");
+    expect(getCachedSessionMessages(queryClient, "ws1", "s2")).toBeUndefined();
+    expect(getSendState("local-2")).toBeUndefined();
+    // Inactive-session deletion must not touch active-session navigation.
+    expect(conversation.switchSession).not.toHaveBeenCalled();
+    expect(conversation.clearChat).not.toHaveBeenCalled();
   });
 });
 

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -255,6 +255,39 @@ describe("useSessionMessages", () => {
       expect(merged).toEqual([unrelated, local]);
       expect(getSendState("local-1")).toBe("failed");
     });
+
+    it("drops a failed local message when a NEW server copy with the same content is fetched", async () => {
+      const { __apiMock } = await getApiMock();
+      const serverCopy = userMessage("srv-1", "hello");
+      __apiMock.getMock.mockResolvedValue([serverCopy]);
+
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [userMessage("local-1", "hello")]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      markOptimisticSendFailed("local-1");
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([serverCopy]);
+      expect(getSendState("local-1")).toBeUndefined();
+    });
+
+    it("carries a failed local message whose content never appears server-side", async () => {
+      const { __apiMock } = await getApiMock();
+      const unrelated = userMessage("srv-1", "unrelated content");
+      __apiMock.getMock.mockResolvedValue([unrelated]);
+
+      const queryClient = newClient();
+      const local = userMessage("local-1", "hello");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [local]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      markOptimisticSendFailed("local-1");
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([unrelated, local]);
+      expect(getSendState("local-1")).toBe("failed");
+    });
   });
 
   describe("resolveCachedOptimisticEcho", () => {

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -9,7 +9,6 @@ import {
   appendCachedSessionMessage,
   invalidateSessionMessages,
   removeCachedSessionMessages,
-  removeCachedSessionMessage,
   resolveCachedOptimisticEcho,
   prefetchSessionMessages,
   fetchAndMergeSessionMessages,
@@ -308,19 +307,6 @@ describe("useSessionMessages", () => {
       expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([userMessage("u1", "other")]);
     });
 
-  });
-
-  describe("removeCachedSessionMessage", () => {
-    it("removes only the targeted message", () => {
-      const queryClient = newClient();
-      const keep = message("a1", "keep");
-      const drop = userMessage("local-1", "drop");
-      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [keep, drop]);
-
-      removeCachedSessionMessage(queryClient, "ws-1", "sess-1", "local-1");
-
-      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([keep]);
-    });
   });
 
   describe("appendCachedSessionMessage", () => {

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -61,14 +61,19 @@ function message(id: string, content: string): ChatMessage {
   };
 }
 
-function userMessage(id: string, content: string): ChatMessage {
+function userMessage(id: string, content: string, clientMessageId?: string): ChatMessage {
   return {
     id,
     sessionId: "sess-1",
     role: "user",
     content,
     timestamp: "2026-02-20T00:00:00.000Z",
+    clientMessageId,
   };
+}
+
+function track(id: string, content: string): void {
+  trackOptimisticSend(id, { content, sessionId: "sess-1" });
 }
 
 describe("useSessionMessages", () => {
@@ -208,21 +213,6 @@ describe("useSessionMessages", () => {
   });
 
   describe("optimistic send reconciliation", () => {
-    it("drops a sending local message when a NEW server copy with the same content is fetched", async () => {
-      const { __apiMock } = await getApiMock();
-      const serverCopy = userMessage("srv-1", "hello");
-      __apiMock.getMock.mockResolvedValue([serverCopy]);
-
-      const queryClient = newClient();
-      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [userMessage("local-1", "hello")]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
-
-      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
-
-      expect(merged).toEqual([serverCopy]);
-      expect(getSendState("local-1")).toBeUndefined();
-    });
-
     it("does not confirm a pending send from an already-cached identical message", async () => {
       const { __apiMock } = await getApiMock();
       const oldServerCopy = userMessage("srv-0", "hello");
@@ -231,7 +221,7 @@ describe("useSessionMessages", () => {
       const queryClient = newClient();
       const local = userMessage("local-1", "hello");
       queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [oldServerCopy, local]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      track("local-1", "hello");
 
       const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
 
@@ -247,7 +237,7 @@ describe("useSessionMessages", () => {
       const queryClient = newClient();
       const local = userMessage("local-1", "hello");
       queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [local]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      track("local-1", "hello");
       markOptimisticSendFailed("local-1");
 
       const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
@@ -256,37 +246,39 @@ describe("useSessionMessages", () => {
       expect(getSendState("local-1")).toBe("failed");
     });
 
-    it("drops a failed local message when a NEW server copy with the same content is fetched", async () => {
+    it("resolves only the exact clientMessageId among two identical image-only sends", async () => {
       const { __apiMock } = await getApiMock();
-      const serverCopy = userMessage("srv-1", "hello");
+      const serverCopy = userMessage("srv-1", "", "local-2");
       __apiMock.getMock.mockResolvedValue([serverCopy]);
 
       const queryClient = newClient();
-      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [userMessage("local-1", "hello")]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
-      markOptimisticSendFailed("local-1");
+      const first = userMessage("local-1", "");
+      const second = userMessage("local-2", "");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [first, second]);
+      track("local-1", "");
+      track("local-2", "");
 
       const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
 
-      expect(merged).toEqual([serverCopy]);
-      expect(getSendState("local-1")).toBeUndefined();
+      expect(merged).toEqual([serverCopy, first]);
+      expect(getSendState("local-1")).toBe("sending");
+      expect(getSendState("local-2")).toBeUndefined();
     });
 
-    it("carries a failed local message whose content never appears server-side", async () => {
+    it("does not resolve a local send when the fetched copy's clientMessageId belongs to another client", async () => {
       const { __apiMock } = await getApiMock();
-      const unrelated = userMessage("srv-1", "unrelated content");
-      __apiMock.getMock.mockResolvedValue([unrelated]);
+      const otherClientCopy = userMessage("srv-1", "hello", "other-client-local-9");
+      __apiMock.getMock.mockResolvedValue([otherClientCopy]);
 
       const queryClient = newClient();
       const local = userMessage("local-1", "hello");
       queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [local]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
-      markOptimisticSendFailed("local-1");
+      track("local-1", "hello");
 
       const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
 
-      expect(merged).toEqual([unrelated, local]);
-      expect(getSendState("local-1")).toBe("failed");
+      expect(merged).toEqual([otherClientCopy, local]);
+      expect(getSendState("local-1")).toBe("sending");
     });
   });
 
@@ -296,9 +288,9 @@ describe("useSessionMessages", () => {
       const assistant = message("a1", "earlier answer");
       const local = userMessage("local-1", "hello");
       queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [assistant, local]);
-      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      track("local-1", "hello");
 
-      const echo = userMessage("srv-1", "hello");
+      const echo = userMessage("srv-1", "hello", "local-1");
       const swapped = resolveCachedOptimisticEcho(queryClient, "ws-1", "sess-1", echo);
 
       expect(swapped).toBe(true);
@@ -315,6 +307,7 @@ describe("useSessionMessages", () => {
       expect(swapped).toBe(false);
       expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([userMessage("u1", "other")]);
     });
+
   });
 
   describe("removeCachedSessionMessage", () => {

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -9,9 +9,17 @@ import {
   appendCachedSessionMessage,
   invalidateSessionMessages,
   removeCachedSessionMessages,
+  removeCachedSessionMessage,
+  resolveCachedOptimisticEcho,
   prefetchSessionMessages,
   fetchAndMergeSessionMessages,
 } from "@/hooks/useSessionMessages";
+import {
+  _resetOptimisticSends,
+  getSendState,
+  markOptimisticSendFailed,
+  trackOptimisticSend,
+} from "@/lib/optimistic-sends";
 import type { ChatMessage } from "@/types";
 
 vi.mock("@/hooks/useApi", () => {
@@ -67,6 +75,7 @@ describe("useSessionMessages", () => {
   beforeEach(async () => {
     const { __apiMock } = await getApiMock();
     __apiMock.reset();
+    _resetOptimisticSends();
   });
 
   it("fetches the session messages once a sessionId is provided", async () => {
@@ -195,6 +204,96 @@ describe("useSessionMessages", () => {
       const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
 
       expect(merged).toEqual([firstUser, firstAssistant, followUp]);
+    });
+  });
+
+  describe("optimistic send reconciliation", () => {
+    it("drops a sending local message when a NEW server copy with the same content is fetched", async () => {
+      const { __apiMock } = await getApiMock();
+      const serverCopy = userMessage("srv-1", "hello");
+      __apiMock.getMock.mockResolvedValue([serverCopy]);
+
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [userMessage("local-1", "hello")]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([serverCopy]);
+      expect(getSendState("local-1")).toBeUndefined();
+    });
+
+    it("does not confirm a pending send from an already-cached identical message", async () => {
+      const { __apiMock } = await getApiMock();
+      const oldServerCopy = userMessage("srv-0", "hello");
+      __apiMock.getMock.mockResolvedValue([oldServerCopy]);
+
+      const queryClient = newClient();
+      const local = userMessage("local-1", "hello");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [oldServerCopy, local]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([oldServerCopy, local]);
+      expect(getSendState("local-1")).toBe("sending");
+    });
+
+    it("carries a failed local message across refetches without confirming it", async () => {
+      const { __apiMock } = await getApiMock();
+      const unrelated = message("a1", "assistant answer");
+      __apiMock.getMock.mockResolvedValue([unrelated]);
+
+      const queryClient = newClient();
+      const local = userMessage("local-1", "hello");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [local]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+      markOptimisticSendFailed("local-1");
+
+      const merged = await fetchAndMergeSessionMessages(queryClient, "ws-1", "sess-1");
+
+      expect(merged).toEqual([unrelated, local]);
+      expect(getSendState("local-1")).toBe("failed");
+    });
+  });
+
+  describe("resolveCachedOptimisticEcho", () => {
+    it("swaps the tracked local message in place and stops tracking it", () => {
+      const queryClient = newClient();
+      const assistant = message("a1", "earlier answer");
+      const local = userMessage("local-1", "hello");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [assistant, local]);
+      trackOptimisticSend("local-1", { content: "hello", sessionId: "sess-1" });
+
+      const echo = userMessage("srv-1", "hello");
+      const swapped = resolveCachedOptimisticEcho(queryClient, "ws-1", "sess-1", echo);
+
+      expect(swapped).toBe(true);
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([assistant, echo]);
+      expect(getSendState("local-1")).toBeUndefined();
+    });
+
+    it("returns false for untracked content so the caller appends normally", () => {
+      const queryClient = newClient();
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [userMessage("u1", "other")]);
+
+      const swapped = resolveCachedOptimisticEcho(queryClient, "ws-1", "sess-1", userMessage("srv-1", "hello"));
+
+      expect(swapped).toBe(false);
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([userMessage("u1", "other")]);
+    });
+  });
+
+  describe("removeCachedSessionMessage", () => {
+    it("removes only the targeted message", () => {
+      const queryClient = newClient();
+      const keep = message("a1", "keep");
+      const drop = userMessage("local-1", "drop");
+      queryClient.setQueryData(sessionMessagesKey("ws-1", "sess-1"), [keep, drop]);
+
+      removeCachedSessionMessage(queryClient, "ws-1", "sess-1", "local-1");
+
+      expect(getCachedSessionMessages(queryClient, "ws-1", "sess-1")).toEqual([keep]);
     });
   });
 

--- a/frontend/tests/lib/optimistic-sends.test.ts
+++ b/frontend/tests/lib/optimistic-sends.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  SEND_CONFIRM_TIMEOUT_MS,
+  _resetOptimisticSends,
+  getSendState,
+  markOptimisticSendFailed,
+  resolveOptimisticSend,
+  subscribeSendStates,
+  trackOptimisticSend,
+} from "@/lib/optimistic-sends";
+
+const payload = { content: "hello", sessionId: "sess-1" };
+
+describe("optimistic-sends timeout", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    _resetOptimisticSends();
+  });
+
+  it("flips a tracked send to failed after SEND_CONFIRM_TIMEOUT_MS and notifies listeners", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSendStates(listener);
+
+    trackOptimisticSend("local-1", payload);
+    listener.mockClear();
+
+    vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
+
+    expect(getSendState("local-1")).toBe("failed");
+    expect(listener).toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("does not flip a send resolved before the timeout", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSendStates(listener);
+
+    trackOptimisticSend("local-1", payload);
+    resolveOptimisticSend("local-1");
+    listener.mockClear();
+
+    vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
+
+    expect(getSendState("local-1")).toBeUndefined();
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it("restarts the timeout when a send is re-tracked (retry)", () => {
+    trackOptimisticSend("local-1", payload);
+    vi.advanceTimersByTime(10_000);
+
+    trackOptimisticSend("local-1", payload);
+    vi.advanceTimersByTime(10_000);
+    expect(getSendState("local-1")).toBe("sending");
+
+    vi.advanceTimersByTime(5_000);
+    expect(getSendState("local-1")).toBe("failed");
+  });
+
+  it("does not double-notify when a manually-failed send's timer later fires", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeSendStates(listener);
+
+    trackOptimisticSend("local-1", payload);
+    markOptimisticSendFailed("local-1");
+    listener.mockClear();
+
+    vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
+
+    expect(getSendState("local-1")).toBe("failed");
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+});

--- a/frontend/tests/lib/optimistic-sends.test.ts
+++ b/frontend/tests/lib/optimistic-sends.test.ts
@@ -2,78 +2,93 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   SEND_CONFIRM_TIMEOUT_MS,
   _resetOptimisticSends,
+  clearTrackedSends,
+  getOptimisticSendPayload,
   getSendState,
   markOptimisticSendFailed,
+  resolveEchoedSend,
   resolveOptimisticSend,
-  subscribeSendStates,
   trackOptimisticSend,
 } from "@/lib/optimistic-sends";
+import type { OptimisticSendPayload } from "@/lib/optimistic-sends";
 
-const payload = { content: "hello", sessionId: "sess-1" };
+function payload(overrides: Partial<OptimisticSendPayload> = {}): OptimisticSendPayload {
+  return { content: "hello", sessionId: "sess-1", ...overrides };
+}
 
-describe("optimistic-sends timeout", () => {
+describe("optimistic sends", () => {
   beforeEach(() => {
     vi.useFakeTimers();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     _resetOptimisticSends();
+    vi.useRealTimers();
   });
 
-  it("flips a tracked send to failed after SEND_CONFIRM_TIMEOUT_MS and notifies listeners", () => {
-    const listener = vi.fn();
-    const unsubscribe = subscribeSendStates(listener);
-
-    trackOptimisticSend("local-1", payload);
-    listener.mockClear();
+  it("marks an unanswered send unconfirmed after the timeout", () => {
+    trackOptimisticSend("local-1", payload());
 
     vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
 
-    expect(getSendState("local-1")).toBe("failed");
-    expect(listener).toHaveBeenCalled();
-    unsubscribe();
+    expect(getSendState("local-1")).toBe("unconfirmed");
   });
 
-  it("does not flip a send resolved before the timeout", () => {
-    const listener = vi.fn();
-    const unsubscribe = subscribeSendStates(listener);
-
-    trackOptimisticSend("local-1", payload);
+  it("does not time out a resolved send", () => {
+    trackOptimisticSend("local-1", payload());
     resolveOptimisticSend("local-1");
-    listener.mockClear();
 
     vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
 
     expect(getSendState("local-1")).toBeUndefined();
-    expect(listener).not.toHaveBeenCalled();
-    unsubscribe();
   });
 
-  it("restarts the timeout when a send is re-tracked (retry)", () => {
-    trackOptimisticSend("local-1", payload);
-    vi.advanceTimersByTime(10_000);
-
-    trackOptimisticSend("local-1", payload);
-    vi.advanceTimersByTime(10_000);
-    expect(getSendState("local-1")).toBe("sending");
-
-    vi.advanceTimersByTime(5_000);
-    expect(getSendState("local-1")).toBe("failed");
-  });
-
-  it("does not double-notify when a manually-failed send's timer later fires", () => {
-    const listener = vi.fn();
-    const unsubscribe = subscribeSendStates(listener);
-
-    trackOptimisticSend("local-1", payload);
+  it("keeps a definite failure failed when the timeout elapses", () => {
+    trackOptimisticSend("local-1", payload());
     markOptimisticSendFailed("local-1");
-    listener.mockClear();
 
     vi.advanceTimersByTime(SEND_CONFIRM_TIMEOUT_MS);
 
     expect(getSendState("local-1")).toBe("failed");
-    expect(listener).not.toHaveBeenCalled();
-    unsubscribe();
+  });
+
+  it("resolves the exact client id among identical sends", () => {
+    trackOptimisticSend("local-1", payload({ content: "continue" }));
+    trackOptimisticSend("local-2", payload({ content: "continue" }));
+
+    expect(resolveEchoedSend("sess-1", {
+      clientMessageId: "local-2",
+      content: "continue",
+    })).toBe("local-2");
+  });
+
+  it("does not content-match an echo carrying another client's id", () => {
+    trackOptimisticSend("local-1", payload());
+
+    expect(resolveEchoedSend("sess-1", {
+      clientMessageId: "other-client-id",
+      content: "hello",
+    })).toBeUndefined();
+  });
+
+  it("keeps the original retry payload", () => {
+    const original = payload({
+      images: [{ name: "shot.png", mediaType: "image/png", dataUrl: "data:image/png;base64,AAAA" }],
+      options: { planMode: true },
+    });
+
+    trackOptimisticSend("local-1", original);
+
+    expect(getOptimisticSendPayload("local-1")).toBe(original);
+  });
+
+  it("clears only sends belonging to the deleted session", () => {
+    trackOptimisticSend("local-1", payload());
+    trackOptimisticSend("local-2", payload({ sessionId: "sess-2" }));
+
+    clearTrackedSends("sess-1");
+
+    expect(getSendState("local-1")).toBeUndefined();
+    expect(getSendState("local-2")).toBe("sending");
   });
 });

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -337,6 +337,8 @@ struct ChatMessage: Codable, Equatable, Identifiable {
     let outputTokens: Int?
     let contextUsedTokens: Int?
     let contextWindowTokens: Int?
+    /// Client-generated id of the optimistic send this message confirms, if any.
+    let clientMessageId: String?
 
     init(id: String, sessionId: String, role: MessageRole, content: String,
          images: [ImageAttachment]?, fileMentions: [FileMention]? = nil,
@@ -347,7 +349,8 @@ struct ChatMessage: Codable, Equatable, Identifiable {
          timestamp: String, cancelled: Bool?, errorDetail: String? = nil,
          durationMs: Int?,
          inputTokens: Int? = nil, outputTokens: Int? = nil,
-         contextUsedTokens: Int? = nil, contextWindowTokens: Int? = nil) {
+         contextUsedTokens: Int? = nil, contextWindowTokens: Int? = nil,
+         clientMessageId: String? = nil) {
         self.id = id
         self.sessionId = sessionId
         self.role = role
@@ -367,6 +370,7 @@ struct ChatMessage: Codable, Equatable, Identifiable {
         self.outputTokens = outputTokens
         self.contextUsedTokens = contextUsedTokens
         self.contextWindowTokens = contextWindowTokens
+        self.clientMessageId = clientMessageId
     }
 
     init(from decoder: Decoder) throws {
@@ -421,6 +425,7 @@ struct ChatMessage: Codable, Equatable, Identifiable {
         } else {
             contextWindowTokens = nil
         }
+        clientMessageId = try container.decodeIfPresent(String.self, forKey: .clientMessageId)
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -428,6 +433,7 @@ struct ChatMessage: Codable, Equatable, Identifiable {
         case goalCommand
         case reasoningSegments, reasoningBlocks, timestamp, cancelled, errorDetail, durationMs
         case inputTokens, outputTokens, contextUsedTokens, contextWindowTokens
+        case clientMessageId
     }
 }
 

--- a/ios/HiveMobile/Models/WebSocketTypes.swift
+++ b/ios/HiveMobile/Models/WebSocketTypes.swift
@@ -81,7 +81,7 @@ enum ToolInputResult: Encodable {
 
 enum WsIncoming: Encodable {
     case switchSession(sessionId: String)
-    case userMessage(content: String, images: [ImageAttachment]?, fileMentions: [FileMention]?, options: MessageOptions?, sessionId: String?)
+    case userMessage(content: String, images: [ImageAttachment]?, fileMentions: [FileMention]?, options: MessageOptions?, sessionId: String?, clientMessageId: String?)
     case stop(sessionId: String?)
     case toolInputResponse(requestId: String, toolName: String, result: ToolInputResult, sessionId: String?)
     /// Ask the backend to replay live status + full snapshot for every currently
@@ -96,13 +96,14 @@ enum WsIncoming: Encodable {
         case .switchSession(let sessionId):
             try container.encode("switch_session", forKey: .type)
             try container.encode(sessionId, forKey: .sessionId)
-        case .userMessage(let content, let images, let fileMentions, let options, let sessionId):
+        case .userMessage(let content, let images, let fileMentions, let options, let sessionId, let clientMessageId):
             try container.encode("user_message", forKey: .type)
             try container.encode(content, forKey: .content)
             try container.encodeIfPresent(images, forKey: .images)
             try container.encodeIfPresent(fileMentions, forKey: .fileMentions)
             try container.encodeIfPresent(options, forKey: .options)
             try container.encodeIfPresent(sessionId, forKey: .sessionId)
+            try container.encodeIfPresent(clientMessageId, forKey: .clientMessageId)
         case .stop(let sessionId):
             try container.encode("stop", forKey: .type)
             try container.encodeIfPresent(sessionId, forKey: .sessionId)
@@ -119,6 +120,7 @@ enum WsIncoming: Encodable {
 
     private enum CodingKeys: String, CodingKey {
         case type, sessionId, content, images, fileMentions, options, requestId, toolName, result
+        case clientMessageId
     }
 }
 
@@ -136,7 +138,7 @@ enum WsOutgoing: Decodable {
     case toolInputRequired(sessionId: String, requestId: String, toolName: String, toolUseId: String, input: String)
     case toolInputResolved(sessionId: String)
     case done(sessionId: String, durationMs: Int?, inputTokens: Int?, outputTokens: Int?, contextUsedTokens: Int?, contextWindowTokens: Int?, pendingToolName: String?)
-    case error(message: String, sessionId: String?)
+    case error(message: String, sessionId: String?, clientMessageId: String?)
     case cancelled(sessionId: String, errorDetail: String?, userInitiated: Bool?, durationMs: Int?)
     case status(status: WorkspaceStatus, sessionId: String?, streaming: Bool?, streamingStartedAt: Double?, lockedProvider: String?)
     case userMessage(message: ChatMessage)
@@ -159,6 +161,7 @@ enum WsOutgoing: Decodable {
         case messages, info, stats
         case scriptType, state, exitCode
         case active
+        case clientMessageId
     }
 
     init(from decoder: Decoder) throws {
@@ -279,7 +282,8 @@ enum WsOutgoing: Decodable {
         case "error":
             self = .error(
                 message: try container.decode(String.self, forKey: .message),
-                sessionId: try container.decodeIfPresent(String.self, forKey: .sessionId)
+                sessionId: try container.decodeIfPresent(String.self, forKey: .sessionId),
+                clientMessageId: try container.decodeIfPresent(String.self, forKey: .clientMessageId)
             )
         case "cancelled":
             let cancelledSid = try container.decode(String.self, forKey: .sessionId)

--- a/ios/HiveMobile/Stores/ConversationStore.swift
+++ b/ios/HiveMobile/Stores/ConversationStore.swift
@@ -329,8 +329,12 @@ final class ConversationStore {
             bumpHistoryToken(for: sid)
             onTurnCompleted?(sid)
 
-        case .error(let message, let errorSessionId):
+        case .error(let message, let errorSessionId, let clientMessageId):
             flushStreamingDeltas()
+            // Delivery state is updated even when its session is in the background.
+            if let clientMessageId, userSendStates[clientMessageId] != nil {
+                markSendFailed(clientMessageId)
+            }
             if let errorSessionId, let currentSessionId = sessionId, errorSessionId != currentSessionId {
                 return
             }
@@ -509,21 +513,16 @@ final class ConversationStore {
             }
         }
 
-        // Carry unresolved optimistic sends across the refetch: history that
-        // already contains the content confirms delivery; anything else is
-        // re-appended so a pending/failed message never silently vanishes.
+        for serverMessage in msgs where !previouslyKnownIds.contains(serverMessage.id) {
+            guard let idx = optimisticSendIndex(for: serverMessage) else { continue }
+            let localId = messages[idx].id
+            userSendStates.removeValue(forKey: localId)
+            optimisticPayloads.removeValue(forKey: localId)
+        }
+
         var merged = msgs
         for local in messages where userSendStates[local.id] != nil && local.sessionId == sessionId {
-            if userSendStates[local.id] == .sending,
-               msgs.contains(where: {
-                   $0.role == .user && $0.content == local.content
-                       && !previouslyKnownIds.contains($0.id)
-               }) {
-                userSendStates.removeValue(forKey: local.id)
-                optimisticPayloads.removeValue(forKey: local.id)
-            } else {
-                merged.append(local)
-            }
+            merged.append(local)
         }
         messages = merged
         if merged.count != msgs.count {
@@ -641,7 +640,7 @@ final class ConversationStore {
         userSendStates[localId] = .sending
         let sent = await send?(.userMessage(
             content: message.content, images: payload?.images, fileMentions: payload?.fileMentions,
-            options: payload?.options, sessionId: message.sessionId
+            options: payload?.options, sessionId: message.sessionId, clientMessageId: localId
         )) ?? false
         if sent {
             bumpHistoryToken(for: message.sessionId)
@@ -663,12 +662,18 @@ final class ConversationStore {
         }
     }
 
+    private func optimisticSendIndex(for serverMessage: ChatMessage) -> Int? {
+        guard serverMessage.role == .user, let clientMessageId = serverMessage.clientMessageId else {
+            return nil
+        }
+        return messages.firstIndex(where: {
+            $0.id == clientMessageId && userSendStates[$0.id] != nil
+        })
+    }
+
     private func resolveOptimisticSend(with serverMessage: ChatMessage) -> Bool {
-        guard serverMessage.role == .user,
-              let idx = messages.firstIndex(where: {
-                  userSendStates[$0.id] != nil && $0.role == .user && $0.content == serverMessage.content
-              })
-        else { return false }
+        let idx = optimisticSendIndex(for: serverMessage)
+        guard let idx else { return false }
         let localId = messages[idx].id
         userSendStates.removeValue(forKey: localId)
         optimisticPayloads.removeValue(forKey: localId)

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -729,7 +729,8 @@ struct ChatView: View {
                 images: images.isEmpty ? nil : images,
                 fileMentions: fileMentions,
                 options: options,
-                sessionId: targetSessionId
+                sessionId: targetSessionId,
+                clientMessageId: localId
             )) ?? false
 
             if sent {

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreFailedSendTests.swift
@@ -15,12 +15,17 @@ struct ConversationStoreFailedSendTests {
         return store
     }
 
-    private func serverEcho(_ content: String, session: String) -> WsOutgoing {
-        .userMessage(message: ChatMessage(
+    private func serverMessage(_ content: String, session: String, clientMessageId: String? = nil) -> ChatMessage {
+        ChatMessage(
             id: "srv-1", sessionId: session, role: .user, content: content,
             images: nil, toolCalls: nil,
-            timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil
-        ))
+            timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil,
+            clientMessageId: clientMessageId
+        )
+    }
+
+    private func serverEcho(_ content: String, session: String, clientMessageId: String? = nil) -> WsOutgoing {
+        .userMessage(message: serverMessage(content, session: session, clientMessageId: clientMessageId))
     }
 
     @Test @MainActor
@@ -42,7 +47,7 @@ struct ConversationStoreFailedSendTests {
             content: "hello", images: nil, options: nil, sessionId: "s1"
         )
 
-        store.handle(serverEcho("hello", session: "s1"))
+        store.handle(serverEcho("hello", session: "s1", clientMessageId: localId))
 
         #expect(store.messages.count == 1)
         #expect(store.messages[0].id == "srv-1")
@@ -95,7 +100,8 @@ struct ConversationStoreFailedSendTests {
             ChatMessage(
                 id: "srv-9", sessionId: "s1", role: .user, content: "made it",
                 images: nil, toolCalls: nil,
-                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil
+                timestamp: "2026-07-08T09:00:00.000Z", cancelled: nil, durationMs: nil,
+                clientMessageId: localId
             )
         ], for: "s1")
 
@@ -154,13 +160,76 @@ struct ConversationStoreFailedSendTests {
             ChatMessage(
                 id: "srv-2", sessionId: "s1", role: .user, content: "ok",
                 images: nil, toolCalls: nil,
-                timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil
+                timestamp: "2026-07-08T10:00:00.000Z", cancelled: nil, durationMs: nil,
+                clientMessageId: localId
             )
         ], for: "s1")
 
         #expect(store.messages.count == 2)
         #expect(store.messages.map(\.id) == ["m1", "srv-2"])
         #expect(store.sendState(for: localId) == nil)
+    }
+
+    @Test @MainActor
+    func fetchedHistoryResolvesTheExactClientIdAmongDuplicates() {
+        let store = store(session: "s1")
+        let firstId = store.appendOptimisticUserMessage(
+            content: "dup", images: nil, options: nil, sessionId: "s1"
+        )
+        let secondId = store.appendOptimisticUserMessage(
+            content: "dup", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.applyFetchedHistory([
+            serverMessage("dup", session: "s1", clientMessageId: secondId)
+        ], for: "s1")
+
+        #expect(store.messages.count == 2)
+        #expect(store.messages.map(\.id) == ["srv-1", firstId])
+        #expect(store.sendState(for: firstId) == .sending)
+        #expect(store.sendState(for: secondId) == nil)
+    }
+
+    @Test @MainActor
+    func fetchedHistoryDoesNotResolveSameContentWithAForeignClientId() {
+        let store = store(session: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "hello", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.applyFetchedHistory([
+            serverMessage("hello", session: "s1", clientMessageId: "other-client-local-9")
+        ], for: "s1")
+
+        #expect(store.messages.count == 2)
+        #expect(store.messages.map(\.id) == ["srv-1", localId])
+        #expect(store.sendState(for: localId) == .sending)
+    }
+
+    @Test @MainActor
+    func correlatedBackendRejectionMarksTheExactSendFailed() {
+        let store = store(session: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "hello", images: nil, options: nil, sessionId: "s1"
+        )
+
+        store.handle(.error(message: "Session not found", sessionId: nil, clientMessageId: localId))
+
+        #expect(store.sendState(for: localId) == .failed)
+    }
+
+    @Test @MainActor
+    func uncorrelatedErrorDoesNotChangeAnUnrelatedSendState() {
+        let store = store(session: "s1")
+        let localId = store.appendOptimisticUserMessage(
+            content: "hello", images: nil, options: nil, sessionId: "s1"
+        )
+
+        // The error carries an id this store never tracked (another client's
+        // send, or no correlation at all) — the pending send is left untouched.
+        store.handle(.error(message: "Some other failure", sessionId: nil, clientMessageId: "unrelated-id"))
+
+        #expect(store.sendState(for: localId) == .sending)
     }
 
     @Test @MainActor
@@ -176,7 +245,7 @@ struct ConversationStoreFailedSendTests {
 
         #expect(sent)
         #expect(store.sendState(for: localId) == .sending)
-        store.handle(serverEcho("again", session: "s1"))
+        store.handle(serverEcho("again", session: "s1", clientMessageId: localId))
         #expect(store.messages.count == 1)
         #expect(store.sendState(for: localId) == nil)
     }

--- a/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ConversationStoreStreamingBufferTests.swift
@@ -133,7 +133,7 @@ struct ConversationStoreStreamingBufferTests {
         ))
 
         store.handle(.textDelta(sessionId: "session-1", text: "partial tail"))
-        store.handle(.error(message: "boom", sessionId: "session-1"))
+        store.handle(.error(message: "boom", sessionId: "session-1", clientMessageId: nil))
 
         #expect(store.currentText == "partial tail")
         #expect(store.messages.last?.content == "Error: boom")

--- a/ios/Tests/ChatDraftStoreTests/HubActivityMarkingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/HubActivityMarkingTests.swift
@@ -71,7 +71,7 @@ struct HubActivityMarkingTests {
             sessionId: "s", durationMs: nil, inputTokens: nil, outputTokens: nil,
             contextUsedTokens: nil, contextWindowTokens: nil, pendingToolName: nil
         )) == .markNow)
-        #expect(hubActivityMarking(for: .error(message: "boom", sessionId: nil)) == .markNow)
+        #expect(hubActivityMarking(for: .error(message: "boom", sessionId: nil, clientMessageId: nil)) == .markNow)
         #expect(hubActivityMarking(for: .cancelled(
             sessionId: "s", errorDetail: nil, userInitiated: nil, durationMs: nil
         )) == .markNow)


### PR DESCRIPTION
## What

User messages now appear in the transcript instantly on send (before the server echo), with per-message delivery tracking mirroring the iOS `ConversationStore` optimistic sends:

- **Optimistic append**: `sendMessage` writes the message into the React Query session cache immediately with a `local-` id; the WS `user_message` echo swaps it in place (matched by session + content, same trade-off as iOS).
- **Delivery states**: a module-level store (`frontend/src/lib/optimistic-sends.ts`) tracks `sending`/`failed` per message so state survives workspace navigation. `ChatMessage` renders "Sending…" and a "Not delivered" row with **Retry**/**Discard** actions. The "Sending…" label only appears after a 2s grace delay, so a normal fast echo (<100ms) never flashes it; "Not delivered" stays immediate.
- **Refetch reconciliation**: unconfirmed local echoes are carried across REST history refetches and confirm-resolved when a *new* server copy with the same content appears (covers missed echoes from backgrounded tabs / zombie sockets).
- **Delivery timeout hardening**: a send unconfirmed after 15s flips to `failed` (surfacing Retry) instead of showing "Sending…" forever — covers zombie sockets, dropped frames, and backend `user_message` errors, none of which produce an echo. The reconciliation also resolves timed-out-but-delivered sends so they never render twice.

Also includes `chore: sync package-lock.json with npm 11.9.0` — `npm ci` failed against the previous lockfile (missing `@emnapi/*` optional entries); regenerated deterministically, `npm ci` now passes and leaves the lockfile unchanged.

## Test plan

- New unit suite `frontend/tests/lib/optimistic-sends.test.ts` (timeout flip, resolve-before-timeout, retry restarts timeout, no double-notify).
- New cases in `useConversation.test.tsx` (optimistic append, echo swap, failed send + retry/discard, timeout-to-failed) and `useSessionMessages.test.tsx` (confirm-resolve of sending *and* failed sends, carry of unconfirmed echoes).
- Full frontend gate: `npm run lint`, `npm run typecheck`, `npm test` → 1577 tests green.

## Follow-up (deferred)

- iOS has the same stuck-"Sending…" gap; port the 15s timeout to `ConversationStore.userSendStates`.
- Optional: auto-retry pending/failed sends on WS reconnect (transport already exposes reconnect listeners).

## Screenshots

Live capture (dev backend frozen with `SIGSTOP` to simulate a zombie socket — the send is written to the wire but no echo ever returns):

| Optimistic append — "Sending…" | After the 15s timeout — "Not delivered" with Retry/Discard |
|---|---|
| ![Sending state](https://raw.githubusercontent.com/0xlny/hive/pr-348-assets/sending.png) | ![Not delivered state](https://raw.githubusercontent.com/0xlny/hive/pr-348-assets/not-delivered.png) |

The second screenshot doubles as an end-to-end verification of the timeout hardening in this PR: without it, the message would show "Sending…" forever.