### PR TITLE
fix(auth): refuse a non-loopback bind without an access token

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -162,10 +162,10 @@ npm run build
 
 ### Configure the access token
 
-**Set a token.** With neither `HIVE_AUTH_TOKEN` nor `HIVE_AUTH_TOKEN_SHA256` configured, the backend
-has no expectation to check against and accepts every request. `backend/ecosystem.config.cjs` does
-not set either one, so a bare `pm2 start ecosystem.config.cjs --env production` produces an
-unauthenticated server.
+**Set a token.** With neither `HIVE_AUTH_TOKEN` nor `HIVE_AUTH_TOKEN_SHA256` configured, the
+backend only starts on a loopback address; requests are then accepted without authentication.
+`backend/ecosystem.config.cjs`'s production profile binds `0.0.0.0` and sets neither variable, so
+a bare `pm2 start ecosystem.config.cjs --env production` refuses to start until you provide one.
 
 Generate one:
 

--- a/README.md
+++ b/README.md
@@ -306,11 +306,11 @@ point at it rather than repeating it.
 | `HIVE_DEBUG_AGENT_LOGS` | unset | Verbose agent process logging when `1`/`true`/`yes`/`on` |
 | `GITHUB_CLIENT_ID` | built in | Override GitHub OAuth app client id |
 
-**With neither `HIVE_AUTH_TOKEN` nor `HIVE_AUTH_TOKEN_SHA256` set, the backend has no expectation to
-check and accepts every request.** `ecosystem.config.cjs` sets neither, so a manually started
-production server is unauthenticated until you configure one. `provision.sh` generates a token,
-writes only its digest, and refuses to finish a run in which an unauthenticated request to
-`/api/projects` does not return `401`.
+**With neither `HIVE_AUTH_TOKEN` nor `HIVE_AUTH_TOKEN_SHA256` set, the backend only starts on a
+loopback address.** Bound to anything else — `ecosystem.config.cjs`'s production profile binds
+`0.0.0.0` and sets neither variable — it refuses to start and names the variable to set.
+`provision.sh` generates a token, writes only its digest, and refuses to finish a run in which an
+unauthenticated request to `/api/projects` does not return `401`.
 
 </details>
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -21,6 +21,7 @@ import {
   createBrowserOriginPolicy,
   createHostGuardHook,
   createWebSocketOriginGuardHook,
+  isBindAllowed,
 } from "./utils/auth.js";
 import { createRateLimitHook } from "./utils/rate-limit.js";
 import { parsePositiveNumber } from "./utils/env.js";
@@ -438,6 +439,18 @@ async function main() {
       "Refusing to start the dev backend without DATA_DIR set: it would use the " +
         "production data dir (~/.hive). Launch via the hive.json runner, or set " +
         "DATA_DIR explicitly (e.g. DATA_DIR=~/.hive-dev).",
+    );
+  }
+
+  // Fail closed: a non-loopback bind with no access token configured would
+  // expose every endpoint unauthenticated to the network.
+  const authExpectation = {
+    expectedToken: process.env.HIVE_AUTH_TOKEN,
+    expectedTokenSha256: process.env.HIVE_AUTH_TOKEN_SHA256,
+  };
+  if (!isBindAllowed(HOST, authExpectation)) {
+    throw new Error(
+      `Refusing to bind ${HOST} without an access token: set HIVE_AUTH_TOKEN or HIVE_AUTH_TOKEN_SHA256.`,
     );
   }
 

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -32,6 +32,7 @@ import {
   extractAuthToken,
   isAllowedHostHeader,
   isAuthorized,
+  isBindAllowed,
 } from "./auth.js";
 
 function bearer(token: string): Record<string, string> {
@@ -475,6 +476,31 @@ describe("createWebSocketOriginGuardHook", () => {
     } finally {
       await app.close();
     }
+  });
+});
+
+describe("isBindAllowed", () => {
+  it("always allows loopback binds, token or not", () => {
+    expect(isBindAllowed("127.0.0.1", undefined)).toBe(true);
+    expect(isBindAllowed("127.1.2.3", undefined)).toBe(true);
+    expect(isBindAllowed("localhost", undefined)).toBe(true);
+    expect(isBindAllowed("::1", undefined)).toBe(true);
+  });
+
+  it("refuses non-loopback binds without a configured token", () => {
+    expect(isBindAllowed("0.0.0.0", undefined)).toBe(false);
+    expect(isBindAllowed("::", undefined)).toBe(false);
+    expect(isBindAllowed("192.168.1.10", {})).toBe(false);
+  });
+
+  it("allows non-loopback binds with either token form", () => {
+    expect(isBindAllowed("0.0.0.0", { expectedToken: "secret" })).toBe(true);
+    expect(isBindAllowed("::", { expectedTokenSha256: sha256Hex("secret") })).toBe(true);
+  });
+
+  it("treats whitespace-only tokens as unset", () => {
+    expect(isBindAllowed("0.0.0.0", { expectedToken: "  " })).toBe(false);
+    expect(isBindAllowed("0.0.0.0", { expectedTokenSha256: "  " })).toBe(false);
   });
 });
 

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -89,6 +89,24 @@ export interface AuthExpectation {
   expectedTokenSha256?: string;
 }
 
