### PR TITLE
fix: notarize macOS release disk image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,12 @@ jobs:
           spctl --assess --type execute --verbose=2 "$app"
           hdiutil detach "$mount_point"
           mount_point=""
+          xcrun notarytool submit "$dmg" \
+            --key "$APPLE_API_KEY_PATH" \
+            --key-id "$APPLE_API_KEY" \
+            --issuer "$APPLE_API_ISSUER" \
+            --wait
+          xcrun stapler staple "$dmg"
           xcrun stapler validate "$dmg"
 
           (

--- a/test/release/release-workflow.test.mjs
+++ b/test/release/release-workflow.test.mjs
@@ -46,3 +46,9 @@ test("release builds the frontend before Tauri", () => {
   assert.notEqual(tauriBuild, -1);
   assert.ok(frontendBuild < tauriBuild);
 });
+
+test("release notarizes and staples the DMG", () => {
+  assert.match(workflow, /xcrun notarytool submit "\$dmg"[\s\S]*--wait/);
+  assert.match(workflow, /xcrun stapler staple "\$dmg"/);
+  assert.match(workflow, /xcrun stapler validate "\$dmg"/);
+});


### PR DESCRIPTION
## Summary

- submit the signed release DMG to Apple notarization
- staple and validate the resulting ticket before upload
- add a release workflow regression test

## Validation

- `npm run test:release`
- `actionlint .github/workflows/*.yml`
- `git diff --check`