### PR TITLE
fix: set a default global git identity 

### DIFF
--- a/backend/src/index.test.ts
+++ b/backend/src/index.test.ts
@@ -7,6 +7,10 @@ import { tmpdir } from "node:os";
 // Prevent the top-level main() from running preflight checks (claude not on CI)
 vi.mock("./utils/preflight.js", () => ({ preflight: vi.fn() }));
 
+// main() sets the global git identity at startup. Stub it so importing this
+// module never mutates the real ~/.gitconfig or calls out to GitHub.
+vi.mock("./utils/git-identity.js", () => ({ ensureGitIdentity: vi.fn(async () => {}) }));
+
 // Prevent the top-level main() from actually listening on a port
 vi.mock("fastify", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fastify")>();

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -25,6 +25,7 @@ import {
 } from "./utils/auth.js";
 import { createRateLimitHook } from "./utils/rate-limit.js";
 import { parsePositiveNumber } from "./utils/env.js";
+import { ensureGitIdentity } from "./utils/git-identity.js";
 import { ensureDataDir, getDataDir, loadAllProjects, saveProject } from "./state/state.js";
 import { type SessionOptions, rebuildNotifier, stopAllSessions } from "./agents/agent-manager.js";
 import { GitSyncService } from "./services/git-sync.js";
@@ -456,6 +457,13 @@ async function main() {
 
   await preflight();
   await detectAvailableProviders();
+
+  // Ensure a global git identity so agent commits never leak the server's
+  // hostname via git's `$USER@$(hostname)` default. Best effort: a failure here
+  // must not stop the server from starting.
+  await ensureGitIdentity().catch((err: unknown) => {
+    console.warn("Could not ensure a git identity for agent commits:", err);
+  });
 
   const dataDir = getDataDir();
   await ensureDataDir(dataDir);

--- a/backend/src/services/setup/auth/github.test.ts
+++ b/backend/src/services/setup/auth/github.test.ts
@@ -16,6 +16,12 @@ vi.mock("../../../utils/github.js", () => ({
   _resetGhState: mocks._resetGhState,
 }));
 
+// The sign-in flow sets the global git identity on success. Stub it so tests
+// never touch the developer's or CI runner's real ~/.gitconfig or hit GitHub.
+vi.mock("../../../utils/git-identity.js", () => ({
+  ensureGitIdentity: vi.fn(async () => {}),
+}));
+
 vi.mock("node:child_process", () => ({
   execFile: mocks.execFile,
 }));

--- a/backend/src/services/setup/auth/github.ts
+++ b/backend/src/services/setup/auth/github.ts
@@ -1,5 +1,6 @@
 import { execFile } from "node:child_process";
 import { gh, _resetGhState } from "../../../utils/github.js";
+import { ensureGitIdentity } from "../../../utils/git-identity.js";
 import type { ToolDetection } from "../detect.js";
 import { ToolAuthError, type AuthFlow, type ToolAuthOutcome } from "./flow.js";
 
@@ -200,6 +201,10 @@ export function githubAuthFlow(deps: GitHubAuthDeps): AuthFlow {
         await loginWithToken(poll.access_token);
         _resetGhState();
         await setupGitCredentials();
+        // Upgrade the global git identity to this account now that it is known,
+        // unless the operator has set their own. A failure here must not fail an
+        // otherwise-successful sign-in.
+        await ensureGitIdentity().catch(() => {});
         return "connected";
       }
     })();

--- a/backend/src/utils/git-identity.test.ts
+++ b/backend/src/utils/git-identity.test.ts
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi } from "vitest";
+
+// Mock gh so its default-runner (production) path can be exercised without
+// calling GitHub. Dependency-injected tests below pass their own fakes.
+vi.mock("./github.js", () => ({ gh: vi.fn(async () => ({ stdout: "", stderr: "" })) }));
+
 import {
   ensureGitIdentity,
+  commitIdentityArgs,
   HIVE_DEFAULT_GIT_NAME,
   HIVE_DEFAULT_GIT_EMAIL,
 } from "./git-identity.js";
+import { gh } from "./github.js";
 
 /**
  * Build a fake `runGit` backed by an in-memory map of global config keys.
@@ -29,7 +36,7 @@ function makeRunGit(initial: Record<string, string> = {}) {
     }
     throw new Error(`git config: key ${key} not set`);
   });
-  return { runGit, config };
+  return { runGit };
 }
 
 /** Fake `runGh` that returns a JSON user payload, or rejects when signed out. */
