### PR TITLE
feat: upgrade Claude Opus default to Opus 5

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -4239,7 +4239,7 @@ describe("ConversationSession", () => {
     session.sendMessage("Hello", { model: "opus-4-7", thinkingLevel: "low", fastMode: true });
     expect(session.metadata.lockedProvider).toBe("claude");
     expect(session.metadata.lastRunOptions).toEqual({
-      model: "claude:opus-4-8",
+      model: "claude:opus-5",
       planMode: false,
       thinkingLevel: "low",
       fastMode: true,
@@ -4317,7 +4317,7 @@ describe("ConversationSession", () => {
     const meta = JSON.parse(raw);
     expect(meta.lockedProvider).toBe("claude");
     expect(meta.lastRunOptions).toEqual({
-      model: "claude:opus-4-8",
+      model: "claude:opus-5",
       planMode: false,
       thinkingLevel: "high",
       fastMode: false,

--- a/backend/src/agents/providers/claude.test.ts
+++ b/backend/src/agents/providers/claude.test.ts
@@ -39,7 +39,7 @@ describe("ClaudeProvider", () => {
   it("includes fable, opus, sonnet, and haiku", () => {
     const ids = provider.models.map((m) => m.id);
     expect(ids).toContain("fable-5");
-    expect(ids).toContain("opus-4-8");
+    expect(ids).toContain("opus-5");
     expect(ids).toContain("sonnet-5");
     expect(ids).toContain("haiku-4-5");
   });
@@ -120,10 +120,12 @@ describe("ClaudeProvider", () => {
     expect(args).toContain("claude-sonnet-5");
   });
 
-  it("maps persisted Opus 4.7 selections to Opus 4.8", () => {
-    const args = provider.buildArgs("Hello", { model: "opus-4-7" }, baseSession());
-    expect(args).toContain("--model");
-    expect(args).toContain("claude-opus-4-8[1m]");
+  it("maps persisted Opus 4.8 and 4.7 selections to Opus 5", () => {
+    for (const model of ["opus-4-8", "opus-4-7"]) {
+      const args = provider.buildArgs("Hello", { model }, baseSession());
+      expect(args).toContain("--model");
+      expect(args).toContain("claude-opus-5[1m]");
+    }
   });
 
   it("omits --model when model is not in the list", () => {
@@ -254,7 +256,7 @@ describe("ClaudeProvider", () => {
 
   it("marks Opus as supporting fast mode and the others as not", () => {
     const fable = provider.models.find((m) => m.id === "fable-5");
-    const opus = provider.models.find((m) => m.id === "opus-4-8");
+    const opus = provider.models.find((m) => m.id === "opus-5");
     const sonnet = provider.models.find((m) => m.id === "sonnet-5");
     const haiku = provider.models.find((m) => m.id === "haiku-4-5");
     expect(opus?.supportsFastMode).toBe(true);
@@ -264,15 +266,17 @@ describe("ClaudeProvider", () => {
   });
 
   it("adds --settings {fastMode:true} when fastMode is on and the model is Opus", () => {
-    const args = provider.buildArgs("Hello", { model: "opus-4-8", fastMode: true }, baseSession());
+    const args = provider.buildArgs("Hello", { model: "opus-5", fastMode: true }, baseSession());
     const idx = args.indexOf("--settings");
     expect(idx).toBeGreaterThan(-1);
     expect(JSON.parse(args[idx + 1])).toEqual({ fastMode: true });
   });
 
-  it("applies fast mode to aliased Opus 4.7 selections", () => {
-    const args = provider.buildArgs("Hello", { model: "opus-4-7", fastMode: true }, baseSession());
-    expect(args).toContain("--settings");
+  it("applies fast mode to aliased Opus 4.8 and 4.7 selections", () => {
+    for (const model of ["opus-4-8", "opus-4-7"]) {
+      const args = provider.buildArgs("Hello", { model, fastMode: true }, baseSession());
+      expect(args).toContain("--settings");
+    }
   });
 
   it("omits --settings when fastMode is on but the model does not support it", () => {
@@ -283,7 +287,7 @@ describe("ClaudeProvider", () => {
   });
 
   it("omits --settings when fastMode is off", () => {
-    const args = provider.buildArgs("Hello", { model: "opus-4-8" }, baseSession());
+    const args = provider.buildArgs("Hello", { model: "opus-5" }, baseSession());
     expect(args).not.toContain("--settings");
   });
 

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -11,11 +11,11 @@ import {
 
 const CLAUDE_MODELS: ModelDefinition[] = [
   // Fable 5 and Sonnet 5 ship with a 1M context window by default, so their
-  // cliValues need no explicit `[1m]` opt-in (unlike Opus 4.8). Fable 5's
+  // cliValues need no explicit `[1m]` opt-in (unlike Opus 5). Fable 5's
   // adaptive thinking is always on and depth is controlled via --effort; it
   // has no fast mode.
   { id: "fable-5", label: "Fable 5", cliValue: "claude-fable-5", contextWindow: 1_000_000 },
-  { id: "opus-4-8", label: "Opus 4.8", cliValue: "claude-opus-4-8[1m]", aliases: ["opus-4-7"], isDefault: true, contextWindow: 1_000_000, supportsFastMode: true },
+  { id: "opus-5", label: "Opus 5", cliValue: "claude-opus-5[1m]", aliases: ["opus-4-8", "opus-4-7"], isDefault: true, contextWindow: 1_000_000, supportsFastMode: true },
   { id: "sonnet-5", label: "Sonnet 5", cliValue: "claude-sonnet-5", aliases: ["sonnet-4-6"], contextWindow: 1_000_000 },
   { id: "haiku-4-5", label: "Haiku 4.5", cliValue: "claude-haiku-4-5", contextWindow: 200_000 },
 ];

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -432,7 +432,7 @@ describe("contextWindow in catalog", () => {
 
     const fable = claudeModels.find((m) => m.id === "claude:fable-5");
     expect(fable?.contextWindow).toBe(1_000_000);
-    const opus = claudeModels.find((m) => m.id === "claude:opus-4-8");
+    const opus = claudeModels.find((m) => m.id === "claude:opus-5");
     expect(opus?.contextWindow).toBe(1_000_000);
     const sonnet = claudeModels.find((m) => m.id === "claude:sonnet-5");
     expect(sonnet?.contextWindow).toBe(1_000_000);


### PR DESCRIPTION
## Summary

Anthropic released **Claude Opus 5** (`claude-opus-5`) on 2026-07-24 ([announcement](https://www.anthropic.com/news/claude-opus-5), [models overview](https://platform.claude.com/docs/en/about-claude/models/overview)), replacing Opus 4.8 as the current Opus tier: same $5/$25 per MTok pricing, 1M context window, 128K max output, adaptive thinking, fast mode supported (~2.5x speed at 2x price). Opus 4.8 is now listed as legacy.

This follows the same pattern as the 4.7 -> 4.8 upgrade (#215):

- `CLAUDE_MODELS` in `backend/src/agents/providers/claude.ts`: the Opus entry becomes `opus-5` (`claude-opus-5[1m]`, default, fast-mode capable) with `opus-4-8` and `opus-4-7` kept as aliases, so persisted sessions and stored `defaultModelId` values resolve to Opus 5 via `findModel`.
- The `[1m]` cliValue suffix is kept: Claude Code still uses it to guarantee the 1M context window for Opus on subscription plans.
- Tests updated: catalog/fast-mode/alias assertions in `claude.test.ts` (alias coverage now spans both `opus-4-8` and `opus-4-7`), and the alias-normalization expectations in `conversation-session.test.ts` and `registry.test.ts` now expect `claude:opus-5`.
- Fixtures elsewhere that store `claude:opus-4-8` (config, automations, stream tests) are intentionally untouched — they exercise the legacy-id alias-resolution path.

Fable 5, Sonnet 5, and Haiku 4.5 are unchanged. Frontend and iOS consume the catalog via `GET /api/models`, so no client changes are needed.

## Testing

- `npm run lint` / `npm run typecheck` (root) clean
- Backend: 1734 tests pass
- Frontend: 1637 tests pass