### PR TITLE
fix: use GitHub HTTPS credentials for repository clones

### DIFF
--- a/backend/src/brain/brain-repo.test.ts
+++ b/backend/src/brain/brain-repo.test.ts
@@ -62,7 +62,7 @@ describe("createBrain", () => {
         owner: "octocat",
         name,
         fullName: `octocat/${name}`,
-        sshUrl: origin,
+        url: origin,
       }),
       deleteRemote: async () => {},
       now: () => new Date("2026-06-05T12:00:00.000Z"),

--- a/backend/src/brain/brain-repo.test.ts
+++ b/backend/src/brain/brain-repo.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { existsSync } from "node:fs";
 import { mkdir, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -100,6 +100,28 @@ describe("connectBrain", () => {
     expect(existsSync(join(brainRepoPath(dataDir), ".git"))).toBe(true);
     const { stdout } = await git(["remote", "get-url", "origin"], brainRepoPath(dataDir));
     expect(stdout).toBe(origin);
+  });
+
+  it("clones a GitHub SSH URL through the resolved transport", async () => {
+    const fixtureDir = join(tempDir, "fixtures");
+    await mkdir(fixtureDir, { recursive: true });
+    const origin = await createFixtureRepo(fixtureDir);
+    const githubModule = await import("../utils/github.js");
+    const resolveSpy = vi
+      .spyOn(githubModule, "resolveGitHubCloneUrl")
+      .mockResolvedValue(origin);
+
+    try {
+      const sshUrl = "git@github.com:acme/brain.git";
+      const state = await connectBrain(sshUrl, dataDir);
+
+      expect(resolveSpy).toHaveBeenCalledWith(sshUrl);
+      expect(state.repoUrl).toBe(origin);
+      const { stdout } = await git(["remote", "get-url", "origin"], brainRepoPath(dataDir));
+      expect(stdout).toBe(origin);
+    } finally {
+      vi.restoreAllMocks();
+    }
   });
 
   it("rejects a second Brain", async () => {

--- a/backend/src/brain/brain-repo.ts
+++ b/backend/src/brain/brain-repo.ts
@@ -5,6 +5,7 @@ import { git } from "../utils/git.js";
 import {
   createGitHubRepository,
   deleteGitHubRepository,
+  resolveGitHubCloneUrl,
   type GitHubRepository,
 } from "../utils/github.js";
 import { brainDir, brainRepoPath } from "../utils/paths.js";
@@ -80,7 +81,7 @@ export async function createBrain(
   const remote = await createRemote(name);
 
   try {
-    await git(["clone", remote.sshUrl, repoPath]);
+    await git(["clone", remote.url, repoPath]);
     await git(["checkout", "-b", "main"], repoPath);
     await writeFile(
       join(repoPath, "README.md"),
@@ -90,7 +91,7 @@ export async function createBrain(
     await git(["add", "README.md"], repoPath);
     await git(["commit", "-m", "Initial Brain"], repoPath);
     await git(["push", "-u", "origin", "main"], repoPath);
-    return await persistBrain(remote.sshUrl, dataDir, options.now ?? (() => new Date()));
+    return await persistBrain(remote.url, dataDir, options.now ?? (() => new Date()));
   } catch (err) {
     await rm(repoPath, { recursive: true, force: true }).catch(() => {});
     await deleteRemote(remote.fullName).catch(() => {});
@@ -108,9 +109,10 @@ export async function connectBrain(
   const validatedUrl = validateRepositoryUrl(url, {
     allowLocalPath: process.env.NODE_ENV === "test",
   });
+  const cloneUrl = await resolveGitHubCloneUrl(validatedUrl);
   await mkdir(brainDir(dataDir), { recursive: true });
-  await git(["clone", validatedUrl, brainRepoPath(dataDir)]);
-  return persistBrain(validatedUrl, dataDir, options.now ?? (() => new Date()));
+  await git(["clone", cloneUrl, brainRepoPath(dataDir)]);
+  return persistBrain(cloneUrl, dataDir, options.now ?? (() => new Date()));
 }
 
 /** Delete the singleton Brain state and normal clone. The remote GitHub repo is not deleted. */

--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -36,6 +36,24 @@ describe("createProject", () => {
     expect(existsSync(join(dataDir, state.id, "state.json"))).toBe(true);
   });
 
+  it("clones a GitHub SSH URL through the resolved transport", async () => {
+    const githubModule = await import("../utils/github.js");
+    const resolveSpy = vi
+      .spyOn(githubModule, "resolveGitHubCloneUrl")
+      .mockResolvedValue(fixtureRepoUrl);
+
+    try {
+      const sshUrl = "git@github.com:acme/widget.git";
+      const state = await createProject(sshUrl, dataDir);
+
+      expect(resolveSpy).toHaveBeenCalledWith(sshUrl);
+      expect(state.url).toBe(fixtureRepoUrl);
+      expect(existsSync(join(dataDir, state.id, "repo.git", "HEAD"))).toBe(true);
+    } finally {
+      vi.restoreAllMocks();
+    }
+  });
+
   it("rejects empty URL", async () => {
     await expect(createProject("", dataDir)).rejects.toThrow("Invalid repository URL");
   });

--- a/backend/src/projects/project-manager.test.ts
+++ b/backend/src/projects/project-manager.test.ts
@@ -133,7 +133,7 @@ describe("initProject", () => {
     expect(loaded?.url).toBeUndefined();
   });
 
-  it("creates a GitHub repo and stores its SSH URL", async () => {
+  it("creates a GitHub repo and stores its HTTPS URL", async () => {
     const githubModule = await import("../utils/github.js");
     const gitModule = await import("../utils/git.js");
     const originalGit = gitModule.git;
@@ -144,7 +144,7 @@ describe("initProject", () => {
         owner: "octocat",
         name: "remote-repo",
         fullName: "octocat/remote-repo",
-        sshUrl: "git@github.com:octocat/remote-repo.git",
+        url: "https://github.com/octocat/remote-repo",
       });
 
     const gitSpy = vi.spyOn(gitModule, "git").mockImplementation(async (args, cwd) => {
@@ -162,17 +162,17 @@ describe("initProject", () => {
       );
 
       expect(warning).toBeUndefined();
-      expect(state.url).toBe("git@github.com:octocat/remote-repo.git");
+      expect(state.url).toBe("https://github.com/octocat/remote-repo");
       expect(createGitHubRepositorySpy).toHaveBeenCalledWith("remote-repo", "private");
       expect(gitSpy).toHaveBeenCalledWith([
         "remote",
         "add",
         "origin",
-        "git@github.com:octocat/remote-repo.git",
+        "https://github.com/octocat/remote-repo",
       ], expect.any(String));
 
       const loaded = await getProject(state.id, dataDir);
-      expect(loaded?.url).toBe("git@github.com:octocat/remote-repo.git");
+      expect(loaded?.url).toBe("https://github.com/octocat/remote-repo");
     } finally {
       vi.restoreAllMocks();
     }

--- a/backend/src/projects/project-manager.ts
+++ b/backend/src/projects/project-manager.ts
@@ -5,6 +5,7 @@ import { git } from "../utils/git.js";
 import {
   createGitHubRepository,
   deleteGitHubRepository,
+  resolveGitHubCloneUrl,
   validateGitHubRepositoryName,
 } from "../utils/github.js";
 import { bareRepoPath } from "../utils/paths.js";
@@ -28,6 +29,7 @@ export async function createProject(
     // Tests use local fixture paths as clone sources.
     allowLocalPath: process.env.NODE_ENV === "test",
   });
+  const cloneUrl = await resolveGitHubCloneUrl(validatedUrl);
 
   const id = `proj-${nanoid(8)}`;
   const bare = bareRepoPath(dataDir, id);
@@ -35,14 +37,14 @@ export async function createProject(
   const logsDir = join(dataDir, id, "logs");
 
   await mkdir(join(dataDir, id), { recursive: true });
-  await git(["clone", "--bare", validatedUrl, bare]);
+  await git(["clone", "--bare", cloneUrl, bare]);
   await mkdir(wsDir, { recursive: true });
   await mkdir(logsDir, { recursive: true });
 
   const state: ProjectState = {
     id,
-    name: extractRepoName(validatedUrl),
-    url: validatedUrl,
+    name: extractRepoName(cloneUrl),
+    url: cloneUrl,
     createdAt: new Date().toISOString(),
     workspaces: [],
   };
@@ -62,9 +64,9 @@ async function createGitHubRepo(
   // Point the bare repo at the new remote and push the initial commit.
   // If any post-create step fails, delete the GitHub repo so we don't leave orphans.
   try {
-    await git(["remote", "add", "origin", repo.sshUrl], bare);
+    await git(["remote", "add", "origin", repo.url], bare);
     await git(["push", "--all", "origin"], bare);
-    return repo.sshUrl;
+    return repo.url;
   } catch (err) {
     await deleteGitHubRepository(repo.fullName).catch(() => {});
     throw err;

--- a/backend/src/services/setup/auth/github.test.ts
+++ b/backend/src/services/setup/auth/github.test.ts
@@ -134,7 +134,10 @@ describe("github sign-in", () => {
     );
     expect(stdin).toEqual(["gho_token_123\n"]);
     expect(mocks._resetGhState).toHaveBeenCalled();
-    expect(mocks.gh).toHaveBeenCalledWith(["auth", "setup-git"]);
+    expect(mocks.gh.mock.calls).toEqual([
+      [["config", "set", "git_protocol", "https", "--host", "github.com"]],
+      [["auth", "setup-git", "--hostname", "github.com"]],
+    ]);
   });
 
   it("polls at GitHub's pace and slows down when told to", async () => {

--- a/backend/src/services/setup/auth/github.ts
+++ b/backend/src/services/setup/auth/github.ts
@@ -103,7 +103,8 @@ async function loginWithToken(token: string): Promise<void> {
  */
 async function setupGitCredentials(): Promise<void> {
   try {
-    await gh(["auth", "setup-git"]);
+    await gh(["config", "set", "git_protocol", "https", "--host", "github.com"]);
+    await gh(["auth", "setup-git", "--hostname", "github.com"]);
   } catch (err: unknown) {
     const detail =
       (err as { stderr?: string }).stderr?.trim() || (err as Error).message;

--- a/backend/src/utils/github.test.ts
+++ b/backend/src/utils/github.test.ts
@@ -6,6 +6,7 @@ import {
   gh,
   createGitHubRepository,
   fetchPrDetail,
+  resolveGitHubCloneUrl,
   _resetGhState,
 } from "./github.js";
 
@@ -77,6 +78,41 @@ describe("parseGitHubRepo", () => {
     // Should still extract owner/repo from first two segments
     const result = parseGitHubRepo("https://github.com/acme/widget/tree/main");
     expect(result).toEqual({ owner: "acme", repo: "widget" });
+  });
+});
+
+describe("resolveGitHubCloneUrl", () => {
+  it("uses HTTPS for a GitHub SSH URL when gh is authenticated", async () => {
+    const ghClient = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+    await expect(
+      resolveGitHubCloneUrl("git@github.com:acme/widget.git", ghClient),
+    ).resolves.toBe("https://github.com/acme/widget.git");
+    expect(ghClient).toHaveBeenCalledWith([
+      "auth",
+      "status",
+      "--hostname",
+      "github.com",
+    ]);
+  });
+
+  it("preserves a GitHub SSH URL when gh is not authenticated", async () => {
+    const ghClient = vi.fn(async () => {
+      throw new Error("not authenticated");
+    });
+    const url = "git@github.com:acme/widget.git";
+
+    await expect(resolveGitHubCloneUrl(url, ghClient)).resolves.toBe(url);
+  });
+
+  it("does not query gh for HTTPS or non-GitHub URLs", async () => {
+    const ghClient = vi.fn(async () => ({ stdout: "", stderr: "" }));
+    const httpsUrl = "https://github.com/acme/widget.git";
+    const gitLabUrl = "git@gitlab.com:acme/widget.git";
+
+    await expect(resolveGitHubCloneUrl(httpsUrl, ghClient)).resolves.toBe(httpsUrl);
+    await expect(resolveGitHubCloneUrl(gitLabUrl, ghClient)).resolves.toBe(gitLabUrl);
+    expect(ghClient).not.toHaveBeenCalled();
   });
 });
 
@@ -198,7 +234,7 @@ describe("createGitHubRepository", () => {
       if (key === "repo view") {
         return handlers.view
           ? handlers.view()
-          : { stdout: "git@github.com:octocat/my-repo.git", stderr: "" };
+          : { stdout: "https://github.com/octocat/my-repo", stderr: "" };
       }
       if (key === "repo delete") return { stdout: "", stderr: "" };
       throw new Error(`unexpected gh args: ${args.join(" ")}`);
@@ -212,12 +248,21 @@ describe("createGitHubRepository", () => {
       owner: "octocat",
       name: "my-repo",
       fullName: "octocat/my-repo",
-      sshUrl: "git@github.com:octocat/my-repo.git",
+      url: "https://github.com/octocat/my-repo",
     });
+    expect(ghClient).toHaveBeenCalledWith([
+      "repo",
+      "view",
+      "octocat/my-repo",
+      "--json",
+      "url",
+      "--jq",
+      ".url",
+    ]);
     expect(ghClient.mock.calls.some((c) => c[0][0] === "repo" && c[0][1] === "delete")).toBe(false);
   });
 
-  it("deletes the just-created repo when the sshUrl fetch fails (no orphan)", async () => {
+  it("deletes the just-created repo when the URL fetch fails (no orphan)", async () => {
     const ghClient = makeGhClient({ view: () => Promise.reject(new Error("replication lag")) });
     await expect(createGitHubRepository("my-repo", "private", ghClient)).rejects.toThrow();
     expect(ghClient).toHaveBeenCalledWith(["repo", "delete", "octocat/my-repo", "--yes"]);

--- a/backend/src/utils/github.test.ts
+++ b/backend/src/utils/github.test.ts
@@ -91,9 +91,18 @@ describe("resolveGitHubCloneUrl", () => {
     expect(ghClient).toHaveBeenCalledWith([
       "auth",
       "status",
+      "--active",
       "--hostname",
       "github.com",
-    ]);
+    ], { timeoutMs: 8_000 });
+  });
+
+  it("uses HTTPS for a GitHub ssh:// URL when gh is authenticated", async () => {
+    const ghClient = vi.fn(async () => ({ stdout: "", stderr: "" }));
+
+    await expect(
+      resolveGitHubCloneUrl("ssh://git@github.com/acme/widget.git", ghClient),
+    ).resolves.toBe("https://github.com/acme/widget.git");
   });
 
   it("preserves a GitHub SSH URL when gh is not authenticated", async () => {

--- a/backend/src/utils/github.ts
+++ b/backend/src/utils/github.ts
@@ -20,7 +20,7 @@ export interface GitHubRepository {
   owner: string;
   name: string;
   fullName: string;
-  sshUrl: string;
+  url: string;
 }
 
 export type GhClient = typeof gh;
@@ -78,6 +78,22 @@ export function parseGitHubRepo(
   }
 }
 
+export async function resolveGitHubCloneUrl(
+  url: string,
+  ghClient: GhClient = gh,
+): Promise<string> {
+  const repo = parseGitHubRepo(url);
+  if (!repo || url.startsWith("https://")) return url;
+
+  try {
+    await ghClient(["auth", "status", "--hostname", "github.com"]);
+  } catch {
+    return url;
+  }
+
+  return `https://github.com/${repo.owner}/${repo.repo}.git`;
+}
+
 export async function gh(
   args: string[],
   opts: { timeoutMs?: number } = {},
@@ -89,7 +105,7 @@ export async function gh(
   return { stdout: stdout.trim(), stderr: stderr.trim() };
 }
 
-/** Create a GitHub repository and return its SSH clone URL. */
+/** Create a GitHub repository and return its HTTPS clone URL. */
 export async function createGitHubRepository(
   name: string,
   visibility: RepositoryVisibility,
@@ -123,14 +139,14 @@ export async function createGitHubRepository(
       "view",
       fullName,
       "--json",
-      "sshUrl",
+      "url",
       "--jq",
-      ".sshUrl",
+      ".url",
     ]);
-    const sshUrl = stdout.trim();
-    if (!sshUrl) throw new Error("Unable to determine GitHub SSH URL");
+    const url = stdout.trim();
+    if (!url) throw new Error("Unable to determine GitHub URL");
 
-    return { owner, name: repoName, fullName, sshUrl };
+    return { owner, name: repoName, fullName, url };
   } catch (err) {
     await deleteGitHubRepository(fullName, ghClient).catch(() => {});
     throw new Error(formatGhFailure(err));

--- a/backend/src/utils/github.ts
+++ b/backend/src/utils/github.ts
@@ -6,6 +6,7 @@ const execFile = promisify(execFileCb);
 
 const GH_RETRY_COOLDOWN_MS = 60_000;
 const GH_RATE_LIMIT_COOLDOWN_MS = 5 * 60_000;
+const GH_AUTH_STATUS_TIMEOUT_MS = 8_000;
 const GH_RATE_LIMIT_MESSAGE = "GitHub rate limit reached — PR status refresh is paused briefly";
 
 // After ENOENT, skip `gh` calls until cooldown expires.
@@ -86,7 +87,10 @@ export async function resolveGitHubCloneUrl(
   if (!repo || url.startsWith("https://")) return url;
 
   try {
-    await ghClient(["auth", "status", "--hostname", "github.com"]);
+    await ghClient(
+      ["auth", "status", "--active", "--hostname", "github.com"],
+      { timeoutMs: GH_AUTH_STATUS_TIMEOUT_MS },
+    );
   } catch {
     return url;
   }


### PR DESCRIPTION
## Summary

- configure GitHub CLI authentication to use HTTPS for Git operations
- convert GitHub SSH clone URLs to HTTPS when `gh` is authenticated, while preserving SSH for users relying on their own keys
- use HTTPS remotes for repositories created by Hive, including Brain
- add regression coverage for authenticated and unauthenticated clone URL resolution

## Root cause

The OAuth flow stored a GitHub token and configured `gh` as an HTTPS credential helper, but Hive still cloned explicit SSH URLs. On a fresh server without a trusted GitHub host key or an uploaded SSH key, cloning failed before GitHub could check repository access.

## Validation

- `npm run lint` in `backend`
- `npm run typecheck` in `backend`
- `npm test` in `backend` — 112 test files, 1,928 tests passed
- `git diff --check`