### PR TITLE
feat(provision): install agent-browser and its Chrome during onboarding, pin the runtime on Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: 20
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
       # No dependency cache: a release must not be built from cached tarballs.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 22
+          node-version: 24
       - name: Build backend tarball
         run: bash scripts/release/build-backend-tarball.sh "${{ needs.validate-tag.outputs.version }}" "${{ matrix.arch }}"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/backend/src/utils/preflight.ts
+++ b/backend/src/utils/preflight.ts
@@ -42,6 +42,12 @@ const DEPENDENCIES: Dependency[] = [
     versionArgs: ["--version"],
     required: false,
   },
+  {
+    name: "agent-browser",
+    command: "agent-browser",
+    versionArgs: ["--version"],
+    required: false,
+  },
 ];
 
 export function meetsMinVersion(version: string, min: [number, number]): boolean {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -112,7 +112,7 @@ changes done. For iOS changes, also run `cd ios && swift test`.
 
 ```bash
 # Build the backend release tarball for the host architecture into dist-release/.
-# Requires a Linux host on Node 22 (native modules are compiled during the build).
+# Requires a Linux host on Node 24 (native modules are compiled during the build).
 npm run release:backend -- 0.0.0-dev
 
 # Bundle scripts/provision/{lib,steps,main}.sh into scripts/provision/dist/provision.sh.

--- a/docs/install-flow-orbstack.md
+++ b/docs/install-flow-orbstack.md
@@ -44,18 +44,18 @@ password on the server screen if one is needed.)
 
 The tarball must be built **on Linux, on the target architecture** (native
 modules are compiled during the build and cannot be cross-compiled), against
-Node 22 with a C++ toolchain. On a Mac the shortest path is a `node:22`
+Node 24 with a C++ toolchain. On a Mac the shortest path is a `node:24`
 container — the same way the e2e harness builds it, and OrbStack ships Docker:
 
 ```bash
 cd /path/to/hive                       # your clone, on the Mac
-docker run --rm -v "$PWD":/repo -w /repo node:22 \
+docker run --rm -v "$PWD":/repo -w /repo node:24 \
   bash scripts/release/build-backend-tarball.sh 0.0.0-dev arm64
 # → dist-release/hive-backend-0.0.0-dev-linux-arm64.tar.gz (+ .sha256)
 ```
 
 (Building inside an OrbStack Linux machine also works — your Mac filesystem is
-mounted there at the same paths — but a bare VM first needs Node 22 and
+mounted there at the same paths — but a bare VM first needs Node 24 and
 `build-essential`, which the test VM deliberately does not have.)
 
 That is all: the debug sidecar probes the server's `uname -m` and picks up the

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -16,6 +16,8 @@ The backend runs a startup preflight and exits if a required dependency is missi
 - **GitHub CLI** (`gh`), installed and authenticated for GitHub-backed flows
 - **PM2** for the documented production process
 - **Codex CLI** (`codex`), optional and required only for its provider features
+- **agent-browser** (`agent-browser`), optional — powers the live browser panel and agent-driven UI
+  checks; run `agent-browser install` once (`--with-deps` on Linux) to download its Chrome build
 
 Install PM2 if it is not already available:
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -73,7 +73,9 @@ claim success while its port may be closed.
 - Creates an unprivileged `hive` service account with the home directory `/home/hive`.
 - Creates the install directory (`/opt/hive` by default) holding Hive's **own pinned Node.js
   runtime**, its releases, and the uninstall script.
-- Installs the Claude Code, Codex and GitHub CLIs under `/home/hive/.local`, as the service account.
+- Installs the Claude Code, Codex, GitHub and `agent-browser` CLIs under `/home/hive/.local`, as the
+  service account, plus a Chrome build under `/home/hive/.agent-browser` and the system libraries it
+  needs (via `agent-browser install --with-deps`).
 - Writes `/etc/hive/hive.env`, root-owned and readable by nobody else, holding the service
   configuration and the SHA-256 digest of the access token.
 - Writes a non-secret install identity manifest containing its schema, port, install directory, and

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -75,7 +75,8 @@ claim success while its port may be closed.
   runtime**, its releases, and the uninstall script.
 - Installs the Claude Code, Codex, GitHub and `agent-browser` CLIs under `/home/hive/.local`, as the
   service account, plus a Chrome build under `/home/hive/.agent-browser` and the system libraries it
-  needs (via `agent-browser install --with-deps`).
+  needs (via `agent-browser install --with-deps`). On arm64 servers the browser step is skipped —
+  Chrome for Testing ships no linux-arm64 build — and Hive runs without browser automation.
 - Writes `/etc/hive/hive.env`, root-owned and readable by nobody else, holding the service
   configuration and the SHA-256 digest of the access token.
 - Writes a non-secret install identity manifest containing its schema, port, install directory, and

--- a/frontend/src/pages/installer/screens/ReadyScreen.tsx
+++ b/frontend/src/pages/installer/screens/ReadyScreen.tsx
@@ -71,8 +71,9 @@ export function ReadyScreen({ inputs, escalates, onContinue, onBack }: ReadyScre
       icon: Bot,
       text: (
         <>
-          Installs Claude Code, Codex and the GitHub CLI inside that prefix, for the{" "}
-          <code>hive</code> account only.
+          Installs Claude Code, Codex, the GitHub CLI and the <code>agent-browser</code>{" "}
+          automation tool inside that prefix, for the <code>hive</code> account only — plus a
+          Chrome build under that account's home and the system libraries it needs.
         </>
       ),
     },

--- a/scripts/provision/main.sh
+++ b/scripts/provision/main.sh
@@ -138,7 +138,7 @@ detect_arch() {
 
 STEPS=(
   probe_os probe_env apt_baseline create_user authorize_ssh_key install_node
-  install_agent_clis install_release generate_token write_secrets write_units
+  install_agent_clis install_agent_browser install_release generate_token write_secrets write_units
   write_uninstall firewall_rule enable_service health_check verify_auth complete_install
 )
 

--- a/scripts/provision/steps.sh
+++ b/scripts/provision/steps.sh
@@ -684,6 +684,77 @@ step_install_agent_clis() {
 
 # ---------------------------------------------------------------------------
 
+title_install_agent_browser() { echo "Install the browser automation tool"; }
+
+# The agent-browser CLI plus the Chrome build it drives. Its npm postinstall
+# fetches a native binary from the tool's GitHub releases and tolerates a
+# failed download, so the package being present proves nothing — the guard and
+# the post-install verification both ask the binary itself. The package is
+# installed without a version spec on purpose: npm resolves the newest version
+# whose engines constraint matches the pinned private runtime, where `@latest`
+# would force-install one that may need a newer Node.
+guard_install_agent_browser() {
+  [ -x "$HIVE_TOOLS_DIR/bin/agent-browser" ] || return 1
+  as_hive agent-browser --version >/dev/null 2>&1 || return 1
+  compgen -G "$HIVE_HOME/.agent-browser/browsers/chrome-*/chrome" >/dev/null 2>&1 || return 1
+  # The step's own verification, repeated: a binary and a Chrome on disk do
+  # not prove the system libraries arrived or that the state directory is the
+  # service account's. Opening a page is the one check that cannot lie, and it
+  # is what keeps a Retry from skipping past a half-repaired install. The
+  # sandbox flag matches the one write_secrets puts in the service
+  # environment: without it Chrome cannot start under the hive unit at all.
+  as_hive env AGENT_BROWSER_ARGS=--no-sandbox agent-browser open about:blank \
+    >/dev/null 2>&1 || return 1
+  as_hive agent-browser close >/dev/null 2>&1 || true
+}
+step_install_agent_browser() {
+  local shim
+  STEP_ERR_CODE=BROWSER_INSTALL_FAILED
+  run_logged install_agent_browser as_hive npm install -g --prefix "$HIVE_TOOLS_DIR" \
+    --no-audit --no-fund agent-browser
+
+  # The state directory is rebuilt root-side before the tool writes into it as
+  # root: an existing tree is hive-writable, and a symlink planted inside it
+  # would redirect root's writes. The step only runs when the install is
+  # absent or broken, so the discarded download is a broken one.
+  rm -rf "$HIVE_HOME/.agent-browser"
+  install -d -o "$HIVE_USER" -g "$HIVE_USER" "$HIVE_HOME/.agent-browser"
+
+  # `install --with-deps` needs root for Chrome's system libraries, but the
+  # browser download lands under $HOME — so it runs as root with the service
+  # account's HOME, and the state directory is handed over afterwards. Not
+  # `as_hive`: the service account cannot install apt packages. Two details:
+  # the tool invokes `sudo apt-get` even when it is already root and a minimal
+  # Debian has no sudo, so it gets a pass-through shim; and the PATH is
+  # root-owned directories only — never $HIVE_TOOLS_DIR/bin, which the service
+  # account can write to. That root runs the hive-installed agent-browser
+  # binary at all is the residual trust this step accepts; it is why the
+  # invocation is by absolute path and nothing else resolves through hive's
+  # prefix.
+  shim="$HIVE_VAR_DIR/sudo-shim"
+  install -d -m 700 "$shim"
+  printf '#!/bin/sh\nexec "$@"\n' >"$shim/sudo"
+  chmod 700 "$shim/sudo"
+  run_logged install_agent_browser env HOME="$HIVE_HOME" \
+    PATH="$shim:$HIVE_RUNTIME_DIR/current/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin" \
+    DEBIAN_FRONTEND=noninteractive \
+    "$HIVE_TOOLS_DIR/bin/agent-browser" install --with-deps
+  rm -rf "$shim"
+  chown -R "$HIVE_USER:$HIVE_USER" "$HIVE_HOME/.agent-browser"
+
+  as_hive agent-browser --version >/dev/null 2>&1 || die BROWSER_INSTALL_FAILED \
+    "'agent-browser' is not runnable as the $HIVE_USER service account after installation"
+  # The installer treats a failed dependency install as a warning, so the only
+  # proof of a working browser is opening a page as the service account.
+  run_logged install_agent_browser as_hive env AGENT_BROWSER_ARGS=--no-sandbox \
+    agent-browser open about:blank || die BROWSER_INSTALL_FAILED \
+    "the installed browser could not open a page as the $HIVE_USER service account"
+  as_hive agent-browser close >/dev/null 2>&1 || true
+  STEP_ERR_CODE=""
+}
+
+# ---------------------------------------------------------------------------
+
 title_install_release() { echo "Install the Hive backend"; }
 
 verify_release_structure() {
@@ -848,6 +919,12 @@ step_generate_token() {
 title_write_secrets() { echo "Write the service configuration"; }
 
 hive_env_base() {
+  # AGENT_BROWSER_ARGS: Chromium's sandbox cannot work under the hive unit —
+  # NoNewPrivileges blocks the setuid helper and Ubuntu 24.04 restricts
+  # unprivileged user namespaces — so the browser the agents drive through
+  # `agent-browser` must run without it. Deliberately not HIVE_-prefixed: the
+  # backend strips HIVE_* from agent environments (backend/src/utils/env.ts)
+  # and this variable must reach them.
   cat <<EOF
 NODE_ENV=production
 HOST=0.0.0.0
@@ -857,6 +934,7 @@ HIVE_AUTH_TOKEN_SHA256=$HIVE_AUTH_TOKEN_SHA256
 HIVE_AUTOMATION_TIMEOUT_SEC=1800
 HOME=$HIVE_HOME
 PATH=$HIVE_SERVICE_PATH
+AGENT_BROWSER_ARGS=--no-sandbox
 EOF
   [ -z "${OPT_ALLOWED_HOST:-}" ] || echo "HIVE_ALLOWED_HOSTS=$OPT_ALLOWED_HOST"
   # A prerelease install is a developer's test server. The webview of a debug

--- a/scripts/provision/steps.sh
+++ b/scripts/provision/steps.sh
@@ -19,9 +19,9 @@ APT_BASELINE="ca-certificates curl git xz-utils iproute2"
 # both digests and RELEASE_NODE_MAJOR in scripts/release/build-backend-tarball.sh.
 # Digests are pinned rather than fetched from SHASUMS256.txt so a compromised
 # mirror cannot serve a matching tarball/checksum pair over the same TLS session.
-NODE_VERSION="22.23.1"
-NODE_SHA256_X64="9749e988f437343b7fa832c69ded82a312e41a03116d766797ac14f6f9eee578"
-NODE_SHA256_ARM64="0294e8b915ab75f92c7513d2fcb830ae06e10684e6c603e99a87dbf8835389c1"
+NODE_VERSION="24.18.0"
+NODE_SHA256_X64="55aa7153f9d88f28d765fcdad5ae6945b5c0f98a36881703817e4c450fa76742"
+NODE_SHA256_ARM64="58c9520501f6ae2b52d5b210444e24b9d0c029a58c5011b797bc1fe7105886f6"
 
 # GitHub CLI, installed from its official release tarball for the same reason:
 # no vendor apt repository is added to the operator's machine.
@@ -689,11 +689,12 @@ title_install_agent_browser() { echo "Install the browser automation tool"; }
 # The agent-browser CLI plus the Chrome build it drives. Its npm postinstall
 # fetches a native binary from the tool's GitHub releases and tolerates a
 # failed download, so the package being present proves nothing — the guard and
-# the post-install verification both ask the binary itself. The package is
-# installed without a version spec on purpose: npm resolves the newest version
-# whose engines constraint matches the pinned private runtime, where `@latest`
-# would force-install one that may need a newer Node.
+# the post-install verification both ask the binary itself.
 guard_install_agent_browser() {
+  # Chrome for Testing publishes no linux-arm64 build, so the tool cannot
+  # install a browser there. The backend treats agent-browser as optional:
+  # an arm64 server provisions without browser automation rather than failing.
+  [ "$ARCH_TAG" = x64 ] || return 0
   [ -x "$HIVE_TOOLS_DIR/bin/agent-browser" ] || return 1
   as_hive agent-browser --version >/dev/null 2>&1 || return 1
   compgen -G "$HIVE_HOME/.agent-browser/browsers/chrome-*/chrome" >/dev/null 2>&1 || return 1

--- a/scripts/release/build-backend-tarball.sh
+++ b/scripts/release/build-backend-tarball.sh
@@ -11,7 +11,7 @@ set -Eeuo pipefail
 # node-pty has no Linux prebuild: it is compiled by node-gyp at install time
 # against the ABI of the Node that runs this build. The runtime provisioned on
 # the server is pinned to the same major, otherwise the addon will not load.
-RELEASE_NODE_MAJOR=22
+RELEASE_NODE_MAJOR=24
 
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 VERSION="${1:-0.0.0-dev}"

--- a/shared/setup-errors.ts
+++ b/shared/setup-errors.ts
@@ -23,6 +23,7 @@ export const SETUP_ERROR_CODES = [
   "APT_FAILURE",
   "NODE_INSTALL_FAILED",
   "AGENT_CLI_INSTALL_FAILED",
+  "BROWSER_INSTALL_FAILED",
   "RELEASE_DOWNLOAD_FAILED",
   "CHECKSUM_MISMATCH",
   "TOKEN_GENERATION_FAILED",
@@ -73,6 +74,8 @@ export const SETUP_ERROR_HINTS: Record<SetupErrorCode, string> = {
     "Hive's private Node.js runtime could not be installed. Check that the server can reach nodejs.org, then press Retry.",
   AGENT_CLI_INSTALL_FAILED:
     "The agent command-line tools could not be installed. Check that the server can reach the npm registry and github.com, then press Retry.",
+  BROWSER_INSTALL_FAILED:
+    "The browser automation tool could not be installed. Check that the server can reach the npm registry, github.com and storage.googleapis.com (the Chrome download), then press Retry.",
   RELEASE_DOWNLOAD_FAILED:
     "The Hive backend could not be fetched onto the server. Check that the server has internet access, then press Retry.",
   CHECKSUM_MISMATCH:

--- a/test/provision/e2e-docker.sh
+++ b/test/provision/e2e-docker.sh
@@ -192,6 +192,17 @@ assert_provisioned() {
     || die "an agent CLI was installed system-wide"
   echo "OK: claude, codex and gh live under /home/hive/.local"
 
+  log "The browser automation tool is installed with a Chrome the service account owns"
+  sh_server 'runuser -u hive -- env HOME=/home/hive PATH=/home/hive/.local/bin:/opt/hive/runtime/current/bin:/usr/bin:/bin agent-browser --version' >/dev/null \
+    || die "agent-browser is not runnable as the hive service account"
+  sh_server 'ls /home/hive/.agent-browser/browsers/chrome-*/chrome >/dev/null' \
+    || die "no Chrome build under /home/hive/.agent-browser/browsers"
+  [ "$(sh_server 'stat -c %U /home/hive/.agent-browser')" = hive ] \
+    || die "the browser state directory is not owned by the service account"
+  sh_server 'grep -q "^AGENT_BROWSER_ARGS=--no-sandbox$" /etc/hive/hive.env' \
+    || die "the service environment does not disable the Chrome sandbox"
+  echo "OK: agent-browser and its Chrome live under /home/hive, sandbox flag configured"
+
   log "The release was activated by symlink and the service is hardened"
   sh_server 'test -L /opt/hive/current' || die "/opt/hive/current is not a symlink"
   [ "$(in_server systemctl show hive -p User --value)" = hive ] || die "the service does not run as hive"
@@ -359,7 +370,7 @@ data_dir=/home/hive/.hive"' || die "the install identity manifest is wrong"
     || die "the resume did not recognise the key as already authorized"
   echo "OK: two entries — ours once, the operator's untouched"
   local step
-  for step in probe_os apt_baseline create_user install_node install_agent_clis install_release; do
+  for step in probe_os apt_baseline create_user install_node install_agent_clis install_agent_browser install_release; do
     grep -q "\"step\":\"$step\",\"status\":\"skip\"" "$WORK/resume.ndjson" \
       || die "step '$step' repeated its work on a resume"
   done

--- a/test/provision/e2e-docker.sh
+++ b/test/provision/e2e-docker.sh
@@ -13,7 +13,7 @@
 # left untouched.
 #
 # The backend tarball is built once by scripts/release/build-backend-tarball.sh
-# inside a node:22 container. Set HIVE_E2E_TARBALL to reuse an existing one.
+# inside a node:24 container. Set HIVE_E2E_TARBALL to reuse an existing one.
 #
 # shellcheck disable=SC2016  # single-quoted bodies are expanded in the container, not here
 set -Eeuo pipefail
@@ -23,7 +23,7 @@ PROV="$ROOT/scripts/provision"
 MODE="${1:-install}"
 VERSION="0.0.0-e2e"
 IMAGE="hive-provision-e2e"
-BUILDER_IMAGE="node:22"
+BUILDER_IMAGE="node:24"
 NETWORK="hive-provision-e2e"
 RELEASE_HOST="hive-e2e-release"
 SERVER_HOST="hive-e2e-server"
@@ -73,7 +73,7 @@ build_release() {
     log "Reusing $HIVE_E2E_TARBALL"
     cp "$HIVE_E2E_TARBALL" "$RELEASE_DIR/$ASSET"
   else
-    log "Build the real backend release tarball (node:22 container)"
+    log "Build the real backend release tarball (node:24 container)"
     local src="$WORK/src"
     mkdir -p "$src"
     # Tracked files from the working tree, so local edits are what gets built.
@@ -192,6 +192,9 @@ assert_provisioned() {
     || die "an agent CLI was installed system-wide"
   echo "OK: claude, codex and gh live under /home/hive/.local"
 
+  # Skipped on arm64 hosts, mirroring the step: Chrome for Testing has no
+  # linux-arm64 build, so those servers provision without browser automation.
+  if [ "$ARCH_TAG" = x64 ]; then
   log "The browser automation tool is installed with a Chrome the service account owns"
   sh_server 'runuser -u hive -- env HOME=/home/hive PATH=/home/hive/.local/bin:/opt/hive/runtime/current/bin:/usr/bin:/bin agent-browser --version' >/dev/null \
     || die "agent-browser is not runnable as the hive service account"
@@ -202,6 +205,7 @@ assert_provisioned() {
   sh_server 'grep -q "^AGENT_BROWSER_ARGS=--no-sandbox$" /etc/hive/hive.env' \
     || die "the service environment does not disable the Chrome sandbox"
   echo "OK: agent-browser and its Chrome live under /home/hive, sandbox flag configured"
+  fi
 
   log "The release was activated by symlink and the service is hardened"
   sh_server 'test -L /opt/hive/current' || die "/opt/hive/current is not a symlink"


### PR DESCRIPTION
## What

Adds the missing `agent-browser` installation to the onboarding install flow, as a dedicated `install_agent_browser` provisioning step between the agent CLIs and the backend release — and moves the pinned private runtime to **Node 24.18.0 (Krypton LTS)** so fresh installs get the current agent-browser (0.33.x) instead of an engines-capped 0.27.

- **New step** installs the `agent-browser` CLI into `/home/hive/.local` as the service account, then runs `agent-browser install --with-deps` as root (with the service account's `HOME`) for the Chrome build and its system libraries, and hands `~/.agent-browser` over to the service account.
- **Node 24 pin** moves together everywhere the major is coupled: `NODE_VERSION` + both SHA256 digests in `steps.sh`, `RELEASE_NODE_MAJOR` in the tarball build, the release workflow's Node, CI's Node (20 → 24), the e2e builder image, and docs.
- **arm64**: Chrome for Testing publishes no linux-arm64 build, so the step's guard returns satisfied on non-x64 — arm64 servers provision without browser automation instead of failing. The e2e browser assertions gate on the host arch to match.
- **`AGENT_BROWSER_ARGS=--no-sandbox`** is written to `/etc/hive/hive.env`: Chrome's sandbox cannot work under the hive unit (`NoNewPrivileges` + Ubuntu 24.04 user-namespace restrictions). Deliberately not `HIVE_`-prefixed so `buildWorkspaceEnv` doesn't strip it from agent processes.
- **Backend preflight** lists `agent-browser` as optional — servers without it (arm64, pre-existing installs) keep booting.
- New `BROWSER_INSTALL_FAILED` error code + hint, e2e assertions, ReadyScreen manifest bullet, docs.

## Why it is built this way (verified empirically in Docker)

- The tool's installer shells out to literal `sudo apt-get` even as root, and **treats a failed dependency install as a warning** — so the step provides a pass-through `sudo` shim and proves the result by actually opening a page as the service account (`agent-browser open about:blank`, exits 1 on failure). The guard repeats the launch probe so a Retry can never skip past a half-repaired install.
- The root-run installer gets a **root-owned PATH only** (never `/home/hive/.local/bin`), and the state directory is rebuilt root-side before the tool writes into it, so the service account cannot pre-plant symlinks or binaries into a root execution.
- Chrome lands in `~/.agent-browser/browsers/chrome-<version>/chrome` (Chrome for Testing CDN) — verified identical on agent-browser 0.27 and 0.33.
- agent-browser ≥ 0.28 requires Node ≥ 24 (`engines`), which is what motivated bumping the runtime rather than maintaining a version bound: on Node 24 the bare `npm install agent-browser` resolves the latest release.

## Scope

Provisioning only: agent-browser has no auth state, so it does not join the Accounts-setup Tools panel (`SETUP_TOOL_IDS`); adding it there later is purely additive. Already-provisioned servers never re-run provisioning and need a one-off manual install.

## Testing

- `bash test/provision/e2e-docker.sh install` — **full lane run locally on the final state: PASS**, with the backend tarball built in `node:24` (node-pty and sharp load under the new ABI, `nodeAbi` accepted), the container asserting the runtime is `v24.18.0`, the new browser assertions green (agent-browser runnable as hive, Chrome under `~/.agent-browser` owned by hive, sandbox flag in `hive.env`), and the resume pass skipping the step
- Step mechanics validated in `node:24` containers: deps install through the sudo shim, launch as hive with `--no-sandbox`, guard probe green on 0.33.1
- `bash test/provision/contract.sh` (shellcheck + error-code set equality), backend tests (1919) under Node 24, backend + frontend `typecheck`/`lint`, frontend installer tests (67) — all pass