### PR TITLE
feat: complete Kimi reasoning and usage parity

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -1900,6 +1900,48 @@ describe("ConversationSession", () => {
     expect(args).not.toContain("--effort");
   });
 
+  it("routes K3 model and effort through every Claude harness path", () => {
+    const session = createSession({ sessionId: "sess-kimi-k3" });
+
+    session.sendMessage("Hello", { model: "kimi:k3-1m", thinkingLevel: "low" });
+
+    const [command, args, spawnOptions] = mockSpawn.mock.calls[0] as [
+      string,
+      string[],
+      { env?: Record<string, string> },
+    ];
+    expect(command).toBe("claude");
+    expect(args).toEqual(expect.arrayContaining(["--model", "k3[1m]", "--effort", "low"]));
+    expect(spawnOptions.env).toMatchObject({
+      ANTHROPIC_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_HAIKU_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_SONNET_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_OPUS_MODEL: "k3[1m]",
+      ANTHROPIC_DEFAULT_FABLE_MODEL: "k3[1m]",
+      CLAUDE_CODE_SUBAGENT_MODEL: "k3[1m]",
+      CLAUDE_CODE_EFFORT_LEVEL: "low",
+    });
+  });
+
+  it("pins K2.7 for parent and subagents without selectable effort", () => {
+    const session = createSession({ sessionId: "sess-kimi-k27" });
+
+    session.sendMessage("Hello", {
+      model: "kimi:kimi-for-coding-highspeed",
+      thinkingLevel: "high",
+    });
+
+    const args = mockSpawn.mock.calls[0]?.[1] as string[];
+    const spawnOptions = mockSpawn.mock.calls[0]?.[2] as { env?: Record<string, string> };
+    expect(args).toEqual(expect.arrayContaining(["--model", "kimi-for-coding-highspeed"]));
+    expect(args).not.toContain("--effort");
+    expect(spawnOptions.env).toMatchObject({
+      ANTHROPIC_MODEL: "kimi-for-coding-highspeed",
+      CLAUDE_CODE_SUBAGENT_MODEL: "kimi-for-coding-highspeed",
+    });
+    expect(spawnOptions.env?.CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+  });
+
   it("always includes CLAUDE_CODE_ENABLE_TASKS in env", () => {
     const session = createSession({ sessionId: "sess-think-default", command: "claude" });
 
@@ -4149,6 +4191,16 @@ describe("ConversationSession", () => {
       thinkingLevel: "low",
       fastMode: false,
     });
+  });
+
+  it("normalizes K3 effort to high by default and preserves supported selections", () => {
+    const defaultSession = createSession({ sessionId: "lock-kimi-default" });
+    defaultSession.sendMessage("Hello", { model: "kimi:k3" });
+    expect(defaultSession.metadata.lastRunOptions?.thinkingLevel).toBe("high");
+
+    const selectedSession = createSession({ sessionId: "lock-kimi-selected" });
+    selectedSession.sendMessage("Hello", { model: "kimi:k3", thinkingLevel: "low" });
+    expect(selectedSession.metadata.lastRunOptions?.thinkingLevel).toBe("low");
   });
 
   it("defaults to claude provider when model has no prefix", () => {

--- a/backend/src/agents/providers/kimi.test.ts
+++ b/backend/src/agents/providers/kimi.test.ts
@@ -39,8 +39,13 @@ describe("KimiProvider", () => {
 
   // ── Models ─────────────────────────────────────────────────────────
 
-  it("exposes k3 (default), k3-1m, and kimi-for-coding", () => {
-    expect(provider.models.map((m) => m.id)).toEqual(["k3", "k3-1m", "kimi-for-coding"]);
+  it("exposes the static K3 and K2.7 catalog", () => {
+    expect(provider.models.map((m) => [m.id, m.label])).toEqual([
+      ["k3", "K3"],
+      ["k3-1m", "K3 1M"],
+      ["kimi-for-coding", "K2.7 Coding"],
+      ["kimi-for-coding-highspeed", "K2.7 Coding Highspeed"],
+    ]);
     const defaults = provider.models.filter((m) => m.isDefault);
     expect(defaults.map((m) => m.id)).toEqual(["k3"]);
   });
@@ -53,6 +58,8 @@ describe("KimiProvider", () => {
     expect(byId.get("k3-1m")?.contextWindow).toBe(1_048_576);
     expect(byId.get("kimi-for-coding")?.cliValue).toBe("kimi-for-coding");
     expect(byId.get("kimi-for-coding")?.contextWindow).toBe(262_144);
+    expect(byId.get("kimi-for-coding-highspeed")?.cliValue).toBe("kimi-for-coding-highspeed");
+    expect(byId.get("kimi-for-coding-highspeed")?.contextWindow).toBe(262_144);
   });
 
   it("has no fast-mode model", () => {
@@ -61,7 +68,7 @@ describe("KimiProvider", () => {
 
   // ── Capabilities ───────────────────────────────────────────────────
 
-  it("exposes claude-like capabilities without thinking levels", () => {
+  it("keeps provider capabilities level-less for models without an override", () => {
     expect(provider.capabilities).toEqual({
       thinkingLevels: [],
       planMode: true,
@@ -73,7 +80,7 @@ describe("KimiProvider", () => {
 
   // ── buildArgs (inherited from ClaudeProvider) ──────────────────────
 
-  it("builds claude print args with --model k3 and no --effort", () => {
+  it("builds claude print args with --model k3 and no implicit --effort", () => {
     const args = provider.buildArgs("Hello", { model: "k3" }, baseSession());
     expect(args).toContain("--print");
     expect(args).toContain("--output-format");
@@ -90,9 +97,25 @@ describe("KimiProvider", () => {
     expect(args[idx + 1]).toBe("k3[1m]");
   });
 
-  it("never emits --effort even if a stale thinkingLevel leaks in", () => {
-    const args = provider.buildArgs("Hello", { model: "k3", thinkingLevel: "high" }, baseSession());
-    expect(args).not.toContain("--effort");
+  it("passes supported K3 effort levels to the CLI", () => {
+    for (const thinkingLevel of ["low", "high", "max"] as const) {
+      const args = provider.buildArgs("Hello", { model: "k3", thinkingLevel }, baseSession());
+      const effortIndex = args.indexOf("--effort");
+      expect(args[effortIndex + 1]).toBe(thinkingLevel);
+    }
+  });
+
+  it("drops unsupported or K2.7 effort levels", () => {
+    expect(provider.buildArgs(
+      "Hello",
+      { model: "k3", thinkingLevel: "medium" },
+      baseSession(),
+    )).not.toContain("--effort");
+    expect(provider.buildArgs(
+      "Hello",
+      { model: "kimi-for-coding", thinkingLevel: "high" },
+      baseSession(),
+    )).not.toContain("--effort");
   });
 
   it("supports plan mode via --permission-mode plan", () => {
@@ -140,9 +163,36 @@ describe("KimiProvider", () => {
     expect(env.ANTHROPIC_API_KEY).toBe("");
   });
 
-  it("does not set ANTHROPIC_MODEL (model goes via --model)", () => {
-    const env = provider.buildEnv({ model: "k3" });
-    expect(env.ANTHROPIC_MODEL).toBeUndefined();
+  it("pins the selected model for the parent, aliases, and subagents", () => {
+    const aliases = [
+      "ANTHROPIC_MODEL",
+      "ANTHROPIC_DEFAULT_HAIKU_MODEL",
+      "ANTHROPIC_DEFAULT_SONNET_MODEL",
+      "ANTHROPIC_DEFAULT_OPUS_MODEL",
+      "ANTHROPIC_DEFAULT_FABLE_MODEL",
+      "CLAUDE_CODE_SUBAGENT_MODEL",
+    ];
+
+    for (const [model, cliValue] of [
+      ["k3", "k3"],
+      ["k3-1m", "k3[1m]"],
+      ["kimi-for-coding", "kimi-for-coding"],
+      ["kimi-for-coding-highspeed", "kimi-for-coding-highspeed"],
+    ] as const) {
+      const env = provider.buildEnv({ model });
+      for (const alias of aliases) {
+        expect(env[alias]).toBe(cliValue);
+      }
+    }
+  });
+
+  it("sets effort in the environment only for supported K3 levels", () => {
+    expect(provider.buildEnv({ model: "k3", thinkingLevel: "low" }).CLAUDE_CODE_EFFORT_LEVEL).toBe("low");
+    expect(provider.buildEnv({ model: "k3", thinkingLevel: "medium" }).CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
+    expect(provider.buildEnv({
+      model: "kimi-for-coding",
+      thinkingLevel: "high",
+    }).CLAUDE_CODE_EFFORT_LEVEL).toBeUndefined();
   });
 
   // ── createStreamAdapter (inherited) ────────────────────────────────

--- a/backend/src/agents/providers/kimi.ts
+++ b/backend/src/agents/providers/kimi.ts
@@ -9,14 +9,15 @@ import {
 } from "./types.js";
 
 const KIMI_MODELS: ModelDefinition[] = [
-  { id: "k3", label: "K3", cliValue: "k3", isDefault: true, contextWindow: 262_144 },
-  { id: "k3-1m", label: "K3 1M", cliValue: "k3[1m]", contextWindow: 1_048_576 },
-  { id: "kimi-for-coding", label: "Kimi for Coding", cliValue: "kimi-for-coding", contextWindow: 262_144 },
+  { id: "k3", label: "K3", cliValue: "k3", isDefault: true, contextWindow: 262_144, thinkingLevels: ["low", "high", "max"] },
+  { id: "k3-1m", label: "K3 1M", cliValue: "k3[1m]", contextWindow: 1_048_576, thinkingLevels: ["low", "high", "max"] },
+  { id: "kimi-for-coding", label: "K2.7 Coding", cliValue: "kimi-for-coding", contextWindow: 262_144 },
+  { id: "kimi-for-coding-highspeed", label: "K2.7 Coding Highspeed", cliValue: "kimi-for-coding-highspeed", contextWindow: 262_144 },
 ];
 
 const KIMI_CAPABILITIES: ProviderCapabilities = {
-  // No reasoning-effort control: with an empty list callers never pick a
-  // thinking level, so the inherited buildArgs never emits --effort.
+  // K2.7 has always-on thinking but no selectable effort. K3 opts into effort
+  // control through its per-model thinkingLevels above.
   thinkingLevels: [],
   planMode: true,
   blockingTools: true,
@@ -36,24 +37,44 @@ export class KimiProvider extends ClaudeProvider {
   override readonly models: ModelDefinition[] = KIMI_MODELS;
   override readonly capabilities: ProviderCapabilities = KIMI_CAPABILITIES;
 
+  private resolveModelOptions(options: ProviderMessageOptions): {
+    model: ModelDefinition | undefined;
+    thinkingLevel: ProviderMessageOptions["thinkingLevel"];
+  } {
+    const model = findModel(this.models, options.model);
+    const thinkingLevels = model?.thinkingLevels ?? this.capabilities.thinkingLevels;
+    const thinkingLevel = options.thinkingLevel && thinkingLevels.includes(options.thinkingLevel)
+      ? options.thinkingLevel
+      : undefined;
+    return { model, thinkingLevel };
+  }
+
   override buildArgs(
     content: string,
     options: ProviderMessageOptions,
     session: ProviderSessionState,
   ): string[] {
-    // No effort levels: drop any thinkingLevel that leaks in (e.g. from a
-    // stale client or stored agent) so --effort is never emitted.
-    const { thinkingLevel: _drop, ...rest } = options;
-    return super.buildArgs(content, rest, session);
+    const { thinkingLevel } = this.resolveModelOptions(options);
+    return super.buildArgs(content, { ...options, thinkingLevel }, session);
   }
 
   override buildEnv(options: ProviderMessageOptions): Record<string, string> {
-    const contextWindow = findModel(this.models, options.model)?.contextWindow
-      ?? DEFAULT_CONTEXT_WINDOW;
+    const { model, thinkingLevel } = this.resolveModelOptions(options);
+    const contextWindow = model?.contextWindow ?? DEFAULT_CONTEXT_WINDOW;
+    const cliModel = model?.cliValue;
     return {
-      ...super.buildEnv(options),
+      ...super.buildEnv({ ...options, thinkingLevel }),
       ANTHROPIC_BASE_URL: "https://api.kimi.com/coding/",
       ANTHROPIC_API_KEY: getKimiApiKey(),
+      ...(cliModel ? {
+        ANTHROPIC_MODEL: cliModel,
+        ANTHROPIC_DEFAULT_HAIKU_MODEL: cliModel,
+        ANTHROPIC_DEFAULT_SONNET_MODEL: cliModel,
+        ANTHROPIC_DEFAULT_OPUS_MODEL: cliModel,
+        ANTHROPIC_DEFAULT_FABLE_MODEL: cliModel,
+        CLAUDE_CODE_SUBAGENT_MODEL: cliModel,
+      } : {}),
+      ...(thinkingLevel ? { CLAUDE_CODE_EFFORT_LEVEL: thinkingLevel } : {}),
       // Moonshot's endpoint 400s on tool_reference content blocks, so keep the
       // CLI's tool-search feature off.
       ENABLE_TOOL_SEARCH: "false",

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -359,14 +359,19 @@ describe("kimi in catalog", () => {
 
     const catalog = getModelCatalog();
     const kimiIds = catalog.models.filter((m) => m.provider === "kimi").map((m) => m.id);
-    expect(kimiIds).toEqual(["kimi:k3", "kimi:k3-1m", "kimi:kimi-for-coding"]);
+    expect(kimiIds).toEqual([
+      "kimi:k3",
+      "kimi:k3-1m",
+      "kimi:kimi-for-coding",
+      "kimi:kimi-for-coding-highspeed",
+    ]);
 
     // Clearing the key hides it again on the next catalog build.
     await updateConfig((c) => { c.kimi.apiKey = ""; }, tempDir);
     expect(getModelCatalog().models.some((m) => m.provider === "kimi")).toBe(false);
   });
 
-  it("exposes label, contextWindow, and effort-free capabilities", async () => {
+  it("exposes labels, context windows, and model-specific effort capabilities", async () => {
     markProviderAvailable("kimi");
     await updateConfig((c) => { c.kimi.apiKey = "sk-kimi"; }, tempDir);
 
@@ -376,11 +381,21 @@ describe("kimi in catalog", () => {
     expect(k3.providerLabel).toBe("Kimi");
     expect(k3.isDefault).toBe(true);
     expect(k3.contextWindow).toBe(262_144);
-    expect(k3.capabilities.thinkingLevels).toEqual([]);
+    expect(k3.capabilities.thinkingLevels).toEqual(["low", "high", "max"]);
     expect(k3.capabilities.planMode).toBe(true);
     expect(k3.supportsFastMode).toBeUndefined();
     expect(byId.get("kimi:k3-1m")?.contextWindow).toBe(1_048_576);
-    expect(byId.get("kimi:kimi-for-coding")?.contextWindow).toBe(262_144);
+    expect(byId.get("kimi:k3-1m")?.capabilities.thinkingLevels).toEqual(["low", "high", "max"]);
+    expect(byId.get("kimi:kimi-for-coding")).toMatchObject({
+      label: "K2.7 Coding",
+      contextWindow: 262_144,
+      capabilities: { thinkingLevels: [] },
+    });
+    expect(byId.get("kimi:kimi-for-coding-highspeed")).toMatchObject({
+      label: "K2.7 Coding Highspeed",
+      contextWindow: 262_144,
+      capabilities: { thinkingLevels: [] },
+    });
   });
 
   it("never becomes the catalog default", async () => {
@@ -400,9 +415,12 @@ describe("kimi in catalog", () => {
     expect(isKnownModelId("kimi:k3-1m")).toBe(true);
   });
 
-  it("has no default thinking level (no effort control)", () => {
-    expect(getDefaultThinkingLevelForModel("kimi:k3")).toBeUndefined();
-    expect(isThinkingLevelSupportedForModel("kimi:k3", "high")).toBe(false);
+  it("defaults K3 to high while keeping K2.7 free of effort control", () => {
+    expect(getDefaultThinkingLevelForModel("kimi:k3")).toBe("high");
+    expect(isThinkingLevelSupportedForModel("kimi:k3", "low")).toBe(true);
+    expect(isThinkingLevelSupportedForModel("kimi:k3", "medium")).toBe(false);
+    expect(getDefaultThinkingLevelForModel("kimi:kimi-for-coding")).toBeUndefined();
+    expect(isThinkingLevelSupportedForModel("kimi:kimi-for-coding", "high")).toBe(false);
   });
 });
 

--- a/backend/src/api/agent-definitions.ts
+++ b/backend/src/api/agent-definitions.ts
@@ -25,7 +25,7 @@ function resolveThinkingLevel(
     return { thinkingLevel: requested };
   }
 
-  // Undefined for models with no thinking-level control (e.g. Kimi): the
+  // Undefined for models with no thinking-level control (e.g. K2.7): the
   // agent is stored without a level and no effort flag is ever emitted.
   return { thinkingLevel: getDefaultThinkingLevelForModel(modelId) };
 }

--- a/backend/src/api/agents-crud.test.ts
+++ b/backend/src/api/agents-crud.test.ts
@@ -149,7 +149,7 @@ describe("POST /api/agents", () => {
     expect(res.json().error).toContain("Thinking level");
   });
 
-  it("creates an agent without a thinkingLevel for level-less models (kimi)", async () => {
+  it("defaults K3 agents to high thinking", async () => {
     const res = await app.inject({
       method: "POST",
       url: "/api/agents",
@@ -161,7 +161,7 @@ describe("POST /api/agents", () => {
       },
     });
     expect(res.statusCode).toBe(201);
-    expect(res.json().thinkingLevel).toBeUndefined();
+    expect(res.json().thinkingLevel).toBe("high");
   });
 
   it("rejects a thinkingLevel supplied for a level-less model (400)", async () => {
@@ -171,7 +171,7 @@ describe("POST /api/agents", () => {
       payload: {
         name: "Kimi Agent",
         systemPrompt: "You are helpful.",
-        modelId: "kimi:k3",
+        modelId: "kimi:kimi-for-coding",
         thinkingLevel: "high",
         readOnly: false,
       },
@@ -261,15 +261,15 @@ describe("PATCH /api/agents/:id", () => {
     expect(res.json().error).toContain("Thinking level");
   });
 
-  it("clears thinkingLevel when switching to a level-less model (kimi)", async () => {
+  it("clears thinkingLevel when switching to a level-less K2.7 model", async () => {
     await saveAgents([makeAgent({ thinkingLevel: "max" })], dataDir);
     const res = await app.inject({
       method: "PATCH",
       url: "/api/agents/agent-1",
-      payload: { modelId: "kimi:k3" },
+      payload: { modelId: "kimi:kimi-for-coding-highspeed" },
     });
     expect(res.statusCode).toBe(200);
-    expect(res.json().modelId).toBe("kimi:k3");
+    expect(res.json().modelId).toBe("kimi:kimi-for-coding-highspeed");
     expect(res.json().thinkingLevel).toBeUndefined();
   });
 
@@ -278,7 +278,7 @@ describe("PATCH /api/agents/:id", () => {
     const res = await app.inject({
       method: "PATCH",
       url: "/api/agents/agent-1",
-      payload: { modelId: "kimi:k3", thinkingLevel: "high" },
+      payload: { modelId: "kimi:kimi-for-coding", thinkingLevel: "high" },
     });
     expect(res.statusCode).toBe(400);
     expect(res.json().error).toContain("Thinking level");

--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -46,6 +46,7 @@ afterEach(async () => {
   delete process.env.HIVE_RATE_LIMIT_MAX;
   delete process.env.HIVE_RATE_LIMIT_WINDOW_MS;
   delete process.env.HIVE_CLAUDE_SKIP_PERMISSIONS;
+  vi.restoreAllMocks();
   if (previousDataDir === undefined) {
     delete process.env.DATA_DIR;
   } else {
@@ -114,6 +115,9 @@ describe("buildApp", () => {
   });
 
   it("registers agent settings routes", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("Not Found", { status: 404 }),
+    );
     app = await buildApp();
     const res = await app.inject({ method: "GET", url: "/api/settings/cli" });
 

--- a/backend/src/services/automation-scheduler.test.ts
+++ b/backend/src/services/automation-scheduler.test.ts
@@ -912,6 +912,48 @@ describe("AutomationScheduler", () => {
 
       scheduler.stop();
     });
+
+    it("runs a level-less K2.7 agent without forwarding stale effort", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue(null as never);
+
+      await saveAgents([makeAgent({
+        modelId: "kimi:kimi-for-coding-highspeed",
+        thinkingLevel: "high",
+      })], dataDir);
+      await saveAutomations([makeAutomation({ projectId: undefined })], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("success");
+      const lastSend = sessionSendCalls[sessionSendCalls.length - 1];
+      expect(lastSend.options?.model).toBe("kimi:kimi-for-coding-highspeed");
+      expect(lastSend.options?.thinkingLevel).toBeUndefined();
+
+      scheduler.stop();
+    });
+
+    it("forwards a supported K3 effort from an automation agent", async () => {
+      const { loadProject } = await import("../state/state.js");
+      vi.mocked(loadProject).mockResolvedValue(null as never);
+
+      await saveAgents([makeAgent({
+        modelId: "kimi:k3",
+        thinkingLevel: "low",
+      })], dataDir);
+      await saveAutomations([makeAutomation({ projectId: undefined })], dataDir);
+
+      const scheduler = new AutomationScheduler(dataDir);
+      const run = await scheduler.triggerNow("auto-1");
+
+      expect(run.status).toBe("success");
+      const lastSend = sessionSendCalls[sessionSendCalls.length - 1];
+      expect(lastSend.options?.model).toBe("kimi:k3");
+      expect(lastSend.options?.thinkingLevel).toBe("low");
+
+      scheduler.stop();
+    });
   });
 
   describe("session lifecycle", () => {

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -3,6 +3,7 @@ import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  getKimiApiKey: vi.fn(),
   getAllProviderInfo: vi.fn(),
   readFile: vi.fn(),
   spawn: vi.fn(),
@@ -14,6 +15,10 @@ vi.mock("node:child_process", () => ({
 
 vi.mock("../agents/providers/registry.js", () => ({
   getAllProviderInfo: mocks.getAllProviderInfo,
+}));
+
+vi.mock("../state/config.js", () => ({
+  getKimiApiKey: mocks.getKimiApiKey,
 }));
 
 vi.mock("node:fs/promises", () => ({
@@ -105,6 +110,8 @@ describe("provider usage", () => {
     vi.stubGlobal("fetch", vi.fn());
     __providerUsageTestHooks.resetProviderUsageCaches();
     mocks.spawn.mockReset();
+    mocks.getKimiApiKey.mockReset();
+    mocks.getKimiApiKey.mockReturnValue("");
     mocks.getAllProviderInfo.mockReturnValue([
       {
         id: "claude",
@@ -231,20 +238,18 @@ describe("provider usage", () => {
     const result = await resultPromise;
 
     expect(mocks.spawn).toHaveBeenCalledWith("codex", ["app-server", "--listen", "stdio://"], expect.any(Object));
-    expect(result.providers).toMatchObject([
-      {
-        id: "codex",
-        status: "available",
-        buckets: [
-          {
-            id: "primary",
-            label: "Primary",
-            usedPercent: 25,
-            resetsAt: 1781110800,
-          },
-        ],
-      },
-    ]);
+    expect(result.providers[0]).toMatchObject({
+      id: "codex",
+      status: "available",
+      buckets: [
+        {
+          id: "primary",
+          label: "Primary",
+          usedPercent: 25,
+          resetsAt: 1781110800,
+        },
+      ],
+    });
   });
 
   it("reports a Codex usage error instead of crashing on malformed App Server output", async () => {
@@ -445,7 +450,7 @@ describe("provider usage", () => {
 
     const result = await getProviderUsageSnapshot();
 
-    expect(result.providers).toHaveLength(1);
+    expect(result.providers).toHaveLength(2);
     expect(result.providers[0]).toMatchObject({
       id: "claude",
       status: "available",
@@ -491,6 +496,328 @@ describe("provider usage", () => {
       status: "error",
       buckets: [],
       message: "Rate limited. Please try again later.",
+    });
+  });
+
+  it("parses Kimi weekly and rolling 5-hour usage variants", () => {
+    expect(__providerUsageTestHooks.parseKimiUsageBuckets({
+      usage: {
+        name: "Weekly limit",
+        used: "375",
+        limit: "1000",
+        resetAt: "2026-06-15T17:00:00Z",
+      },
+      limits: [
+        {
+          detail: {
+            used: "1",
+            limit: "0",
+          },
+          window: {
+            duration: 300,
+            timeUnit: "TIME_UNIT_MINUTE",
+          },
+        },
+        {
+          detail: {
+            remaining: "35",
+            limit: "100",
+            reset_at: "2026-06-10T17:00:00Z",
+          },
+          window: {
+            duration: 300,
+            time_unit: "TIME_UNIT_MINUTE",
+          },
+        },
+        {
+          detail: {
+            name: "Parallel requests",
+            used: 1,
+            limit: 4,
+          },
+        },
+      ],
+      boosterWallet: {
+        balance: {
+          type: "BOOSTER",
+          amountLeft: 50_000_000,
+        },
+      },
+    })).toEqual([
+      {
+        id: "weekly",
+        label: "Weekly",
+        usedPercent: 38,
+        windowDurationMins: 10_080,
+        resetsAt: 1781542800,
+      },
+      {
+        id: "five_hour",
+        label: "5h",
+        usedPercent: 65,
+        windowDurationMins: 300,
+        resetsAt: 1781110800,
+      },
+    ]);
+
+    expect(__providerUsageTestHooks.parseKimiUsageBuckets({
+      usage: {
+        remaining: 8,
+        limit: 10,
+        reset_time: 1781542800,
+      },
+      limits: [
+        {
+          title: "Rolling 5-hour limit",
+          used: 1,
+          limit: 8,
+          resetTime: 1781110800000,
+          window: {
+            duration: 18_000,
+            timeUnit: "TIME_UNIT_SECOND",
+          },
+        },
+      ],
+    })).toEqual([
+      {
+        id: "weekly",
+        label: "Weekly",
+        usedPercent: 20,
+        windowDurationMins: 10_080,
+        resetsAt: 1781542800,
+      },
+      {
+        id: "five_hour",
+        label: "5h",
+        usedPercent: 13,
+        windowDurationMins: 300,
+        resetsAt: 1781110800,
+      },
+    ]);
+  });
+
+  it("reports Kimi usage as unavailable without a configured API key", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([]);
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers).toEqual([
+      {
+        id: "kimi",
+        label: "Kimi",
+        status: "unavailable",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Kimi API key is not configured.",
+      },
+    ]);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("fetches and caches successful Kimi usage until the cache expires", async () => {
+    vi.useFakeTimers();
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    mockFetchJson(200, {
+      usage: {
+        used: 25,
+        limit: 100,
+        resetAt: "2026-06-15T17:00:00Z",
+      },
+      limits: [{
+        detail: {
+          used: 45,
+          limit: 100,
+          resetAt: "2026-06-10T17:00:00Z",
+        },
+        window: {
+          duration: 5,
+          timeUnit: "HOUR",
+        },
+      }],
+    });
+
+    const first = await getProviderUsageSnapshot();
+    const cached = await getProviderUsageSnapshot();
+
+    expect(first.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "available",
+      buckets: [
+        { id: "weekly", usedPercent: 25 },
+        { id: "five_hour", usedPercent: 45 },
+      ],
+    });
+    expect(cached.providers[0]).toEqual(first.providers[0]);
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith("https://api.kimi.com/coding/v1/usages", expect.objectContaining({
+      method: "GET",
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer test-kimi-key",
+      },
+      signal: expect.any(AbortSignal),
+    }));
+
+    mocks.getKimiApiKey.mockReturnValue("replacement-kimi-key");
+    await getProviderUsageSnapshot();
+
+    expect(fetch).toHaveBeenCalledTimes(2);
+    expect(fetch).toHaveBeenNthCalledWith(2, "https://api.kimi.com/coding/v1/usages", expect.objectContaining({
+      headers: {
+        Accept: "application/json",
+        Authorization: "Bearer replacement-kimi-key",
+      },
+    }));
+
+    await vi.advanceTimersByTimeAsync(180_001);
+    await getProviderUsageSnapshot();
+
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns unknown Kimi usage without stale buckets when usable windows disappear", async () => {
+    vi.useFakeTimers();
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    const responses = [
+      {
+        usage: { used: 25, limit: 100 },
+        limits: [{
+          detail: { used: 45, limit: 100 },
+          window: { duration: 300, timeUnit: "MINUTE" },
+        }],
+      },
+      {
+        usage: { used: 10, limit: 0 },
+        limits: [],
+        boosterWallet: { balance: { type: "BOOSTER", amount: 100_000_000 } },
+      },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => responses.shift(),
+    } as Response)));
+
+    const first = await getProviderUsageSnapshot();
+    expect(first.providers[0].buckets).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(180_001);
+    const second = await getProviderUsageSnapshot();
+
+    expect(second.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "unknown",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: "Kimi usage API returned no weekly or 5-hour usage windows.",
+    });
+  });
+
+  it("returns Kimi HTTP errors without stale cached buckets", async () => {
+    vi.useFakeTimers();
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    const responses = [
+      {
+        status: 200,
+        body: {
+          usage: { used: 25, limit: 100 },
+          limits: [{
+            detail: { used: 45, limit: 100 },
+            window: { duration: 300, timeUnit: "MINUTE" },
+          }],
+        },
+      },
+      {
+        status: 401,
+        body: {
+          error: {
+            message: "Invalid API key.",
+          },
+        },
+      },
+    ];
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      const response = responses.shift()!;
+      return {
+        ok: response.status >= 200 && response.status < 300,
+        status: response.status,
+        json: async () => response.body,
+      } as Response;
+    }));
+
+    const first = await getProviderUsageSnapshot();
+    expect(first.providers[0].buckets).toHaveLength(2);
+
+    await vi.advanceTimersByTimeAsync(180_001);
+    const second = await getProviderUsageSnapshot();
+
+    expect(second.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "error",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: "Invalid API key.",
+    });
+  });
+
+  it("reports an invalid successful Kimi response as an error", async () => {
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    vi.stubGlobal("fetch", vi.fn(async () => ({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError("invalid JSON");
+      },
+    } as Response)));
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "error",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: "Kimi usage API returned an invalid response.",
+    });
+  });
+
+  it("reports Kimi timeouts and network failures", async () => {
+    vi.useFakeTimers();
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    vi.stubGlobal("fetch", vi.fn((_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+      init.signal?.addEventListener("abort", () => {
+        const error = new Error("aborted");
+        error.name = "AbortError";
+        reject(error);
+      });
+    })));
+
+    const timeoutResultPromise = getProviderUsageSnapshot();
+    await vi.advanceTimersByTimeAsync(5_000);
+    const timeoutResult = await timeoutResultPromise;
+
+    expect(timeoutResult.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "error",
+      buckets: [],
+      message: "Kimi usage API timed out.",
+    });
+
+    vi.stubGlobal("fetch", vi.fn(async () => {
+      throw new Error("connection refused");
+    }));
+    const networkResult = await getProviderUsageSnapshot();
+
+    expect(networkResult.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "error",
+      buckets: [],
+      message: "connection refused",
     });
   });
 });

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -102,6 +102,29 @@ function mockFetchJson(status: number, body: unknown, headers: Record<string, st
   vi.stubGlobal("fetch", vi.fn(async () => response));
 }
 
+// Quota values and timestamps are synthetic. Field names, nesting, and scalar
+// types match the live /coding/v1/usages response captured on 2026-07-23.
+const SANITIZED_KIMI_LIVE_USAGE_RESPONSE = {
+  usage: {
+    limit: "100",
+    used: "5",
+    remaining: "95",
+    resetTime: "2026-07-29T12:00:00Z",
+  },
+  limits: [{
+    detail: {
+      limit: "100",
+      used: "20",
+      remaining: "80",
+      resetTime: "2026-07-23T17:00:00Z",
+    },
+    window: {
+      duration: 300,
+      timeUnit: "TIME_UNIT_MINUTE",
+    },
+  }],
+};
+
 describe("provider usage", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -499,55 +522,50 @@ describe("provider usage", () => {
     });
   });
 
-  it("parses Kimi weekly and rolling 5-hour usage variants", () => {
+  it("parses the sanitized live Kimi usage contract", () => {
+    expect(__providerUsageTestHooks.parseKimiUsageBuckets(
+      SANITIZED_KIMI_LIVE_USAGE_RESPONSE,
+    )).toEqual([
+      {
+        id: "weekly",
+        label: "7d",
+        usedPercent: 5,
+        windowDurationMins: 10_080,
+        resetsAt: 1785326400,
+      },
+      {
+        id: "five_hour",
+        label: "5h",
+        usedPercent: 20,
+        windowDurationMins: 300,
+        resetsAt: 1784826000,
+      },
+    ]);
+  });
+
+  it("accepts snake_case aliases for confirmed Kimi fields", () => {
     expect(__providerUsageTestHooks.parseKimiUsageBuckets({
       usage: {
-        name: "Weekly limit",
-        used: "375",
-        limit: "1000",
-        resetAt: "2026-06-15T17:00:00Z",
+        used: "25",
+        limit: "100",
+        reset_time: "2026-06-15T17:00:00Z",
       },
-      limits: [
-        {
-          detail: {
-            used: "1",
-            limit: "0",
-          },
-          window: {
-            duration: 300,
-            timeUnit: "TIME_UNIT_MINUTE",
-          },
+      limits: [{
+        detail: {
+          used: "65",
+          limit: "100",
+          reset_time: "2026-06-10T17:00:00Z",
         },
-        {
-          detail: {
-            remaining: "35",
-            limit: "100",
-            reset_at: "2026-06-10T17:00:00Z",
-          },
-          window: {
-            duration: 300,
-            time_unit: "TIME_UNIT_MINUTE",
-          },
+        window: {
+          duration: 300,
+          time_unit: "TIME_UNIT_MINUTE",
         },
-        {
-          detail: {
-            name: "Parallel requests",
-            used: 1,
-            limit: 4,
-          },
-        },
-      ],
-      boosterWallet: {
-        balance: {
-          type: "BOOSTER",
-          amountLeft: 50_000_000,
-        },
-      },
+      }],
     })).toEqual([
       {
         id: "weekly",
-        label: "Weekly",
-        usedPercent: 38,
+        label: "7d",
+        usedPercent: 25,
         windowDurationMins: 10_080,
         resetsAt: 1781542800,
       },
@@ -555,41 +573,6 @@ describe("provider usage", () => {
         id: "five_hour",
         label: "5h",
         usedPercent: 65,
-        windowDurationMins: 300,
-        resetsAt: 1781110800,
-      },
-    ]);
-
-    expect(__providerUsageTestHooks.parseKimiUsageBuckets({
-      usage: {
-        remaining: 8,
-        limit: 10,
-        reset_time: 1781542800,
-      },
-      limits: [
-        {
-          title: "Rolling 5-hour limit",
-          used: 1,
-          limit: 8,
-          resetTime: 1781110800000,
-          window: {
-            duration: 18_000,
-            timeUnit: "TIME_UNIT_SECOND",
-          },
-        },
-      ],
-    })).toEqual([
-      {
-        id: "weekly",
-        label: "Weekly",
-        usedPercent: 20,
-        windowDurationMins: 10_080,
-        resetsAt: 1781542800,
-      },
-      {
-        id: "five_hour",
-        label: "5h",
-        usedPercent: 13,
         windowDurationMins: 300,
         resetsAt: 1781110800,
       },
@@ -618,24 +601,7 @@ describe("provider usage", () => {
     vi.useFakeTimers();
     mocks.getAllProviderInfo.mockReturnValue([]);
     mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
-    mockFetchJson(200, {
-      usage: {
-        used: 25,
-        limit: 100,
-        resetAt: "2026-06-15T17:00:00Z",
-      },
-      limits: [{
-        detail: {
-          used: 45,
-          limit: 100,
-          resetAt: "2026-06-10T17:00:00Z",
-        },
-        window: {
-          duration: 5,
-          timeUnit: "HOUR",
-        },
-      }],
-    });
+    mockFetchJson(200, SANITIZED_KIMI_LIVE_USAGE_RESPONSE);
 
     const first = await getProviderUsageSnapshot();
     const cached = await getProviderUsageSnapshot();
@@ -644,8 +610,8 @@ describe("provider usage", () => {
       id: "kimi",
       status: "available",
       buckets: [
-        { id: "weekly", usedPercent: 25 },
-        { id: "five_hour", usedPercent: 45 },
+        { id: "weekly", usedPercent: 5 },
+        { id: "five_hour", usedPercent: 20 },
       ],
     });
     expect(cached.providers[0]).toEqual(first.providers[0]);
@@ -681,24 +647,16 @@ describe("provider usage", () => {
     mocks.getAllProviderInfo.mockReturnValue([]);
     mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
     const responses = [
+      SANITIZED_KIMI_LIVE_USAGE_RESPONSE,
       {
-        usage: { used: 25, limit: 100 },
-        limits: [{
-          detail: { used: 45, limit: 100 },
-          window: { duration: 300, timeUnit: "MINUTE" },
-        }],
-      },
-      {
-        usage: { used: 10, limit: 0 },
+        usage: { used: "10", limit: "0" },
         limits: [],
-        boosterWallet: { balance: { type: "BOOSTER", amount: 100_000_000 } },
       },
     ];
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
+    vi.stubGlobal("fetch", vi.fn(async () => new Response(JSON.stringify(responses.shift()), {
       status: 200,
-      json: async () => responses.shift(),
-    } as Response)));
+      headers: { "Content-Type": "application/json" },
+    })));
 
     const first = await getProviderUsageSnapshot();
     expect(first.providers[0].buckets).toHaveLength(2);
@@ -722,13 +680,7 @@ describe("provider usage", () => {
     const responses = [
       {
         status: 200,
-        body: {
-          usage: { used: 25, limit: 100 },
-          limits: [{
-            detail: { used: 45, limit: 100 },
-            window: { duration: 300, timeUnit: "MINUTE" },
-          }],
-        },
+        body: SANITIZED_KIMI_LIVE_USAGE_RESPONSE,
       },
       {
         status: 401,
@@ -741,11 +693,10 @@ describe("provider usage", () => {
     ];
     vi.stubGlobal("fetch", vi.fn(async () => {
       const response = responses.shift()!;
-      return {
-        ok: response.status >= 200 && response.status < 300,
+      return new Response(JSON.stringify(response.body), {
         status: response.status,
-        json: async () => response.body,
-      } as Response;
+        headers: { "Content-Type": "application/json" },
+      });
     }));
 
     const first = await getProviderUsageSnapshot();
@@ -763,16 +714,75 @@ describe("provider usage", () => {
     });
   });
 
+  it("backs off Kimi polling after a 429 and honors Retry-After", async () => {
+    vi.useFakeTimers();
+    mocks.getAllProviderInfo.mockReturnValue([]);
+    mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
+    const fetchMock = vi.fn(async () => {
+      if (fetchMock.mock.calls.length === 1) {
+        return new Response(JSON.stringify({
+          error: {
+            message: "Rate limited.",
+          },
+        }), {
+          status: 429,
+          headers: {
+            "Content-Type": "application/json",
+            "Retry-After": "600",
+          },
+        });
+      }
+      return new Response(JSON.stringify(SANITIZED_KIMI_LIVE_USAGE_RESPONSE), {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+        },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const limited = await getProviderUsageSnapshot();
+    const backedOff = await getProviderUsageSnapshot();
+
+    expect(limited.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "error",
+      buckets: [],
+      message: "Rate limited.",
+    });
+    expect(backedOff.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "unknown",
+      buckets: [],
+      message: "Kimi usage polling is backing off after a rate limit. Try again in 10m.",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(180_001);
+    await getProviderUsageSnapshot();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    mocks.getKimiApiKey.mockReturnValue("replacement-kimi-key");
+    const recovered = await getProviderUsageSnapshot();
+
+    expect(recovered.providers[0]).toMatchObject({
+      id: "kimi",
+      status: "available",
+      buckets: [
+        { id: "weekly", usedPercent: 5 },
+        { id: "five_hour", usedPercent: 20 },
+      ],
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it("reports an invalid successful Kimi response as an error", async () => {
     mocks.getAllProviderInfo.mockReturnValue([]);
     mocks.getKimiApiKey.mockReturnValue("test-kimi-key");
-    vi.stubGlobal("fetch", vi.fn(async () => ({
-      ok: true,
+    vi.stubGlobal("fetch", vi.fn(async () => new Response("{invalid", {
       status: 200,
-      json: async () => {
-        throw new SyntaxError("invalid JSON");
-      },
-    } as Response)));
+      headers: { "Content-Type": "application/json" },
+    })));
 
     const result = await getProviderUsageSnapshot();
 

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -108,6 +108,9 @@ let kimiUsageCache:
   | { apiKey: string; value: ProviderUsageEntry; expiresAt: number }
   | null = null;
 let claudeBackoffUntil = 0;
+let kimiBackoff:
+  | { apiKey: string; until: number }
+  | null = null;
 
 export async function getProviderUsageSnapshot(): Promise<ProviderUsageResponse> {
   const providerInfo = getAllProviderInfo();
@@ -227,7 +230,7 @@ async function getClaudeUsage(label: string, installed: boolean, version: string
     claudeBackoffUntil = 0;
     return entry;
   } catch (err) {
-    if (err instanceof ClaudeUsageHttpError && err.status === 429) {
+    if (err instanceof UsageHttpError && err.status === 429) {
       claudeBackoffUntil = Date.now() + Math.max(err.retryAfterMs ?? 0, CLAUDE_USAGE_CACHE_TTL_MS);
     }
     return {
@@ -245,10 +248,14 @@ async function getKimiUsage(label: string): Promise<ProviderUsageEntry> {
   const apiKey = getKimiApiKey();
   if (!apiKey) {
     kimiUsageCache = null;
+    kimiBackoff = null;
     return unavailableProvider("kimi", label, "Kimi API key is not configured.");
   }
 
   const now = Date.now();
+  if (kimiBackoff && kimiBackoff.apiKey !== apiKey) {
+    kimiBackoff = null;
+  }
   if (
     kimiUsageCache
     && kimiUsageCache.apiKey === apiKey
@@ -257,10 +264,23 @@ async function getKimiUsage(label: string): Promise<ProviderUsageEntry> {
     return kimiUsageCache.value;
   }
 
+  if (kimiBackoff && kimiBackoff.until > now) {
+    return {
+      id: "kimi",
+      label,
+      status: "unknown",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: `Kimi usage polling is backing off after a rate limit. Try again ${formatRetryTime(kimiBackoff.until)}.`,
+    };
+  }
+  kimiBackoff = null;
+
   try {
     const buckets = parseKimiUsageBuckets(await fetchKimiUsage(apiKey));
     if (buckets.length === 0) {
       kimiUsageCache = null;
+      kimiBackoff = null;
       return {
         id: "kimi",
         label,
@@ -283,9 +303,16 @@ async function getKimiUsage(label: string): Promise<ProviderUsageEntry> {
       value: entry,
       expiresAt: now + KIMI_USAGE_CACHE_TTL_MS,
     };
+    kimiBackoff = null;
     return entry;
   } catch (err) {
     kimiUsageCache = null;
+    kimiBackoff = err instanceof UsageHttpError && err.status === 429
+      ? {
+          apiKey,
+          until: Date.now() + Math.max(err.retryAfterMs ?? 0, KIMI_USAGE_CACHE_TTL_MS),
+        }
+      : null;
     return {
       id: "kimi",
       label,
@@ -338,7 +365,7 @@ async function fetchClaudeUsage(token: string, version: string | null): Promise<
       "anthropic-beta": CLAUDE_OAUTH_BETA_HEADER,
       "User-Agent": `claude-code/${version ?? "2.0"}`,
     },
-    createHttpError: (response, body) => new ClaudeUsageHttpError(
+    createHttpError: (response, body) => new UsageHttpError(
       response.status,
       errorMessageFromBody(body) ?? `Claude usage API returned HTTP ${response.status}.`,
       retryAfterMs(response.headers.get("retry-after")),
@@ -356,6 +383,11 @@ async function fetchKimiUsage(apiKey: string): Promise<unknown> {
       Accept: "application/json",
       Authorization: `Bearer ${apiKey}`,
     },
+    createHttpError: (response, body) => new UsageHttpError(
+      response.status,
+      errorMessageFromBody(body) ?? `Kimi usage API returned HTTP ${response.status}.`,
+      retryAfterMs(response.headers.get("retry-after")),
+    ),
   });
 }
 
@@ -391,7 +423,7 @@ async function fetchUsageJson(request: UsageFetchRequest): Promise<unknown> {
 
     return body;
   } catch (err) {
-    if (err instanceof ClaudeUsageHttpError) throw err;
+    if (err instanceof UsageHttpError) throw err;
     if (err instanceof Error && err.name === "AbortError") {
       throw new Error(`${request.providerLabel} usage API timed out.`);
     }
@@ -444,7 +476,7 @@ function parseKimiUsageBuckets(result: unknown): ProviderUsageBucket[] {
   const buckets: ProviderUsageBucket[] = [];
   const weekly = parseKimiUsageBucket(
     "weekly",
-    "Weekly",
+    "7d",
     10_080,
     asRecord(record.usage),
   );
@@ -454,17 +486,15 @@ function parseKimiUsageBuckets(result: unknown): ProviderUsageBucket[] {
   for (const rawLimit of limits) {
     const limit = asRecord(rawLimit);
     if (!limit) continue;
-    const detail = asRecord(limit.detail) ?? limit;
+    const detail = asRecord(limit.detail);
     const window = asRecord(limit.window);
-    if (!isKimiFiveHourWindow(limit, detail, window)) continue;
+    if (!detail || !isKimiFiveHourWindow(window)) continue;
 
     const fiveHour = parseKimiUsageBucket(
       "five_hour",
       "5h",
       300,
       detail,
-      limit,
-      window,
     );
     if (fiveHour) {
       buckets.push(fiveHour);
@@ -480,17 +510,12 @@ function parseKimiUsageBucket(
   label: string,
   windowDurationMins: number,
   usage: Record<string, unknown> | null,
-  ...resetSources: Array<Record<string, unknown> | null>
 ): ProviderUsageBucket | null {
   if (!usage) return null;
-  const limit = asNumericValue(usage.limit);
+  const limit = asNumericString(usage.limit);
   if (limit === null || limit <= 0) return null;
 
-  let used = asNumericValue(usage.used);
-  if (used === null) {
-    const remaining = asNumericValue(usage.remaining);
-    if (remaining !== null) used = limit - remaining;
-  }
+  const used = asNumericString(usage.used);
   if (used === null) return null;
 
   return {
@@ -498,53 +523,13 @@ function parseKimiUsageBucket(
     label,
     usedPercent: normalizePercentNumber((used / limit) * 100),
     windowDurationMins,
-    resetsAt: parseKimiResetTimestamp(usage, ...resetSources),
+    resetsAt: parseResetTimestamp(usage.resetTime ?? usage.reset_time),
   };
 }
 
-function isKimiFiveHourWindow(
-  limit: Record<string, unknown>,
-  detail: Record<string, unknown>,
-  window: Record<string, unknown> | null,
-): boolean {
-  const duration = asNumericValue(window?.duration ?? limit.duration ?? detail.duration);
-  const unit = asString(
-    window?.timeUnit
-    ?? window?.time_unit
-    ?? limit.timeUnit
-    ?? limit.time_unit
-    ?? detail.timeUnit
-    ?? detail.time_unit,
-  )?.toUpperCase() ?? "";
-  if (duration !== null) {
-    if (unit.includes("MINUTE") && duration === 300) return true;
-    if (unit.includes("HOUR") && duration === 5) return true;
-    if (unit.includes("SECOND") && duration === 18_000) return true;
-    if (!unit && duration === 18_000) return true;
-  }
-
-  const label = [
-    limit.name,
-    limit.title,
-    limit.scope,
-    detail.name,
-    detail.title,
-    detail.scope,
-  ].find((value) => typeof value === "string");
-  return typeof label === "string" && /\b5[\s-]*(?:h|hours?)\b/i.test(label);
-}
-
-function parseKimiResetTimestamp(
-  usage: Record<string, unknown>,
-  ...sources: Array<Record<string, unknown> | null>
-): number | null {
-  for (const source of [usage, ...sources]) {
-    if (!source) continue;
-    const reset = source.reset_at ?? source.resetAt ?? source.reset_time ?? source.resetTime;
-    const parsed = parseResetTimestamp(reset);
-    if (parsed !== null) return parsed;
-  }
-  return null;
+function isKimiFiveHourWindow(window: Record<string, unknown> | null): boolean {
+  return asNumber(window?.duration) === 300
+    && asString(window?.timeUnit ?? window?.time_unit) === "TIME_UNIT_MINUTE";
 }
 
 function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
@@ -654,14 +639,13 @@ function asNumber(value: unknown): number | null {
   return value;
 }
 
-function asNumericValue(value: unknown): number | null {
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+function asNumericString(value: unknown): number | null {
   if (typeof value !== "string" || !value.trim()) return null;
   const parsed = Number(value);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-class ClaudeUsageHttpError extends Error {
+class UsageHttpError extends Error {
   constructor(
     readonly status: number,
     message: string,
@@ -681,6 +665,7 @@ export const __providerUsageTestHooks = {
     claudeUsageCache = null;
     kimiUsageCache = null;
     claudeBackoffUntil = 0;
+    kimiBackoff = null;
     stopProviderUsagePolling();
   },
 };

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -7,6 +7,7 @@ import {
   type JsonRpcRequest,
 } from "../agents/providers/json-rpc-stdio.js";
 import { getAllProviderInfo } from "../agents/providers/registry.js";
+import { getKimiApiKey } from "../state/config.js";
 import { buildWorkspaceEnv } from "../utils/env.js";
 
 type UsageStatus = "available" | "unavailable" | "unknown" | "error";
@@ -71,6 +72,15 @@ interface ClaudeUsageWindow {
   resets_at?: unknown;
 }
 
+interface UsageFetchRequest {
+  url: string;
+  headers: Record<string, string>;
+  timeoutMs: number;
+  providerLabel: string;
+  invalidResponseMessage?: string;
+  createHttpError?: (response: Response, body: unknown) => Error;
+}
+
 const CODEX_USAGE_CACHE_TTL_MS = 120_000;
 const CODEX_REQUEST_TIMEOUT_MS = 5_000;
 const CODEX_USAGE_IDLE_TIMEOUT_MS = 120_000;
@@ -78,6 +88,9 @@ const CLAUDE_USAGE_CACHE_TTL_MS = 180_000;
 const CLAUDE_REQUEST_TIMEOUT_MS = 5_000;
 const CLAUDE_USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 const CLAUDE_OAUTH_BETA_HEADER = "oauth-2025-04-20";
+const KIMI_USAGE_CACHE_TTL_MS = 180_000;
+const KIMI_REQUEST_TIMEOUT_MS = 5_000;
+const KIMI_USAGE_URL = "https://api.kimi.com/coding/v1/usages";
 const CLIENT_INFO = {
   name: "hive",
   title: "Hive",
@@ -90,6 +103,9 @@ let codexUsageCache:
   | null = null;
 let claudeUsageCache:
   | { value: ProviderUsageEntry; expiresAt: number }
+  | null = null;
+let kimiUsageCache:
+  | { apiKey: string; value: ProviderUsageEntry; expiresAt: number }
   | null = null;
 let claudeBackoffUntil = 0;
 
@@ -107,6 +123,8 @@ export async function getProviderUsageSnapshot(): Promise<ProviderUsageResponse>
   if (claude) {
     providerTasks.push(getClaudeUsage(claude.label, claude.installed, claude.version));
   }
+
+  providerTasks.push(getKimiUsage("Kimi"));
 
   const providers = await Promise.all(providerTasks);
   return { providers, generatedAt };
@@ -186,8 +204,7 @@ async function getClaudeUsage(label: string, installed: boolean, version: string
       };
     }
 
-    const response = await fetchClaudeUsage(token, version);
-    const buckets = parseClaudeUsageBuckets(response.body);
+    const buckets = parseClaudeUsageBuckets(await fetchClaudeUsage(token, version));
     if (buckets.length === 0) {
       return {
         id: "claude",
@@ -224,6 +241,62 @@ async function getClaudeUsage(label: string, installed: boolean, version: string
   }
 }
 
+async function getKimiUsage(label: string): Promise<ProviderUsageEntry> {
+  const apiKey = getKimiApiKey();
+  if (!apiKey) {
+    kimiUsageCache = null;
+    return unavailableProvider("kimi", label, "Kimi API key is not configured.");
+  }
+
+  const now = Date.now();
+  if (
+    kimiUsageCache
+    && kimiUsageCache.apiKey === apiKey
+    && kimiUsageCache.expiresAt > now
+  ) {
+    return kimiUsageCache.value;
+  }
+
+  try {
+    const buckets = parseKimiUsageBuckets(await fetchKimiUsage(apiKey));
+    if (buckets.length === 0) {
+      kimiUsageCache = null;
+      return {
+        id: "kimi",
+        label,
+        status: "unknown",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Kimi usage API returned no weekly or 5-hour usage windows.",
+      };
+    }
+
+    const entry = {
+      id: "kimi",
+      label,
+      status: "available" as const,
+      buckets,
+      lastUpdatedAt: new Date().toISOString(),
+    };
+    kimiUsageCache = {
+      apiKey,
+      value: entry,
+      expiresAt: now + KIMI_USAGE_CACHE_TTL_MS,
+    };
+    return entry;
+  } catch (err) {
+    kimiUsageCache = null;
+    return {
+      id: "kimi",
+      label,
+      status: "error",
+      buckets: [],
+      lastUpdatedAt: null,
+      message: err instanceof Error ? err.message : "Could not read Kimi account usage.",
+    };
+  }
+}
+
 function unavailableProvider(id: string, label: string, message: string): ProviderUsageEntry {
   return {
     id,
@@ -253,41 +326,74 @@ async function readClaudeAccessToken(): Promise<string | null> {
   return asString(oauth.accessToken);
 }
 
-async function fetchClaudeUsage(token: string, version: string | null): Promise<{ body: unknown }> {
+async function fetchClaudeUsage(token: string, version: string | null): Promise<unknown> {
+  return fetchUsageJson({
+    url: CLAUDE_USAGE_URL,
+    timeoutMs: CLAUDE_REQUEST_TIMEOUT_MS,
+    providerLabel: "Claude",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      "anthropic-beta": CLAUDE_OAUTH_BETA_HEADER,
+      "User-Agent": `claude-code/${version ?? "2.0"}`,
+    },
+    createHttpError: (response, body) => new ClaudeUsageHttpError(
+      response.status,
+      errorMessageFromBody(body) ?? `Claude usage API returned HTTP ${response.status}.`,
+      retryAfterMs(response.headers.get("retry-after")),
+    ),
+  });
+}
+
+async function fetchKimiUsage(apiKey: string): Promise<unknown> {
+  return fetchUsageJson({
+    url: KIMI_USAGE_URL,
+    timeoutMs: KIMI_REQUEST_TIMEOUT_MS,
+    providerLabel: "Kimi",
+    invalidResponseMessage: "Kimi usage API returned an invalid response.",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+  });
+}
+
+async function fetchUsageJson(request: UsageFetchRequest): Promise<unknown> {
   const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), CLAUDE_REQUEST_TIMEOUT_MS);
+  const timeout = setTimeout(() => controller.abort(), request.timeoutMs);
   try {
-    const response = await fetch(CLAUDE_USAGE_URL, {
-      headers: {
-        Accept: "application/json",
-        Authorization: `Bearer ${token}`,
-        "Content-Type": "application/json",
-        "anthropic-beta": CLAUDE_OAUTH_BETA_HEADER,
-        "User-Agent": `claude-code/${version ?? "2.0"}`,
-      },
+    const response = await fetch(request.url, {
+      method: "GET",
+      headers: request.headers,
       signal: controller.signal,
     });
 
     let body: unknown = null;
+    let parsed = false;
     try {
       body = await response.json();
+      parsed = true;
     } catch {
-      // Non-JSON failures are converted into the generic HTTP error below.
+      // Non-JSON failures are converted into the HTTP error below.
     }
 
     if (!response.ok) {
-      throw new ClaudeUsageHttpError(
-        response.status,
-        errorMessageFromBody(body) ?? `Claude usage API returned HTTP ${response.status}.`,
-        retryAfterMs(response.headers.get("retry-after")),
+      throw request.createHttpError?.(response, body) ?? new Error(
+        errorMessageFromBody(body)
+        ?? `${request.providerLabel} usage API returned HTTP ${response.status}.`,
       );
     }
 
-    return { body };
+    if (!parsed && request.invalidResponseMessage) {
+      throw new Error(request.invalidResponseMessage);
+    }
+
+    return body;
   } catch (err) {
     if (err instanceof ClaudeUsageHttpError) throw err;
     if (err instanceof Error && err.name === "AbortError") {
-      throw new Error("Claude usage API timed out.");
+      throw new Error(`${request.providerLabel} usage API timed out.`);
     }
     throw err;
   } finally {
@@ -329,6 +435,116 @@ function parseClaudeUsageBucket(
     windowDurationMins: config.windowDurationMins,
     resetsAt: parseResetTimestamp(window.resets_at),
   };
+}
+
+function parseKimiUsageBuckets(result: unknown): ProviderUsageBucket[] {
+  const record = asRecord(result);
+  if (!record) return [];
+
+  const buckets: ProviderUsageBucket[] = [];
+  const weekly = parseKimiUsageBucket(
+    "weekly",
+    "Weekly",
+    10_080,
+    asRecord(record.usage),
+  );
+  if (weekly) buckets.push(weekly);
+
+  const limits = Array.isArray(record.limits) ? record.limits : [];
+  for (const rawLimit of limits) {
+    const limit = asRecord(rawLimit);
+    if (!limit) continue;
+    const detail = asRecord(limit.detail) ?? limit;
+    const window = asRecord(limit.window);
+    if (!isKimiFiveHourWindow(limit, detail, window)) continue;
+
+    const fiveHour = parseKimiUsageBucket(
+      "five_hour",
+      "5h",
+      300,
+      detail,
+      limit,
+      window,
+    );
+    if (fiveHour) {
+      buckets.push(fiveHour);
+      break;
+    }
+  }
+
+  return buckets;
+}
+
+function parseKimiUsageBucket(
+  id: string,
+  label: string,
+  windowDurationMins: number,
+  usage: Record<string, unknown> | null,
+  ...resetSources: Array<Record<string, unknown> | null>
+): ProviderUsageBucket | null {
+  if (!usage) return null;
+  const limit = asNumericValue(usage.limit);
+  if (limit === null || limit <= 0) return null;
+
+  let used = asNumericValue(usage.used);
+  if (used === null) {
+    const remaining = asNumericValue(usage.remaining);
+    if (remaining !== null) used = limit - remaining;
+  }
+  if (used === null) return null;
+
+  return {
+    id,
+    label,
+    usedPercent: normalizePercentNumber((used / limit) * 100),
+    windowDurationMins,
+    resetsAt: parseKimiResetTimestamp(usage, ...resetSources),
+  };
+}
+
+function isKimiFiveHourWindow(
+  limit: Record<string, unknown>,
+  detail: Record<string, unknown>,
+  window: Record<string, unknown> | null,
+): boolean {
+  const duration = asNumericValue(window?.duration ?? limit.duration ?? detail.duration);
+  const unit = asString(
+    window?.timeUnit
+    ?? window?.time_unit
+    ?? limit.timeUnit
+    ?? limit.time_unit
+    ?? detail.timeUnit
+    ?? detail.time_unit,
+  )?.toUpperCase() ?? "";
+  if (duration !== null) {
+    if (unit.includes("MINUTE") && duration === 300) return true;
+    if (unit.includes("HOUR") && duration === 5) return true;
+    if (unit.includes("SECOND") && duration === 18_000) return true;
+    if (!unit && duration === 18_000) return true;
+  }
+
+  const label = [
+    limit.name,
+    limit.title,
+    limit.scope,
+    detail.name,
+    detail.title,
+    detail.scope,
+  ].find((value) => typeof value === "string");
+  return typeof label === "string" && /\b5[\s-]*(?:h|hours?)\b/i.test(label);
+}
+
+function parseKimiResetTimestamp(
+  usage: Record<string, unknown>,
+  ...sources: Array<Record<string, unknown> | null>
+): number | null {
+  for (const source of [usage, ...sources]) {
+    if (!source) continue;
+    const reset = source.reset_at ?? source.resetAt ?? source.reset_time ?? source.resetTime;
+    const parsed = parseResetTimestamp(reset);
+    if (parsed !== null) return parsed;
+  }
+  return null;
 }
 
 function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
@@ -438,6 +654,13 @@ function asNumber(value: unknown): number | null {
   return value;
 }
 
+function asNumericValue(value: unknown): number | null {
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value !== "string" || !value.trim()) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 class ClaudeUsageHttpError extends Error {
   constructor(
     readonly status: number,
@@ -451,10 +674,12 @@ class ClaudeUsageHttpError extends Error {
 export const __providerUsageTestHooks = {
   parseCodexRateLimitBuckets,
   parseClaudeUsageBuckets,
+  parseKimiUsageBuckets,
   parseResetTimestamp,
   resetProviderUsageCaches() {
     codexUsageCache = null;
     claudeUsageCache = null;
+    kimiUsageCache = null;
     claudeBackoffUntil = 0;
     stopProviderUsagePolling();
   },

--- a/backend/src/state/agents.test.ts
+++ b/backend/src/state/agents.test.ts
@@ -74,9 +74,16 @@ describe("agents persistence", () => {
   });
 
   it("clears a stale thinkingLevel for models with no thinking-level control", async () => {
-    await saveAgents([makeAgent({ modelId: "kimi:k3", thinkingLevel: "high" })], dataDir);
+    await saveAgents([makeAgent({ modelId: "kimi:kimi-for-coding", thinkingLevel: "high" })], dataDir);
 
     const loaded = await loadAgents(dataDir);
     expect(loaded[0].thinkingLevel).toBeUndefined();
+  });
+
+  it("preserves a supported K3 thinkingLevel", async () => {
+    await saveAgents([makeAgent({ modelId: "kimi:k3", thinkingLevel: "low" })], dataDir);
+
+    const loaded = await loadAgents(dataDir);
+    expect(loaded[0].thinkingLevel).toBe("low");
   });
 });

--- a/backend/src/state/agents.ts
+++ b/backend/src/state/agents.ts
@@ -30,7 +30,7 @@ function agentsFilePath(dataDir: string): string {
 
 function normalizeAgent(raw: Agent): Agent {
   // Keep a stored level only while the model supports it; otherwise fall back
-  // to the model's default, which is undefined for level-less models (Kimi).
+  // to the model's default, which is undefined for level-less models.
   const thinkingLevel = raw.thinkingLevel && isThinkingLevelSupportedForModel(raw.modelId, raw.thinkingLevel)
     ? raw.thinkingLevel
     : getDefaultThinkingLevelForModel(raw.modelId);

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -598,7 +598,7 @@ export interface Agent {
   description?: string;
   systemPrompt: string;
   modelId: string;
-  /** Absent for models with no thinking-level control (e.g. Kimi). */
+  /** Absent for models with no thinking-level control (e.g. K2.7). */
   thinkingLevel?: ThinkingLevel;
   readOnly: boolean;
   createdAt: string;

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -170,8 +170,14 @@ function sortProviderBuckets(provider: ProviderUsageEntry): ProviderUsageBucket[
   return [...provider.buckets].sort((a, b) => {
     if (a.id === provider.id && b.id !== provider.id) return -1;
     if (b.id === provider.id && a.id !== provider.id) return 1;
-    return 0;
+    return bucketOrder(a) - bucketOrder(b);
   });
+}
+
+function bucketOrder(bucket: ProviderUsageBucket): number {
+  if (bucket.id === "five_hour") return 0;
+  if (bucket.id === "weekly" || bucket.id === "seven_day") return 1;
+  return 2;
 }
 
 function statusLabel(status: ProviderUsageEntry["status"]): string {

--- a/frontend/src/pages/settings/TeamSettings.tsx
+++ b/frontend/src/pages/settings/TeamSettings.tsx
@@ -262,7 +262,7 @@ function FormFields({
         </Field>
       </div>
 
-      {/* Hidden for models with no thinking-level control (e.g. Kimi). */}
+      {/* Hidden for models with no thinking-level control (e.g. K2.7). */}
       {resolvedThinkingLevel && thinkingLevels.length > 0 && (
         <Field label="Thinking">
           <ThinkingLevelChips
@@ -360,7 +360,7 @@ function AgentDetail({
       description: description.trim(),
       systemPrompt: systemPrompt.trim(),
       modelId,
-      // Omitted for models with no thinking-level control (e.g. Kimi); the
+      // Omitted for models with no thinking-level control (e.g. K2.7); the
       // backend rejects any level supplied for them.
       ...(resolvedThinkingLevel && { thinkingLevel: resolvedThinkingLevel }),
       readOnly,
@@ -445,7 +445,7 @@ function CreateAgentForm({
       ...(description.trim() && { description: description.trim() }),
       systemPrompt: systemPrompt.trim(),
       modelId: resolvedModelId,
-      // Omitted for models with no thinking-level control (e.g. Kimi).
+      // Omitted for models with no thinking-level control (e.g. K2.7).
       ...(resolvedThinkingLevel && { thinkingLevel: resolvedThinkingLevel }),
       readOnly,
     });
@@ -610,7 +610,7 @@ function resolveThinkingLevel(
 ): ThinkingLevel | undefined {
   const levels = model?.capabilities.thinkingLevels;
   if (!levels) return thinkingLevel; // model not in catalog: keep as stored
-  if (levels.length === 0) return undefined; // no thinking-level control (e.g. Kimi)
+  if (levels.length === 0) return undefined; // no thinking-level control (e.g. K2.7)
   if (thinkingLevel && levels.includes(thinkingLevel)) return thinkingLevel;
   return levels.includes("high") ? "high" : levels[0];
 }

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -590,7 +590,7 @@ export interface Agent {
   description?: string;
   systemPrompt: string;
   modelId: string;
-  /** Absent for models with no thinking-level control (e.g. Kimi). */
+  /** Absent for models with no thinking-level control (e.g. K2.7). */
   thinkingLevel?: ThinkingLevel;
   readOnly: boolean;
   createdAt: string;

--- a/frontend/tests/components/ProviderUsage.test.tsx
+++ b/frontend/tests/components/ProviderUsage.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 import { ProviderUsage } from "@/components/ProviderUsage";
 
@@ -53,8 +54,8 @@ describe("ProviderUsage", () => {
         generatedAt: "2026-06-10T00:00:00.000Z",
         providers: [
           {
-            id: "codex",
-            label: "Codex",
+            id: "kimi",
+            label: "Kimi",
             status: "unavailable",
             lastUpdatedAt: null,
             buckets: [],
@@ -66,5 +67,103 @@ describe("ProviderUsage", () => {
     const { container } = render(<ProviderUsage />);
 
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("uses Kimi's most-consumed window in the compact bar and shows both windows", async () => {
+    const user = userEvent.setup();
+    mocks.useProviderUsage.mockReturnValue({
+      data: {
+        generatedAt: "2026-06-10T00:00:00.000Z",
+        providers: [
+          {
+            id: "kimi",
+            label: "Kimi",
+            status: "available",
+            lastUpdatedAt: "2026-06-10T00:00:00.000Z",
+            buckets: [
+              {
+                id: "weekly",
+                label: "Weekly",
+                usedPercent: 38,
+                windowDurationMins: 10_080,
+                resetsAt: null,
+              },
+              {
+                id: "five_hour",
+                label: "5h",
+                usedPercent: 72,
+                windowDurationMins: 300,
+                resetsAt: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(<ProviderUsage />);
+
+    const label = screen.getByText("Kimi");
+    const compactFill = label.nextElementSibling?.firstElementChild;
+    expect(compactFill).toHaveStyle({ width: "72%" });
+
+    await user.hover(label);
+    expect(await screen.findAllByText("Kimi Weekly")).not.toHaveLength(0);
+    expect(screen.getAllByText("Kimi 5h")).not.toHaveLength(0);
+    expect(screen.getAllByText("38%")).not.toHaveLength(0);
+    expect(screen.getAllByText("72%")).not.toHaveLength(0);
+  });
+
+  it("shows n/a and the explanatory message for unknown Kimi usage", async () => {
+    const user = userEvent.setup();
+    mocks.useProviderUsage.mockReturnValue({
+      data: {
+        generatedAt: "2026-06-10T00:00:00.000Z",
+        providers: [
+          {
+            id: "kimi",
+            label: "Kimi",
+            status: "unknown",
+            lastUpdatedAt: null,
+            buckets: [],
+            message: "Kimi usage API returned no weekly or 5-hour usage windows.",
+          },
+        ],
+      },
+    });
+
+    render(<ProviderUsage />);
+
+    await user.hover(screen.getByText("Kimi"));
+    expect(await screen.findAllByText("n/a")).not.toHaveLength(0);
+    expect(screen.getAllByText("Kimi usage API returned no weekly or 5-hour usage windows.")).not.toHaveLength(0);
+  });
+
+  it("shows Kimi errors without a stale compact bar", async () => {
+    const user = userEvent.setup();
+    mocks.useProviderUsage.mockReturnValue({
+      data: {
+        generatedAt: "2026-06-10T00:00:00.000Z",
+        providers: [
+          {
+            id: "kimi",
+            label: "Kimi",
+            status: "error",
+            lastUpdatedAt: null,
+            buckets: [],
+            message: "Invalid API key.",
+          },
+        ],
+      },
+    });
+
+    render(<ProviderUsage />);
+
+    const label = screen.getByText("Kimi");
+    const compactFill = label.nextElementSibling?.firstElementChild;
+    expect(compactFill).toHaveStyle({ width: "0%" });
+
+    await user.hover(label);
+    expect(await screen.findAllByText("Invalid API key.")).not.toHaveLength(0);
   });
 });

--- a/frontend/tests/components/ProviderUsage.test.tsx
+++ b/frontend/tests/components/ProviderUsage.test.tsx
@@ -69,12 +69,34 @@ describe("ProviderUsage", () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it("uses Kimi's most-consumed window in the compact bar and shows both windows", async () => {
+  it("uses Kimi's most-consumed window and orders 5h before 7d for Claude and Kimi", async () => {
     const user = userEvent.setup();
     mocks.useProviderUsage.mockReturnValue({
       data: {
         generatedAt: "2026-06-10T00:00:00.000Z",
         providers: [
+          {
+            id: "claude",
+            label: "Claude Code",
+            status: "available",
+            lastUpdatedAt: "2026-06-10T00:00:00.000Z",
+            buckets: [
+              {
+                id: "seven_day",
+                label: "7d",
+                usedPercent: 30,
+                windowDurationMins: 10_080,
+                resetsAt: null,
+              },
+              {
+                id: "five_hour",
+                label: "5h",
+                usedPercent: 20,
+                windowDurationMins: 300,
+                resetsAt: null,
+              },
+            ],
+          },
           {
             id: "kimi",
             label: "Kimi",
@@ -83,7 +105,7 @@ describe("ProviderUsage", () => {
             buckets: [
               {
                 id: "weekly",
-                label: "Weekly",
+                label: "7d",
                 usedPercent: 38,
                 windowDurationMins: 10_080,
                 resetsAt: null,
@@ -108,8 +130,13 @@ describe("ProviderUsage", () => {
     expect(compactFill).toHaveStyle({ width: "72%" });
 
     await user.hover(label);
-    expect(await screen.findAllByText("Kimi Weekly")).not.toHaveLength(0);
-    expect(screen.getAllByText("Kimi 5h")).not.toHaveLength(0);
+    await screen.findAllByText("Kimi 5h");
+    expect(screen.getAllByText("Claude 5h")[0].compareDocumentPosition(
+      screen.getAllByText("Claude 7d")[0],
+    ) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(screen.getAllByText("Kimi 5h")[0].compareDocumentPosition(
+      screen.getAllByText("Kimi 7d")[0],
+    ) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     expect(screen.getAllByText("38%")).not.toHaveLength(0);
     expect(screen.getAllByText("72%")).not.toHaveLength(0);
   });

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -256,7 +256,7 @@ describe("useModels", () => {
           provider: "kimi",
           providerLabel: "Kimi",
           isDefault: true,
-          capabilities: { thinkingLevels: [], planMode: true, blockingTools: true, completions: true, goals: false },
+          capabilities: { thinkingLevels: ["low", "high", "max"], planMode: true, blockingTools: true, completions: true, goals: false },
         },
       ],
     };
@@ -305,7 +305,7 @@ describe("useModels", () => {
           label: "K3",
           provider: "kimi",
           providerLabel: "Kimi",
-          capabilities: { thinkingLevels: [], planMode: true, blockingTools: true, completions: true, goals: false },
+          capabilities: { thinkingLevels: ["low", "high", "max"], planMode: true, blockingTools: true, completions: true, goals: false },
         },
       ],
     };

--- a/frontend/tests/pages/ModelsSettings.test.tsx
+++ b/frontend/tests/pages/ModelsSettings.test.tsx
@@ -123,7 +123,7 @@ describe("ModelsSettings", () => {
         ...MOCK_CATALOG,
         models: [
           ...MOCK_CATALOG.models,
-          { id: "kimi:k3", label: "K3", provider: "kimi", providerLabel: "Kimi", capabilities: { ...CAPABILITIES, thinkingLevels: [] } },
+          { id: "kimi:k3", label: "K3", provider: "kimi", providerLabel: "Kimi", capabilities: { ...CAPABILITIES, thinkingLevels: ["low", "high", "max"] } },
         ],
       };
       return { apiKey: "sk-new-key" };

--- a/frontend/tests/pages/TeamSettings.test.tsx
+++ b/frontend/tests/pages/TeamSettings.test.tsx
@@ -88,6 +88,19 @@ const catalog: ModelCatalogResponse = {
       provider: "kimi",
       providerLabel: "Kimi",
       capabilities: {
+        thinkingLevels: ["low", "high", "max"],
+        planMode: true,
+        blockingTools: true,
+        completions: true,
+        goals: false,
+      },
+    },
+    {
+      id: "kimi:kimi-for-coding",
+      label: "K2.7 Coding",
+      provider: "kimi",
+      providerLabel: "Kimi",
+      capabilities: {
         thinkingLevels: [],
         planMode: true,
         blockingTools: true,
@@ -200,7 +213,29 @@ describe("TeamSettings", () => {
     });
   });
 
-  it("hides the thinking control and omits thinkingLevel for a level-less model (kimi)", async () => {
+  it("defaults K3 to high thinking", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Add Agent" }));
+    await user.type(screen.getByPlaceholderText("e.g. Code Auditor"), "K3 Agent");
+    await user.type(screen.getByPlaceholderText("You are a code auditor..."), "Do things.");
+    await user.selectOptions(screen.getByRole("combobox"), "kimi:k3");
+
+    expect(screen.getByRole("button", { name: "High" })).toHaveAttribute("aria-pressed", "true");
+    await user.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(mocks.createMutateAsync).toHaveBeenCalledWith(
+        expect.objectContaining({
+          modelId: "kimi:k3",
+          thinkingLevel: "high",
+        }),
+      );
+    });
+  });
+
+  it("hides the thinking control and omits thinkingLevel for K2.7", async () => {
     const user = userEvent.setup();
     renderPage();
 
@@ -209,7 +244,7 @@ describe("TeamSettings", () => {
     await user.type(screen.getByPlaceholderText("You are a code auditor..."), "Do things.");
 
     expect(screen.getByText("Thinking")).toBeInTheDocument();
-    await user.selectOptions(screen.getByRole("combobox"), "kimi:k3");
+    await user.selectOptions(screen.getByRole("combobox"), "kimi:kimi-for-coding");
     await waitFor(() => expect(screen.queryByText("Thinking")).not.toBeInTheDocument());
 
     await user.click(screen.getByRole("button", { name: "Create" }));
@@ -218,7 +253,7 @@ describe("TeamSettings", () => {
       expect(mocks.createMutateAsync).toHaveBeenCalledWith({
         name: "Kimi Agent",
         systemPrompt: "Do things.",
-        modelId: "kimi:k3",
+        modelId: "kimi:kimi-for-coding",
         readOnly: false,
       });
     });

--- a/ios/Tests/ChatDraftStoreTests/ModelCatalogDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ModelCatalogDecodingTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+struct ModelCatalogDecodingTests {
+    @Test
+    func decodesKimiLabelsAndModelSpecificThinkingLevels() throws {
+        let data = Data(
+            """
+            {
+              "models": [
+                {
+                  "id": "kimi:k3",
+                  "label": "K3",
+                  "provider": "kimi",
+                  "providerLabel": "Kimi",
+                  "capabilities": {
+                    "thinkingLevels": ["low", "high", "max"],
+                    "planMode": true,
+                    "blockingTools": true,
+                    "completions": true,
+                    "goals": false
+                  },
+                  "contextWindow": 262144
+                },
+                {
+                  "id": "kimi:k3-1m",
+                  "label": "K3 1M",
+                  "provider": "kimi",
+                  "providerLabel": "Kimi",
+                  "capabilities": {
+                    "thinkingLevels": ["low", "high", "max"],
+                    "planMode": true,
+                    "blockingTools": true,
+                    "completions": true,
+                    "goals": false
+                  },
+                  "contextWindow": 1048576
+                },
+                {
+                  "id": "kimi:kimi-for-coding",
+                  "label": "K2.7 Coding",
+                  "provider": "kimi",
+                  "providerLabel": "Kimi",
+                  "capabilities": {
+                    "thinkingLevels": [],
+                    "planMode": true,
+                    "blockingTools": true,
+                    "completions": true,
+                    "goals": false
+                  },
+                  "contextWindow": 262144
+                },
+                {
+                  "id": "kimi:kimi-for-coding-highspeed",
+                  "label": "K2.7 Coding Highspeed",
+                  "provider": "kimi",
+                  "providerLabel": "Kimi",
+                  "capabilities": {
+                    "thinkingLevels": [],
+                    "planMode": true,
+                    "blockingTools": true,
+                    "completions": true,
+                    "goals": false
+                  },
+                  "contextWindow": 262144
+                }
+              ],
+              "defaultModelId": "claude:opus-4-8"
+            }
+            """.utf8
+        )
+
+        let catalog = try JSONDecoder().decode(ModelCatalogResponse.self, from: data)
+
+        #expect(catalog.models.map(\.label) == [
+            "K3",
+            "K3 1M",
+            "K2.7 Coding",
+            "K2.7 Coding Highspeed"
+        ])
+        #expect(catalog.models[0].capabilities.thinkingLevels == [.low, .high, .max])
+        #expect(catalog.models[1].capabilities.thinkingLevels == [.low, .high, .max])
+        #expect(catalog.models[2].capabilities.thinkingLevels.isEmpty)
+        #expect(catalog.models[3].capabilities.thinkingLevels.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary

- expose the static K3, K3 1M, K2.7 Coding, and K2.7 Coding Highspeed catalog with model-specific reasoning capabilities
- route the selected Kimi model and supported K3 effort through the Claude Code parent process, aliases, and subagents
- add weekly and rolling 5-hour Kimi quota usage to the existing provider status contract with key-aware caching and stale-data rejection
- reuse the existing generic web/desktop status UI and model-capability plumbing across conversations, Team agents, automations, and iOS
- share HTTP timeout/JSON/error handling between Claude and Kimi usage requests

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run knip`
- `npm run test` — 1,730 backend and 1,608 frontend tests passed
- backend and frontend production builds passed
- live Kimi usage request returned two normalized quota windows
- live K3 `low` smoke returned a successful response with thinking and text blocks
- `swift test` was not run because Swift is unavailable in the current environment

Closes #359
Closes #360
