### PR TITLE
chore: prepare public beta release pipeline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: cargo
+    directory: /frontend/src-tauri
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types: [minor, patch]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,48 @@ jobs:
       - name: Build frontend
         run: npm run build --workspace=frontend
 
+  desktop:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install Tauri system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            build-essential \
+            curl \
+            file \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libwebkit2gtk-4.1-dev \
+            libxdo-dev \
+            patchelf \
+            wget
+
+      - run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Test Rust
+        run: cargo test --manifest-path frontend/src-tauri/Cargo.toml --locked
+
+      - name: Compile Tauri desktop
+        working-directory: frontend
+        run: npm run tauri -- build --debug --no-bundle
+
   ios:
-    # Temporarily disabled to avoid paid macOS runner usage on the private repository.
-    # Remove this condition to restore Swift tests and the iOS build.
-    if: ${{ false }}
+    # Standard macOS runners are free once the repository is public.
+    if: ${{ github.event.repository.private == false }}
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,6 @@ jobs:
         run: npm run tauri -- build --debug --no-bundle
 
   ios:
-    # Standard macOS runners are free once the repository is public.
-    if: ${{ github.event.repository.private == false }}
     runs-on: macos-26
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,38 +1,91 @@
 name: release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact Cargo version to release (for example 0.1.0-beta.1)
+        required: true
+        type: string
 
-# Least privilege: only the publish job writes release contents. The build jobs
-# run npm install (third-party install scripts) and must not hold a write token.
-# Every third-party action is pinned by commit SHA.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+# Build and verification jobs cannot publish repository contents. Only the
+# final draft-release job receives a write token.
 permissions:
   contents: read
 
 jobs:
-  validate-tag:
+  validate:
     runs-on: ubuntu-24.04
     outputs:
       version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      macos-version: ${{ steps.version.outputs.macos-version }}
