### PR TITLE
fix: hide models for signed-out harnesses

### DIFF
--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -151,6 +151,16 @@ describe("getModelCatalog", () => {
     expect(providers.has("codex")).toBe(false);
   });
 
+  it("excludes explicitly disabled providers from models and the default", () => {
+    markProviderAvailable("claude");
+    markProviderAvailable("codex");
+
+    const catalog = getModelCatalog({ excludedProviderIds: new Set(["codex"]) });
+
+    expect(catalog.models.every((model) => model.provider === "claude")).toBe(true);
+    expect(catalog.defaultModelId).toMatch(/^claude:/);
+  });
+
   it("includes all claude models when claude is available", () => {
     markProviderAvailable("claude");
     const catalog = getModelCatalog();

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -155,12 +155,17 @@ export function isThinkingLevelSupportedForModel(
   return resolved ? modelThinkingLevels(resolved.provider, resolved.model).includes(thinkingLevel) : false;
 }
 
+export interface ModelCatalogOptions {
+  excludedProviderIds?: ReadonlySet<string>;
+}
+
 /** Build the model catalog for the frontend, only including available providers. */
-export function getModelCatalog(): ModelCatalogResponse {
+export function getModelCatalog(options: ModelCatalogOptions = {}): ModelCatalogResponse {
   const models: ModelCatalogEntry[] = [];
 
   for (const provider of ALL_PROVIDERS) {
     if (!availableProviderIds.has(provider.id)) continue;
+    if (options.excludedProviderIds?.has(provider.id)) continue;
     // Kimi needs a stored API key on top of the (claude) CLI: without one the
     // Moonshot endpoint can't authenticate, so hide it from the picker. Checked
     // at catalog build time so saving a key takes effect without a restart.

--- a/backend/src/api/models.test.ts
+++ b/backend/src/api/models.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -6,31 +6,49 @@ import { tmpdir } from "node:os";
 import { modelRoutes } from "./models.js";
 import { getModelCatalog, markProviderAvailable } from "../agents/providers/registry.js";
 import { loadConfig, saveConfig } from "../state/config.js";
+import type { SetupToolId } from "@hive/shared/setup-types";
+import type { DetectDeps } from "../services/setup/detect.js";
 
 let tempDir: string;
 let app: ReturnType<typeof Fastify>;
-let previousDataDir: string | undefined;
+let authenticated: Partial<Record<SetupToolId, boolean>>;
 
 beforeEach(async () => {
   tempDir = await mkdtemp(join(tmpdir(), "hive-models-api-test-"));
-  previousDataDir = process.env.DATA_DIR;
-  process.env.DATA_DIR = tempDir;
   markProviderAvailable("claude");
+  markProviderAvailable("codex");
+  authenticated = { claude: true, codex: false };
+  const detect: DetectDeps = {
+    env: {},
+    run: vi.fn(async (command) => {
+      const signedIn = authenticated[command as SetupToolId] === true;
+      if (command === "claude") {
+        return {
+          stdout: JSON.stringify({ loggedIn: signedIn }),
+          stderr: "",
+          exitCode: 0,
+          timedOut: false,
+        };
+      }
+      return {
+        stdout: signedIn ? "Logged in using ChatGPT" : "Not logged in",
+        stderr: "",
+        exitCode: 0,
+        timedOut: false,
+      };
+    }),
+  };
 
   app = Fastify();
-  await app.register((instance: FastifyInstance) => modelRoutes(instance));
+  await app.register((instance: FastifyInstance) =>
+    modelRoutes(instance, { dataDir: tempDir, detect }),
+  );
   await app.ready();
 });
 
 afterEach(async () => {
   await app.close();
   await rm(tempDir, { recursive: true, force: true });
-
-  if (previousDataDir === undefined) {
-    delete process.env.DATA_DIR;
-  } else {
-    process.env.DATA_DIR = previousDataDir;
-  }
 });
 
 describe("GET /api/models", () => {
@@ -38,7 +56,9 @@ describe("GET /api/models", () => {
     const res = await app.inject({ method: "GET", url: "/api/models" });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().defaultModelId).toBe(getModelCatalog().defaultModelId);
+    expect(res.json().defaultModelId).toBe(
+      getModelCatalog({ excludedProviderIds: new Set(["codex"]) }).defaultModelId,
+    );
   });
 
   it("returns the saved default when it is in the catalog", async () => {
@@ -60,6 +80,85 @@ describe("GET /api/models", () => {
     const res = await app.inject({ method: "GET", url: "/api/models" });
 
     expect(res.statusCode).toBe(200);
-    expect(res.json().defaultModelId).toBe(getModelCatalog().defaultModelId);
+    expect(res.json().defaultModelId).toMatch(/^claude:/);
+  });
+
+  it("ignores a saved default whose harness is not authenticated", async () => {
+    const codexDefault = getModelCatalog().models.find(
+      (model) => model.provider === "codex" && model.isDefault,
+    )!;
+    const config = await loadConfig(tempDir);
+    await saveConfig({ ...config, defaultModelId: codexDefault.id }, tempDir);
+
+    const res = await app.inject({ method: "GET", url: "/api/models" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json().defaultModelId).toMatch(/^claude:/);
+  });
+
+  it.each([
+    {
+      name: "Claude only",
+      authentication: { claude: true, codex: false },
+      providers: ["claude"],
+    },
+    {
+      name: "Codex only",
+      authentication: { claude: false, codex: true },
+      providers: ["codex"],
+    },
+    {
+      name: "both harnesses",
+      authentication: { claude: true, codex: true },
+      providers: ["claude", "codex"],
+    },
+    {
+      name: "no harness",
+      authentication: { claude: false, codex: false },
+      providers: [],
+    },
+  ])("returns models for $name", async ({ authentication, providers }) => {
+    authenticated = authentication;
+
+    const res = await app.inject({ method: "GET", url: "/api/models" });
+    const body = res.json();
+
+    expect(res.statusCode).toBe(200);
+    expect([...new Set(body.models.map((model: { provider: string }) => model.provider))])
+      .toEqual(providers);
+    if (providers.length === 0) {
+      expect(body.defaultModelId).toBe("");
+    } else {
+      expect(body.defaultModelId).toEqual(expect.any(String));
+    }
+  });
+
+  it("re-probes authentication on every request", async () => {
+    authenticated = { claude: true, codex: false };
+    const first = await app.inject({ method: "GET", url: "/api/models" });
+
+    authenticated = { claude: false, codex: true };
+    const second = await app.inject({ method: "GET", url: "/api/models" });
+
+    expect(new Set(first.json().models.map((model: { provider: string }) => model.provider)))
+      .toEqual(new Set(["claude"]));
+    expect(new Set(second.json().models.map((model: { provider: string }) => model.provider)))
+      .toEqual(new Set(["codex"]));
+  });
+
+  it("keeps Kimi available with its key when Claude is not authenticated", async () => {
+    authenticated = { claude: false, codex: false };
+    markProviderAvailable("kimi");
+    const config = await loadConfig(tempDir);
+    await saveConfig({ ...config, kimi: { apiKey: "sk-kimi" } }, tempDir);
+
+    const res = await app.inject({ method: "GET", url: "/api/models" });
+    const providers = new Set(
+      res.json().models.map((model: { provider: string }) => model.provider),
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(providers).toEqual(new Set(["kimi"]));
+    expect(res.json().defaultModelId).toMatch(/^kimi:/);
   });
 });

--- a/backend/src/api/models.ts
+++ b/backend/src/api/models.ts
@@ -1,15 +1,51 @@
 import type { FastifyInstance } from "fastify";
 import { getModelCatalog } from "../agents/providers/registry.js";
+import {
+  SETUP_TOOLS,
+  type SetupToolSpec,
+} from "../services/setup/catalog.js";
+import {
+  defaultDetectDeps,
+  detectToolAuthentication,
+  type DetectDeps,
+} from "../services/setup/detect.js";
 import { loadConfig } from "../state/config.js";
 
-export async function modelRoutes(app: FastifyInstance) {
+export interface ModelRoutesOptions {
+  dataDir?: string;
+  detect?: DetectDeps;
+}
+
+export async function modelRoutes(
+  app: FastifyInstance,
+  options: ModelRoutesOptions = {},
+) {
+  const detect = options.detect ?? defaultDetectDeps();
+  const providerTools = SETUP_TOOLS.filter(
+    (tool): tool is SetupToolSpec & { authenticatedProviderId: string } =>
+      tool.authenticatedProviderId !== undefined,
+  );
+
   app.get("/api/models", async (_req, reply) => {
     // Load config first: it also refreshes the cached Kimi API key that
     // getModelCatalog uses to decide whether Kimi models are offered.
-    const { defaultModelId } = await loadConfig();
-    const catalog = getModelCatalog();
+    const [{ defaultModelId }, providerAuthentication] = await Promise.all([
+      loadConfig(options.dataDir),
+      Promise.all(
+        providerTools.map(async (tool) => ({
+          providerId: tool.authenticatedProviderId,
+          authenticated: await detectToolAuthentication(tool.id, detect),
+        })),
+      ),
+    ]);
+    const excludedProviderIds = new Set(
+      providerAuthentication
+        .filter(({ authenticated }) => !authenticated)
+        .map(({ providerId }) => providerId),
+    );
+    const catalog = getModelCatalog({ excludedProviderIds });
     // Apply the user-configured default only while its model is still in the
-    // catalog (provider CLI installed); otherwise keep the computed default.
+    // catalog; otherwise keep the computed default.
     if (defaultModelId && catalog.models.some((m) => m.id === defaultModelId)) {
       catalog.defaultModelId = defaultModelId;
     }

--- a/backend/src/services/setup/catalog.ts
+++ b/backend/src/services/setup/catalog.ts
@@ -10,6 +10,8 @@ export interface SetupToolSpec {
   command: string;
   /** npm package backing install and update; empty when Hive does not manage it. */
   npmPackage: string;
+  /** Model provider hidden from the catalog while this tool is signed out. */
+  authenticatedProviderId?: string;
 }
 
 /**
@@ -25,12 +27,14 @@ export const SETUP_TOOLS: readonly SetupToolSpec[] = [
     label: PROVIDER_LABELS.claude,
     command: "claude",
     npmPackage: NPM_PACKAGES.claude,
+    authenticatedProviderId: "claude",
   },
   {
     id: "codex",
     label: PROVIDER_LABELS.codex,
     command: "codex",
     npmPackage: NPM_PACKAGES.codex,
+    authenticatedProviderId: "codex",
   },
   { id: "gh", label: "GitHub CLI", command: "gh", npmPackage: "" },
 ];

--- a/backend/src/services/setup/detect.ts
+++ b/backend/src/services/setup/detect.ts
@@ -40,9 +40,9 @@ async function probeVersion(
  * output shape reads as "not authenticated", which understates rather than
  * claiming a sign-in that is not there.
  */
-async function probeAuthenticated(
+export async function detectToolAuthentication(
   id: SetupToolId,
-  deps: DetectDeps,
+  deps: DetectDeps = defaultDetectDeps(),
 ): Promise<boolean> {
   switch (id) {
     case "claude": {
@@ -92,6 +92,6 @@ export async function detectTool(
     version,
     // Asking an absent binary whether it is signed in only produces a second
     // spawn failure.
-    authenticated: installed ? await probeAuthenticated(spec.id, deps) : false,
+    authenticated: installed ? await detectToolAuthentication(spec.id, deps) : false,
   };
 }

--- a/frontend/src/components/setup/useSetupTools.ts
+++ b/frontend/src/components/setup/useSetupTools.ts
@@ -148,12 +148,13 @@ export function useSetupTools(target?: SetupApiTarget) {
       actedOn.set(scope, watched);
     }
     let finished = false;
+    let catalogChanged = false;
     for (const operation of operations) {
       if (operation.status === "running") {
         watched.add(operation.id);
       } else if (watched.delete(operation.id)) {
         finished = true;
-        if (operation.status === "succeeded") void refreshModelCatalog();
+        if (operation.status === "succeeded") catalogChanged = true;
       }
     }
     for (const session of authSessions) {
@@ -162,8 +163,10 @@ export function useSetupTools(target?: SetupApiTarget) {
         watched.add(key);
       } else if (watched.delete(key)) {
         finished = true;
+        if (session.state === "connected") catalogChanged = true;
       }
     }
+    if (catalogChanged) void refreshModelCatalog();
     if (finished) void queryClient.invalidateQueries({ queryKey: toolsKey });
   }, [operations, authSessions, queryClient, toolsKey, scope]);
 

--- a/frontend/tests/components/ToolsPanel.test.tsx
+++ b/frontend/tests/components/ToolsPanel.test.tsx
@@ -184,6 +184,54 @@ describe("ToolsPanel", () => {
     expect(mocks.refreshModelCatalog).not.toHaveBeenCalled();
   });
 
+  it("refreshes the model catalog when a sign-in connects", async () => {
+    const connecting = session({
+      tool: "codex",
+      state: "awaiting_authorization",
+      verificationUri: "https://auth.openai.com/codex/device",
+    });
+    respond({
+      tools: [tool({ id: "codex", label: "Codex", installed: true })],
+      authSessions: [connecting],
+    });
+
+    renderPanel();
+    expect(await screen.findByText("Waiting for authorization…")).toBeInTheDocument();
+    expect(mocks.refreshModelCatalog).not.toHaveBeenCalled();
+
+    respond({
+      tools: [tool({ id: "codex", label: "Codex", installed: true, authenticated: true })],
+      authSessions: [{ ...connecting, state: "connected" }],
+    });
+
+    await waitFor(() => expect(mocks.refreshModelCatalog).toHaveBeenCalledTimes(1), {
+      timeout: 5_000,
+    });
+  });
+
+  it("does not refresh the model catalog when a sign-in expires", async () => {
+    const connecting = session({
+      tool: "codex",
+      state: "awaiting_authorization",
+      verificationUri: "https://auth.openai.com/codex/device",
+    });
+    respond({
+      tools: [tool({ id: "codex", label: "Codex", installed: true })],
+      authSessions: [connecting],
+    });
+
+    renderPanel();
+    expect(await screen.findByText("Waiting for authorization…")).toBeInTheDocument();
+
+    respond({
+      tools: [tool({ id: "codex", label: "Codex", installed: true })],
+      authSessions: [{ ...connecting, state: "expired" }],
+    });
+
+    await screen.findByText(/code expired before it was confirmed/i, {}, { timeout: 5_000 });
+    expect(mocks.refreshModelCatalog).not.toHaveBeenCalled();
+  });
+
   it("offers an update only when one is available", async () => {
     respond({
       tools: [

--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -120,6 +120,7 @@ struct HiveApp: App {
                     if let bg = backgroundedAt {
                         let elapsed = Date().timeIntervalSince(bg)
                         projectStore.statusMonitor.appDidBecomeActive()
+                        Task { await modelCatalog.load() }
                         if elapsed > 30 {
                             Task { await projectStore.refresh(force: true) }
                         }


### PR DESCRIPTION
## Summary

- hide Claude and Codex models unless their harness is authenticated
- keep Kimi availability independent through its configured API key
- refresh the web model catalog after a successful harness sign-in
- refresh the iOS model catalog when the app returns to the foreground

## Validation

- npm run lint
- npm run typecheck
- npm run test
- iOS runtime tests not run because Swift and Xcode are unavailable in this environment