### PR TITLE
fix: restore the saved accent color on startup

### DIFF
--- a/frontend/src/hooks/useAccentColor.ts
+++ b/frontend/src/hooks/useAccentColor.ts
@@ -21,7 +21,11 @@ const DEFAULT_ID = "violet";
 const listeners = new Set<() => void>();
 
 function getSnapshot(): string {
-  return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_ID;
+  try {
+    return localStorage.getItem(STORAGE_KEY) ?? DEFAULT_ID;
+  } catch {
+    return DEFAULT_ID;
+  }
 }
 
 function getServerSnapshot(): string {
@@ -38,8 +42,13 @@ function applyAccent(id: string) {
   document.documentElement.style.setProperty("--hive-accent", option.color);
 }
 
-// Apply on module load so the accent is set before first render
-applyAccent(getSnapshot());
+// Called from main.tsx so the stored accent is applied before the first render.
+// This module is otherwise only imported by the lazily loaded Appearance page,
+// so relying on a module-load side effect would leave the accent at its CSS
+// fallback until that route is visited.
+export function initAccentColor() {
+  applyAccent(getSnapshot());
+}
 
 export function useAccentColor() {
   const accentId = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,8 +5,13 @@ import { queryClient } from "@/lib/query-client";
 import "./index.css";
 import { copyToClipboard } from "@/lib/clipboard";
 import { wsTransport } from "@/lib/ws-transport";
+import { initAccentColor } from "@/hooks/useAccentColor";
 import App from "./App";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
+
+// The stored theme mode is restored by the inline script in index.html; the
+// accent color is restored here.
+initAccentColor();
 
 // A hub WebSocket can stay readyState OPEN after the OS sleeps/wakes or the
 // network changes, never firing onclose — leaving the UI stuck on stale data.

--- a/frontend/tests/hooks/useAccentColor.test.tsx
+++ b/frontend/tests/hooks/useAccentColor.test.tsx
@@ -1,0 +1,50 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { ACCENT_OPTIONS, initAccentColor, useAccentColor } from "@/hooks/useAccentColor";
+
+function currentAccent(): string {
+  return document.documentElement.style.getPropertyValue("--hive-accent");
+}
+
+describe("accent color store", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.removeProperty("--hive-accent");
+  });
+
+  it("applies the stored accent at startup", () => {
+    localStorage.setItem("hive-accent", "emerald");
+
+    initAccentColor();
+
+    expect(currentAccent()).toBe("#10b981");
+  });
+
+  it("falls back to the default accent when nothing is stored", () => {
+    initAccentColor();
+
+    expect(currentAccent()).toBe(ACCENT_OPTIONS[0].color);
+  });
+
+  it("ignores an unknown stored accent id", () => {
+    localStorage.setItem("hive-accent", "chartreuse");
+
+    initAccentColor();
+
+    expect(currentAccent()).toBe(ACCENT_OPTIONS[0].color);
+  });
+
+  it("persists a selection and publishes it to every subscriber", () => {
+    const first = renderHook(() => useAccentColor());
+    const second = renderHook(() => useAccentColor());
+
+    act(() => {
+      first.result.current.setAccent("rose");
+    });
+
+    expect(localStorage.getItem("hive-accent")).toBe("rose");
+    expect(currentAccent()).toBe("#f43f5e");
+    expect(second.result.current.accentId).toBe("rose");
+    expect(second.result.current.current.label).toBe("Rose");
+  });
+});


### PR DESCRIPTION
## Problem

Restarting Hive always came back with the default Indigo accent, even though the user's choice was still in `localStorage`.

The stored accent was applied by a module-load side effect in `frontend/src/hooks/useAccentColor.ts`, but that module is only imported by `frontend/src/pages/settings/AppearanceSettings.tsx`, which is a lazy route (`frontend/src/App.tsx:24`). On a fresh start the chunk never loaded, so `--hive-accent` stayed unset and every consumer fell back to its CSS default `#635BFF` (`frontend/src/index.css:109`). The accent reappeared as soon as Settings > Appearance was opened, then "forgot" itself again on the next launch.

The theme mode was unaffected because `frontend/index.html` restores it with an inline script.

## Fix

- Expose `initAccentColor()` from the hook instead of relying on a module-load side effect.
- Call it from `frontend/src/main.tsx`, before the first render. The palette stays defined in one place rather than being duplicated into the HTML bootstrap.

## Tests

- New `frontend/tests/hooks/useAccentColor.test.tsx`: startup restoration (the regression), default fallback, unknown stored id, and selection persistence/propagation.
- `npx vitest run tests/hooks/useAccentColor.test.tsx` — 4 passed.
- `npx vitest run tests/pages/SettingsView.test.tsx` — 19 passed.
- `npm run lint` and `npm run typecheck` in `frontend/` — clean.