### PR TITLE
ci: disable iOS job on paid macOS runners; test: accessible-role query for + button

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
         run: npm run build --workspace=frontend
 
   ios:
+    # Temporarily disabled to avoid paid macOS runner usage on the private repository.
+    # Remove this condition to restore Swift tests and the iOS build.
+    if: ${{ false }}
     runs-on: macos-26
 
     steps:

--- a/frontend/tests/components/ConversationTabs.test.tsx
+++ b/frontend/tests/components/ConversationTabs.test.tsx
@@ -64,7 +64,7 @@ describe("ConversationTabs", () => {
     const user = userEvent.setup();
     const { onCreateSession } = renderTabs();
 
-    await user.click(screen.getByTitle("New conversation"));
+    await user.click(screen.getByRole("button", { name: "New conversation" }));
 
     expect(onCreateSession).toHaveBeenCalledTimes(1);
   });
@@ -79,7 +79,7 @@ describe("ConversationTabs", () => {
       { ...makeSession("term-2", "2026-02-12T00:02:00.000Z"), kind: "terminal" },
     ];
     renderTabs({ sessions, activeSessionId: "chat-0" });
-    expect(screen.getByTitle("New conversation")).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: "New conversation" })).not.toBeDisabled();
   });
 
   it("disables the + button at the chat-session cap regardless of terminals", () => {
@@ -163,9 +163,9 @@ describe("ConversationTabs", () => {
     expect(inactiveTab.className).not.toContain("after:bg-primary");
   });
 
-  it("renders the + button with 'New conversation' title", () => {
+  it("renders the + button with an accessible name", () => {
     renderTabs();
-    const plusBtn = screen.getByTitle("New conversation");
+    const plusBtn = screen.getByRole("button", { name: "New conversation" });
     expect(plusBtn).toBeInTheDocument();
   });
 
@@ -174,7 +174,7 @@ describe("ConversationTabs", () => {
 
     // Empty state still shows an active Untitled tab
     expect(screen.getByText("Untitled")).toBeInTheDocument();
-    expect(screen.getByTitle("New conversation")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "New conversation" })).toBeInTheDocument();
   });
 
   it("shows streaming indicator on empty Untitled tab when streaming", () => {


### PR DESCRIPTION
## Summary
- Temporarily disable the iOS CI job (`if: ${{ false }}`) to avoid paid macOS runner usage on the private repository — the condition is documented inline so it's a one-line removal to restore Swift tests and the iOS build.
- Update `ConversationTabs` tests to locate the "New conversation" button via `getByRole("button", { name: ... })` instead of `getByTitle`, relying on the accessible name rather than the `title` attribute.

## Testing
- `npx vitest run tests/components/ConversationTabs.test.tsx` — 46/46 passed.