### PR TITLE
fix: surface the constraining usage window for Codex and Claude

### DIFF
--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -521,6 +521,87 @@ describe("provider usage", () => {
     expect(mocks.spawn).toHaveBeenCalledTimes(1);
   });
 
+  // Field names, nesting, and null-vs-populated keys mirror the live /api/oauth/usage response
+  // captured on 2026-07-28 (claude-code 2.1.217). Percentages are synthetic.
+  it("parses the per-model Claude limits that the legacy top-level keys no longer carry", () => {
+    expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
+      five_hour: { utilization: 2, resets_at: "2026-07-29T02:50:00Z" },
+      seven_day: { utilization: 34, resets_at: "2026-08-04T05:00:00Z" },
+      seven_day_opus: null,
+      seven_day_sonnet: null,
+      limits: [
+        {
+          kind: "session",
+          percent: 2,
+          resets_at: "2026-07-29T02:50:00Z",
+          scope: null,
+        },
+        {
+          kind: "weekly_all",
+          percent: 34,
+          resets_at: "2026-08-04T05:00:00Z",
+          scope: null,
+        },
+        {
+          kind: "weekly_scoped",
+          percent: 60,
+          resets_at: "2026-08-04T05:00:00Z",
+          scope: { model: { id: null, display_name: "Fable" }, surface: null },
+        },
+      ],
+    })).toEqual([
+      {
+        id: "session",
+        label: "5h",
+        usedPercent: 2,
+        windowDurationMins: 300,
+        resetsAt: 1785293400,
+      },
+      {
+        id: "weekly_all",
+        label: "7d",
+        usedPercent: 34,
+        windowDurationMins: 10_080,
+        resetsAt: 1785819600,
+      },
+      {
+        id: "weekly_scoped:fable",
+        label: "7d Fable",
+        usedPercent: 60,
+        windowDurationMins: 10_080,
+        resetsAt: 1785819600,
+      },
+    ]);
+  });
+
+  it("falls back to the legacy Claude usage keys when the response carries no limits", () => {
+    expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
+      five_hour: { utilization: 42, resets_at: "2026-06-10T17:00:00Z" },
+      limits: [],
+    })).toMatchObject([
+      { id: "five_hour", label: "5h", usedPercent: 42 },
+    ]);
+  });
+
+  it("reports an expired Claude sign-in without calling the usage endpoint", async () => {
+    mocks.readFile.mockResolvedValue(JSON.stringify({
+      claudeAiOauth: {
+        accessToken: "expired-token",
+        expiresAt: Date.now() - 1_000,
+      },
+    }));
+
+    const result = await getProviderUsageSnapshot();
+
+    expect(result.providers[0]).toMatchObject({
+      id: "claude",
+      status: "unknown",
+      buckets: [],
+      message: "Claude sign-in expired. Run `claude` to refresh the token.",
+    });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it("parses Claude OAuth usage windows", () => {
     expect(__providerUsageTestHooks.parseClaudeUsageBuckets({
       five_hour: { utilization: 42, resets_at: "2026-06-10T17:00:00Z" },

--- a/backend/src/services/provider-usage.test.ts
+++ b/backend/src/services/provider-usage.test.ts
@@ -160,8 +160,8 @@ describe("provider usage", () => {
       },
     })).toEqual([
       {
-        id: "codex",
-        label: null,
+        id: "codex:primary",
+        label: "5h",
         usedPercent: 0.4,
         windowDurationMins: 300,
         resetsAt: 1781110800,
@@ -184,8 +184,8 @@ describe("provider usage", () => {
       },
     })).toMatchObject([
       {
-        id: "weekly",
-        label: "Weekly",
+        id: "weekly:primary",
+        label: "Weekly primary",
         usedPercent: 87,
         resetsAt: 1781542800,
       },
@@ -198,7 +198,7 @@ describe("provider usage", () => {
       },
     })).toMatchObject([
       {
-        id: "codex",
+        id: "codex:primary",
         usedPercent: 1,
       },
     ]);
@@ -209,7 +209,7 @@ describe("provider usage", () => {
       },
     })).toMatchObject([
       {
-        id: "codex",
+        id: "codex:primary",
         usedPercent: 1,
       },
     ]);
@@ -220,10 +220,105 @@ describe("provider usage", () => {
       },
     })).toMatchObject([
       {
-        id: "codex",
+        id: "codex:primary",
         usedPercent: 42,
       },
     ]);
+  });
+
+  // Field names and nesting mirror the RateLimitSnapshot bindings emitted by
+  // `codex app-server generate-ts` (codex-cli 0.145.0).
+  it("surfaces both the primary and secondary window of every Codex limit", () => {
+    expect(__providerUsageTestHooks.parseCodexRateLimitBuckets({
+      rateLimits: {
+        limitId: "codex",
+        limitName: "Codex",
+        primary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1781542800 },
+        secondary: { usedPercent: 64, windowDurationMins: 300, resetsAt: 1781110800 },
+      },
+      rateLimitsByLimitId: {
+        codex: {
+          limitId: "codex",
+          limitName: "Codex",
+          primary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1781542800 },
+          secondary: { usedPercent: 64, windowDurationMins: 300, resetsAt: 1781110800 },
+        },
+        "gpt-5.3-codex": {
+          limitId: "gpt-5.3-codex",
+          limitName: "GPT-5.3-Codex",
+          primary: { usedPercent: 0, windowDurationMins: 10080, resetsAt: 1781542800 },
+          secondary: null,
+        },
+      },
+    })).toEqual([
+      {
+        id: "codex:primary",
+        label: "7d",
+        usedPercent: 0,
+        windowDurationMins: 10080,
+        resetsAt: 1781542800,
+        planType: null,
+        credits: undefined,
+        rateLimitReachedType: null,
+      },
+      {
+        id: "codex:secondary",
+        label: "5h",
+        usedPercent: 64,
+        windowDurationMins: 300,
+        resetsAt: 1781110800,
+        planType: null,
+        credits: undefined,
+        rateLimitReachedType: null,
+      },
+      {
+        id: "gpt-5.3-codex:primary",
+        label: "GPT-5.3-Codex 7d",
+        usedPercent: 0,
+        windowDurationMins: 10080,
+        resetsAt: 1781542800,
+        planType: null,
+        credits: undefined,
+        rateLimitReachedType: null,
+      },
+    ]);
+  });
+
+  it("reports an expired Codex sign-in instead of the raw upstream error", async () => {
+    const proc = createMockProcess();
+    mocks.spawn.mockReturnValue(proc);
+    mocks.getAllProviderInfo.mockReturnValue([
+      {
+        id: "codex",
+        label: "Codex",
+        npmPackage: "@openai/codex",
+        installed: true,
+        version: "1.0.0",
+      },
+    ]);
+
+    const resultPromise = getProviderUsageSnapshot();
+    const init = findMethod(proc, "initialize");
+    proc._stdout.push(appServerResponse(init.id, {}));
+    await flushPromises();
+    const read = findMethod(proc, "account/rateLimits/read");
+    proc._stdout.push(JSON.stringify({
+      id: read.id,
+      error: {
+        code: -32603,
+        message: "failed to fetch codex rate limits: GET https://chatgpt.com/backend-api/wham/usage"
+          + ' failed: 401 Unauthorized; content-type=text/plain; body={"error":{"code":"token_invalidated"}}',
+      },
+    }) + "\n");
+
+    const result = await resultPromise;
+
+    expect(result.providers[0]).toMatchObject({
+      id: "codex",
+      status: "unknown",
+      buckets: [],
+      message: "Codex sign-in expired. Run `codex login`.",
+    });
   });
 
   it("reads Codex usage through the App Server JSON-RPC endpoint", async () => {
@@ -266,8 +361,8 @@ describe("provider usage", () => {
       status: "available",
       buckets: [
         {
-          id: "primary",
-          label: "Primary",
+          id: "primary:primary",
+          label: "Primary 5h",
           usedPercent: 25,
           resetsAt: 1781110800,
         },
@@ -353,7 +448,7 @@ describe("provider usage", () => {
     expect(secondResult.providers[0]).toMatchObject({
       id: "codex",
       status: "available",
-      buckets: [{ id: "codex", usedPercent: 12 }],
+      buckets: [{ id: "codex:primary", usedPercent: 12 }],
     });
   });
 
@@ -414,7 +509,7 @@ describe("provider usage", () => {
     const secondResult = await getProviderUsageSnapshot();
     expect(secondResult.providers[0]).toMatchObject({
       id: "codex",
-      buckets: [{ id: "codex", usedPercent: 12 }],
+      buckets: [{ id: "codex:primary", usedPercent: 12 }],
     });
     expect(parseWrites(proc).filter((entry) => entry.method === "account/rateLimits/read")).toHaveLength(1);
 

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -74,6 +74,13 @@ interface ClaudeUsageWindow {
   resets_at?: unknown;
 }
 
+interface ClaudeUsageLimit {
+  kind?: unknown;
+  percent?: unknown;
+  resets_at?: unknown;
+  scope?: unknown;
+}
+
 interface UsageFetchRequest {
   url: string;
   headers: Record<string, string>;
@@ -218,8 +225,8 @@ async function getClaudeUsage(label: string, installed: boolean, version: string
   }
 
   try {
-    const token = await readClaudeAccessToken();
-    if (!token) {
+    const credentials = await readClaudeCredentials();
+    if (!credentials) {
       return {
         id: "claude",
         label,
@@ -230,7 +237,19 @@ async function getClaudeUsage(label: string, installed: boolean, version: string
       };
     }
 
-    const buckets = parseClaudeUsageBuckets(await fetchClaudeUsage(token, version));
+    // The CLI refreshes the access token on startup; polling an expired one only earns a 401.
+    if (credentials.expiresAt !== null && credentials.expiresAt <= now) {
+      return {
+        id: "claude",
+        label,
+        status: "unknown",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Claude sign-in expired. Run `claude` to refresh the token.",
+      };
+    }
+
+    const buckets = parseClaudeUsageBuckets(await fetchClaudeUsage(credentials.token, version));
     if (buckets.length === 0) {
       return {
         id: "claude",
@@ -363,7 +382,7 @@ function getCodexClient(): CodexUsageClient {
   return codexClient;
 }
 
-async function readClaudeAccessToken(): Promise<string | null> {
+async function readClaudeCredentials(): Promise<{ token: string; expiresAt: number | null } | null> {
   const credentialsPath = join(process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude"), ".credentials.json");
   let parsed: ClaudeCredentials;
   try {
@@ -373,7 +392,8 @@ async function readClaudeAccessToken(): Promise<string | null> {
   }
 
   const oauth = asRecord(parsed.claudeAiOauth) ?? parsed;
-  return asString(oauth.accessToken);
+  const token = asString(oauth.accessToken);
+  return token ? { token, expiresAt: asNumber(oauth.expiresAt) } : null;
 }
 
 async function fetchClaudeUsage(token: string, version: string | null): Promise<unknown> {
@@ -456,13 +476,47 @@ async function fetchUsageJson(request: UsageFetchRequest): Promise<unknown> {
   }
 }
 
+// The usage API reports every window in `limits`, including the per-model weekly limits that the
+// legacy top-level `seven_day_*` keys now return as null. Those keys remain the fallback for
+// accounts whose response predates `limits`.
 function parseClaudeUsageBuckets(result: unknown): ProviderUsageBucket[] {
   const record = asRecord(result);
   if (!record) return [];
 
+  const limits = Array.isArray(record.limits) ? record.limits : [];
+  const fromLimits = limits
+    .map((limit) => parseClaudeUsageLimit(asRecord(limit) as ClaudeUsageLimit | null))
+    .filter((bucket): bucket is ProviderUsageBucket => bucket !== null);
+  if (fromLimits.length > 0) return fromLimits;
+
   return Object.entries(CLAUDE_USAGE_BUCKETS)
     .map(([id, config]) => parseClaudeUsageBucket(id, config, asRecord(record[id]) as ClaudeUsageWindow | null))
     .filter((bucket): bucket is ProviderUsageBucket => bucket !== null);
+}
+
+const CLAUDE_LIMIT_KINDS: Record<string, { label: string; windowDurationMins: number }> = {
+  session: { label: "5h", windowDurationMins: 300 },
+  weekly_all: { label: "7d", windowDurationMins: 10_080 },
+  weekly_scoped: { label: "7d", windowDurationMins: 10_080 },
+};
+
+function parseClaudeUsageLimit(limit: ClaudeUsageLimit | null): ProviderUsageBucket | null {
+  const kind = limit ? asString(limit.kind) : null;
+  const config = kind ? CLAUDE_LIMIT_KINDS[kind] : null;
+  if (!limit || !kind || !config) return null;
+
+  const usedPercent = normalizeClaudePercent(limit.percent);
+  if (usedPercent === null) return null;
+
+  // A scoped limit applies to one model, so its name disambiguates it from the account-wide window.
+  const model = asString(asRecord(asRecord(limit.scope)?.model)?.display_name);
+  return {
+    id: model ? `${kind}:${model.toLowerCase()}` : kind,
+    label: model ? `${config.label} ${model}` : config.label,
+    usedPercent,
+    windowDurationMins: config.windowDurationMins,
+    resetsAt: parseResetTimestamp(limit.resets_at),
+  };
 }
 
 const CLAUDE_USAGE_BUCKETS: Record<string, { label: string; windowDurationMins: number | null }> = {

--- a/backend/src/services/provider-usage.ts
+++ b/backend/src/services/provider-usage.ts
@@ -58,6 +58,8 @@ interface CodexRateLimitBucket {
   rateLimitReachedType?: unknown;
 }
 
+const CODEX_WINDOW_SLOTS = ["primary", "secondary"] as const;
+
 interface ClaudeCredentials {
   claudeAiOauth?: {
     accessToken?: unknown;
@@ -162,15 +164,36 @@ async function getCodexUsage(label: string, installed: boolean): Promise<Provide
     codexUsageCache = { value: entry, expiresAt: now + CODEX_USAGE_CACHE_TTL_MS };
     return entry;
   } catch (err) {
+    const raw = err instanceof Error ? err.message : "";
+    if (isCodexAuthError(raw)) {
+      return {
+        id: "codex",
+        label,
+        status: "unknown",
+        buckets: [],
+        lastUpdatedAt: null,
+        message: "Codex sign-in expired. Run `codex login`.",
+      };
+    }
     return {
       id: "codex",
       label,
       status: "error",
       buckets: [],
       lastUpdatedAt: codexUsageCache?.value.lastUpdatedAt ?? null,
-      message: err instanceof Error ? err.message : "Could not read Codex account usage.",
+      message: raw ? summarizeCodexError(raw) : "Could not read Codex account usage.",
     };
   }
+}
+
+// The app-server surfaces upstream failures as a single line embedding the HTTP status and body.
+function isCodexAuthError(message: string): boolean {
+  return /\b401\b|\b403\b|token_invalidated|signing in again|not logged in/i.test(message);
+}
+
+function summarizeCodexError(message: string): string {
+  const firstLine = message.split("\n")[0]!.trim();
+  return firstLine.length > 160 ? `${firstLine.slice(0, 157)}...` : firstLine;
 }
 
 async function getClaudeUsage(label: string, installed: boolean, version: string | null): Promise<ProviderUsageEntry> {
@@ -543,27 +566,52 @@ function parseCodexRateLimitBuckets(result: unknown): ProviderUsageBucket[] {
         record,
       ];
 
-  return source
-    .map((value) => parseCodexRateLimitBucket(asRecord(value) as CodexRateLimitBucket | null))
-    .filter((bucket): bucket is ProviderUsageBucket => bucket !== null);
+  return source.flatMap((value) => parseCodexRateLimitBucket(asRecord(value) as CodexRateLimitBucket | null));
 }
 
-function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): ProviderUsageBucket | null {
-  if (!bucket) return null;
-  const primary = asRecord(bucket.primary) as CodexRateLimitWindow | null;
-  const id = asString(bucket.limitId) ?? asString(bucket.limitName) ?? (primary ? "codex" : null);
-  if (!id || !primary) return null;
+// Codex reports two windows per metered limit: `primary` and `secondary`. Which one holds the
+// short (5h) or long (weekly) window varies by plan, so both are surfaced and labelled by duration.
+function parseCodexRateLimitBucket(bucket: CodexRateLimitBucket | null): ProviderUsageBucket[] {
+  if (!bucket) return [];
+  const limitId = asString(bucket.limitId) ?? asString(bucket.limitName) ?? "codex";
+  const limitName = asString(bucket.limitName);
 
-  return {
-    id,
-    label: asString(bucket.limitName),
-    usedPercent: normalizeCodexPercent(primary),
-    windowDurationMins: asNumber(primary.windowDurationMins),
-    resetsAt: parseResetTimestamp(primary.resetsAt ?? primary.resetAt),
-    planType: asString(bucket.planType),
-    credits: bucket.credits,
-    rateLimitReachedType: asString(bucket.rateLimitReachedType),
-  };
+  return CODEX_WINDOW_SLOTS.flatMap((slot) => {
+    const window = asRecord(bucket[slot]) as CodexRateLimitWindow | null;
+    if (!window) return [];
+    const usedPercent = normalizeCodexPercent(window);
+    if (usedPercent === null) return [];
+    const windowDurationMins = asNumber(window.windowDurationMins);
+
+    return [{
+      id: `${limitId}:${slot}`,
+      label: codexBucketLabel(limitName, windowDurationMins, slot),
+      usedPercent,
+      windowDurationMins,
+      resetsAt: parseResetTimestamp(window.resetsAt ?? window.resetAt),
+      planType: asString(bucket.planType),
+      credits: bucket.credits,
+      rateLimitReachedType: asString(bucket.rateLimitReachedType),
+    }];
+  });
+}
+
+function codexBucketLabel(
+  limitName: string | null,
+  windowDurationMins: number | null,
+  slot: string,
+): string {
+  const window = formatWindowLabel(windowDurationMins) ?? slot;
+  // The default limit is named after the provider; repeating it would render "Codex Codex 5h".
+  return !limitName || limitName.toLowerCase() === "codex"
+    ? window
+    : `${limitName} ${window}`;
+}
+
+function formatWindowLabel(windowDurationMins: number | null): string | null {
+  if (windowDurationMins === null || windowDurationMins <= 0) return null;
+  if (windowDurationMins < 1440) return `${Math.round(windowDurationMins / 60)}h`;
+  return `${Math.round(windowDurationMins / 1440)}d`;
 }
 
 function normalizeCodexPercent(window: CodexRateLimitWindow): number | null {
@@ -771,16 +819,27 @@ class CodexUsageClient {
     this.rpc?.respondError(request.id, `${request.method} is not supported by Hive usage polling`);
   }
 
+  // `account/rateLimits/updated` is a sparse rolling update covering a single limit, so it is
+  // merged into the cached snapshot instead of replacing every bucket read earlier.
   private cacheRateLimits(params: unknown): void {
-    const entry = {
-      id: "codex",
-      label: "Codex",
-      status: "available" as const,
-      buckets: parseCodexRateLimitBuckets(params),
-      lastUpdatedAt: new Date().toISOString(),
-    };
-    if (entry.buckets.length > 0) {
-      codexUsageCache = { value: entry, expiresAt: Date.now() + CODEX_USAGE_CACHE_TTL_MS };
+    const updated = parseCodexRateLimitBuckets(params);
+    if (updated.length === 0) return;
+
+    const cached = codexUsageCache?.value;
+    const merged = new Map(cached?.buckets.map((bucket) => [bucket.id, bucket]));
+    for (const bucket of updated) {
+      merged.set(bucket.id, bucket);
     }
+
+    codexUsageCache = {
+      value: {
+        id: "codex",
+        label: cached?.label ?? "Codex",
+        status: "available",
+        buckets: [...merged.values()],
+        lastUpdatedAt: new Date().toISOString(),
+      },
+      expiresAt: Date.now() + CODEX_USAGE_CACHE_TTL_MS,
+    };
   }
 }

--- a/frontend/src/components/ProviderUsage.tsx
+++ b/frontend/src/components/ProviderUsage.tsx
@@ -177,7 +177,8 @@ function sortProviderBuckets(provider: ProviderUsageEntry): ProviderUsageBucket[
 function bucketOrder(bucket: ProviderUsageBucket): number {
   if (bucket.id === "five_hour") return 0;
   if (bucket.id === "weekly" || bucket.id === "seven_day") return 1;
-  return 2;
+  // Providers without well-known bucket ids (Codex) sort shortest window first.
+  return bucket.windowDurationMins ?? 2;
 }
 
 function statusLabel(status: ProviderUsageEntry["status"]): string {


### PR DESCRIPTION
## Problem

The sidebar usage panel parsed only part of each provider's payload, and in both cases the part it dropped was the window that actually constrains you.

**Codex stuck at 0%.** `RateLimitSnapshot` carries two windows per metered limit — `primary` **and** `secondary` — but only `primary` was parsed. Which slot holds the short (5h) or long (weekly) window varies by plan, so on accounts where `primary` is the weekly window the panel showed a flat 0% right after a window roll, while the real 5h consumption sat in the discarded `secondary` field.

**Claude hid its per-model limits.** The usage API reports every window in `limits`, including per-model weekly limits. The legacy top-level `seven_day_opus` / `seven_day_sonnet` keys the panel parsed now return `null`. Verified live against `/api/oauth/usage`: an account displayed `5h 3%` and `7d 34%` while its **active** weekly limit for one model sat at **60%**, invisible.

**Raw HTTP dumps in the tooltip.** An invalidated ChatGPT token surfaced as `failed to fetch codex rate limits: GET https://chatgpt.com/... 401 Unauthorized; body={...}` inside a 10px tooltip. Note `codex login status` still reports "Logged in using ChatGPT" in this state — it only reads the local `auth.json`. On the Claude side, `expiresAt` was declared on the credentials type and never read, so an expired token was sent anyway.

## Changes

**Codex**
- Both windows are parsed, keyed `${limitId}:${slot}` and labelled by window duration (`5h`, `7d`, `GPT-5.3-Codex 7d`).
- `account/rateLimits/updated` is merged, not substituted. It is documented as a *sparse* rolling update covering a single limit, but it replaced the entire cached snapshot — a notification about one limit erased every other bucket until the 120s TTL expired.
- Expired sign-ins report ``Codex sign-in expired. Run `codex login`.`` with status `unknown`; other errors are truncated to their first line.

**Claude**
- `limits` is now the primary source (`session` = 5h, `weekly_all` = 7d, `weekly_scoped` = per model); the legacy top-level keys remain the fallback for responses without it.
- Access-token expiry is checked before the request, reporting ``Claude sign-in expired. Run `claude` to refresh the token.``

**Frontend** — buckets without well-known ids sort shortest window first.

Payload shapes verified against `codex app-server generate-ts` (codex-cli 0.145.0) and the live `/api/oauth/usage` response (claude-code 2.1.217), not inferred from recollection.

## Review notes

- `isCodexAuthError` pattern-matches the error **text**. Fragile by construction, but the app-server collapses upstream failures into a generic `-32603` with the HTTP body concatenated into `message`, so there is no structured code to test. `account/read` and `getAuthStatus` are not usable alternatives — both answer from the local `auth.json` and report "logged in" while the token is invalidated server-side (verified live).
- `bucketOrder` mixes two scales (`0`/`1`/`2` for known ids, minutes for the fallback). Correct because sorting is per-provider and no provider mixes both families, but it would break if one ever did.
- Bucket ids changed shape (`codex` → `codex:primary`, `five_hour` → `session`). Only `ProviderUsage.tsx` consumes them; nothing is persisted and there is no iOS consumer.

## Not addressed here

`extra_usage` (credit balance) and the `severity` / `is_active` fields on Claude limits, which would let the bar reflect the binding limit. And `normalizeCodexPercent` still accepts `usagePercent` / `usedFraction` aliases that the schema marks as non-existent — left in place to keep the fix separate from a cleanup.

## Testing

- `backend`: lint, typecheck, 1739 tests pass (102 files) — added coverage for the Codex dual-window payload, the Codex 401 path, the live Claude `limits` shape, the legacy fallback, and the expired-token path.
- `frontend`: lint, typecheck, 625 component tests pass.

The Codex dual-window fix follows from the generated schema rather than a live payload of an affected account — I could not capture one. The Claude fix was verified end-to-end against a real account response.