@@ -109,6 +116,28 @@ describe("ensureGitIdentity()", () => {
     ]);
   });
 
+  it("fills the missing name when only the operator's email is set", async () => {
+    const { runGit } = makeRunGit({ "user.email": "me@real.dev" });
+    const runGh = makeRunGh(null);
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    // The operator's email is kept; the missing name is completed so a commit
+    // never fails under user.useConfigOnly.
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.name", HIVE_DEFAULT_GIT_NAME],
+    ]);
+  });
+
+  it("passes the timeout to gh on the default (production) path", async () => {
+    const { runGit } = makeRunGit();
+
+    // No runGh injected → the default runner calls the real (mocked) gh.
+    await ensureGitIdentity({ runGit });
+
+    expect(gh).toHaveBeenCalledWith(["api", "user"], { timeoutMs: 5000 });
+  });
+
   it("upgrades the sentinel identity to github once gh is connected", async () => {
     const { runGit } = makeRunGit({
       "user.name": HIVE_DEFAULT_GIT_NAME,
@@ -134,5 +163,57 @@ describe("ensureGitIdentity()", () => {
     await ensureGitIdentity({ runGit, runGh });
 
     expect(writes(runGit)).toEqual([]);
+  });
+});
+
+describe("commitIdentityArgs()", () => {
+  /** Fake `runGit` reading effective (non-scoped) config from a map, rejecting when unset. */
+  function makeReader(initial: Record<string, string> = {}) {
+    const config = new Map(Object.entries(initial));
+    return vi.fn(async (args: string[]) => {
+      const [cmd, key] = args;
+      if (cmd !== "config") throw new Error(`unexpected git args: ${args.join(" ")}`);
+      if (config.has(key)) return { stdout: config.get(key)! };
+      throw new Error(`git config: key ${key} not set`);
+    });
+  }
+
+  it("reuses the configured identity when both fields resolve", async () => {
+    const runGit = makeReader({ "user.name": "Real Operator", "user.email": "me@real.dev" });
+
+    const args = await commitIdentityArgs("/tmp/wt", { runGit });
+
+    expect(args).toEqual([
+      "-c",
+      "user.name=Real Operator",
+      "-c",
+      "user.email=me@real.dev",
+    ]);
+  });
+
+  it("falls back to the neutral default when no identity resolves", async () => {
+    const runGit = makeReader();
+
+    const args = await commitIdentityArgs("/tmp/wt", { runGit });
+
+    expect(args).toEqual([
+      "-c",
+      `user.name=${HIVE_DEFAULT_GIT_NAME}`,
+      "-c",
+      `user.email=${HIVE_DEFAULT_GIT_EMAIL}`,
+    ]);
+  });
+
+  it("fills only the missing field", async () => {
+    const runGit = makeReader({ "user.email": "me@real.dev" });
+
+    const args = await commitIdentityArgs("/tmp/wt", { runGit });
+
+    expect(args).toEqual([
+      "-c",
+      `user.name=${HIVE_DEFAULT_GIT_NAME}`,
+      "-c",
+      "user.email=me@real.dev",
+    ]);
   });
 });

--- a/backend/src/utils/git-identity.test.ts
+++ b/backend/src/utils/git-identity.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ensureGitIdentity,
+  HIVE_DEFAULT_GIT_NAME,
+  HIVE_DEFAULT_GIT_EMAIL,
+} from "./git-identity.js";
+
+/**
+ * Build a fake `runGit` backed by an in-memory map of global config keys.
+ *
+ * Reads (`config --global <key>`) resolve with the stored value, or REJECT for
+ * an unset key — matching real git, which exits non-zero when a config key is
+ * absent. Writes (`config --global <key> <value>`) update the map so later
+ * reads within the same call reflect the write.
+ */
+function makeRunGit(initial: Record<string, string> = {}) {
+  const config = new Map(Object.entries(initial));
+  const runGit = vi.fn(async (args: string[]) => {
+    const [cmd, scope, key, value] = args;
+    if (cmd !== "config" || scope !== "--global") {
+      throw new Error(`unexpected git args: ${args.join(" ")}`);
+    }
+    if (args.length === 4) {
+      config.set(key, value);
+      return { stdout: "" };
+    }
+    if (config.has(key)) {
+      return { stdout: config.get(key)! };
+    }
+    throw new Error(`git config: key ${key} not set`);
+  });
+  return { runGit, config };
+}
+
+/** Fake `runGh` that returns a JSON user payload, or rejects when signed out. */
+function makeRunGh(user: unknown | null) {
+  return vi.fn(async (args: string[]) => {
+    if (args[0] !== "api" || args[1] !== "user") {
+      throw new Error(`unexpected gh args: ${args.join(" ")}`);
+    }
+    if (user === null) throw new Error("not signed in");
+    return { stdout: JSON.stringify(user) };
+  });
+}
+
+/** Write-shaped calls carry 4 args; reads carry 3. */
+function writes(runGit: ReturnType<typeof vi.fn>): string[][] {
+  return runGit.mock.calls.map((c) => c[0] as string[]).filter((a) => a.length === 4);
+}
+
+describe("ensureGitIdentity()", () => {
+  it("writes the neutral default when gh is not signed in on a fresh machine", async () => {
+    const { runGit } = makeRunGit();
+    const runGh = makeRunGh(null);
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.name", HIVE_DEFAULT_GIT_NAME],
+      ["config", "--global", "user.email", HIVE_DEFAULT_GIT_EMAIL],
+    ]);
+  });
+
+  it("writes the github identity when gh is signed in on a fresh machine", async () => {
+    const { runGit } = makeRunGit();
+    const runGh = makeRunGh({ id: 583231, login: "octocat", name: "The Octocat" });
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.name", "The Octocat"],
+      ["config", "--global", "user.email", "583231+octocat@users.noreply.github.com"],
+    ]);
+  });
+
+  it("falls back to the login when the github name is empty", async () => {
+    const { runGit } = makeRunGit();
+    const runGh = makeRunGh({ id: 583231, login: "octocat", name: null });
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.name", "octocat"],
+      ["config", "--global", "user.email", "583231+octocat@users.noreply.github.com"],
+    ]);
+  });
+
+  it("never overwrites an operator-set identity", async () => {
+    const { runGit } = makeRunGit({
+      "user.name": "Real Operator",
+      "user.email": "me@real.dev",
+    });
+    const runGh = makeRunGh({ id: 583231, login: "octocat", name: "The Octocat" });
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([]);
+  });
+
+  it("upgrades the sentinel identity to github once gh is connected", async () => {
+    const { runGit } = makeRunGit({
+      "user.name": HIVE_DEFAULT_GIT_NAME,
+      "user.email": HIVE_DEFAULT_GIT_EMAIL,
+    });
+    const runGh = makeRunGh({ id: 583231, login: "octocat", name: "The Octocat" });
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.name", "The Octocat"],
+      ["config", "--global", "user.email", "583231+octocat@users.noreply.github.com"],
+    ]);
+  });
+
+  it("is idempotent when the resolved target already matches", async () => {
+    const { runGit } = makeRunGit({
+      "user.name": HIVE_DEFAULT_GIT_NAME,
+      "user.email": HIVE_DEFAULT_GIT_EMAIL,
+    });
+    const runGh = makeRunGh(null);
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    expect(writes(runGit)).toEqual([]);
+  });
+});

