### PR TITLE
feat: Kimi provider (Moonshot K3) via the Claude Code harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Run Hive as a **local web app**, a **Tauri desktop app** (pointed at a local or 
 ### 🔌 Providers
 - **Claude** via streaming JSON from the Claude CLI.
 - **Codex** interactive chat via `codex app-server`; automations via `codex exec --json`.
+- **Kimi** (Moonshot K3 / Kimi for Coding) through the Claude CLI pointed at Moonshot's Anthropic-compatible Kimi Code subscription endpoint. Requires a [Kimi Code subscription](https://www.kimi.com/membership/pricing) API key (Settings → Models); models appear in the picker once the key is saved. The `k3-1m` 1M-context model needs the Allegretto tier or above. WebFetch is not supported by the endpoint and fails at runtime.
 - Command execution, file changes, plans, goals, diagnostics, image views, token usage, and collaborative tool calls normalized into Hive events.
 
 ### 🤖 Automation

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Run Hive as a **local web app**, a **Tauri desktop app** (pointed at a local or 
 ### 🔌 Providers
 - **Claude** via streaming JSON from the Claude CLI.
 - **Codex** interactive chat via `codex app-server`; automations via `codex exec --json`.
-- **Kimi** (Moonshot K3 / Kimi for Coding) through the Claude CLI pointed at Moonshot's Anthropic-compatible Kimi Code subscription endpoint. Requires a [Kimi Code subscription](https://www.kimi.com/membership/pricing) API key (Settings → Models); models appear in the picker once the key is saved. The `k3-1m` 1M-context model needs the Allegretto tier or above. WebFetch is not supported by the endpoint and fails at runtime.
+- **Kimi** (Moonshot K3 / Kimi for Coding) through the Claude CLI pointed at Moonshot's Anthropic-compatible Kimi Code subscription endpoint. Requires a [Kimi Code subscription](https://www.kimi.com/membership/pricing) API key (Settings → Models); models appear in the picker once the key is saved. The `k3-1m` 1M-context model needs the Allegretto tier or above.
 - Command execution, file changes, plans, goals, diagnostics, image views, token usage, and collaborative tool calls normalized into Hive events.
 
 ### 🤖 Automation

--- a/backend/src/agents/agent-manager.notifier.test.ts
+++ b/backend/src/agents/agent-manager.notifier.test.ts
@@ -50,6 +50,7 @@ function makeConfig(overrides?: Partial<AppConfig["notifications"]["telegram"]>)
       },
       apns: { ...DEFAULT_APNS },
     },
+    kimi: { apiKey: "" },
   };
 }
 
@@ -93,6 +94,7 @@ describe("rebuildNotifier", () => {
         telegram: { enabled: false, botToken: "", chatId: "" },
         apns: { enabled: true, teamId: "T", keyId: "K", keyContent: "PEM", bundleId: "com.x", sandbox: false, deviceTokens: [] },
       },
+      kimi: { apiKey: "" },
     };
     rebuildNotifier(config);
 
@@ -113,6 +115,7 @@ describe("rebuildNotifier", () => {
         telegram: { enabled: false, botToken: "", chatId: "" },
         apns: { enabled: true, teamId: "T", keyId: "K", keyContent: "PEM", bundleId: "com.x", sandbox: false, deviceTokens: [] },
       },
+      kimi: { apiKey: "" },
     };
     rebuildNotifier(config);
     rebuildNotifier(config);

--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -3064,6 +3064,24 @@ describe("ConversationSession", () => {
     }
   });
 