+function isLoopbackBindHost(host: string): boolean {
+  const value = host.trim().toLowerCase();
+  if (value === "localhost" || value === "::1") return true;
+  // Anything in 127.0.0.0/8, not just 127.0.0.1.
+  return isIP(value) === 4 && value.startsWith("127.");
+}
+
+/**
+ * Whether the server may start listening on `host` under the given auth
+ * expectation. A non-loopback bind (0.0.0.0 and :: included) with no token
+ * configured would serve every endpoint unauthenticated to the network, so it
+ * is refused; loopback binds are always allowed.
+ */
+export function isBindAllowed(host: string, expectation?: AuthExpectation): boolean {
+  if (isLoopbackBindHost(host)) return true;
+  return Boolean(expectation?.expectedToken?.trim() || expectation?.expectedTokenSha256?.trim());
+}
+
 /** Routes exempt from the auth, Host and origin guards; they carry no secrets. */
 function isPublicRoute(url: string): boolean {
   return url.startsWith("/health");

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -1,6 +1,7 @@
 /** Exact env vars set by pm2 / the Hive backend / Claude Code that should not leak into workspace child processes. */
 const STRIPPED_VARS = [
   "NODE_ENV",
+  "HOST",
   "PORT",
   "DATA_DIR",
   "TELEGRAM_BOT_TOKEN",

--- a/backend/vitest.config.ts
+++ b/backend/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     exclude: ["dist/**"],
     env: {
       NODE_ENV: "test",
+      // Pin the bind address: the suite must not inherit a HOST from the
+      // shell (a backend-spawned shell carries HOST=0.0.0.0, which would
+      // trip the fail-closed bind guard when index.test.ts imports main()).
+      HOST: "127.0.0.1",
     },
   },
 });


### PR DESCRIPTION
A backend bound to a non-loopback address with neither `HIVE_AUTH_TOKEN` nor `HIVE_AUTH_TOKEN_SHA256` configured used to start unauthenticated and open to anyone who could route to it — including every WebSocket, where agent execution lives. `pm2 start ecosystem.config.cjs --env production` was exactly that server.

The backend now **fails closed**: before listening, a non-loopback bind (`0.0.0.0` and `::` included) with no token expectation refuses to start:

```
Refusing to bind 0.0.0.0 without an access token: set HIVE_AUTH_TOKEN or HIVE_AUTH_TOKEN_SHA256.
```

Loopback binds (`localhost`, `::1`, 127.0.0.0/8) stay tokenless for local development. Every path the installer controls already guarantees a token (`provision.sh` generates one and verifies the 401 before finishing); this closes the one remaining gap, the manual from-source install. After this change a tokenless server can only exist on loopback.

- `isBindAllowed(host, expectation)` in `backend/src/utils/auth.ts`, guard at the top of `main()` using the existing fatal-startup path; unit tests cover loopback/non-loopback and both token forms including whitespace-only values.
- `GETTING_STARTED.md` and the README configuration section now state the fail-closed behaviour instead of warning about the open server, so profile, guide and code agree.
- Found while testing: the backend leaked its own `HOST` into workspace child processes (`buildWorkspaceEnv` stripped `PORT` and `DATA_DIR` but not `HOST`), which made the suite fail inside a backend-spawned shell. `HOST` is now stripped, and the backend vitest env pins `HOST: "127.0.0.1"` so the suite is hermetic.

Verified: full backend suite 1914/1914, lint and typecheck clean.

Closes #384