+      macos-build: ${{ steps.version.outputs.macos-build }}
+      prerelease: ${{ steps.version.outputs.prerelease }}
+      commit: ${{ steps.version.outputs.commit }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
       - id: version
-        name: Validate the tag against the desktop package version
+        name: Validate main and release version
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
         shell: bash
         run: |
-          version="$(awk '
-            /^\[package\]$/ { in_package=1; next }
-            /^\[/ && in_package { exit }
-            in_package && /^version = / { gsub(/["[:space:]]/, "", $3); print $3; exit }
-          ' frontend/src-tauri/Cargo.toml)"
-          [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]
-          test "$GITHUB_REF_NAME" = "v$version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+          if [ "$GITHUB_REF" != "refs/heads/main" ]; then
+            echo "releases must be dispatched from main, not $GITHUB_REF" >&2
+            exit 1
+          fi
+          node scripts/release/release-version.mjs check "$REQUESTED_VERSION"
+          version="$(node scripts/release/release-version.mjs get)"
+          macos_version="$(node scripts/release/release-version.mjs macos "$version")"
+          macos_build="$(git rev-list --count HEAD)"
+          commit="$(git rev-parse HEAD)"
+          prerelease=false
+          case "$version" in *-*) prerelease=true ;; esac
+
+          if git ls-remote --exit-code --tags origin "refs/tags/v$version" >/dev/null 2>&1; then
+            echo "tag v$version already exists" >&2
+            exit 1
+          fi
+
+          {
+            echo "version=$version"
+            echo "tag=v$version"
+            echo "macos-version=$macos_version"
+            echo "macos-build=$macos_build"
+            echo "prerelease=$prerelease"
+            echo "commit=$commit"
+          } >> "$GITHUB_OUTPUT"
+
+  verify:
+    needs: validate
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+        env:
+          NODE_ENV: test
+      - run: npm run test:release
+      - run: npm run test:provision
 
   backend-tarball:
-    needs: validate-tag
+    needs: [validate, verify]
     strategy:
       fail-fast: false
       matrix:
@@ -44,41 +97,144 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      # Must match RELEASE_NODE_MAJOR in scripts/release/build-backend-tarball.sh
-      # and the Node major installed on the deployment host: node-pty is compiled
-      # here against this Node's ABI. The build fails loudly on a mismatch.
-      # No dependency cache: a release must not be built from cached tarballs.
+
+      # Must match RELEASE_NODE_MAJOR in build-backend-tarball.sh and the Node
+      # major provisioned on servers because node-pty is compiled in this job.
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24
+
       - name: Build backend tarball
-        run: bash scripts/release/build-backend-tarball.sh "${{ needs.validate-tag.outputs.version }}" "${{ matrix.arch }}"
+        run: bash scripts/release/build-backend-tarball.sh "${{ needs.validate.outputs.version }}" "${{ matrix.arch }}"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backend-${{ matrix.arch }}
           path: dist-release/*
           if-no-files-found: error
 
-  # provision.sh is published alongside the tarballs so an operator can install
-  # with `curl -fsSL .../provision.sh | bash`. It carries the release version,
-  # which is the version of the backend tarball it downloads.
   provision-script:
-    needs: validate-tag
+    needs: [validate, verify]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Provision contracts
-        run: bash test/provision/contract.sh
+
       - name: Build provision.sh
-        run: bash scripts/provision/build.sh "${{ needs.validate-tag.outputs.version }}"
+        run: bash scripts/provision/build.sh "${{ needs.validate.outputs.version }}"
+
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: provision-script
           path: scripts/provision/dist/provision.sh
           if-no-files-found: error
 
-  publish:
-    needs: [validate-tag, backend-tarball, provision-script]
+  desktop-macos-arm64:
+    needs: [validate, verify]
+    runs-on: macos-26
+    environment:
+      name: release
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+
+      - run: npm ci
+
+      - name: Build signed and notarized Apple Silicon DMG
+        working-directory: frontend
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          RELEASE_VERSION: ${{ needs.validate.outputs.version }}
+          MACOS_VERSION: ${{ needs.validate.outputs.macos-version }}
+          MACOS_BUILD: ${{ needs.validate.outputs.macos-build }}
+        shell: bash
+        run: |
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY; do
+            if [ -z "${!name:-}" ]; then
+              echo "missing release environment secret: $name" >&2
+              exit 1
+            fi
+          done
+          case "$APPLE_API_KEY" in
+            *[!A-Za-z0-9]*)
+              echo "APPLE_API_KEY must contain only letters and digits" >&2
+              exit 1
+              ;;
+          esac
+          export APPLE_API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY}.p8"
+          mount_point=""
+          cleanup() {
+            if [ -n "$mount_point" ]; then
+              hdiutil detach "$mount_point" >/dev/null 2>&1 || true
+            fi
+            if [ -n "${APPLE_API_KEY_PATH:-}" ]; then
+              rm -f -- "$APPLE_API_KEY_PATH"
+            fi
+          }
+          trap cleanup EXIT
+          umask 077
+          printf '%s' "$APPLE_API_PRIVATE_KEY" > "$APPLE_API_KEY_PATH"
+          unset APPLE_API_PRIVATE_KEY
+          test -s "$APPLE_API_KEY_PATH"
+          rustup target add aarch64-apple-darwin
+          release_config="$(jq -cn \
+            --arg version "$MACOS_VERSION" \
+            --arg build "$MACOS_BUILD" \
+            '{version: $version, bundle: {macOS: {bundleVersion: $build}}}')"
+          npm run tauri build -- \
+            --target aarch64-apple-darwin \
+            --bundles dmg \
+            --config "$release_config"
+
+          generated_dir="src-tauri/target/aarch64-apple-darwin/release/bundle/dmg"
+          generated_count="$(find "$generated_dir" -maxdepth 1 -type f -name '*.dmg' | wc -l | tr -d ' ')"
+          test "$generated_count" = 1
+          generated_dmg="$(find "$generated_dir" -maxdepth 1 -type f -name '*.dmg' -print -quit)"
+          mkdir -p ../dist-release
+          dmg="../dist-release/Hive-$RELEASE_VERSION-macos-arm64.dmg"
+          cp "$generated_dmg" "$dmg"
+
+          mount_point="$RUNNER_TEMP/hive-release-dmg"
+          mkdir -p "$mount_point"
+          hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mount_point"
+          app="$mount_point/Hive.app"
+          test -d "$app"
+          test "$(lipo -archs "$app/Contents/MacOS/Hive")" = arm64
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "$app/Contents/Info.plist")" = io.419labs.hive
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")" = "$MACOS_VERSION"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$app/Contents/Info.plist")" = "$MACOS_BUILD"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :LSMinimumSystemVersion' "$app/Contents/Info.plist")" = 14.0
+          test -f "$app/Contents/Resources/LICENSE"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          spctl --assess --type execute --verbose=2 "$app"
+          hdiutil detach "$mount_point"
+          mount_point=""
+          xcrun stapler validate "$dmg"
+
+          (
+            cd ../dist-release
+            shasum -a 256 "$(basename "$dmg")" > "$(basename "$dmg").sha256"
+          )
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: desktop-macos-arm64
+          path: |
+            dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.dmg
+            dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.dmg.sha256
+          if-no-files-found: error
+
+  draft-release:
+    needs: [validate, backend-tarball, provision-script, desktop-macos-arm64]
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -86,21 +242,40 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+
       - name: Assemble release assets
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
         shell: bash
         run: |
-          mkdir -p release
-          find artifacts -type f -exec cp {} release/ \;
-          ls -l release
-          test -f "release/hive-backend-${{ needs.validate-tag.outputs.version }}-linux-x64.tar.gz"
-          test -f "release/hive-backend-${{ needs.validate-tag.outputs.version }}-linux-x64.tar.gz.sha256"
-          test -f "release/hive-backend-${{ needs.validate-tag.outputs.version }}-linux-arm64.tar.gz"
-          test -f "release/hive-backend-${{ needs.validate-tag.outputs.version }}-linux-arm64.tar.gz.sha256"
-          test -f "release/provision.sh"
-      - name: Publish GitHub release
+          mkdir release
+          while IFS= read -r asset; do
+            cp -n "$asset" release/
+          done < <(find artifacts -type f | sort)
+
+          for asset in \
+            "hive-backend-$VERSION-linux-x64.tar.gz" \
+            "hive-backend-$VERSION-linux-x64.tar.gz.sha256" \
+            "hive-backend-$VERSION-linux-arm64.tar.gz" \
+            "hive-backend-$VERSION-linux-arm64.tar.gz.sha256" \
+            "Hive-$VERSION-macos-arm64.dmg" \
+            "Hive-$VERSION-macos-arm64.dmg.sha256" \
+            "provision.sh"; do
+            test -f "release/$asset" || {
+              echo "missing release asset: $asset" >&2
+              exit 1
+            }
+          done
+          test "$(find release -type f | wc -l)" = 7
+
+      - name: Create draft GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
+          tag_name: ${{ needs.validate.outputs.tag }}
+          name: Hive ${{ needs.validate.outputs.tag }}
+          target_commitish: ${{ needs.validate.outputs.commit }}
           files: release/*
           fail_on_unmatched_files: true
           generate_release_notes: true
-          prerelease: ${{ contains(needs.validate-tag.outputs.version, '-') }}
+          draft: true
+          prerelease: ${{ needs.validate.outputs.prerelease }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 # Contributing to Hive
 
 Thanks for your interest in Hive! Contributions of all kinds are welcome — bug reports, docs,
-and code.
+and code. Support is provided on a best-effort basis.
 
 ## Before you start
 
@@ -9,6 +9,8 @@ and code.
   PR directly.
 - For larger changes or new features, open an issue first so we can discuss the approach before you
   invest time in it.
+- Report suspected vulnerabilities privately as described in [SECURITY.md](SECURITY.md), never in
+  a public issue.
 
 ## Development setup
 
@@ -37,4 +39,5 @@ To exercise the real server install flow end to end, see
 ## License
 
 By contributing, you agree that your contributions are licensed under the
-[GNU General Public License v3.0](LICENSE).
+[GNU General Public License v3.0 or later](LICENSE). The project does not require a contributor
+license agreement; you retain copyright in your contribution.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 **Orchestrate AI coding agents across isolated git workspaces — from your desktop, browser, or phone.**
 
 [![CI](https://github.com/unfence-labs/hive/actions/workflows/ci.yml/badge.svg)](https://github.com/unfence-labs/hive/actions/workflows/ci.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-FF7048.svg)](LICENSE)
+[![License: GPL v3 or later](https://img.shields.io/badge/License-GPLv3%2B-FF7048.svg)](LICENSE)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](#contributing)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-5FA04E?logo=node.js&logoColor=white)](https://nodejs.org)
 
@@ -69,7 +69,8 @@ Hive separates the machine doing the work from the client controlling it. The ba
 > Tailscale or WireGuard. It does not terminate HTTPS in V1, so the backend port must never be
 > reachable from the public Internet. See **[Networking](docs/networking.md)**.
 
-1. **[Download the desktop app](https://github.com/unfence-labs/hive/releases/latest)** (macOS).
+1. **[Download the desktop app](https://github.com/unfence-labs/hive/releases)** for an
+   Apple Silicon Mac running macOS 14 or later.
 2. Point it at your server: the guided installer connects over SSH, runs a read-only preflight, and installs the complete backend as a systemd service. Check **[Prerequisites](docs/prerequisites.md)** for what it needs and what it changes.
 3. Connect from anywhere — the desktop app, a browser, or the iOS app share the same backend.
 
@@ -87,6 +88,7 @@ follow the **[Manual Installation guide](docs/manual-installation.md)**.
 | [Manual Installation](docs/manual-installation.md) | Building from source and managing the runtime yourself |
 | [Configuration](docs/configuration.md) | Backend and frontend environment variables |
 | [Architecture](docs/architecture.md) | Monorepo layout, core model, HTTP and WebSocket APIs, testing |
+| [Releasing](docs/releasing.md) | Maintainer checklist for beta and stable releases |
 
 ## Contributing
 
@@ -95,7 +97,10 @@ guidelines — and **[AGENTS.md](AGENTS.md)** for the commands, repository map, 
 (written for coding agents, works just as well for humans).
 
 Found a bug or have an idea? [Open an issue](https://github.com/unfence-labs/hive/issues).
+Support is best-effort. Report vulnerabilities privately as described in
+[SECURITY.md](SECURITY.md).
 
 ## License
 
-Released under the [GNU General Public License v3.0](LICENSE). Copyright (C) 2026 419Labs.
+Released under the [GNU General Public License v3.0 or later](LICENSE).
+Copyright (C) 2026 419Labs.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## Supported versions
+
+Until Hive publishes its first stable release, security fixes target the latest public prerelease.
+After `1.0.0`, the latest stable release is supported. Older releases may receive fixes when the
+maintainers consider the risk and backport reasonable.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability. Use
+[GitHub's private vulnerability reporting](https://github.com/unfence-labs/hive/security/advisories/new)
+and include:
+
+- the affected version or commit;
+- the deployment topology;
+- reproduction steps or a proof of concept;
+- the expected and observed impact;
+- any suggested mitigation.
+
+The project is maintained on a best-effort basis and does not promise a response deadline. We will
+acknowledge useful reports, investigate them privately, and coordinate disclosure when a fix is
+available.
+
+Never include real access tokens, credentials, repository contents, or personal data in a report.

--- a/backend/package.json
+++ b/backend/package.json
@@ -2,6 +2,7 @@
   "name": "@hive/backend",
   "version": "0.1.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {
     "predev": "npm --prefix ../shared run build",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,9 +100,8 @@ Public backend surface exposed by route modules under `backend/src/api/`.
 
 - Backend/frontend tests use **Vitest**; iOS uses **Swift Testing**.
 - Tests live next to source: `backend/src/**/*.test.ts`, `frontend/tests/**`, `ios/Tests/**`.
-- CI runs Node lint, typecheck, build, tests, and Rust/Tauri compilation
-  on pushes and pull requests to `main`. Swift tests and the unsigned iOS simulator build run once
-  the repository is public, when standard GitHub-hosted macOS runners are free.
+- CI runs Node lint, typecheck, build, tests, Rust/Tauri compilation, Swift tests, and an unsigned
+  iOS simulator build on pushes and pull requests to `main`.
 - Provisioning has two lanes. `test/provision/contract.sh` (`npm run test:provision`, in CI) asserts the shell and TypeScript error taxonomies stay in sync, that the deliberate departures from the reference install flow stay departed, that the token never reaches a log file, and that shellcheck is clean. `test/provision/e2e-docker.sh` (`npm run test:provision:e2e`) is the Docker lane: it builds a real backend tarball, provisions a bare Ubuntu 24.04 systemd container from it, and proves the backend comes up healthy, rejects a request with no token, and accepts one with the right token. Its `neighbour` mode installs onto a server already running a web server on port 80 and a service on 5432 and proves an outside peer can still reach them afterwards — first with `ufw` installed but inactive, then with `ufw` active under the operator's own policy, where exactly one rule is added and the default policy is untouched. `preflight` compares a filesystem and service-table snapshot before and after, `paths` drives a non-default install and data directory end to end, and `uninstall` proves the generated script removes the install, keeps the data, and removes that too under `--purge`. All modes run on demand via `.github/workflows/provision-e2e.yml`.
 - A maintainer manually dispatches `.github/workflows/release.yml` from `main`. The requested
   version must match `frontend/src-tauri/Cargo.toml`. The workflow reruns release-critical checks,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -100,10 +100,15 @@ Public backend surface exposed by route modules under `backend/src/api/`.
 
 - Backend/frontend tests use **Vitest**; iOS uses **Swift Testing**.
 - Tests live next to source: `backend/src/**/*.test.ts`, `frontend/tests/**`, `ios/Tests/**`.
-- CI runs Node lint, typecheck, build, and tests on pushes and pull requests to `main`. The iOS CI
-  job is currently disabled.
+- CI runs Node lint, typecheck, build, tests, and Rust/Tauri compilation
+  on pushes and pull requests to `main`. Swift tests and the unsigned iOS simulator build run once
+  the repository is public, when standard GitHub-hosted macOS runners are free.
 - Provisioning has two lanes. `test/provision/contract.sh` (`npm run test:provision`, in CI) asserts the shell and TypeScript error taxonomies stay in sync, that the deliberate departures from the reference install flow stay departed, that the token never reaches a log file, and that shellcheck is clean. `test/provision/e2e-docker.sh` (`npm run test:provision:e2e`) is the Docker lane: it builds a real backend tarball, provisions a bare Ubuntu 24.04 systemd container from it, and proves the backend comes up healthy, rejects a request with no token, and accepts one with the right token. Its `neighbour` mode installs onto a server already running a web server on port 80 and a service on 5432 and proves an outside peer can still reach them afterwards — first with `ufw` installed but inactive, then with `ufw` active under the operator's own policy, where exactly one rule is added and the default policy is untouched. `preflight` compares a filesystem and service-table snapshot before and after, `paths` drives a non-default install and data directory end to end, and `uninstall` proves the generated script removes the install, keeps the data, and removes that too under `--purge`. All modes run on demand via `.github/workflows/provision-e2e.yml`.
-- Pushing a `v<version>` tag runs `.github/workflows/release.yml`, which builds the backend tarball on native linux-x64 and linux-arm64 runners and attaches `hive-backend-<version>-linux-<arch>.tar.gz` plus its `.sha256`, and the generated `provision.sh`, to the GitHub release. The tag must match the version in `frontend/src-tauri/Cargo.toml`.
+- A maintainer manually dispatches `.github/workflows/release.yml` from `main`. The requested
+  version must match `frontend/src-tauri/Cargo.toml`. The workflow reruns release-critical checks,
+  builds backend tarballs on native linux-x64 and linux-arm64 runners, builds and notarizes an
+  Apple Silicon DMG, verifies every artifact, and creates a draft GitHub release. A maintainer
+  reviews and publishes the draft. See [Releasing](releasing.md).
 
 Run the narrowest relevant checks during development, then the root checks before considering broad
 changes done. For iOS changes, also run `cd ios && swift test`.
@@ -117,6 +122,11 @@ npm run release:backend -- 0.0.0-dev
 
 # Bundle scripts/provision/{lib,steps,main}.sh into scripts/provision/dist/provision.sh.
 npm run release:provision -- 0.0.0-dev
+
+# Read, validate, or update the canonical release version in Cargo.toml and Cargo.lock.
+npm run release:version -- get
+npm run release:version -- check 0.1.0-beta.1
+npm run release:version -- set 0.1.0-beta.1
 
 # Provisioning checks: contracts run anywhere in a second; the end-to-end lane
 # needs Docker and builds a real release tarball.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,6 +41,11 @@ server layout and systemd service. Choose whichever fits how you work.
 
 ### From the desktop app
 
+The distributed desktop app supports Apple Silicon Macs running macOS 14 or later. Intel builds are
+not published. Download the latest stable DMG, or an explicitly selected prerelease, from
+[GitHub Releases](https://github.com/unfence-labs/hive/releases), open it, and drag Hive to
+Applications. Desktop updates are manual in V1: install a newer DMG from the same page.
+
 The desktop app installs Hive on a server itself, over SSH, with no terminal. With no server
 configured it opens on launch; otherwise it is under **Settings → Server → Install Hive on a
 server**.
@@ -67,6 +72,9 @@ Ubuntu 22.04/24.04 or Debian 12/13 (x86-64 or arm64) with systemd:
 ```bash
 curl -fsSL https://github.com/unfence-labs/hive/releases/latest/download/provision.sh | bash
 ```
+
+The `latest` URL selects only stable releases. To test a prerelease, use its explicit tag instead,
+for example `releases/download/v0.1.0-beta.1/provision.sh`.
 
 It installs Hive's own pinned Node.js runtime and the agent CLIs inside `/opt/hive` and the `hive`
 service account, downloads the backend release, verifies it against its published checksum, and

--- a/docs/install-flow-orbstack.md
+++ b/docs/install-flow-orbstack.md
@@ -4,10 +4,10 @@ This walks through running the real installer wizard against a local Ubuntu VM
 on your Mac: wizard → system `ssh` → `provision.sh` → a real Hive backend →
 connect.
 
-The repository is private, so there is no GitHub release to download. A **debug
-build** of the desktop app closes that gap itself: it looks for a locally built
-tarball, uploads it to the server over the same SSH connection, and installs
-from the uploaded copy (`--release-file`). Release builds never do this.
+A **debug build** deliberately tests the current checkout instead of downloading an older
+published release. It looks for a locally built tarball, uploads it to the server over the same SSH
+connection, and installs from that copy (`--release-file`). Release builds never sideload a local
+tarball.
 
 OrbStack is a local development exception. Its private VM address is suitable
 for this test, but it is not production transport guidance. A real server still

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -125,16 +125,27 @@ HIVE_ALLOWED_ORIGINS=https://hive.example.internal
 
 Native clients do not send an `Origin` header and are unaffected.
 
-## Update
+## Update a manual installation
+
+This procedure applies only to a source checkout that you manage yourself. It does not update a
+backend installed by `provision.sh`; provisioned V1 installations deliberately reject in-place
+updates.
+
+Back up the configured data directory before changing versions. Build the new version before
+restarting the running process, and keep the previous tag available for rollback.
 
 ```bash
 cd hive
-git pull
-npm install
+git fetch --tags --prune
+git checkout v<version>
+npm ci
 cd backend
 npm run build
 pm2 restart hive-backend
 ```
+
+Repeat the authenticated and unauthenticated checks above after restart. If either check fails,
+check out the previous tag, run `npm ci` and `npm run build` again, then restart the process.
 
 ## Connect a client
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -8,6 +8,18 @@ automatic installer connects over SSH, installs the backend as a systemd service
 back a running server and its access token. Setup instructions are in
 **[Getting Started](getting-started.md)**.
 
+## The desktop client
+
+| | |
+|---|---|
+| Operating system | macOS 14 or later |
+| Architecture | Apple Silicon (arm64) |
+| Distribution | Signed and notarized DMG from GitHub Releases |
+| Updates | Manual DMG download in V1 |
+
+Intel DMGs are not published. The web and iOS clients use the same backend but have their own
+runtime requirements.
+
 ## The server
 
 | | |

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,123 @@
+# Releasing Hive
+
+This is the maintainer procedure for publishing signed desktop and server artifacts. Releases are
+manual, originate from `main`, and stop as drafts for final review.
+
+## Release channels
+
+Use Semantic Versioning:
+
+- beta: `0.2.0-beta.1`, `0.2.0-beta.2`;
+- release candidate: `0.2.0-rc.1`;
+- stable: `0.2.0`.
+
+GitHub marks versions containing a prerelease suffix as prereleases. They do not replace
+`/releases/latest`. Never move or reuse a published tag; fix a bad build with a new version.
+
+Cargo is the canonical source of the full release version. Private npm workspace versions are not
+product versions. The macOS bundle uses the numeric core version required by Apple while the app's
+embedded provisioning code retains the full Cargo version.
+
+## One-time GitHub and Apple setup
+
+Create a GitHub environment named `release`:
+
+1. restrict deployment branches to `main`;
+2. add the maintainer as a required reviewer;
+3. leave **Prevent self-review** disabled when there is only one release maintainer;
+4. store these environment secrets:
+
+| Secret | Value |
+|---|---|
+| `APPLE_CERTIFICATE` | Base64-encoded Developer ID Application `.p12` |
+| `APPLE_CERTIFICATE_PASSWORD` | Password used when exporting the `.p12` |
+| `APPLE_API_ISSUER` | App Store Connect team API issuer ID |
+| `APPLE_API_KEY` | App Store Connect team API key ID |
+| `APPLE_API_PRIVATE_KEY` | Complete contents of the matching `.p8` private key |
+
+Use an App Store Connect **team** API key for notarization, not an individual API key. Keep local
+backups of the certificate and private keys in a secure credential store. Anyone who obtains the
+certificate and password can sign software as the certificate holder; revoke a compromised API key
+immediately and contact Apple about a compromised Developer ID certificate.
+
+The application identifier is permanently `io.419labs.hive`. The distributed desktop supports
+Apple Silicon and macOS 14 or later.
+
+After making the repository public, configure a `main` branch ruleset that:
+
+- requires a pull request before merging, with no approving review required;
+- requires the `ci`, `desktop`, and `ios` status checks;
+- requires branches to be up to date before merging;
+- blocks force pushes and branch deletion.
+
+Run the workflows once before selecting their status checks in the ruleset. Also enable private
+vulnerability reporting, secret scanning, and push protection in the repository security settings.
+Dependabot version updates are configured in the repository and start automatically once enabled by
+GitHub.
+
+## Prepare the version
+
+Create a branch from the latest `main`, then update the version:
+
+```bash
+git switch -c release/0.1.0-beta.1 main
+npm run release:version -- set 0.1.0-beta.1
+npm run release:version:check
+npm run lint
+npm run typecheck
+npm test
+npm run test:release
+npm run test:provision
+```
+
+Commit the version through a normal pull request. Merge only after required checks pass. Do not let
+the release workflow modify `main`.
+
+## Build the draft
+
+From the repository's **Actions** tab:
+
+1. open the `release` workflow;
+2. choose **Run workflow**;
+3. select `main`;
+4. enter the exact version merged above;
+5. approve the `release` environment when the macOS signing job reaches it.
+
+The workflow rejects another branch, a mismatched Cargo version, or an existing tag. It reruns
+release-critical checks before producing artifacts.
+
+Expected draft assets:
+
+```text
+Hive-<version>-macos-arm64.dmg
+Hive-<version>-macos-arm64.dmg.sha256
+hive-backend-<version>-linux-x64.tar.gz
+hive-backend-<version>-linux-x64.tar.gz.sha256
+hive-backend-<version>-linux-arm64.tar.gz
+hive-backend-<version>-linux-arm64.tar.gz.sha256
+provision.sh
+```
+
+GitHub also exposes source `.zip` and `.tar.gz` archives for the release tag.
+
+## Review and publish
+
+Before publishing the draft:
+
+1. confirm the tag and target commit match the intended `main` commit;
+2. review the generated notes and labels;
+3. confirm all seven assets exist;
+4. compare the published checksums with locally calculated SHA-256 values;
+5. install the DMG on a clean Apple Silicon Mac;
+6. confirm Gatekeeper shows only the normal downloaded-from-Internet confirmation;
+7. open Hive and complete a connection;
+8. install the backend on clean Linux x64 and arm64 servers;
+9. verify unauthenticated access is rejected and authenticated access succeeds;
+10. restart each server and confirm Hive reconnects.
+
+For a prerelease test, use its direct tag URLs because `/releases/latest` resolves only to a stable
+release. Publish the draft only after the relevant smoke tests pass.
+
+Creating the draft also creates its tag. If a draft is wrong, correct the code through another pull
+request and use a new prerelease version. If a published release is wrong, document the issue and
+publish a new version. Never replace assets or move an existing tag.

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -2,6 +2,7 @@
   "name": "@hive/frontend",
   "version": "0.1.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "type": "module",
   "scripts": {
     "predev": "npm --prefix ../shared run build",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1546,7 +1546,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "hive"
-version = "0.1.0"
+version = "0.1.0-beta.1"
 description = "Hive"
-authors = ["you"]
+authors = ["419Labs"]
 license = "GPL-3.0-or-later"
 repository = "https://github.com/unfence-labs/hive"
+homepage = "https://github.com/unfence-labs/hive"
 edition = "2021"
 rust-version = "1.77.2"
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,8 +1,7 @@
 {
   "$schema": "../../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Hive",
-  "version": "0.1.0",
-  "identifier": "com.hive.desktop",
+  "identifier": "io.419labs.hive",
   "build": {
     "frontendDist": "../dist",
     "devUrl": "http://localhost:5173"
@@ -28,6 +27,12 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "resources": {
+      "../../LICENSE": "LICENSE"
+    },
+    "macOS": {
+      "minimumSystemVersion": "14.0"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "name": "hive",
+      "license": "GPL-3.0-or-later",
       "workspaces": [
         "backend",
         "frontend",
@@ -24,6 +25,7 @@
       "name": "@hive/backend",
       "version": "0.1.0",
       "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@fastify/compress": "^8.3.1",
         "@fastify/cors": "^11.2.0",
@@ -48,6 +50,7 @@
     "frontend": {
       "name": "@hive/frontend",
       "version": "0.1.0",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@codemirror/lang-markdown": "^6.5.0",
         "@codemirror/language": "^6.12.3",
@@ -15154,6 +15157,7 @@
     "shared": {
       "name": "@hive/shared",
       "version": "0.1.0",
+      "license": "GPL-3.0-or-later",
       "devDependencies": {
         "typescript": "^5.9.3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "hive",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "workspaces": [
     "backend",
     "frontend",
@@ -10,9 +11,11 @@
     "lint": "npm run lint --workspace @hive/backend --workspace @hive/frontend",
     "lint:fix": "npm run lint:fix --workspace @hive/backend --workspace @hive/frontend",
     "knip": "knip",
+    "release:version": "node scripts/release/release-version.mjs",
+    "release:version:check": "node scripts/release/release-version.mjs check",
     "release:backend": "bash scripts/release/build-backend-tarball.sh",
     "release:provision": "bash scripts/provision/build.sh",
-    "test:release": "bash test/release/build-backend-tarball.test.sh",
+    "test:release": "node --test test/release/*.test.mjs && bash test/release/build-backend-tarball.test.sh",
     "test:provision": "bash test/provision/contract.sh",
     "test:provision:e2e": "bash test/provision/e2e-docker.sh",
     "typecheck": "npm run typecheck --workspace @hive/backend --workspace @hive/frontend",

--- a/scripts/provision/build.sh
+++ b/scripts/provision/build.sh
@@ -9,10 +9,11 @@
 set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$HERE/../.." && pwd)"
 OUT="$HERE/dist/provision.sh"
 VERSION="${1:-0.0.0-dev}"
 
-if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+if ! node "$ROOT/scripts/release/release-version.mjs" macos "$VERSION" >/dev/null 2>&1; then
   echo "invalid semantic version: $VERSION" >&2
   exit 2
 fi

--- a/scripts/release/build-backend-tarball.sh
+++ b/scripts/release/build-backend-tarball.sh
@@ -17,7 +17,7 @@ ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 VERSION="${1:-0.0.0-dev}"
 ARCH="${2:-}"
 
-if [[ ! "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+if ! node "$ROOT/scripts/release/release-version.mjs" macos "$VERSION" >/dev/null 2>&1; then
   echo "invalid semantic version: $VERSION" >&2
   exit 2
 fi
@@ -89,6 +89,7 @@ pkg="$staging/pkg"
 mkdir -p "$pkg"
 cp -R "$ROOT/backend/dist" "$pkg/dist"
 cp -R "$install_root/node_modules" "$pkg/node_modules"
+cp "$ROOT/LICENSE" "$pkg/"
 
 # The manifest carries the release version and the build facts an installer
 # needs to reject a tarball its runtime cannot load.
@@ -134,6 +135,7 @@ unpacked="$staging/unpacked"
 mkdir -p "$unpacked"
 tar -xzf "$OUT_DIR/$NAME.tar.gz" -C "$unpacked"
 [ -f "$unpacked/dist/index.js" ] || { echo "archive has no dist/index.js" >&2; exit 1; }
+[ -f "$unpacked/LICENSE" ] || { echo "archive has no LICENSE" >&2; exit 1; }
 artifact_version="$(node -p 'require(process.argv[1]).version' "$unpacked/package.json")"
 [ "$artifact_version" = "$VERSION" ] || {
   echo "archive version mismatch: expected $VERSION, got $artifact_version" >&2

--- a/scripts/release/release-version.mjs
+++ b/scripts/release/release-version.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const CARGO_TOML = path.join(ROOT, "frontend/src-tauri/Cargo.toml");
+const CARGO_LOCK = path.join(ROOT, "frontend/src-tauri/Cargo.lock");
+
+function invalid(version) {
+  throw new Error(`invalid semantic version: ${version}`);
+}
+
+export function parseVersion(version) {
+  if (typeof version !== "string" || version === "" || version.trim() !== version) {
+    invalid(version);
+  }
+
+  const plus = version.indexOf("+");
+  if (plus !== -1 && version.indexOf("+", plus + 1) !== -1) {
+    invalid(version);
+  }
+  const withoutBuild = plus === -1 ? version : version.slice(0, plus);
+  const build = plus === -1 ? "" : version.slice(plus + 1);
+  if (build && !build.split(".").every((part) => /^[0-9A-Za-z-]+$/.test(part))) {
+    invalid(version);
+  }
+  if (plus !== -1 && build === "") {
+    invalid(version);
+  }
+
+  const dash = withoutBuild.indexOf("-");
+  const core = dash === -1 ? withoutBuild : withoutBuild.slice(0, dash);
+  const prerelease = dash === -1 ? "" : withoutBuild.slice(dash + 1);
+  const coreParts = core.split(".");
+  if (
+    coreParts.length !== 3 ||
+    !coreParts.every((part) => /^(0|[1-9][0-9]*)$/.test(part))
+  ) {
+    invalid(version);
+  }
+  if (dash !== -1) {
+    const validPrerelease =
+      prerelease !== "" &&
+      prerelease.split(".").every((part) => {
+        if (!/^[0-9A-Za-z-]+$/.test(part)) return false;
+        return !/^[0-9]+$/.test(part) || /^(0|[1-9][0-9]*)$/.test(part);
+      });
+    if (!validPrerelease) invalid(version);
+  }
+
+  return {
+    version,
+    core,
+    prerelease,
+    isPrerelease: prerelease !== "",
+  };
+}
+
+function packageBlock(contents, header) {
+  const start = contents.indexOf(header);
+  if (start === -1) throw new Error(`missing ${header}`);
+  const bodyStart = start + header.length;
+  const next = contents.indexOf("\n[", bodyStart);
+  return {
+    start: bodyStart,
+    end: next === -1 ? contents.length : next,
+    body: contents.slice(bodyStart, next === -1 ? contents.length : next),
+  };
+}
+
+export function cargoVersion(contents) {
+  const { body } = packageBlock(contents, "[package]");
+  const match = body.match(/^\s*version\s*=\s*"([^"]+)"\s*$/m);
+  if (!match) throw new Error("missing Cargo package version");
+  return parseVersion(match[1]).version;
+}
+
+export function cargoLockVersion(contents) {
+  for (const block of contents.split("[[package]]").slice(1)) {
+    if (/^\s*name\s*=\s*"hive"\s*$/m.test(block) && !/^\s*source\s*=/m.test(block)) {
+      const match = block.match(/^\s*version\s*=\s*"([^"]+)"\s*$/m);
+      if (!match) throw new Error("missing hive version in Cargo.lock");
+      return parseVersion(match[1]).version;
+    }
+  }
+  throw new Error("missing hive package in Cargo.lock");
+}
+
+function replaceCargoVersion(contents, version) {
+  const block = packageBlock(contents, "[package]");
+  if (!/^(\s*version\s*=\s*)"[^"]+"(\s*)$/m.test(block.body)) {
+    throw new Error("missing Cargo package version");
+  }
+  const body = block.body.replace(
+    /^(\s*version\s*=\s*)"[^"]+"(\s*)$/m,
+    `$1"${version}"$2`,
+  );
+  return contents.slice(0, block.start) + body + contents.slice(block.end);
+}
+
+function replaceCargoLockVersion(contents, version) {
+  let replaced = false;
+  const updated = contents
+    .split("[[package]]")
+    .map((block, index) => {
+      if (
+        index > 0 &&
+        /^\s*name\s*=\s*"hive"\s*$/m.test(block) &&
+        !/^\s*source\s*=/m.test(block)
+      ) {
+        replaced = true;
+        return block.replace(
+          /^(\s*version\s*=\s*)"[^"]+"(\s*)$/m,
+          `$1"${version}"$2`,
+        );
+      }
+      return block;
+    })
+    .join("[[package]]");
+  if (!replaced) throw new Error("missing hive package in Cargo.lock");
+  return updated;
+}
+
+export function readVersion() {
+  return cargoVersion(readFileSync(CARGO_TOML, "utf8"));
+}
+
+export function checkVersion(expected) {
+  const version = readVersion();
+  const lockVersion = cargoLockVersion(readFileSync(CARGO_LOCK, "utf8"));
+  if (lockVersion !== version) {
+    throw new Error(`Cargo.lock version ${lockVersion} does not match Cargo.toml ${version}`);
+  }
+  if (expected !== undefined && expected !== version) {
+    throw new Error(`requested version ${expected} does not match Cargo.toml ${version}`);
+  }
+  return parseVersion(version);
+}
+
+function setVersion(version) {
+  parseVersion(version);
+  writeFileSync(
+    CARGO_TOML,
+    replaceCargoVersion(readFileSync(CARGO_TOML, "utf8"), version),
+  );
+  writeFileSync(
+    CARGO_LOCK,
+    replaceCargoLockVersion(readFileSync(CARGO_LOCK, "utf8"), version),
+  );
+}
+
+function usage() {
+  console.error(
+    "usage: release-version.mjs get | check [version] | set <version> | macos <version>",
+  );
+  process.exitCode = 2;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const [command, argument] = process.argv.slice(2);
+  try {
+    if (command === "get" && argument === undefined) {
+      console.log(checkVersion().version);
+    } else if (command === "check") {
+      checkVersion(argument);
+    } else if (command === "set" && argument !== undefined) {
+      setVersion(argument);
+      console.log(argument);
+    } else if (command === "macos" && argument !== undefined) {
+      console.log(parseVersion(argument).core);
+    } else {
+      usage();
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 2;
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -2,6 +2,7 @@
   "name": "@hive/shared",
   "version": "0.1.0",
   "private": true,
+  "license": "GPL-3.0-or-later",
   "type": "module",
   "exports": {
     "./agent-activity": "./dist/agent-activity.js",

--- a/test/release/build-backend-tarball.test.sh
+++ b/test/release/build-backend-tarball.test.sh
@@ -36,6 +36,7 @@ expect_rejected() {
 
 expect_rejected "rejects a non-semantic version" "invalid semantic version" 1.0
 expect_rejected "rejects a leading-zero version" "invalid semantic version" 1.0.01
+expect_rejected "rejects a leading-zero prerelease" "invalid semantic version" 1.0.0-rc.01
 expect_rejected "rejects an unknown architecture" "unsupported release architecture" 1.0.0 mips
 expect_rejected "rejects a cross-architecture build" \
   "must be built on a linux-$FOREIGN_ARCH host" 1.0.0 "$FOREIGN_ARCH"

--- a/test/release/release-version.test.mjs
+++ b/test/release/release-version.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  cargoLockVersion,
+  cargoVersion,
+  parseVersion,
+} from "../../scripts/release/release-version.mjs";
+
+test("stable and prerelease versions expose a numeric macOS version", () => {
+  assert.deepEqual(parseVersion("1.2.3"), {
+    version: "1.2.3",
+    core: "1.2.3",
+    prerelease: "",
+    isPrerelease: false,
+  });
+  assert.deepEqual(parseVersion("1.2.3-beta.4"), {
+    version: "1.2.3-beta.4",
+    core: "1.2.3",
+    prerelease: "beta.4",
+    isPrerelease: true,
+  });
+  assert.equal(parseVersion("1.2.3-rc.1+build.5").core, "1.2.3");
+});
+
+test("invalid semantic versions are rejected", () => {
+  for (const version of [
+    "1.2",
+    "1.2.03",
+    "1.2.3-",
+    "1.2.3-01",
+    "1.2.3+",
+    "1.2.3+bad_value",
+  ]) {
+    assert.throws(() => parseVersion(version), /invalid semantic version/);
+  }
+});
+
+test("Cargo package versions are read from their exact package blocks", () => {
+  assert.equal(
+    cargoVersion('[package]\nname = "hive"\nversion = "2.0.0-beta.1"\n\n[dependencies]\n'),
+    "2.0.0-beta.1",
+  );
+  assert.equal(
+    cargoLockVersion(
+      '[[package]]\nname = "hive"\nversion = "2.0.0-beta.1"\ndependencies = []\n',
+    ),
+    "2.0.0-beta.1",
+  );
+});

--- a/test/release/release-workflow.test.mjs
+++ b/test/release/release-workflow.test.mjs
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const workflow = await readFile(
+  new URL("../../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
+
+test("release is a main-only manual workflow", () => {
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /GITHUB_REF.*refs\/heads\/main/);
+  assert.doesNotMatch(workflow, /^\s+tags:/m);
+});
+
+test("release waits for protected Apple secrets and creates a draft", () => {
+  assert.match(workflow, /environment:\s*\n\s+name: release/);
+  assert.match(workflow, /APPLE_CERTIFICATE/);
+  assert.match(workflow, /APPLE_API_PRIVATE_KEY/);
+  assert.match(workflow, /draft: true/);
+  assert.match(workflow, /tag_name:/);
+  assert.match(workflow, /target_commitish:/);
+});
+
+test("release requires native backends and an Apple Silicon DMG", () => {
+  for (const expected of [
+    "ubuntu-24.04-arm",
+    "aarch64-apple-darwin",
+    "linux-x64.tar.gz.sha256",
+    "linux-arm64.tar.gz.sha256",
+    "macos-arm64.dmg.sha256",
+    "provision.sh",
+  ]) {
+    assert.ok(workflow.includes(expected), `missing ${expected}`);
+  }
+});


### PR DESCRIPTION
## Summary

- add a manual main-only beta/stable release workflow for native Linux backend tarballs and a signed, notarized Apple Silicon DMG
- centralize release versioning and set the first public version to 0.1.0-beta.1
- extend CI with Rust/Tauri checks and public-repository iOS builds
- add the minimal licensing, security, Dependabot, and release documentation needed for the public repository

## Validation

- npm run lint
- npm run typecheck
- npm test
- npm run test:release
- npm run test:provision
- cargo test --manifest-path frontend/src-tauri/Cargo.toml --locked
- Tauri debug application and Debian bundle builds
- native Node 24 Linux x64 backend tarball build and checksum verification
- Actionlint validation for all workflows
- Gitleaks scan across 1,430 commits

## Manual follow-up

The macOS signing and notarization path requires the protected Apple release environment secrets described in docs/releasing.md. The workflow creates a draft release for manual smoke testing and publication.