--- a/backend/src/utils/git-identity.test.ts
+++ b/backend/src/utils/git-identity.test.ts
@@ -97,6 +97,18 @@ describe("ensureGitIdentity()", () => {
     expect(writes(runGit)).toEqual([]);
   });
 
+  it("never overwrites an operator-set name when only the email is missing", async () => {
+    const { runGit } = makeRunGit({ "user.name": "Real Operator" });
+    const runGh = makeRunGh(null);
+
+    await ensureGitIdentity({ runGit, runGh });
+
+    // The name the operator set is kept; only the missing email is filled.
+    expect(writes(runGit)).toEqual([
+      ["config", "--global", "user.email", HIVE_DEFAULT_GIT_EMAIL],
+    ]);
+  });
+
   it("upgrades the sentinel identity to github once gh is connected", async () => {
     const { runGit } = makeRunGit({
       "user.name": HIVE_DEFAULT_GIT_NAME,

--- a/backend/src/utils/git-identity.ts
+++ b/backend/src/utils/git-identity.ts
@@ -11,6 +11,9 @@ import { gh } from "./github.js";
 export const HIVE_DEFAULT_GIT_NAME = "Hive Agent";
 export const HIVE_DEFAULT_GIT_EMAIL = "hive@orchestrator.local";
 
+/** Cap the `gh api user` lookup so a stalled network or credential prompt cannot hang startup. */
+const GH_IDENTITY_TIMEOUT_MS = 5000;
+
 interface GitIdentity {
   name: string;
   email: string;
@@ -71,10 +74,12 @@ async function githubIdentity(runGh: Runner): Promise<GitIdentity | null> {
  */
 export async function ensureGitIdentity(deps: EnsureGitIdentityDeps = {}): Promise<void> {
   const runGit = deps.runGit ?? ((args: string[]) => git(args));
-  const runGh = deps.runGh ?? ((args: string[]) => gh(args));
+  const runGh = deps.runGh ?? ((args: string[]) => gh(args, { timeoutMs: GH_IDENTITY_TIMEOUT_MS }));
 
   const currentEmail = await readGlobal(runGit, "user.email");
-  // The operator owns their identity once it is anything but our sentinel.
+  // Email is the only field that can leak the hostname (git's `$USER@$(hostname)`
+  // default), so once it is anything but our sentinel the operator owns their
+  // identity and we leave it — name included.
   if (currentEmail && currentEmail !== HIVE_DEFAULT_GIT_EMAIL) return;
 
   const currentName = await readGlobal(runGit, "user.name");
@@ -83,7 +88,10 @@ export async function ensureGitIdentity(deps: EnsureGitIdentityDeps = {}): Promi
     email: HIVE_DEFAULT_GIT_EMAIL,
   };
 
-  if (currentName !== target.name) {
+  // Never overwrite a name the operator set themselves; only fill it when it is
+  // empty or still our own default.
+  const nameClaimed = currentName !== "" && currentName !== HIVE_DEFAULT_GIT_NAME;
+  if (!nameClaimed && currentName !== target.name) {
     await runGit(["config", "--global", "user.name", target.name]);
   }
   if (currentEmail !== target.email) {

--- a/backend/src/utils/git-identity.ts
+++ b/backend/src/utils/git-identity.ts
@@ -4,9 +4,10 @@ import { gh } from "./github.js";
 /**
  * Neutral default identity for agent commits.
  *
- * Its email doubles as a sentinel: a global identity equal to this is treated
- * as "unclaimed" and may be upgraded to the connected GitHub account later;
- * any other value is the operator's own choice and is never overwritten.
+ * Its name and email double as sentinels: global fields equal to these values
+ * are treated as "unclaimed" and may be upgraded to the connected GitHub
+ * account later; any other value is the operator's own choice and is never
+ * overwritten.
  */
 export const HIVE_DEFAULT_GIT_NAME = "Hive Agent";
 export const HIVE_DEFAULT_GIT_EMAIL = "hive@orchestrator.local";
@@ -77,24 +78,52 @@ export async function ensureGitIdentity(deps: EnsureGitIdentityDeps = {}): Promi
   const runGh = deps.runGh ?? ((args: string[]) => gh(args, { timeoutMs: GH_IDENTITY_TIMEOUT_MS }));
 
   const currentEmail = await readGlobal(runGit, "user.email");
-  // Email is the only field that can leak the hostname (git's `$USER@$(hostname)`
-  // default), so once it is anything but our sentinel the operator owns their
-  // identity and we leave it — name included.
-  if (currentEmail && currentEmail !== HIVE_DEFAULT_GIT_EMAIL) return;
-
   const currentName = await readGlobal(runGit, "user.name");
+
+  // A field is "claimed" once it holds anything but empty or our own default.
+  // We never overwrite a claimed field, and we fill every unclaimed one — so a
+  // partial config (name-only or email-only) ends up complete rather than
+  // leaving git to invent the missing half from `$USER@$(hostname)`.
+  const emailClaimed = currentEmail !== "" && currentEmail !== HIVE_DEFAULT_GIT_EMAIL;
+  const nameClaimed = currentName !== "" && currentName !== HIVE_DEFAULT_GIT_NAME;
+  if (emailClaimed && nameClaimed) return;
+
   const target = (await githubIdentity(runGh)) ?? {
     name: HIVE_DEFAULT_GIT_NAME,
     email: HIVE_DEFAULT_GIT_EMAIL,
   };
 
-  // Never overwrite a name the operator set themselves; only fill it when it is
-  // empty or still our own default.
-  const nameClaimed = currentName !== "" && currentName !== HIVE_DEFAULT_GIT_NAME;
   if (!nameClaimed && currentName !== target.name) {
     await runGit(["config", "--global", "user.name", target.name]);
   }
-  if (currentEmail !== target.email) {
+  if (!emailClaimed && currentEmail !== target.email) {
     await runGit(["config", "--global", "user.email", target.email]);
   }
+}
+
+/**
+ * Build `-c user.name=… -c user.email=…` arguments that guarantee a commit
+ * identity for a single git command run in `cwd`, without mutating any config.
+ *
+ * The effective identity already resolved by git (operator global, repo-local,
+ * …) is reused when present; only a missing field falls back to the neutral
+ * default. This lets Hive's own merge commit succeed even when no identity is
+ * configured, while never overriding one the operator set and never leaking the
+ * host through git's `$USER@$(hostname)` default.
+ */
+export async function commitIdentityArgs(
+  cwd: string,
+  deps: { runGit?: Runner } = {},
+): Promise<string[]> {
+  const runGit = deps.runGit ?? ((args: string[]) => git(args, cwd));
+  const read = async (key: string): Promise<string> => {
+    try {
+      return (await runGit(["config", key])).stdout.trim();
+    } catch {
+      return "";
+    }
+  };
+  const name = (await read("user.name")) || HIVE_DEFAULT_GIT_NAME;
+  const email = (await read("user.email")) || HIVE_DEFAULT_GIT_EMAIL;
+  return ["-c", `user.name=${name}`, "-c", `user.email=${email}`];
 }

--- a/backend/src/utils/git-identity.ts
+++ b/backend/src/utils/git-identity.ts
@@ -1,0 +1,92 @@
+import { git } from "./git.js";
+import { gh } from "./github.js";
+
+/**
+ * Neutral default identity for agent commits.
+ *
+ * Its email doubles as a sentinel: a global identity equal to this is treated
+ * as "unclaimed" and may be upgraded to the connected GitHub account later;
+ * any other value is the operator's own choice and is never overwritten.
+ */
+export const HIVE_DEFAULT_GIT_NAME = "Hive Agent";
+export const HIVE_DEFAULT_GIT_EMAIL = "hive@orchestrator.local";
+
+interface GitIdentity {
+  name: string;
+  email: string;
+}
+
+type Runner = (args: string[]) => Promise<{ stdout: string }>;
+
+export interface EnsureGitIdentityDeps {
+  runGit?: Runner;
+  runGh?: Runner;
+}
+
+/** Read a global git config value, treating an unset key (non-zero exit) as empty. */
+async function readGlobal(runGit: Runner, key: string): Promise<string> {
+  try {
+    const { stdout } = await runGit(["config", "--global", key]);
+    return stdout.trim();
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Identity of the connected GitHub account, or null when `gh` is not signed in.
+ *
+ * The email is GitHub's noreply form (`<id>+<login>@users.noreply.github.com`)
+ * rather than the profile email: it attributes commits correctly, is never
+ * null, and can never trip GitHub's "block command line pushes that expose my
+ * email" rejection.
+ */
+async function githubIdentity(runGh: Runner): Promise<GitIdentity | null> {
+  try {
+    const { stdout } = await runGh(["api", "user"]);
+    const data = JSON.parse(stdout) as { id?: number; login?: string; name?: string };
+    if (typeof data.id !== "number" || !data.login) return null;
+    return {
+      name: data.name || data.login,
+      email: `${data.id}+${data.login}@users.noreply.github.com`,
+    };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Guarantee a global git identity so agent commits never fall back to git's
+ * `$USER@$(hostname)` default, which leaks the server's fully-qualified name
+ * into every pushed commit.
+ *
+ * Precedence, highest first:
+ *  1. An operator-set global identity (anything other than our own default) is
+ *     left untouched.
+ *  2. A connected GitHub account supplies name and noreply email.
+ *  3. The neutral default, which leaks nothing.
+ *
+ * Idempotent: writes only the values that differ, so it is safe to call at
+ * every startup and after each GitHub sign-in.
+ */
+export async function ensureGitIdentity(deps: EnsureGitIdentityDeps = {}): Promise<void> {
+  const runGit = deps.runGit ?? ((args: string[]) => git(args));
+  const runGh = deps.runGh ?? ((args: string[]) => gh(args));
+
+  const currentEmail = await readGlobal(runGit, "user.email");
+  // The operator owns their identity once it is anything but our sentinel.
+  if (currentEmail && currentEmail !== HIVE_DEFAULT_GIT_EMAIL) return;
+
+  const currentName = await readGlobal(runGit, "user.name");
+  const target = (await githubIdentity(runGh)) ?? {
+    name: HIVE_DEFAULT_GIT_NAME,
+    email: HIVE_DEFAULT_GIT_EMAIL,
+  };
+
+  if (currentName !== target.name) {
+    await runGit(["config", "--global", "user.name", target.name]);
+  }
+  if (currentEmail !== target.email) {
+    await runGit(["config", "--global", "user.email", target.email]);
+  }
+}

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -26,6 +26,7 @@ let tempDir: string;
 let dataDir: string;
 let fixtureRepoUrl: string;
 let projectId: string;
+let previousHome: string | undefined;
 
 async function pushRemoteMainFile(
   cloneName: string,
@@ -52,6 +53,17 @@ beforeEach(async () => {
   const { mkdir } = await import("node:fs/promises");
   await mkdir(dataDir, { recursive: true });
   await mkdir(fixtureDir, { recursive: true });
+
+  // mergeWorkspace calls ensureGitIdentity(), which reads/writes the global git
+  // config. Point HOME at a throwaway dir with a test identity already set, so
+  // the helper short-circuits and the suite never touches the real ~/.gitconfig.
+  previousHome = process.env.HOME;
+  const homeDir = join(tempDir, "home");
+  await mkdir(homeDir, { recursive: true });
+  process.env.HOME = homeDir;
+  await git(["config", "--global", "user.email", "test@hive.dev"]);
+  await git(["config", "--global", "user.name", "Hive Test"]);
+
   fixtureRepoUrl = await createFixtureRepo(fixtureDir);
 
   const project = await createProject(fixtureRepoUrl, dataDir);
@@ -60,6 +72,8 @@ beforeEach(async () => {
 
 afterEach(async () => {
   clearWorkspaceIndexForTests();
+  if (previousHome === undefined) delete process.env.HOME;
+  else process.env.HOME = previousHome;
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -854,6 +868,38 @@ describe("mergeWorkspace", () => {
     const ws2 = await createWorkspace(projectId, dataDir);
     const ws2Path = join(dataDir, projectId, "workspaces", ws2.name);
     expect(existsSync(join(ws2Path, "merged-file.txt"))).toBe(true);
+  });
+
+  it("creates a merge commit when the default branch has diverged", async () => {
+    // ws1 branches off main, then main advances by merging ws2. ws1 is now
+    // behind main, so merging it is a non-fast-forward that creates a merge
+    // commit — the path that actually needs a git identity.
+    const ws1 = await createWorkspace(projectId, dataDir);
+    const ws1Path = join(dataDir, projectId, "workspaces", ws1.name);
+    await writeFile(join(ws1Path, "from-ws1.txt"), "ws1\n");
+    await git(["add", "."], ws1Path);
+    await git(["config", "user.email", "test@hive.dev"], ws1Path);
+    await git(["config", "user.name", "Test"], ws1Path);
+    await git(["commit", "-m", "add from-ws1"], ws1Path);
+
+    const ws2 = await createWorkspace(projectId, dataDir);
+    const ws2Path = join(dataDir, projectId, "workspaces", ws2.name);
+    await writeFile(join(ws2Path, "from-ws2.txt"), "ws2\n");
+    await git(["add", "."], ws2Path);
+    await git(["config", "user.email", "test@hive.dev"], ws2Path);
+    await git(["config", "user.name", "Test"], ws2Path);
+    await git(["commit", "-m", "add from-ws2"], ws2Path);
+
+    // Advances main to include from-ws2 (fast-forward).
+    await mergeWorkspace(ws2.id, dataDir);
+    // Diverged merge: must not throw "identity unknown".
+    await mergeWorkspace(ws1.id, dataDir);
+
+    // Both branches' changes land on the default branch.
+    const ws3 = await createWorkspace(projectId, dataDir);
+    const ws3Path = join(dataDir, projectId, "workspaces", ws3.name);
+    expect(existsSync(join(ws3Path, "from-ws1.txt"))).toBe(true);
+    expect(existsSync(join(ws3Path, "from-ws2.txt"))).toBe(true);
   });
 
   it("throws for non-existent workspace", async () => {

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -26,7 +26,6 @@ let tempDir: string;
 let dataDir: string;
 let fixtureRepoUrl: string;
 let projectId: string;
-let previousHome: string | undefined;
 
 async function pushRemoteMainFile(
   cloneName: string,
@@ -53,17 +52,6 @@ beforeEach(async () => {
   const { mkdir } = await import("node:fs/promises");
   await mkdir(dataDir, { recursive: true });
   await mkdir(fixtureDir, { recursive: true });
-
-  // mergeWorkspace calls ensureGitIdentity(), which reads/writes the global git
-  // config. Point HOME at a throwaway dir with a test identity already set, so
-  // the helper short-circuits and the suite never touches the real ~/.gitconfig.
-  previousHome = process.env.HOME;
-  const homeDir = join(tempDir, "home");
-  await mkdir(homeDir, { recursive: true });
-  process.env.HOME = homeDir;
-  await git(["config", "--global", "user.email", "test@hive.dev"]);
-  await git(["config", "--global", "user.name", "Hive Test"]);
-
   fixtureRepoUrl = await createFixtureRepo(fixtureDir);
 
   const project = await createProject(fixtureRepoUrl, dataDir);
@@ -72,8 +60,6 @@ beforeEach(async () => {
 
 afterEach(async () => {
   clearWorkspaceIndexForTests();
-  if (previousHome === undefined) delete process.env.HOME;
-  else process.env.HOME = previousHome;
   await rm(tempDir, { recursive: true, force: true });
 });
 
@@ -878,17 +864,35 @@ describe("mergeWorkspace", () => {
     const ws1Path = join(dataDir, projectId, "workspaces", ws1.name);
     await writeFile(join(ws1Path, "from-ws1.txt"), "ws1\n");
     await git(["add", "."], ws1Path);
-    await git(["config", "user.email", "test@hive.dev"], ws1Path);
-    await git(["config", "user.name", "Test"], ws1Path);
-    await git(["commit", "-m", "add from-ws1"], ws1Path);
+    await git(
+      [
+        "-c",
+        "user.email=test@hive.dev",
+        "-c",
+        "user.name=Test",
+        "commit",
+        "-m",
+        "add from-ws1",
+      ],
+      ws1Path,
+    );
 
     const ws2 = await createWorkspace(projectId, dataDir);
     const ws2Path = join(dataDir, projectId, "workspaces", ws2.name);
     await writeFile(join(ws2Path, "from-ws2.txt"), "ws2\n");
     await git(["add", "."], ws2Path);
-    await git(["config", "user.email", "test@hive.dev"], ws2Path);
-    await git(["config", "user.name", "Test"], ws2Path);
-    await git(["commit", "-m", "add from-ws2"], ws2Path);
+    await git(
+      [
+        "-c",
+        "user.email=test@hive.dev",
+        "-c",
+        "user.name=Test",
+        "commit",
+        "-m",
+        "add from-ws2",
+      ],
+      ws2Path,
+    );
 
     // Advances main to include from-ws2 (fast-forward).
     await mergeWorkspace(ws2.id, dataDir);

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -3,7 +3,7 @@ import { readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promi
 import { join, resolve } from "node:path";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
-import { ensureGitIdentity } from "../utils/git-identity.js";
+import { commitIdentityArgs } from "../utils/git-identity.js";
 import {
   addWorktreeFromBranch,
   addWorktreeWithNewBranch,
@@ -719,13 +719,16 @@ export async function mergeWorkspace(
     await git(["worktree", "add", tempPath, defaultBranch], bare);
 
     // A non-fast-forward merge creates a merge commit, which needs a git
-    // identity. Ensure the global one is in place (idempotent; honours the
-    // connected GitHub account) so the merge never fails with "identity unknown"
-    // if startup could not set it.
-    await ensureGitIdentity();
+    // identity. Supply one for this command only (honouring a configured
+    // identity, falling back to the neutral default) so the merge never fails
+    // with "identity unknown" and never mutates global config.
+    const identityArgs = await commitIdentityArgs(tempPath);
 
     // Merge the workspace branch
-    await git(["merge", workspace.branch, "-m", `Merge workspace ${workspace.name}`], tempPath);
+    await git(
+      [...identityArgs, "merge", workspace.branch, "-m", `Merge workspace ${workspace.name}`],
+      tempPath,
+    );
 
     // Update the bare repo's default branch ref to point to the merge commit
     const { stdout: mergeHash } = await git(["rev-parse", "HEAD"], tempPath);

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -3,6 +3,7 @@ import { readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promi
 import { join, resolve } from "node:path";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
+import { ensureGitIdentity } from "../utils/git-identity.js";
 import {
   addWorktreeFromBranch,
   addWorktreeWithNewBranch,
@@ -717,9 +718,12 @@ export async function mergeWorkspace(
   try {
     await git(["worktree", "add", tempPath, defaultBranch], bare);
 
-    // The merge commit's identity comes from the global git identity Hive
-    // maintains (see ensureGitIdentity), so the connected GitHub account is
-    // honoured here instead of a hardcoded orchestrator identity.
+    // A non-fast-forward merge creates a merge commit, which needs a git
+    // identity. Ensure the global one is in place (idempotent; honours the
+    // connected GitHub account) so the merge never fails with "identity unknown"
+    // if startup could not set it.
+    await ensureGitIdentity();
+
     // Merge the workspace branch
     await git(["merge", workspace.branch, "-m", `Merge workspace ${workspace.name}`], tempPath);
 

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -717,10 +717,9 @@ export async function mergeWorkspace(
   try {
     await git(["worktree", "add", tempPath, defaultBranch], bare);
 
-    // Configure git user in the temp worktree
-    await git(["config", "user.email", "hive@orchestrator.local"], tempPath);
-    await git(["config", "user.name", "Hive Orchestrator"], tempPath);
-
+    // The merge commit's identity comes from the global git identity Hive
+    // maintains (see ensureGitIdentity), so the connected GitHub account is
+    // honoured here instead of a hardcoded orchestrator identity.
     // Merge the workspace branch
     await git(["merge", workspace.branch, "-m", `Merge workspace ${workspace.name}`], tempPath);
 


### PR DESCRIPTION
## Problem

Agent commits inherit git's ambient config. On a freshly provisioned server `user.email` is unset, so git auto-builds `$USER@$(hostname -f)` and stamps the machine's fully-qualified name into every commit that gets pushed.

This is not hypothetical: it already leaked a real VPS hostname into this repo's own history via a `root@srv…hstgr.cloud` commit on `main`. That hostname resolves publicly, so publishing the repo would hand anyone a one-hop pivot from the open-source project to the maintainer's infrastructure. Every user who installs Hive on a fresh box would reproduce the same leak on their own servers.

The only place Hive set a git identity was the merge worktree (`hive@orchestrator.local`, hardcoded), so agent commits everywhere else fell through to git's hostname default.

## Fix

A new idempotent `ensureGitIdentity()` (`backend/src/utils/git-identity.ts`) guarantees a **global** git identity with this precedence:

1. **Operator's own identity wins** — any global identity whose email isn't our default is left untouched.
2. **Connected GitHub account** — supplies `name` and a noreply email (`<id>+<login>@users.noreply.github.com`), which attributes commits correctly and can never trip GitHub's "block command line pushes that expose my email" rejection.
3. **Neutral default** — `Hive Agent <hive@orchestrator.local>`, which leaks nothing.

The neutral email doubles as a sentinel: an identity equal to it is treated as *unclaimed* and upgraded once GitHub is connected. Writing to the **global** scope (not repo-local) is deliberate — it stays overridable per-repo and by a later `git config --global`, so we only ever supply a default, never override the user.

The same helper is called from two places:
- **backend startup** — best-effort, a failure never stops the server;
- **after each GitHub sign-in** — covers the common fresh-install order (boot writes the neutral default, operator connects GitHub during setup, identity upgrades to the account).

The hardcoded merge-worktree identity is removed: merges now inherit the global identity and are attributed to the connected account instead of a separate "Hive Orchestrator" actor.

## Scope

Git identity only. The token-in-Fastify-logs leak and the non-production CORS `() => true` bypass surfaced in the same pre-release audit are intentionally left for separate PRs.

**Known limitations (accepted):** identity is per-machine, so a future multi-operator instance would need `extensions.worktreeConfig`; and GitHub attribution only applies where `gh` is signed in (SSH/local-repo setups get the neutral default).

## Testing

- New unit tests (`backend/src/utils/git-identity.test.ts`) cover all cascade branches with injected `git`/`gh` runners (no real processes): neutral default, GitHub identity, name→login fallback, operator-identity-preserved, sentinel-upgrade, and idempotency.
- Full backend suite green: **1918 tests / 112 files**.
- Verified the merge-worktree change is safe on a clean CI: re-ran the touched suites under a fresh `HOME` with no global git identity — all pass (the test merge fast-forwards, so no merge commit / identity is needed; in production startup sets the global identity before any merge can run).
- `lint` and `typecheck` clean.