+  it("suppresses the benign claude.ai connectors stderr notice but keeps real errors", () => {
+    const session = createSession();
+    const messages: WsOutgoing[] = [];
+    session.on("message", (msg) => messages.push(msg));
+
+    session.sendMessage("Hi");
+    mockProc._stderr.push("⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY or another auth source is set and takes precedence over your claude.ai login · Unset it to load your organization's connectors");
+    expect(messages.filter((m) => m.type === "error")).toHaveLength(0);
+
+    mockProc._stderr.push("⚠ claude.ai connectors are disabled because ANTHROPIC_API_KEY is set\nreal failure");
+    const errors = messages.filter((m) => m.type === "error");
+    expect(errors).toHaveLength(1);
+    if (errors[0].type === "error") {
+      expect(errors[0].message).toContain("real failure");
+      expect(errors[0].message).not.toContain("connectors");
+    }
+  });
+
   it("defaults command to claude", () => {
     const session = createSession();
     session.sendMessage("Hi");

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -1024,7 +1024,16 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     });
 
     runner.on("stderr", ({ text }) => {
-      const stderrLine = `stderr: ${sanitizeErrorDetail(text)}`;
+      // Expected CLI notice when we inject ANTHROPIC_API_KEY (Kimi sessions):
+      // claude.ai connectors can't work against a third-party endpoint anyway,
+      // so don't surface it as an error in the conversation. Filter per line —
+      // a chunk can bundle the notice with real errors.
+      const kept = text
+        .split("\n")
+        .filter((line) => !line.includes("connectors are disabled because ANTHROPIC_API_KEY"))
+        .join("\n");
+      if (!kept.trim()) return;
+      const stderrLine = `stderr: ${sanitizeErrorDetail(kept)}`;
       lastStderr = stderrLine;
       this.emit("message", { type: "error", message: stderrLine, sessionId: this.sessionId } as WsOutgoing);
     });

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -39,10 +39,12 @@ const CLAUDE_CAPABILITIES: ProviderCapabilities = {
 };
 
 export class ClaudeProvider implements AgentProvider {
-  readonly id = "claude";
-  readonly command = "claude";
-  readonly models = CLAUDE_MODELS;
-  readonly capabilities = CLAUDE_CAPABILITIES;
+  // Annotated (not inferred literals) so subclasses like KimiProvider can
+  // override id/models/capabilities while reusing the CLI plumbing.
+  readonly id: string = "claude";
+  readonly command: string = "claude";
+  readonly models: ModelDefinition[] = CLAUDE_MODELS;
+  readonly capabilities: ProviderCapabilities = CLAUDE_CAPABILITIES;
 
   buildArgs(
     content: string,

--- a/backend/src/agents/providers/kimi.test.ts
+++ b/backend/src/agents/providers/kimi.test.ts
@@ -90,6 +90,11 @@ describe("KimiProvider", () => {
     expect(args[idx + 1]).toBe("k3[1m]");
   });
 
+  it("never emits --effort even if a stale thinkingLevel leaks in", () => {
+    const args = provider.buildArgs("Hello", { model: "k3", thinkingLevel: "high" }, baseSession());
+    expect(args).not.toContain("--effort");
+  });
+
   it("supports plan mode via --permission-mode plan", () => {
     const args = provider.buildArgs("Hello", { model: "k3", planMode: true }, baseSession());
     expect(args).toContain("--permission-mode");

--- a/backend/src/agents/providers/kimi.test.ts
+++ b/backend/src/agents/providers/kimi.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { rm } from "node:fs/promises";
+import { KimiProvider } from "./kimi.js";
+import { StreamParser } from "../stream-parser.js";
+import { loadConfig, updateConfig } from "../../state/config.js";
+import { createTempDir } from "../../utils/test-helpers.js";
+import type { ProviderSessionState } from "./types.js";
+
+function baseSession(overrides?: Partial<ProviderSessionState>): ProviderSessionState {
+  return {
+    isFirstMessage: true,
+    sessionId: "test-session-id",
+    skipPermissions: true,
+    ...overrides,
+  };
+}
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await createTempDir("hive-kimi-provider-");
+  // Warm the module-level key cache from an empty config (key = "").
+  await loadConfig(tempDir);
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("KimiProvider", () => {
+  const provider = new KimiProvider();
+
+  // ── Identity ───────────────────────────────────────────────────────
+
+  it("has id 'kimi' but runs the claude CLI", () => {
+    expect(provider.id).toBe("kimi");
+    expect(provider.command).toBe("claude");
+  });
+
+  // ── Models ─────────────────────────────────────────────────────────
+
+  it("exposes k3 (default), k3-1m, and kimi-for-coding", () => {
+    expect(provider.models.map((m) => m.id)).toEqual(["k3", "k3-1m", "kimi-for-coding"]);
+    const defaults = provider.models.filter((m) => m.isDefault);
+    expect(defaults.map((m) => m.id)).toEqual(["k3"]);
+  });
+
+  it("maps models to their cli values and context windows", () => {
+    const byId = new Map(provider.models.map((m) => [m.id, m]));
+    expect(byId.get("k3")?.cliValue).toBe("k3");
+    expect(byId.get("k3")?.contextWindow).toBe(262_144);
+    expect(byId.get("k3-1m")?.cliValue).toBe("k3[1m]");
+    expect(byId.get("k3-1m")?.contextWindow).toBe(1_048_576);
+    expect(byId.get("kimi-for-coding")?.cliValue).toBe("kimi-for-coding");
+    expect(byId.get("kimi-for-coding")?.contextWindow).toBe(262_144);
+  });
+
+  it("has no fast-mode model", () => {
+    expect(provider.models.every((m) => !m.supportsFastMode)).toBe(true);
+  });
+
+  // ── Capabilities ───────────────────────────────────────────────────
+
+  it("exposes claude-like capabilities without thinking levels", () => {
+    expect(provider.capabilities).toEqual({
+      thinkingLevels: [],
+      planMode: true,
+      blockingTools: true,
+      completions: true,
+      goals: false,
+    });
+  });
+
+  // ── buildArgs (inherited from ClaudeProvider) ──────────────────────
+
+  it("builds claude print args with --model k3 and no --effort", () => {
+    const args = provider.buildArgs("Hello", { model: "k3" }, baseSession());
+    expect(args).toContain("--print");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("stream-json");
+    const idx = args.indexOf("--model");
+    expect(args[idx + 1]).toBe("k3");
+    expect(args).not.toContain("--effort");
+    expect(args.slice(-2)).toEqual(["-p", "Hello"]);
+  });
+
+  it("passes k3[1m] as the cli value for k3-1m", () => {
+    const args = provider.buildArgs("Hello", { model: "k3-1m" }, baseSession());
+    const idx = args.indexOf("--model");
+    expect(args[idx + 1]).toBe("k3[1m]");
+  });
+
+  it("supports plan mode via --permission-mode plan", () => {
+    const args = provider.buildArgs("Hello", { model: "k3", planMode: true }, baseSession());
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("plan");
+  });
+
+  // ── buildEnv ───────────────────────────────────────────────────────
+
+  it("points the claude CLI at Moonshot with the stored key", async () => {
+    await updateConfig((c) => { c.kimi.apiKey = "sk-kimi-test"; }, tempDir);
+
+    const env = provider.buildEnv({ model: "k3" });
+    expect(env.ANTHROPIC_BASE_URL).toBe("https://api.kimi.com/coding/");
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-kimi-test");
+    expect(env.ENABLE_TOOL_SEARCH).toBe("false");
+  });
+
+  it("keeps the inherited claude env vars", () => {
+    const env = provider.buildEnv({ model: "k3" });
+    expect(env.CLAUDE_CODE_ENABLE_TASKS).toBe("true");
+    expect(env.CLAUDE_CODE_DISABLE_CRON).toBe("1");
+    expect(env.CLAUDE_CODE_DISABLE_BACKGROUND_TASKS).toBe("1");
+  });
+
+  it("sets the context-window vars from the selected model", () => {
+    const k3 = provider.buildEnv({ model: "k3" });
+    expect(k3.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("262144");
+    expect(k3.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("262144");
+
+    const oneM = provider.buildEnv({ model: "k3-1m" });
+    expect(oneM.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("1048576");
+    expect(oneM.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("1048576");
+  });
+
+  it("falls back to 262144 context tokens for an unknown model", () => {
+    const env = provider.buildEnv({});
+    expect(env.CLAUDE_CODE_MAX_CONTEXT_TOKENS).toBe("262144");
+    expect(env.CLAUDE_CODE_AUTO_COMPACT_WINDOW).toBe("262144");
+  });
+
+  it("uses an empty key when none is stored", () => {
+    const env = provider.buildEnv({ model: "k3" });
+    expect(env.ANTHROPIC_API_KEY).toBe("");
+  });
+
+  it("does not set ANTHROPIC_MODEL (model goes via --model)", () => {
+    const env = provider.buildEnv({ model: "k3" });
+    expect(env.ANTHROPIC_MODEL).toBeUndefined();
+  });
+
+  // ── createStreamAdapter (inherited) ────────────────────────────────
+
+  it("reuses the claude StreamParser", () => {
+    expect(provider.createStreamAdapter()).toBeInstanceOf(StreamParser);
+  });
+});

--- a/backend/src/agents/providers/kimi.ts
+++ b/backend/src/agents/providers/kimi.ts
@@ -5,6 +5,7 @@ import {
   type ModelDefinition,
   type ProviderCapabilities,
   type ProviderMessageOptions,
+  type ProviderSessionState,
 } from "./types.js";
 
 const KIMI_MODELS: ModelDefinition[] = [
@@ -34,6 +35,17 @@ export class KimiProvider extends ClaudeProvider {
   override readonly id: string = "kimi";
   override readonly models: ModelDefinition[] = KIMI_MODELS;
   override readonly capabilities: ProviderCapabilities = KIMI_CAPABILITIES;
+
+  override buildArgs(
+    content: string,
+    options: ProviderMessageOptions,
+    session: ProviderSessionState,
+  ): string[] {
+    // No effort levels: drop any thinkingLevel that leaks in (e.g. from a
+    // stale client or stored agent) so --effort is never emitted.
+    const { thinkingLevel: _drop, ...rest } = options;
+    return super.buildArgs(content, rest, session);
+  }
 
   override buildEnv(options: ProviderMessageOptions): Record<string, string> {
     const contextWindow = findModel(this.models, options.model)?.contextWindow

--- a/backend/src/agents/providers/kimi.ts
+++ b/backend/src/agents/providers/kimi.ts
@@ -1,0 +1,54 @@
+import { getKimiApiKey } from "../../state/config.js";
+import { ClaudeProvider } from "./claude.js";
+import {
+  findModel,
+  type ModelDefinition,
+  type ProviderCapabilities,
+  type ProviderMessageOptions,
+} from "./types.js";
+
+const KIMI_MODELS: ModelDefinition[] = [
+  { id: "k3", label: "K3", cliValue: "k3", isDefault: true, contextWindow: 262_144 },
+  { id: "k3-1m", label: "K3 1M", cliValue: "k3[1m]", contextWindow: 1_048_576 },
+  { id: "kimi-for-coding", label: "Kimi for Coding", cliValue: "kimi-for-coding", contextWindow: 262_144 },
+];
+
+const KIMI_CAPABILITIES: ProviderCapabilities = {
+  // No reasoning-effort control: with an empty list callers never pick a
+  // thinking level, so the inherited buildArgs never emits --effort.
+  thinkingLevels: [],
+  planMode: true,
+  blockingTools: true,
+  completions: true,
+  goals: false,
+};
+
+const DEFAULT_CONTEXT_WINDOW = 262_144;
+
+/**
+ * Kimi rides the Claude Code CLI pointed at Moonshot's Anthropic-compatible
+ * subscription endpoint: same binary, args, and stream format as Claude, with
+ * env overrides for the base URL, API key, and per-model context window.
+ */
+export class KimiProvider extends ClaudeProvider {
+  override readonly id: string = "kimi";
+  override readonly models: ModelDefinition[] = KIMI_MODELS;
+  override readonly capabilities: ProviderCapabilities = KIMI_CAPABILITIES;
+
+  override buildEnv(options: ProviderMessageOptions): Record<string, string> {
+    const contextWindow = findModel(this.models, options.model)?.contextWindow
+      ?? DEFAULT_CONTEXT_WINDOW;
+    return {
+      ...super.buildEnv(options),
+      ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
+      ANTHROPIC_API_KEY: getKimiApiKey(),
+      // Moonshot's endpoint 400s on tool_reference content blocks, so keep the
+      // CLI's tool-search feature off.
+      ENABLE_TOOL_SEARCH: "false",
+      // Tell the harness the real window so context tracking and auto-compact
+      // trigger at Moonshot's limits instead of Claude's defaults.
+      CLAUDE_CODE_MAX_CONTEXT_TOKENS: String(contextWindow),
+      CLAUDE_CODE_AUTO_COMPACT_WINDOW: String(contextWindow),
+    };
+  }
+}

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 
 vi.mock("node:child_process", () => ({
   execFile: vi.fn(
@@ -9,6 +9,9 @@ vi.mock("node:child_process", () => ({
 }));
 
 import { execFile } from "node:child_process";
+import { rm } from "node:fs/promises";
+import { loadConfig, updateConfig } from "../../state/config.js";
+import { createTempDir } from "../../utils/test-helpers.js";
 import {
   resolveProvider,
   getProvider,
@@ -276,6 +279,9 @@ describe("detectAvailableProviders", () => {
     const providers = new Set(catalog.models.map((m) => m.provider));
     expect(providers.has("claude")).toBe(true);
     expect(providers.has("codex")).toBe(true);
+    // Kimi's CLI (claude) was detected too, but the catalog gates it on a
+    // stored API key.
+    expect(providers.has("kimi")).toBe(false);
   });
 
   it("ignores providers whose CLI is not found", async () => {
@@ -317,6 +323,86 @@ describe("markProviderAvailable", () => {
     markProviderAvailable("codex");
 
     expect(getModelCatalog().models.some((m) => m.provider === "codex")).toBe(true);
+  });
+});
+
+describe("kimi in catalog", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await createTempDir("hive-registry-kimi-");
+    // Warm the module-level key cache from an empty config (key = "").
+    await loadConfig(tempDir);
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+    // Leave the cache empty for the other describe blocks.
+    await loadConfig(tempDir);
+  });
+
+  it("is absent when the CLI is available but no API key is stored", () => {
+    markProviderAvailable("kimi");
+    const catalog = getModelCatalog();
+    expect(catalog.models.some((m) => m.provider === "kimi")).toBe(false);
+  });
+
+  it("is absent when a key is stored but the CLI is unavailable", async () => {
+    await updateConfig((c) => { c.kimi.apiKey = "sk-kimi"; }, tempDir);
+    const catalog = getModelCatalog();
+    expect(catalog.models.some((m) => m.provider === "kimi")).toBe(false);
+  });
+
+  it("appears once the CLI is available and a key is stored, without a re-detect", async () => {
+    markProviderAvailable("kimi");
+    await updateConfig((c) => { c.kimi.apiKey = "sk-kimi"; }, tempDir);
+
+    const catalog = getModelCatalog();
+    const kimiIds = catalog.models.filter((m) => m.provider === "kimi").map((m) => m.id);
+    expect(kimiIds).toEqual(["kimi:k3", "kimi:k3-1m", "kimi:kimi-for-coding"]);
+
+    // Clearing the key hides it again on the next catalog build.
+    await updateConfig((c) => { c.kimi.apiKey = ""; }, tempDir);
+    expect(getModelCatalog().models.some((m) => m.provider === "kimi")).toBe(false);
+  });
+
+  it("exposes label, contextWindow, and effort-free capabilities", async () => {
+    markProviderAvailable("kimi");
+    await updateConfig((c) => { c.kimi.apiKey = "sk-kimi"; }, tempDir);
+
+    const byId = new Map(getModelCatalog().models.map((m) => [m.id, m]));
+    const k3 = byId.get("kimi:k3")!;
+    expect(k3.label).toBe("K3");
+    expect(k3.providerLabel).toBe("Kimi");
+    expect(k3.isDefault).toBe(true);
+    expect(k3.contextWindow).toBe(262_144);
+    expect(k3.capabilities.thinkingLevels).toEqual([]);
+    expect(k3.capabilities.planMode).toBe(true);
+    expect(k3.supportsFastMode).toBeUndefined();
+    expect(byId.get("kimi:k3-1m")?.contextWindow).toBe(1_048_576);
+    expect(byId.get("kimi:kimi-for-coding")?.contextWindow).toBe(262_144);
+  });
+
+  it("never becomes the catalog default", async () => {
+    markProviderAvailable("kimi");
+    markProviderAvailable("claude");
+    await updateConfig((c) => { c.kimi.apiKey = "sk-kimi"; }, tempDir);
+
+    const catalog = getModelCatalog();
+    expect(catalog.defaultModelId).toMatch(/^claude:/);
+  });
+
+  it("resolves kimi:model ids without a stored key", () => {
+    const { provider, modelId } = resolveProvider("kimi:k3");
+    expect(provider.id).toBe("kimi");
+    expect(modelId).toBe("k3");
+    expect(getProvider("kimi")?.id).toBe("kimi");
+    expect(isKnownModelId("kimi:k3-1m")).toBe(true);
+  });
+
+  it("has no default thinking level (no effort control)", () => {
+    expect(getDefaultThinkingLevelForModel("kimi:k3")).toBeUndefined();
+    expect(isThinkingLevelSupportedForModel("kimi:k3", "high")).toBe(false);
   });
 });
 
@@ -387,7 +473,7 @@ describe("getAllProviderInfo", () => {
     await detectAvailableProviders();
 
     const info = getAllProviderInfo();
-    expect(info).toHaveLength(2);
+    expect(info).toHaveLength(3);
     expect(info.every((p) => !p.installed)).toBe(true);
     expect(info.every((p) => p.version === null)).toBe(true);
   });
@@ -417,11 +503,14 @@ describe("getAllProviderInfo", () => {
     const info = getAllProviderInfo();
     const claude = info.find((p) => p.id === "claude")!;
     const codex = info.find((p) => p.id === "codex")!;
+    const kimi = info.find((p) => p.id === "kimi")!;
 
     expect(claude.label).toBe("Claude Code");
     expect(claude.npmPackage).toBe("@anthropic-ai/claude-code");
     expect(codex.label).toBe("Codex");
     expect(codex.npmPackage).toBe("@openai/codex");
+    expect(kimi.label).toBe("Kimi");
+    expect(kimi.npmPackage).toBe(""); // rides the claude CLI
   });
 
   it("sets version null when CLI output is unparseable", async () => {

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -473,9 +473,16 @@ describe("getAllProviderInfo", () => {
     await detectAvailableProviders();
 
     const info = getAllProviderInfo();
-    expect(info).toHaveLength(3);
+    expect(info).toHaveLength(2);
     expect(info.every((p) => !p.installed)).toBe(true);
     expect(info.every((p) => p.version === null)).toBe(true);
+  });
+
+  it("excludes kimi, which rides the claude CLI and has no binary of its own", async () => {
+    mockNoProviderCli();
+    await detectAvailableProviders();
+
+    expect(getAllProviderInfo().some((p) => p.id === "kimi")).toBe(false);
   });
 
   it("includes detected version for installed providers", async () => {
@@ -503,14 +510,11 @@ describe("getAllProviderInfo", () => {
     const info = getAllProviderInfo();
     const claude = info.find((p) => p.id === "claude")!;
     const codex = info.find((p) => p.id === "codex")!;
-    const kimi = info.find((p) => p.id === "kimi")!;
 
     expect(claude.label).toBe("Claude Code");
     expect(claude.npmPackage).toBe("@anthropic-ai/claude-code");
     expect(codex.label).toBe("Codex");
     expect(codex.npmPackage).toBe("@openai/codex");
-    expect(kimi.label).toBe("Kimi");
-    expect(kimi.npmPackage).toBe(""); // rides the claude CLI
   });
 
   it("sets version null when CLI output is unparseable", async () => {

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -1,7 +1,9 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
+import { getKimiApiKey } from "../../state/config.js";
 import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
+import { KimiProvider } from "./kimi.js";
 import {
   findModel,
   type AgentProvider,
@@ -16,12 +18,14 @@ const execFile = promisify(execFileCb);
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude Code",
   codex: "Codex",
+  kimi: "Kimi",
 };
 
 /** npm package name for each provider, used to check for updates. */
 const NPM_PACKAGES: Record<string, string> = {
   claude: "@anthropic-ai/claude-code",
   codex: "@openai/codex",
+  kimi: "", // rides the claude CLI — no package of its own to update
 };
 
 const DEFAULT_PROVIDER_PRIORITY = ["codex", "claude"];
@@ -30,6 +34,7 @@ const DEFAULT_PROVIDER_PRIORITY = ["codex", "claude"];
 const ALL_PROVIDERS: AgentProvider[] = [
   new ClaudeProvider(),
   new CodexProvider(),
+  new KimiProvider(),
 ];
 
 const providerMap = new Map<string, AgentProvider>(
@@ -156,6 +161,11 @@ export function getModelCatalog(): ModelCatalogResponse {
 
   for (const provider of ALL_PROVIDERS) {
     if (!availableProviderIds.has(provider.id)) continue;
+    // Kimi needs a stored API key on top of the (claude) CLI: without one the
+    // Moonshot endpoint can't authenticate, so hide it from the picker. Checked
+    // at catalog build time so saving a key takes effect without a restart.
+    // resolveProvider is intentionally not gated — stored sessions must resolve.
+    if (provider.id === "kimi" && !getKimiApiKey()) continue;
     const providerLabel = PROVIDER_LABELS[provider.id] ?? provider.id;
 
     for (const model of provider.models) {

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -25,7 +25,6 @@ const PROVIDER_LABELS: Record<string, string> = {
 const NPM_PACKAGES: Record<string, string> = {
   claude: "@anthropic-ai/claude-code",
   codex: "@openai/codex",
-  kimi: "", // rides the claude CLI — no package of its own to update
 };
 
 const DEFAULT_PROVIDER_PRIORITY = ["codex", "claude"];
@@ -217,7 +216,8 @@ export interface AgentProviderInfo {
 
 /** Return info about all known providers (installed or not). */
 export function getAllProviderInfo(): AgentProviderInfo[] {
-  return ALL_PROVIDERS.map((p) => ({
+  // Kimi rides the claude CLI and has no binary of its own to list or update.
+  return ALL_PROVIDERS.filter((p) => p.id !== "kimi").map((p) => ({
     id: p.id,
     label: PROVIDER_LABELS[p.id] ?? p.id,
     npmPackage: NPM_PACKAGES[p.id] ?? "",

--- a/backend/src/api/agent-definitions.ts
+++ b/backend/src/api/agent-definitions.ts
@@ -17,7 +17,7 @@ interface AgentRoutesOptions {
 function resolveThinkingLevel(
   modelId: string,
   requested: ThinkingLevel | undefined,
-): { thinkingLevel: ThinkingLevel } | { error: string } {
+): { thinkingLevel?: ThinkingLevel } | { error: string } {
   if (requested !== undefined) {
     if (!isThinkingLevelSupportedForModel(modelId, requested)) {
       return { error: `Thinking level "${requested}" is not supported by model ${modelId}` };
@@ -25,11 +25,9 @@ function resolveThinkingLevel(
     return { thinkingLevel: requested };
   }
 
-  const thinkingLevel = getDefaultThinkingLevelForModel(modelId);
-  if (!thinkingLevel) {
-    return { error: `Model ${modelId} does not support thinking levels` };
-  }
-  return { thinkingLevel };
+  // Undefined for models with no thinking-level control (e.g. Kimi): the
+  // agent is stored without a level and no effort flag is ever emitted.
+  return { thinkingLevel: getDefaultThinkingLevelForModel(modelId) };
 }
 
 export async function agentRoutes(
@@ -78,7 +76,7 @@ export async function agentRoutes(
       ...(description?.trim() && { description: description.trim() }),
       systemPrompt: systemPrompt.trim(),
       modelId: modelId.trim(),
-      thinkingLevel: thinkingResult.thinkingLevel,
+      ...(thinkingResult.thinkingLevel && { thinkingLevel: thinkingResult.thinkingLevel }),
       readOnly: readOnly ?? false,
       createdAt: now,
       updatedAt: now,
@@ -132,12 +130,13 @@ export async function agentRoutes(
             return { status: 400 as const, error: thinkingResult.error };
           }
           nextThinkingLevel = thinkingResult.thinkingLevel;
-        } else if (updates.modelId !== undefined && !isThinkingLevelSupportedForModel(nextModelId, nextThinkingLevel)) {
-          const thinkingResult = resolveThinkingLevel(nextModelId, undefined);
-          if ("error" in thinkingResult) {
-            return { status: 400 as const, error: thinkingResult.error };
-          }
-          nextThinkingLevel = thinkingResult.thinkingLevel;
+        } else if (
+          updates.modelId !== undefined &&
+          (nextThinkingLevel === undefined || !isThinkingLevelSupportedForModel(nextModelId, nextThinkingLevel))
+        ) {
+          // Model changed and the stored level no longer applies: fall back to
+          // the new model's default (undefined for level-less models).
+          nextThinkingLevel = getDefaultThinkingLevelForModel(nextModelId);
         }
 
         const merged: Agent = {

--- a/backend/src/api/agents-crud.test.ts
+++ b/backend/src/api/agents-crud.test.ts
@@ -148,6 +148,37 @@ describe("POST /api/agents", () => {
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toContain("Thinking level");
   });
+
+  it("creates an agent without a thinkingLevel for level-less models (kimi)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/agents",
+      payload: {
+        name: "Kimi Agent",
+        systemPrompt: "You are helpful.",
+        modelId: "kimi:k3",
+        readOnly: false,
+      },
+    });
+    expect(res.statusCode).toBe(201);
+    expect(res.json().thinkingLevel).toBeUndefined();
+  });
+
+  it("rejects a thinkingLevel supplied for a level-less model (400)", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/api/agents",
+      payload: {
+        name: "Kimi Agent",
+        systemPrompt: "You are helpful.",
+        modelId: "kimi:k3",
+        thinkingLevel: "high",
+        readOnly: false,
+      },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Thinking level");
+  });
 });
 
 describe("PATCH /api/agents/:id", () => {
@@ -225,6 +256,29 @@ describe("PATCH /api/agents/:id", () => {
       method: "PATCH",
       url: "/api/agents/agent-1",
       payload: { modelId: "codex:gpt-5.5", thinkingLevel: "max" },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toContain("Thinking level");
+  });
+
+  it("clears thinkingLevel when switching to a level-less model (kimi)", async () => {
+    await saveAgents([makeAgent({ thinkingLevel: "max" })], dataDir);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/agents/agent-1",
+      payload: { modelId: "kimi:k3" },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().modelId).toBe("kimi:k3");
+    expect(res.json().thinkingLevel).toBeUndefined();
+  });
+
+  it("rejects a thinkingLevel supplied for a level-less model on update (400)", async () => {
+    await saveAgents([makeAgent()], dataDir);
+    const res = await app.inject({
+      method: "PATCH",
+      url: "/api/agents/agent-1",
+      payload: { modelId: "kimi:k3", thinkingLevel: "high" },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toContain("Thinking level");

--- a/backend/src/api/completions.test.ts
+++ b/backend/src/api/completions.test.ts
@@ -236,6 +236,43 @@ description: Fix CI failures
     );
   });
 
+  it("maps provider=kimi to the claude scan", async () => {
+    const workspaceDir = join(dataDir, projectId, "workspaces", wsName);
+
+    await writeSkill(
+      workspaceDir,
+      "kimi-lint",
+      `---
+name: kimi-lint
+description: Lint via a claude skill
+---
+`,
+    );
+
+    const res = await app.inject({
+      method: "GET",
+      url: `/api/workspaces/${wsId}/completions?provider=kimi`,
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "slash_command",
+          name: "help",
+          label: "/help",
+          source: "builtin",
+        }),
+        expect.objectContaining({
+          type: "slash_command",
+          name: "kimi-lint",
+          label: "/kimi-lint",
+          source: "project_skill",
+        }),
+      ]),
+    );
+  });
+
   it("rejects unsupported completion providers", async () => {
     const res = await app.inject({
       method: "GET",

--- a/backend/src/api/completions.ts
+++ b/backend/src/api/completions.ts
@@ -35,7 +35,8 @@ export async function completionRoutes(
 }
 
 function parseCompletionProvider(value: string | undefined): CompletionProvider | null {
-  if (value === undefined || value === "" || value === "claude") return "claude";
+  // Kimi rides the Claude CLI, so its skills/agents live in the claude scan.
+  if (value === undefined || value === "" || value === "claude" || value === "kimi") return "claude";
   if (value === "codex") return "codex";
   return null;
 }

--- a/backend/src/api/models.ts
+++ b/backend/src/api/models.ts
@@ -4,8 +4,10 @@ import { loadConfig } from "../state/config.js";
 
 export async function modelRoutes(app: FastifyInstance) {
   app.get("/api/models", async (_req, reply) => {
-    const catalog = getModelCatalog();
+    // Load config first: it also refreshes the cached Kimi API key that
+    // getModelCatalog uses to decide whether Kimi models are offered.
     const { defaultModelId } = await loadConfig();
+    const catalog = getModelCatalog();
     // Apply the user-configured default only while its model is still in the
     // catalog (provider CLI installed); otherwise keep the computed default.
     if (defaultModelId && catalog.models.some((m) => m.id === defaultModelId)) {

--- a/backend/src/api/settings.test.ts
+++ b/backend/src/api/settings.test.ts
@@ -121,6 +121,63 @@ describe("defaults routes", () => {
   });
 });
 
+describe("kimi routes", () => {
+  it("GET /api/settings/kimi returns an empty key by default", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/settings/kimi" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ apiKey: "" });
+  });
+
+  it("PUT /api/settings/kimi rejects non-string payloads", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/kimi",
+      payload: { apiKey: 42 },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(res.json()).toEqual({ error: "Invalid payload" });
+  });
+
+  it("PUT /api/settings/kimi saves the trimmed key and GET returns it", async () => {
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/kimi",
+      payload: { apiKey: "  sk-kimi-key  " },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ apiKey: "sk-kimi-key" });
+
+    const config = await loadConfig(tempDir);
+    expect(config.kimi.apiKey).toBe("sk-kimi-key");
+
+    const getRes = await app.inject({ method: "GET", url: "/api/settings/kimi" });
+    expect(getRes.json()).toEqual({ apiKey: "sk-kimi-key" });
+  });
+
+  it("PUT /api/settings/kimi with an empty string clears the saved key", async () => {
+    await app.inject({
+      method: "PUT",
+      url: "/api/settings/kimi",
+      payload: { apiKey: "sk-kimi-key" },
+    });
+
+    const res = await app.inject({
+      method: "PUT",
+      url: "/api/settings/kimi",
+      payload: { apiKey: "" },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ apiKey: "" });
+
+    const config = await loadConfig(tempDir);
+    expect(config.kimi.apiKey).toBe("");
+  });
+});
+
 describe("settings routes", () => {
   it("GET /api/settings/notifications returns default config", async () => {
     const res = await app.inject({
@@ -168,6 +225,7 @@ describe("settings routes", () => {
         telegram: { enabled: true, botToken: "bot-token", chatId: "chat-id" },
         apns: { ...DEFAULT_APNS },
       },
+      kimi: { apiKey: "" },
     });
 
     expect(mocks.rebuildNotifier).toHaveBeenCalledTimes(1);
@@ -228,6 +286,7 @@ describe("settings routes", () => {
         telegram: { enabled: false, botToken: "", chatId: "" },
         apns: { ...DEFAULT_APNS, deviceTokens: ["deadbeef"] },
       },
+      kimi: { apiKey: "" },
     }, tempDir);
 
     const res = await app.inject({
@@ -266,6 +325,7 @@ describe("settings routes", () => {
         telegram: { enabled: false, botToken: "", chatId: "" },
         apns: { ...DEFAULT_APNS, deviceTokens: ["aabbccdd11223344aabbccdd11223344"] },
       },
+      kimi: { apiKey: "" },
     }, tempDir);
 
     const res = await app.inject({

--- a/backend/src/api/settings.ts
+++ b/backend/src/api/settings.ts
@@ -31,6 +31,24 @@ export async function settingsRoutes(app: FastifyInstance): Promise<void> {
     return { defaultModelId: config.defaultModelId ?? null };
   });
 
+  app.get("/api/settings/kimi", async () => {
+    const config = await loadConfig();
+    return { apiKey: config.kimi.apiKey };
+  });
+
+  app.put<{
+    Body: { apiKey?: string };
+  }>("/api/settings/kimi", async (req, reply) => {
+    const { apiKey } = req.body ?? {};
+    if (typeof apiKey !== "string") {
+      return reply.status(400).send({ error: "Invalid payload" });
+    }
+    const config = await updateConfig((c) => {
+      c.kimi.apiKey = apiKey.trim();
+    });
+    return { apiKey: config.kimi.apiKey };
+  });
+
   app.get("/api/settings/notifications", async () => {
     const config = await loadConfig();
     return config.notifications;

--- a/backend/src/state/agents.test.ts
+++ b/backend/src/state/agents.test.ts
@@ -72,4 +72,11 @@ describe("agents persistence", () => {
     const loaded = await loadAgents(dataDir);
     expect(loaded[0].thinkingLevel).toBe("high");
   });
+
+  it("clears a stale thinkingLevel for models with no thinking-level control", async () => {
+    await saveAgents([makeAgent({ modelId: "kimi:k3", thinkingLevel: "high" })], dataDir);
+
+    const loaded = await loadAgents(dataDir);
+    expect(loaded[0].thinkingLevel).toBeUndefined();
+  });
 });

--- a/backend/src/state/agents.ts
+++ b/backend/src/state/agents.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getDataDir, writeJsonAtomic } from "./state.js";
 import { getDefaultThinkingLevelForModel, isThinkingLevelSupportedForModel } from "../agents/providers/registry.js";
-import type { Agent, ThinkingLevel } from "../types.js";
+import type { Agent } from "../types.js";
 
 // Global lock for agents.json (shared array of all agent definitions).
 // CRUD operations must serialize on this because they load-modify-save the same file.
@@ -29,11 +29,11 @@ function agentsFilePath(dataDir: string): string {
 }
 
 function normalizeAgent(raw: Agent): Agent {
-  const fallbackThinkingLevel = getDefaultThinkingLevelForModel(raw.modelId) ?? "high";
-  const rawThinkingLevel = (raw as Agent & { thinkingLevel?: ThinkingLevel }).thinkingLevel;
-  const thinkingLevel = rawThinkingLevel && isThinkingLevelSupportedForModel(raw.modelId, rawThinkingLevel)
-    ? rawThinkingLevel
-    : fallbackThinkingLevel;
+  // Keep a stored level only while the model supports it; otherwise fall back
+  // to the model's default, which is undefined for level-less models (Kimi).
+  const thinkingLevel = raw.thinkingLevel && isThinkingLevelSupportedForModel(raw.modelId, raw.thinkingLevel)
+    ? raw.thinkingLevel
+    : getDefaultThinkingLevelForModel(raw.modelId);
   const { injectGitContext: _drop, ...rest } = raw as Agent & { injectGitContext?: boolean };
   return { ...rest, thinkingLevel };
 }

--- a/backend/src/state/config.test.ts
+++ b/backend/src/state/config.test.ts
@@ -11,6 +11,7 @@ const DEFAULT_CONFIG: AppConfig = {
     telegram: { enabled: false, botToken: "", chatId: "" },
     apns: { ...DEFAULT_APNS },
   },
+  kimi: { apiKey: "" },
 };
 
 let dataDir: string;
@@ -51,6 +52,7 @@ describe("loadConfig", () => {
         telegram: { enabled: true, botToken: "", chatId: "" },
         apns: { ...DEFAULT_APNS },
       },
+      kimi: { apiKey: "" },
     });
   });
 
@@ -69,6 +71,7 @@ describe("loadConfig", () => {
         telegram: { enabled: true, botToken: "tok", chatId: "cid" },
         apns: { enabled: true, teamId: "T", keyId: "K", keyContent: "PEM", bundleId: "com.x", sandbox: true, deviceTokens: ["abc"] },
       },
+      kimi: { apiKey: "kimi-key" },
     };
     await writeFile(join(dataDir, "config.json"), JSON.stringify(full), "utf-8");
 
@@ -92,6 +95,7 @@ describe("loadConfig", () => {
         telegram: { enabled: true, botToken: "t", chatId: "c" },
         apns: { ...DEFAULT_APNS },
       },
+      kimi: { apiKey: "" },
     });
     expect((config as unknown as Record<string, unknown>)["unknownKey"]).toBeUndefined();
   });
@@ -105,6 +109,28 @@ describe("loadConfig", () => {
 
     const config = await loadConfig(dataDir);
     expect(config).toEqual(DEFAULT_CONFIG);
+  });
+
+  it("defaults kimi when the config file predates the field", async () => {
+    await writeFile(
+      join(dataDir, "config.json"),
+      JSON.stringify({ notifications: { telegram: { enabled: true, botToken: "t", chatId: "c" } } }),
+      "utf-8",
+    );
+
+    const config = await loadConfig(dataDir);
+    expect(config.kimi).toEqual({ apiKey: "" });
+  });
+
+  it("loads a saved kimi api key", async () => {
+    await writeFile(
+      join(dataDir, "config.json"),
+      JSON.stringify({ kimi: { apiKey: "sk-kimi" } }),
+      "utf-8",
+    );
+
+    const config = await loadConfig(dataDir);
+    expect(config.kimi.apiKey).toBe("sk-kimi");
   });
 
   it("fills missing apns fields with defaults when only some are present", async () => {
@@ -143,6 +169,7 @@ describe("saveConfig", () => {
         telegram: { enabled: true, botToken: "bot-token", chatId: "chat-id" },
         apns: { enabled: true, teamId: "T", keyId: "K", keyContent: "PEM", bundleId: "com.x", sandbox: false, deviceTokens: ["deadbeef"] },
       },
+      kimi: { apiKey: "kimi-key" },
     };
 
     await saveConfig(config, dataDir);

--- a/backend/src/state/config.test.ts
+++ b/backend/src/state/config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { loadConfig, saveConfig, updateConfig, type AppConfig } from "./config.js";
@@ -181,6 +181,17 @@ describe("saveConfig", () => {
     const loaded = await loadConfig(dataDir);
     expect(loaded).toEqual(config);
   });
+
+  // File modes are meaningless on Windows.
+  it.skipIf(process.platform === "win32")(
+    "writes config.json with owner-only permissions (it holds credentials)",
+    async () => {
+      await saveConfig({ ...DEFAULT_CONFIG, kimi: { apiKey: "sk-secret" } }, dataDir);
+
+      const { mode } = await stat(join(dataDir, "config.json"));
+      expect(mode & 0o777).toBe(0o600);
+    },
+  );
 });
 
 describe("updateConfig", () => {

--- a/backend/src/state/config.ts
+++ b/backend/src/state/config.ts
@@ -24,8 +24,13 @@ export interface NotificationsConfig {
   apns: ApnsConfig;
 }
 
+export interface KimiConfig {
+  apiKey: string;
+}
+
 export interface AppConfig {
   notifications: NotificationsConfig;
+  kimi: KimiConfig;
   /** Compound model id ("provider:model") used as the default for new conversations. */
   defaultModelId?: string;
 }
@@ -45,7 +50,18 @@ const DEFAULT_CONFIG: AppConfig = {
     telegram: { enabled: false, botToken: "", chatId: "" },
     apns: { ...DEFAULT_APNS },
   },
+  kimi: { apiKey: "" },
 };
+
+// Synchronous consumers (KimiProvider.buildEnv, getModelCatalog) cannot await
+// loadConfig, so keep the latest Kimi key in memory. Every loadConfig and
+// updateConfig refreshes it; startup warms it via main()'s loadConfig, and the
+// settings PUT refreshes it through updateConfig — no restart needed.
+let cachedKimiApiKey = "";
+
+export function getKimiApiKey(): string {
+  return cachedKimiApiKey;
+}
 
 function configFilePath(dataDir: string): string {
   return join(dataDir, "config.json");
@@ -69,6 +85,9 @@ function withDefaults(parsed: Partial<AppConfig>): AppConfig {
         sandbox: apns?.sandbox ?? DEFAULT_APNS.sandbox,
         deviceTokens: apns?.deviceTokens ?? [],
       },
+    },
+    kimi: {
+      apiKey: parsed.kimi?.apiKey ?? DEFAULT_CONFIG.kimi.apiKey,
     },
     defaultModelId: typeof parsed.defaultModelId === "string" && parsed.defaultModelId
       ? parsed.defaultModelId
@@ -103,7 +122,9 @@ export async function loadConfig(dataDir = getDataDir()): Promise<AppConfig> {
     console.error("[config] failed to read config.json, using defaults:", err);
     parsed = null;
   }
-  return parsed ? withDefaults(parsed) : structuredClone(DEFAULT_CONFIG);
+  const config = parsed ? withDefaults(parsed) : structuredClone(DEFAULT_CONFIG);
+  cachedKimiApiKey = config.kimi.apiKey;
+  return config;
 }
 
 export async function saveConfig(config: AppConfig, dataDir = getDataDir()): Promise<void> {
@@ -130,6 +151,7 @@ export function updateConfig(
     const config = parsed ? withDefaults(parsed) : structuredClone(DEFAULT_CONFIG);
     mutate(config);
     await saveConfig(config, dataDir);
+    cachedKimiApiKey = config.kimi.apiKey;
     return config;
   });
   updateQueue = task.catch(() => undefined); // keep the chain alive on failure

--- a/backend/src/state/config.ts
+++ b/backend/src/state/config.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, rename, mkdir } from "node:fs/promises";
+import { readFile, writeFile, rename, mkdir, chmod } from "node:fs/promises";
 import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { getDataDir } from "./state.js";
@@ -131,8 +131,11 @@ export async function saveConfig(config: AppConfig, dataDir = getDataDir()): Pro
   await mkdir(dataDir, { recursive: true });
   const target = configFilePath(dataDir);
   const tmp = join(dataDir, `config.${randomUUID()}.tmp`);
-  await writeFile(tmp, JSON.stringify(config, null, 2), "utf-8");
+  // Owner-only permissions: config.json holds credentials (Kimi API key,
+  // notification tokens). Same pattern as project-env.ts.
+  await writeFile(tmp, JSON.stringify(config, null, 2), { encoding: "utf-8", mode: 0o600 });
   await rename(tmp, target);
+  await chmod(target, 0o600).catch(() => {});
 }
 
 // Serializes read-modify-write cycles so concurrent writers (settings routes,

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -536,7 +536,8 @@ export interface Agent {
   description?: string;
   systemPrompt: string;
   modelId: string;
-  thinkingLevel: ThinkingLevel;
+  /** Absent for models with no thinking-level control (e.g. Kimi). */
+  thinkingLevel?: ThinkingLevel;
   readOnly: boolean;
   createdAt: string;
   updatedAt: string;

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -19,7 +19,7 @@ import {
   _clearActiveSessions,
 } from "../agents/agent-manager.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
-import { streamRoutes, broadcastToWorkspace, _getChannelsForTests, _getHubSocketsForTests, _tickHubLivenessForTests } from "./stream.js";
+import { streamRoutes, broadcastToWorkspace, completionProviderForMessage, _getChannelsForTests, _getHubSocketsForTests, _tickHubLivenessForTests } from "./stream.js";
 import {
   _setScriptStatusForTests,
   _clearAll as clearScripts,
@@ -2103,5 +2103,29 @@ describe("WS /ws/hub", () => {
     expect(ws.readyState).toBe(ws.OPEN);
 
     ws.close();
+  });
+});
+
+describe("completionProviderForMessage", () => {
+  it("maps claude model ids to the claude scan", () => {
+    expect(completionProviderForMessage("claude:opus-4-8", undefined)).toBe("claude");
+  });
+
+  it("maps codex model ids to the codex scan", () => {
+    expect(completionProviderForMessage("codex:gpt-5.5", undefined)).toBe("codex");
+  });
+
+  it("maps kimi model ids to the claude scan (kimi rides the claude CLI)", () => {
+    expect(completionProviderForMessage("kimi:k3", undefined)).toBe("claude");
+  });
+
+  it("prefers the session's locked provider over the message model", () => {
+    expect(completionProviderForMessage("claude:opus-4-8", "codex")).toBe("codex");
+    expect(completionProviderForMessage("codex:gpt-5.5", "kimi")).toBe("claude");
+  });
+
+  it("returns null for unknown or missing providers", () => {
+    expect(completionProviderForMessage(undefined, undefined)).toBeNull();
+    expect(completionProviderForMessage("mystery:model", undefined)).toBeNull();
   });
 });

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -115,12 +115,14 @@ function replaceFileMentionsWithAbsolutePaths(
   return resolved;
 }
 
-function completionProviderForMessage(
+export function completionProviderForMessage(
   modelId: string | undefined,
   lockedProvider: string | undefined,
 ): CompletionProvider | null {
   const provider = lockedProvider ?? modelId?.split(":")[0];
-  return provider === "claude" || provider === "codex" ? provider : null;
+  // Kimi rides the Claude CLI, so its aliases resolve via the claude scan.
+  if (provider === "claude" || provider === "kimi") return "claude";
+  return provider === "codex" ? "codex" : null;
 }
 
 // ── Sending helpers ─────────────────────────────────────────────────

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -94,7 +94,7 @@ export default function SettingsSidebar() {
           <SidebarSection label="Agents">
             <NavItem
               to="/settings/cli"
-              label="CLI"
+              label="Harness"
               icon={<Bot className="h-4 w-4" />}
               active={pathname === "/settings/cli"}
             />

--- a/frontend/src/components/chat/ProviderIcon.tsx
+++ b/frontend/src/components/chat/ProviderIcon.tsx
@@ -1,16 +1,17 @@
 import { cn } from "@/lib/utils";
 
 /** Providers we render a brand mark for today. Extend the map below to add more. */
-export type KnownProvider = "codex" | "claude";
+export type KnownProvider = "codex" | "claude" | "kimi";
 
 export function isKnownProvider(provider?: string): provider is KnownProvider {
-  return provider === "codex" || provider === "claude";
+  return provider === "codex" || provider === "claude" || provider === "kimi";
 }
 
 /** Brand color per provider, applied to the mark so it reads in its own hue. */
 const BRAND_COLOR: Record<string, string> = {
   codex: "#10A37F", // OpenAI green
   claude: "#D97757", // Anthropic clay
+  kimi: "#00B899", // Moonshot teal
 };
 
 /**
@@ -35,6 +36,14 @@ export function ProviderIcon({
     return (
       <svg className={cn("size-3.5", className)} style={style} viewBox="0 0 24 24" fill="currentColor">
         <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.985 5.985 0 0 0-3.998 2.9 6.046 6.046 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+      </svg>
+    );
+  }
+  if (provider === "kimi") {
+    // Crescent-moon mark for Kimi (Moonshot AI).
+    return (
+      <svg className={cn("size-3.5", className)} style={style} viewBox="0 0 24 24" fill="currentColor">
+        <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
       </svg>
     );
   }

--- a/frontend/src/hooks/useModels.ts
+++ b/frontend/src/hooks/useModels.ts
@@ -45,7 +45,10 @@ export async function refreshModelCatalog(): Promise<void> {
   catalogPromise = null;
   try {
     const data = await loadCatalog();
-    catalogListeners.forEach((listener) => listener(data));
+    // A newer refresh may have superseded this one; the cache always holds the
+    // current response (see loadCatalog), so prefer it.
+    const current = catalogCache ?? data;
+    catalogListeners.forEach((listener) => listener(current));
   } catch {
     // Keep whatever the hooks already show; the next mount retries.
   }
@@ -61,9 +64,19 @@ export function setCachedDefaultModelId(defaultModelId: string): void {
 
 function loadCatalog(): Promise<ModelCatalogResponse> {
   if (!catalogPromise) {
-    catalogPromise = api.get<ModelCatalogResponse>("/api/models")
-      .then((data) => { catalogCache = data; return data; })
-      .catch((err) => { catalogPromise = null; throw err; });
+    // Only the promise currently stored in catalogPromise may write the cache:
+    // a request superseded by refreshModelCatalog (which resets catalogPromise)
+    // must not overwrite the fresher response when it finally resolves.
+    const promise: Promise<ModelCatalogResponse> = api.get<ModelCatalogResponse>("/api/models")
+      .then((data) => {
+        if (catalogPromise === promise) catalogCache = data;
+        return data;
+      })
+      .catch((err) => {
+        if (catalogPromise === promise) catalogPromise = null;
+        throw err;
+      });
+    catalogPromise = promise;
   }
   return catalogPromise;
 }
@@ -109,10 +122,13 @@ export function useModels(lockedProvider?: string, preferredModelId?: string): U
     loadCatalog()
       .then((data) => {
         if (cancelled) return;
-        setModels(data.models);
-        setDefaultModelId(data.defaultModelId);
+        // If a refresh superseded this request, the cache already holds the
+        // fresher response — adopt it instead of our stale one.
+        const current = catalogCache ?? data;
+        setModels(current.models);
+        setDefaultModelId(current.defaultModelId);
         setSelectedModelId((prev) =>
-          prev || seedModelId(data, lockedProviderRef.current, preferredModelIdRef.current));
+          prev || seedModelId(current, lockedProviderRef.current, preferredModelIdRef.current));
         setIsLoading(false);
       })
       .catch(() => {

--- a/frontend/src/hooks/useModels.ts
+++ b/frontend/src/hooks/useModels.ts
@@ -27,10 +27,28 @@ const FALLBACK_CAPABILITIES: ProviderCapabilities = {
 let catalogCache: ModelCatalogResponse | null = null;
 let catalogPromise: Promise<ModelCatalogResponse> | null = null;
 
+/** Mounted useModels hooks, notified when refreshModelCatalog refetches. */
+const catalogListeners = new Set<(data: ModelCatalogResponse) => void>();
+
 /** Test-only: clear the module-level catalog cache so cases stay isolated. */
 export function __resetModelCatalogCacheForTests(): void {
   catalogCache = null;
   catalogPromise = null;
+}
+
+/** Drop the cache and refetch the catalog, pushing the result to every mounted
+ *  useModels hook. Used when the server-side catalog changes at runtime (e.g.
+ *  saving a Kimi API key adds/removes its models). Keeps the old catalog on
+ *  fetch failure. */
+export async function refreshModelCatalog(): Promise<void> {
+  catalogCache = null;
+  catalogPromise = null;
+  try {
+    const data = await loadCatalog();
+    catalogListeners.forEach((listener) => listener(data));
+  } catch {
+    // Keep whatever the hooks already show; the next mount retries.
+  }
 }
 
 /** Settings saved a new global default: patch the cached catalog so composers
@@ -102,6 +120,22 @@ export function useModels(lockedProvider?: string, preferredModelId?: string): U
         setIsLoading(false);
       });
     return () => { cancelled = true; };
+  }, []);
+
+  // Follow runtime catalog refreshes (refreshModelCatalog) while mounted.
+  useEffect(() => {
+    const listener = (data: ModelCatalogResponse) => {
+      setModels(data.models);
+      setDefaultModelId(data.defaultModelId);
+      // Keep the current selection when it survives the refresh; reseed otherwise.
+      setSelectedModelId((prev) =>
+        prev && data.models.some((m) => m.id === prev)
+          ? prev
+          : seedModelId(data, lockedProviderRef.current, preferredModelIdRef.current));
+      setIsLoading(false);
+    };
+    catalogListeners.add(listener);
+    return () => { catalogListeners.delete(listener); };
   }, []);
 
   const selectedModel = models.find((m) => m.id === selectedModelId);

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -2,8 +2,18 @@ import { useQuery } from "@tanstack/react-query";
 import { Loader2, CheckCircle2, ArrowUpCircle, CircleSlash } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { ProviderIcon, type KnownProvider } from "@/components/chat/ProviderIcon";
 import { api } from "@/hooks/useApi";
 import { cn } from "@/lib/utils";
+
+/** Model providers that run on each harness (the Claude CLI also runs Kimi sessions). */
+const HARNESS_PROVIDERS: Record<string, { id: KnownProvider; label: string }[]> = {
+  claude: [
+    { id: "claude", label: "Claude" },
+    { id: "kimi", label: "Kimi" },
+  ],
+  codex: [{ id: "codex", label: "Codex" }],
+};
 
 interface AgentStatusEntry {
   id: string;
@@ -27,13 +37,13 @@ export default function AgentSettings() {
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
       <SettingsHeader>
-        <h1 className="text-sm font-medium">CLI</h1>
+        <h1 className="text-sm font-medium">Harness</h1>
       </SettingsHeader>
 
       <CenterCard scroll>
       <div className="max-w-2xl space-y-4 px-4 py-5">
         <p className="text-xs text-muted-foreground">
-          Agent CLI tools detected on this server.
+          Agent harnesses detected on this server.
         </p>
 
         {isLoading && (
@@ -75,7 +85,23 @@ function AgentCard({ agent }: { agent: AgentStatusEntry }) {
             </p>
           )}
         </div>
-        <StatusBadge agent={agent} />
+        <div className="flex flex-col items-end gap-2">
+          <StatusBadge agent={agent} />
+          {HARNESS_PROVIDERS[agent.id] && (
+            <div className="flex flex-wrap items-center justify-end gap-1.5">
+              {HARNESS_PROVIDERS[agent.id].map((provider) => (
+                <span
+                  key={provider.id}
+                  title={`Runs ${provider.label} sessions`}
+                  className="inline-flex items-center gap-1.5 rounded-full border border-border/50 bg-muted/30 px-2 py-0.5 text-[11px] font-medium text-muted-foreground"
+                >
+                  <ProviderIcon provider={provider.id} colored className="size-3" />
+                  {provider.label}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
       </div>
     </section>
   );

--- a/frontend/src/pages/settings/ModelsSettings.tsx
+++ b/frontend/src/pages/settings/ModelsSettings.tsx
@@ -156,7 +156,7 @@ function KimiSection() {
         <p className="mt-1 text-xs text-muted-foreground">
           API key from the{" "}
           <a
-            href="https://www.kimi.com/code"
+            href="https://www.kimi.com/code/console"
             target="_blank"
             rel="noreferrer"
             className="underline hover:text-foreground"

--- a/frontend/src/pages/settings/ModelsSettings.tsx
+++ b/frontend/src/pages/settings/ModelsSettings.tsx
@@ -1,11 +1,12 @@
-import { useMemo, useState } from "react";
-import { Check, Loader2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Check, Eye, EyeOff, Loader2, Save } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
 import { ProviderIcon } from "@/components/chat/ProviderIcon";
 import { groupModelsByProvider } from "@/components/chat/ModelSelector";
+import { Input } from "@/components/ui/input";
 import { api } from "@/hooks/useApi";
-import { useModels, setCachedDefaultModelId } from "@/hooks/useModels";
+import { useModels, refreshModelCatalog, setCachedDefaultModelId } from "@/hooks/useModels";
 import { cn } from "@/lib/utils";
 
 export default function ModelsSettings() {
@@ -102,8 +103,137 @@ export default function ModelsSettings() {
             )}
           </div>
         </section>
+
+        <KimiSection />
       </div>
       </CenterCard>
     </div>
+  );
+}
+
+function KimiSection() {
+  const [apiKey, setApiKey] = useState("");
+  const [showKey, setShowKey] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<"saved" | "error" | null>(null);
+  // Gate the form on the initial GET: rendering an empty input over a stored
+  // key would let a single Save silently wipe the credential.
+  const [loadState, setLoadState] = useState<"loading" | "loaded" | "error">("loading");
+
+  useEffect(() => {
+    let cancelled = false;
+    api.get<{ apiKey: string }>("/api/settings/kimi")
+      .then((data) => {
+        if (cancelled) return;
+        setApiKey(data.apiKey ?? "");
+        setLoadState("loaded");
+      })
+      .catch(() => { if (!cancelled) setLoadState("error"); });
+    return () => { cancelled = true; };
+  }, []);
+
+  const save = async () => {
+    setSaving(true);
+    setFeedback(null);
+    try {
+      const saved = await api.put<{ apiKey: string }>("/api/settings/kimi", { apiKey });
+      setApiKey(saved.apiKey);
+      setFeedback("saved");
+      // The key gates the Kimi models server-side: refetch so they
+      // appear/disappear without a reload.
+      await refreshModelCatalog();
+    } catch {
+      setFeedback("error");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section>
+      <div className="rounded-lg border border-border/50 bg-card/50 p-5">
+        <h2 className="text-sm font-medium text-foreground">Kimi</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          API key from the{" "}
+          <a
+            href="https://www.kimi.com/code"
+            target="_blank"
+            rel="noreferrer"
+            className="underline hover:text-foreground"
+          >
+            Kimi Code console
+          </a>
+          , used to enable the Kimi provider.
+        </p>
+
+        {loadState === "loading" && (
+          <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading saved key…
+          </div>
+        )}
+
+        {loadState === "error" && (
+          <p className="py-4 text-xs text-destructive">
+            Could not load the saved API key. Reload the page to try again.
+          </p>
+        )}
+
+        {loadState === "loaded" && (
+          <>
+            <div className="mt-4">
+              <label htmlFor="kimi-api-key" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+                Kimi API key
+              </label>
+              <div className="relative">
+                <Input
+                  id="kimi-api-key"
+                  type={showKey ? "text" : "password"}
+                  value={apiKey}
+                  onChange={(e) => { setApiKey(e.target.value); setFeedback(null); }}
+                  placeholder="sk-..."
+                  className="pr-9 font-mono text-xs"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowKey(!showKey)}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
+                >
+                  {showKey
+                    ? <EyeOff className="h-3.5 w-3.5" />
+                    : <Eye className="h-3.5 w-3.5" />}
+                </button>
+              </div>
+            </div>
+
+            <div className="mt-4 flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void save()}
+                disabled={saving}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+                  saving && "pointer-events-none opacity-60",
+                )}
+              >
+                {saving
+                  ? <Loader2 className="h-3 w-3 animate-spin" />
+                  : <Save className="h-3 w-3" />}
+                Save
+              </button>
+
+              {feedback && (
+                <span className={cn(
+                  "text-xs font-medium",
+                  feedback === "saved" ? "text-success-foreground" : "text-destructive",
+                )}>
+                  {feedback === "saved" ? "Saved" : "Failed to save"}
+                </span>
+              )}
+            </div>
+          </>
+        )}
+      </div>
+    </section>
   );
 }

--- a/frontend/src/pages/settings/TeamSettings.tsx
+++ b/frontend/src/pages/settings/TeamSettings.tsx
@@ -24,15 +24,14 @@ import {
   SettingsResourceListItem,
 } from "@/components/settings/SettingsResourceList";
 import { cn } from "@/lib/utils";
-import { useQuery } from "@tanstack/react-query";
-import { api } from "@/hooks/useApi";
 import {
   useAgents,
   useCreateAgent,
   useUpdateAgent,
   useDeleteAgent,
 } from "@/hooks/useAgents";
-import type { Agent, ModelCatalogEntry, ModelCatalogResponse, ThinkingLevel } from "@/types";
+import { useModels } from "@/hooks/useModels";
+import type { Agent, ModelCatalogEntry, ThinkingLevel } from "@/types";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
@@ -45,7 +44,7 @@ type Selection =
 
 export default function TeamSettings() {
   const { data: agents, isLoading } = useAgents();
-  const { data: catalog } = useModelCatalog();
+  const { models, defaultModelId } = useModels();
   const [selection, setSelection] = useState<Selection>(null);
   const [deleteTarget, setDeleteTarget] = useState<Agent | null>(null);
 
@@ -97,8 +96,8 @@ export default function TeamSettings() {
           <RightPanel
             selection={selection}
             selectedAgent={selectedAgent}
-            models={catalog?.models ?? []}
-            defaultModelId={catalog?.defaultModelId ?? ""}
+            models={models}
+            defaultModelId={defaultModelId}
             onDelete={handleDelete}
             onCreated={handleCreated}
             onCancel={() => setSelection(null)}
@@ -229,15 +228,16 @@ function FormFields({
   setSystemPrompt: (v: string) => void;
   modelId: string;
   setModelId: (v: string) => void;
-  thinkingLevel: ThinkingLevel;
-  setThinkingLevel: (v: ThinkingLevel) => void;
+  thinkingLevel: ThinkingLevel | undefined;
+  setThinkingLevel: (v: ThinkingLevel | undefined) => void;
   models: ModelCatalogEntry[];
   readOnly: boolean;
   setReadOnly: (v: boolean) => void;
 }) {
   const selectedModel = modelForId(models, modelId);
   const resolvedThinkingLevel = resolveThinkingLevel(selectedModel, thinkingLevel);
-  const thinkingLevels = selectedModel?.capabilities.thinkingLevels ?? [resolvedThinkingLevel];
+  const thinkingLevels = selectedModel?.capabilities.thinkingLevels
+    ?? (resolvedThinkingLevel ? [resolvedThinkingLevel] : []);
 
   useEffect(() => {
     if (resolvedThinkingLevel !== thinkingLevel) {
@@ -262,13 +262,16 @@ function FormFields({
         </Field>
       </div>
 
-      <Field label="Thinking">
-        <ThinkingLevelChips
-          value={resolvedThinkingLevel}
-          onChange={setThinkingLevel}
-          levels={thinkingLevels}
-        />
-      </Field>
+      {/* Hidden for models with no thinking-level control (e.g. Kimi). */}
+      {resolvedThinkingLevel && thinkingLevels.length > 0 && (
+        <Field label="Thinking">
+          <ThinkingLevelChips
+            value={resolvedThinkingLevel}
+            onChange={setThinkingLevel}
+            levels={thinkingLevels}
+          />
+        </Field>
+      )}
 
       {/* Description */}
       <Field label="Description (optional)">
@@ -347,7 +350,7 @@ function AgentDetail({
     modelId !== agent.modelId ||
     resolvedThinkingLevel !== agent.thinkingLevel ||
     readOnly !== agent.readOnly;
-  const isValid = name.trim() && systemPrompt.trim() && modelId && resolvedThinkingLevel;
+  const isValid = name.trim() && systemPrompt.trim() && modelId;
 
   const handleSave = async () => {
     if (!isValid) return;
@@ -357,7 +360,9 @@ function AgentDetail({
       description: description.trim(),
       systemPrompt: systemPrompt.trim(),
       modelId,
-      thinkingLevel: resolvedThinkingLevel,
+      // Omitted for models with no thinking-level control (e.g. Kimi); the
+      // backend rejects any level supplied for them.
+      ...(resolvedThinkingLevel && { thinkingLevel: resolvedThinkingLevel }),
       readOnly,
     });
   };
@@ -425,13 +430,13 @@ function CreateAgentForm({
   const [description, setDescription] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
   const [modelId, setModelId] = useState("");
-  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel>("high");
+  const [thinkingLevel, setThinkingLevel] = useState<ThinkingLevel | undefined>("high");
   const [readOnly, setReadOnly] = useState(false);
 
   const resolvedModelId = modelId || defaultModelId;
   const resolvedThinkingLevel = resolveThinkingLevel(modelForId(models, resolvedModelId), thinkingLevel);
 
-  const isValid = name.trim() && systemPrompt.trim() && resolvedModelId && resolvedThinkingLevel;
+  const isValid = name.trim() && systemPrompt.trim() && resolvedModelId;
 
   const handleSubmit = async () => {
     if (!isValid) return;
@@ -440,7 +445,8 @@ function CreateAgentForm({
       ...(description.trim() && { description: description.trim() }),
       systemPrompt: systemPrompt.trim(),
       modelId: resolvedModelId,
-      thinkingLevel: resolvedThinkingLevel,
+      // Omitted for models with no thinking-level control (e.g. Kimi).
+      ...(resolvedThinkingLevel && { thinkingLevel: resolvedThinkingLevel }),
       readOnly,
     });
     onCreated(result.id);
@@ -533,18 +539,6 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 }
 
 // ── Model catalog + select ─────────────────────────────────────────────
-// Local to this page: it is the only place that picks a model now that the
-// automation dialog selects an agent (which owns its model) instead.
-
-function useModelCatalog() {
-  return useQuery({
-    queryKey: ["models"],
-    queryFn: () => api.get<ModelCatalogResponse>("/api/models"),
-    staleTime: 5 * 60_000,
-    gcTime: 10 * 60_000,
-  });
-}
-
 function ModelSelect({
   value,
   onChange,
@@ -612,11 +606,13 @@ function modelForId(models: ModelCatalogEntry[], modelId: string): ModelCatalogE
 
 function resolveThinkingLevel(
   model: ModelCatalogEntry | undefined,
-  thinkingLevel: ThinkingLevel,
-): ThinkingLevel {
+  thinkingLevel: ThinkingLevel | undefined,
+): ThinkingLevel | undefined {
   const levels = model?.capabilities.thinkingLevels;
-  if (!levels || levels.length === 0 || levels.includes(thinkingLevel)) return thinkingLevel;
-  return levels.includes("high") ? "high" : levels[0] ?? "high";
+  if (!levels) return thinkingLevel; // model not in catalog: keep as stored
+  if (levels.length === 0) return undefined; // no thinking-level control (e.g. Kimi)
+  if (thinkingLevel && levels.includes(thinkingLevel)) return thinkingLevel;
+  return levels.includes("high") ? "high" : levels[0];
 }
 
 function thinkingLevelLabel(level: ThinkingLevel): string {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -536,7 +536,8 @@ export interface Agent {
   description?: string;
   systemPrompt: string;
   modelId: string;
-  thinkingLevel: ThinkingLevel;
+  /** Absent for models with no thinking-level control (e.g. Kimi). */
+  thinkingLevel?: ThinkingLevel;
   readOnly: boolean;
   createdAt: string;
   updatedAt: string;

--- a/frontend/tests/components/SettingsSidebar.test.tsx
+++ b/frontend/tests/components/SettingsSidebar.test.tsx
@@ -171,7 +171,7 @@ describe("SettingsSidebar", () => {
       </MemoryRouter>,
     );
 
-    await user.click(screen.getByRole("link", { name: /CLI/i }));
+    await user.click(screen.getByRole("link", { name: /Harness/i }));
     await waitFor(() => {
       expect(screen.getByText("CLI settings")).toBeInTheDocument();
     });
@@ -227,7 +227,7 @@ describe("SettingsSidebar", () => {
     );
 
     await screen.findByText("CLI settings");
-    expect(screen.getByRole("link", { name: /CLI/i })).toHaveClass("bg-primary/10");
+    expect(screen.getByRole("link", { name: /Harness/i })).toHaveClass("bg-primary/10");
   });
 
   it("groups agent settings in their own section", () => {
@@ -243,7 +243,7 @@ describe("SettingsSidebar", () => {
 
     expect(screen.getByRole("heading", { name: "General" })).toBeInTheDocument();
     expect(screen.getByRole("heading", { name: "Agents" })).toBeInTheDocument();
-    expect(screen.getByRole("link", { name: /CLI/i })).toHaveAttribute("href", "/settings/cli");
+    expect(screen.getByRole("link", { name: /Harness/i })).toHaveAttribute("href", "/settings/cli");
     expect(screen.getByRole("link", { name: /Subagents/i })).toHaveAttribute("href", "/settings/subagents");
     expect(screen.getByRole("link", { name: /Instructions/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Prompt/i })).toBeInTheDocument();

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -288,6 +288,42 @@ describe("useModels", () => {
     expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
   });
 
+  it("a stale in-flight initial load cannot overwrite a completed refresh", async () => {
+    let resolveInitial!: (value: ModelCatalogResponse) => void;
+    mockApi.get.mockReturnValueOnce(new Promise((resolve) => { resolveInitial = resolve; }));
+    const { result } = renderHook(() => useModels());
+    expect(result.current.isLoading).toBe(true);
+
+    // The Kimi key was saved while the slow initial request was in flight:
+    // the refresh fetches a newer catalog and completes first.
+    const refreshed: ModelCatalogResponse = {
+      ...MOCK_CATALOG,
+      models: [
+        ...MOCK_CATALOG.models,
+        {
+          id: "kimi:k3",
+          label: "K3",
+          provider: "kimi",
+          providerLabel: "Kimi",
+          capabilities: { thinkingLevels: [], planMode: true, blockingTools: true, completions: true, goals: false },
+        },
+      ],
+    };
+    mockApi.get.mockResolvedValue(refreshed);
+    await act(() => refreshModelCatalog());
+    expect(result.current.models).toHaveLength(4);
+
+    // The superseded initial request finally resolves with the stale catalog.
+    await act(async () => { resolveInitial(MOCK_CATALOG); });
+
+    // The fresh catalog wins in the mounted hook…
+    expect(result.current.models).toHaveLength(4);
+    // …and in the cache later mounts seed from (no third fetch).
+    const second = renderHook(() => useModels());
+    expect(second.result.current.models).toHaveLength(4);
+    expect(mockApi.get).toHaveBeenCalledTimes(2);
+  });
+
   it("stops receiving catalog refreshes after unmount", async () => {
     mockApi.get.mockResolvedValue(MOCK_CATALOG);
     const { result, unmount } = renderHook(() => useModels());

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, waitFor, act } from "@testing-library/react";
-import { useModels, __resetModelCatalogCacheForTests } from "@/hooks/useModels";
+import { useModels, refreshModelCatalog, __resetModelCatalogCacheForTests } from "@/hooks/useModels";
 import { api } from "@/hooks/useApi";
 import type { ModelCatalogResponse } from "@/types";
 
@@ -235,6 +235,72 @@ describe("useModels", () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
+  it("refreshModelCatalog pushes the refetched catalog to mounted hooks, keeping a surviving selection", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const { result } = renderHook(() => useModels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setSelectedModelId("claude:sonnet-4-6");
+    });
+
+    const refreshed: ModelCatalogResponse = {
+      ...MOCK_CATALOG,
+      models: [
+        ...MOCK_CATALOG.models,
+        {
+          id: "kimi:k3",
+          label: "K3",
+          provider: "kimi",
+          providerLabel: "Kimi",
+          isDefault: true,
+          capabilities: { thinkingLevels: [], planMode: true, blockingTools: true, completions: true, goals: false },
+        },
+      ],
+    };
+    mockApi.get.mockResolvedValue(refreshed);
+    await act(() => refreshModelCatalog());
+
+    expect(mockApi.get).toHaveBeenCalledTimes(2);
+    expect(result.current.models).toHaveLength(4);
+    // The previous selection survives the refresh, so it is kept.
+    expect(result.current.selectedModelId).toBe("claude:sonnet-4-6");
+  });
+
+  it("refreshModelCatalog reseeds the selection when it vanished from the catalog", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const { result } = renderHook(() => useModels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.setSelectedModelId("claude:sonnet-4-6");
+    });
+
+    const refreshed: ModelCatalogResponse = {
+      ...MOCK_CATALOG,
+      models: MOCK_CATALOG.models.filter((m) => m.id !== "claude:sonnet-4-6"),
+    };
+    mockApi.get.mockResolvedValue(refreshed);
+    await act(() => refreshModelCatalog());
+
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
+  it("stops receiving catalog refreshes after unmount", async () => {
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    const { result, unmount } = renderHook(() => useModels());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    unmount();
+
+    const refreshed: ModelCatalogResponse = { ...MOCK_CATALOG, models: [] };
+    mockApi.get.mockResolvedValue(refreshed);
+    await act(() => refreshModelCatalog());
+
+    // The unmounted hook kept its last render; no update (or React warning) fired.
+    expect(result.current.models).toHaveLength(3);
   });
 
   it("seeds synchronously from the cache on a remount (no second fetch)", async () => {

--- a/frontend/tests/pages/AgentSettings.test.tsx
+++ b/frontend/tests/pages/AgentSettings.test.tsx
@@ -36,7 +36,7 @@ describe("AgentSettings", () => {
   it("renders heading with drag region", async () => {
     mocks.get.mockResolvedValueOnce({ agents: [] });
     renderPage();
-    const heading = await screen.findByRole("heading", { name: "CLI" });
+    const heading = await screen.findByRole("heading", { name: "Harness" });
     expect(heading.closest("div")).toHaveAttribute("data-tauri-drag-region");
   });
 
@@ -50,7 +50,7 @@ describe("AgentSettings", () => {
     mocks.get.mockResolvedValueOnce({ agents: [] });
     renderPage();
 
-    await screen.findByRole("heading", { name: "CLI" });
+    await screen.findByRole("heading", { name: "Harness" });
     expect(mocks.get).toHaveBeenCalledWith("/api/settings/cli");
   });
 
@@ -84,7 +84,7 @@ describe("AgentSettings", () => {
       ],
     });
     renderPage();
-    expect(await screen.findByText("Codex")).toBeInTheDocument();
+    expect(await screen.findByRole("heading", { name: "Codex" })).toBeInTheDocument();
     expect(screen.getByText("Not installed")).toBeInTheDocument();
   });
 
@@ -123,8 +123,23 @@ describe("AgentSettings", () => {
       ],
     });
     renderPage();
-    await screen.findByText("Codex");
+    await screen.findByRole("heading", { name: "Codex" });
     expect(screen.queryByText(/^v/)).not.toBeInTheDocument();
+  });
+
+  it("shows provider pills for the models each harness runs", async () => {
+    mocks.get.mockResolvedValueOnce({
+      agents: [
+        { id: "claude", label: "Claude Code", installed: true, version: "1.0.35", latestVersion: "1.0.35", updateAvailable: false },
+        { id: "codex", label: "Codex", installed: true, version: "0.1.2", latestVersion: "0.1.2", updateAvailable: false },
+      ],
+    });
+    renderPage();
+
+    await screen.findByText("Claude Code");
+    expect(screen.getByTitle("Runs Claude sessions")).toBeInTheDocument();
+    expect(screen.getByTitle("Runs Kimi sessions")).toBeInTheDocument();
+    expect(screen.getByTitle("Runs Codex sessions")).toBeInTheDocument();
   });
 
   it("renders multiple agents", async () => {
@@ -136,6 +151,6 @@ describe("AgentSettings", () => {
     });
     renderPage();
     expect(await screen.findByText("Claude Code")).toBeInTheDocument();
-    expect(screen.getByText("Codex")).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Codex" })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/ModelsSettings.test.tsx
+++ b/frontend/tests/pages/ModelsSettings.test.tsx
@@ -37,6 +37,12 @@ const MOCK_CATALOG: ModelCatalogResponse = {
   defaultModelId: "codex:gpt-5.5",
 };
 
+function mockApiGet(catalog: unknown, kimi: { apiKey: string } = { apiKey: "" }) {
+  mocks.get.mockImplementation((url: string) =>
+    url === "/api/settings/kimi" ? Promise.resolve(kimi) : Promise.resolve(catalog),
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   __resetModelCatalogCacheForTests();
@@ -44,7 +50,7 @@ beforeEach(() => {
 
 describe("ModelsSettings", () => {
   it("renders models grouped by provider with the current default checked", async () => {
-    mocks.get.mockResolvedValue(MOCK_CATALOG);
+    mockApiGet(MOCK_CATALOG);
     render(<ModelsSettings />);
 
     expect(await screen.findByText("Claude Code")).toBeInTheDocument();
@@ -54,7 +60,7 @@ describe("ModelsSettings", () => {
   });
 
   it("saves the clicked model as the new default", async () => {
-    mocks.get.mockResolvedValue(MOCK_CATALOG);
+    mockApiGet(MOCK_CATALOG);
     mocks.put.mockResolvedValue({ defaultModelId: "claude:sonnet-5" });
     render(<ModelsSettings />);
 
@@ -67,7 +73,7 @@ describe("ModelsSettings", () => {
   });
 
   it("reverts the selection and shows an error when saving fails", async () => {
-    mocks.get.mockResolvedValue(MOCK_CATALOG);
+    mockApiGet(MOCK_CATALOG);
     mocks.put.mockRejectedValue(new Error("boom"));
     render(<ModelsSettings />);
 
@@ -79,9 +85,103 @@ describe("ModelsSettings", () => {
   });
 
   it("shows an empty state when no provider CLI is available", async () => {
-    mocks.get.mockResolvedValue({ models: [], defaultModelId: "" });
+    mockApiGet({ models: [], defaultModelId: "" });
     render(<ModelsSettings />);
 
     expect(await screen.findByText(/No agent CLI detected/)).toBeInTheDocument();
+  });
+
+  it("loads the saved Kimi API key into the input", async () => {
+    mockApiGet(MOCK_CATALOG, { apiKey: "sk-kimi-key" });
+    render(<ModelsSettings />);
+
+    await waitFor(() =>
+      expect(screen.getByLabelText("Kimi API key")).toHaveValue("sk-kimi-key"),
+    );
+  });
+
+  it("saves the Kimi API key and shows confirmation", async () => {
+    mockApiGet(MOCK_CATALOG);
+    mocks.put.mockResolvedValue({ apiKey: "sk-new-key" });
+    render(<ModelsSettings />);
+
+    await userEvent.type(await screen.findByLabelText("Kimi API key"), "sk-new-key");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(mocks.put).toHaveBeenCalledWith("/api/settings/kimi", { apiKey: "sk-new-key" });
+    expect(await screen.findByText("Saved")).toBeInTheDocument();
+  });
+
+  it("refetches the model catalog after saving the Kimi key", async () => {
+    let catalog: ModelCatalogResponse = MOCK_CATALOG;
+    mocks.get.mockImplementation((url: string) =>
+      url === "/api/settings/kimi" ? Promise.resolve({ apiKey: "" }) : Promise.resolve(catalog),
+    );
+    // The saved key enables Kimi server-side: the refetched catalog includes it.
+    mocks.put.mockImplementation(async () => {
+      catalog = {
+        ...MOCK_CATALOG,
+        models: [
+          ...MOCK_CATALOG.models,
+          { id: "kimi:k3", label: "K3", provider: "kimi", providerLabel: "Kimi", capabilities: { ...CAPABILITIES, thinkingLevels: [] } },
+        ],
+      };
+      return { apiKey: "sk-new-key" };
+    });
+    render(<ModelsSettings />);
+
+    expect(await screen.findByText("Claude Code")).toBeInTheDocument();
+    expect(screen.queryByRole("radio", { name: "K3" })).not.toBeInTheDocument();
+
+    await userEvent.type(await screen.findByLabelText("Kimi API key"), "sk-new-key");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByRole("radio", { name: "K3" })).toBeInTheDocument();
+    const catalogFetches = mocks.get.mock.calls.filter(([url]) => url === "/api/models");
+    expect(catalogFetches).toHaveLength(2);
+  });
+
+  it("shows an error when saving the Kimi API key fails", async () => {
+    mockApiGet(MOCK_CATALOG);
+    mocks.put.mockRejectedValue(new Error("boom"));
+    render(<ModelsSettings />);
+
+    await userEvent.type(await screen.findByLabelText("Kimi API key"), "sk-new-key");
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    expect(await screen.findByText("Failed to save")).toBeInTheDocument();
+  });
+
+  it("hides the Kimi form until the saved key has loaded", async () => {
+    let resolveKimi!: (value: { apiKey: string }) => void;
+    mocks.get.mockImplementation((url: string) =>
+      url === "/api/settings/kimi"
+        ? new Promise<{ apiKey: string }>((resolve) => { resolveKimi = resolve; })
+        : Promise.resolve(MOCK_CATALOG),
+    );
+    render(<ModelsSettings />);
+
+    expect(await screen.findByText("Loading saved key…")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Kimi API key")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+
+    resolveKimi({ apiKey: "sk-stored" });
+
+    expect(await screen.findByLabelText("Kimi API key")).toHaveValue("sk-stored");
+    expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+  });
+
+  it("does not offer Save (which could wipe the stored key) when the load fails", async () => {
+    mocks.get.mockImplementation((url: string) =>
+      url === "/api/settings/kimi"
+        ? Promise.reject(new Error("boom"))
+        : Promise.resolve(MOCK_CATALOG),
+    );
+    render(<ModelsSettings />);
+
+    expect(await screen.findByText(/Could not load the saved API key/)).toBeInTheDocument();
+    expect(screen.queryByLabelText("Kimi API key")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Save" })).not.toBeInTheDocument();
+    expect(mocks.put).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/pages/TeamSettings.test.tsx
+++ b/frontend/tests/pages/TeamSettings.test.tsx
@@ -1,8 +1,9 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import TeamSettings from "@/pages/settings/TeamSettings";
+import { __resetModelCatalogCacheForTests, refreshModelCatalog } from "@/hooks/useModels";
 import type { Agent, ModelCatalogResponse } from "@/types";
 
 const mocks = vi.hoisted(() => ({
@@ -81,6 +82,19 @@ const catalog: ModelCatalogResponse = {
         goals: false,
       },
     },
+    {
+      id: "kimi:k3",
+      label: "K3",
+      provider: "kimi",
+      providerLabel: "Kimi",
+      capabilities: {
+        thinkingLevels: [],
+        planMode: true,
+        blockingTools: true,
+        completions: true,
+        goals: false,
+      },
+    },
   ],
 };
 
@@ -98,13 +112,16 @@ function makeAgent(overrides: Partial<Agent> = {}): Agent {
   };
 }
 
-function renderPage() {
-  const queryClient = new QueryClient({
+function createQueryClient() {
+  return new QueryClient({
     defaultOptions: {
       queries: { retry: false },
       mutations: { retry: false },
     },
   });
+}
+
+function renderPage(queryClient = createQueryClient()) {
   return render(
     <QueryClientProvider client={queryClient}>
       <TeamSettings />
@@ -115,6 +132,7 @@ function renderPage() {
 describe("TeamSettings", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    __resetModelCatalogCacheForTests();
     mocks.apiGet.mockResolvedValue(catalog);
     mocks.useAgents.mockReturnValue({ data: [], isLoading: false });
     mocks.useCreateAgent.mockReturnValue({
@@ -180,5 +198,51 @@ describe("TeamSettings", () => {
         }),
       );
     });
+  });
+
+  it("hides the thinking control and omits thinkingLevel for a level-less model (kimi)", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Add Agent" }));
+    await user.type(screen.getByPlaceholderText("e.g. Code Auditor"), "Kimi Agent");
+    await user.type(screen.getByPlaceholderText("You are a code auditor..."), "Do things.");
+
+    expect(screen.getByText("Thinking")).toBeInTheDocument();
+    await user.selectOptions(screen.getByRole("combobox"), "kimi:k3");
+    await waitFor(() => expect(screen.queryByText("Thinking")).not.toBeInTheDocument());
+
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(mocks.createMutateAsync).toHaveBeenCalledWith({
+        name: "Kimi Agent",
+        systemPrompt: "Do things.",
+        modelId: "kimi:k3",
+        readOnly: false,
+      });
+    });
+    expect(mocks.createMutateAsync.mock.calls[0][0]).not.toHaveProperty("thinkingLevel");
+  });
+
+  it("uses the refreshed model catalog after the Kimi key changes", async () => {
+    const withoutKimi: ModelCatalogResponse = {
+      ...catalog,
+      models: catalog.models.filter((model) => model.provider !== "kimi"),
+    };
+    mocks.apiGet.mockResolvedValueOnce(withoutKimi).mockResolvedValueOnce(catalog);
+    const queryClient = createQueryClient();
+
+    const firstRender = renderPage(queryClient);
+    await userEvent.click(screen.getByRole("button", { name: "Add Agent" }));
+    await screen.findByRole("option", { name: "Sonnet 4.6 (Claude Code)" });
+    expect(screen.queryByRole("option", { name: "K3 (Kimi)" })).not.toBeInTheDocument();
+    firstRender.unmount();
+
+    await act(() => refreshModelCatalog());
+    renderPage(queryClient);
+    await userEvent.click(screen.getByRole("button", { name: "Add Agent" }));
+
+    expect(screen.getByRole("option", { name: "K3 (Kimi)" })).toBeInTheDocument();
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -287,7 +287,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1318,7 +1317,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1359,7 +1357,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -1543,6 +1540,28 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3440,7 +3459,6 @@
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -7891,7 +7909,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -8266,7 +8285,6 @@
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
       "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "*"
       }
@@ -8293,7 +8311,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8304,7 +8321,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -8391,7 +8407,6 @@
       "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.0",
         "@typescript-eslint/types": "8.56.0",
@@ -8815,7 +8830,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9180,7 +9194,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9395,7 +9408,6 @@
       "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.1.tgz",
       "integrity": "sha512-f0yv5CPKaFxfsPTBzX7vGuim4oIC1/gcS7LUGdBSwl2dU6+FON6LVUksdOo1qJjoUvXNn45urgh8C+0a24pACQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@chevrotain/cst-dts-gen": "11.1.1",
         "@chevrotain/gast": "11.1.1",
@@ -9861,7 +9873,6 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
       "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10"
       }
@@ -10271,7 +10282,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -10578,7 +10588,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.1",
@@ -10851,7 +10862,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -12177,7 +12187,6 @@
       "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -12708,7 +12717,6 @@
       "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.31",
         "@asamuzakjp/dom-selector": "^6.8.1",
@@ -13391,6 +13399,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -13828,7 +13837,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -14465,8 +14473,7 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -15443,6 +15450,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15458,6 +15466,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15792,7 +15801,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15802,7 +15810,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15815,7 +15822,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -17569,7 +17577,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -17653,7 +17660,6 @@
       "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
       "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -17983,7 +17989,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -18450,7 +18455,6 @@
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -18569,7 +18573,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }


### PR DESCRIPTION
## Summary

Adds **Kimi** (Moonshot) as a third provider. Kimi rides the existing Claude Code harness: `KimiProvider extends ClaudeProvider` with env-only overrides pointing the CLI at Moonshot's Anthropic-compatible **Kimi Code subscription endpoint** (`https://api.kimi.com/coding/`). No new runner, no new stream parser.

- **Models**: `k3` (default, 256K), `k3-1m` (`k3[1m]`, 1M context — Allegretto tier+), `kimi-for-coding` (256K). No thinking-level control (K3 reasoning is server-locked to max), no fast mode; plan mode and completions work.
- **API key**: stored in `config.json` (Telegram-token pattern) via a new field in Settings → Models; `config.json` is now written `0600`. The catalog gates Kimi dynamically on key presence — models appear in the picker the moment the key is saved, no restart.
- **Completions**: `/` and `@` aliases map to the claude scan on both the REST picker and the WS send path (Kimi sessions genuinely use `~/.claude` skills/agents through the shared sync).
- **Team agents**: `thinkingLevel` is now optional for models without thinking levels, so Team agents can run on Kimi models (#352). `KimiProvider.buildArgs` drops any leaked level so `--effort` is never emitted.
- **Settings polish**: "CLI" page renamed **Harness**, cards show provider pills (Claude Code runs both Claude and Kimi sessions); Kimi is excluded from the harness list (no binary of its own).
- The CLI's benign "claude.ai connectors are disabled" stderr notice is filtered from chat errors (expected when we inject `ANTHROPIC_API_KEY`).

Closes #349, #350, #351, #352.

## Quality gate

- Multi-agent adversarial review (5 lenses, 2 verifiers per finding): 3 confirmed findings, all fixed (WS alias mapping, settings key-wipe hazard on slow/failed load, useModels listener coverage).
- External audit follow-up: config file permissions, catalog stale-response race, misleading CLI listing, #352 — all fixed. Dependency advisories deliberately deferred to a separate PR.
- Checks: root lint + typecheck clean; backend 1659 tests, frontend 1569 tests, all passing. iOS untouched (catalog decoding is data-driven, verified).

## Live smoke test (real Allegretto subscription key)

Streaming + reasoning blocks, session resume, tool calls (WebSearch), and WebFetch all verified in the web UI. All three models route correctly — confirmed via the server-echoed `model` field in CLI transcripts (Kimi models self-identify as Claude; harmless confabulation). No headless trust prompt for the injected key. Full log on #351.

## Out of scope / follow-ups

- Kimi usage card (no verified Moonshot usage API yet)
- Tier warning message for `k3-1m` on sub-Allegretto plans
- Phase 2: native `kimi-code` CLI (headless JSONL / ACP) once it stabilizes
- npm dependency advisories (pre-existing, separate PR)