### PR TITLE
fix: build frontend before packaging macOS release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,10 @@ jobs:
 
       - run: npm ci
 
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
       - name: Build signed and notarized Apple Silicon DMG
         working-directory: frontend
         env:

--- a/test/release/release-workflow.test.mjs
+++ b/test/release/release-workflow.test.mjs
@@ -34,3 +34,15 @@ test("release requires native backends and an Apple Silicon DMG", () => {
     assert.ok(workflow.includes(expected), `missing ${expected}`);
   }
 });
+
+test("release builds the frontend before Tauri", () => {
+  const frontendBuild = workflow.indexOf("- name: Build frontend");
+  const tauriBuild = workflow.indexOf("- name: Build signed and notarized Apple Silicon DMG");
+  assert.match(
+    workflow,
+    /- name: Build frontend\n\s+working-directory: frontend\n\s+run: npm run build/
+  );
+  assert.notEqual(frontendBuild, -1);
+  assert.notEqual(tauriBuild, -1);
+  assert.ok(frontendBuild < tauriBuild);
+});


### PR DESCRIPTION
## Summary

- build the frontend before invoking Tauri in the macOS release job
- keep the frontend build outside the step that receives Apple signing secrets
- add a release workflow regression test

## Validation

- `npm run test:release`
- `npm run build --workspace @hive/frontend`
- `actionlint .github/workflows/*.yml`
- `git diff --check`