### PR TITLE
feat: add desktop auto-update via tauri-plugin-updater

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -157,12 +157,16 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          # The updater signing key is generated without a password, but the
+          # variable must be set so the Tauri CLI never prompts.
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ""
           RELEASE_VERSION: ${{ needs.validate.outputs.version }}
           MACOS_VERSION: ${{ needs.validate.outputs.macos-version }}
           MACOS_BUILD: ${{ needs.validate.outputs.macos-build }}
         shell: bash
         run: |
-          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY; do
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_API_ISSUER APPLE_API_KEY APPLE_API_PRIVATE_KEY TAURI_SIGNING_PRIVATE_KEY; do
             if [ -z "${!name:-}" ]; then
               echo "missing release environment secret: $name" >&2
               exit 1
@@ -196,7 +200,7 @@ jobs:
             '{version: $version, bundle: {macOS: {bundleVersion: $build}}}')"
           npm run tauri build -- \
             --target aarch64-apple-darwin \
-            --bundles dmg \
+            --bundles app,dmg \
             --config "$release_config"
 
           generated_dir="src-tauri/target/aarch64-apple-darwin/release/bundle/dmg"
@@ -230,9 +234,30 @@ jobs:
           xcrun stapler staple "$dmg"
           xcrun stapler validate "$dmg"
 
+          updater_dir="src-tauri/target/aarch64-apple-darwin/release/bundle/macos"
+          tarball_count="$(find "$updater_dir" -maxdepth 1 -type f -name '*.app.tar.gz' | wc -l | tr -d ' ')"
+          test "$tarball_count" = 1
+          signature_count="$(find "$updater_dir" -maxdepth 1 -type f -name '*.app.tar.gz.sig' | wc -l | tr -d ' ')"
+          test "$signature_count" = 1
+          generated_tarball="$(find "$updater_dir" -maxdepth 1 -type f -name '*.app.tar.gz' -print -quit)"
+          generated_signature="$(find "$updater_dir" -maxdepth 1 -type f -name '*.app.tar.gz.sig' -print -quit)"
+          tarball="../dist-release/Hive-$RELEASE_VERSION-macos-arm64.app.tar.gz"
+          cp "$generated_tarball" "$tarball"
+          cp "$generated_signature" "$tarball.sig"
+
+          # The updater signature exists only in this job, so latest.json is written here.
+          jq -n \
+            --arg version "$RELEASE_VERSION" \
+            --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            --arg signature "$(cat "$tarball.sig")" \
+            --arg url "https://github.com/unfence-labs/hive/releases/download/v$RELEASE_VERSION/Hive-$RELEASE_VERSION-macos-arm64.app.tar.gz" \
+            '{version: $version, pub_date: $pub_date, platforms: {"darwin-aarch64": {signature: $signature, url: $url}}}' \
+            > ../dist-release/latest.json
+
           (
             cd ../dist-release
             shasum -a 256 "$(basename "$dmg")" > "$(basename "$dmg").sha256"
+            shasum -a 256 "$(basename "$tarball")" > "$(basename "$tarball").sha256"
           )
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -241,6 +266,10 @@ jobs:
           path: |
             dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.dmg
             dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.dmg.sha256
+            dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.app.tar.gz
+            dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.app.tar.gz.sig
+            dist-release/Hive-${{ needs.validate.outputs.version }}-macos-arm64.app.tar.gz.sha256
+            dist-release/latest.json
           if-no-files-found: error
 
   draft-release:
@@ -270,13 +299,17 @@ jobs:
             "hive-backend-$VERSION-linux-arm64.tar.gz.sha256" \
             "Hive-$VERSION-macos-arm64.dmg" \
             "Hive-$VERSION-macos-arm64.dmg.sha256" \
+            "Hive-$VERSION-macos-arm64.app.tar.gz" \
+            "Hive-$VERSION-macos-arm64.app.tar.gz.sig" \
+            "Hive-$VERSION-macos-arm64.app.tar.gz.sha256" \
+            "latest.json" \
             "provision.sh"; do
             test -f "release/$asset" || {
               echo "missing release asset: $asset" >&2
               exit 1
             }
           done
-          test "$(find release -type f | wc -l)" = 7
+          test "$(find release -type f | wc -l)" = 11
 
       - name: Create draft GitHub release
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,7 +44,9 @@ server layout and systemd service. Choose whichever fits how you work.
 The distributed desktop app supports Apple Silicon Macs running macOS 14 or later. Intel builds are
 not published. Download the latest stable DMG, or an explicitly selected prerelease, from
 [GitHub Releases](https://github.com/unfence-labs/hive/releases), open it, and drag Hive to
-Applications. Desktop updates are manual in V1: install a newer DMG from the same page.
+Applications. The app then checks for new stable releases and offers to install them: accepting
+downloads the update and restarts Hive. Prerelease builds are not offered automatically; update
+those by installing a newer DMG from the same page.
 
 The desktop app installs Hive on a server itself, over SSH, with no terminal. With no server
 configured it opens on launch; otherwise it is under **Settings → Server → Install Hive on a

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -34,11 +34,19 @@ Create a GitHub environment named `release`:
 | `APPLE_API_ISSUER` | App Store Connect team API issuer ID |
 | `APPLE_API_KEY` | App Store Connect team API key ID |
 | `APPLE_API_PRIVATE_KEY` | Complete contents of the matching `.p8` private key |
+| `TAURI_SIGNING_PRIVATE_KEY` | Contents of the updater signing private key generated with `npm run tauri -- signer generate`, generated without a password |
 
 Use an App Store Connect **team** API key for notarization, not an individual API key. Keep local
 backups of the certificate and private keys in a secure credential store. Anyone who obtains the
 certificate and password can sign software as the certificate holder; revoke a compromised API key
 immediately and contact Apple about a compromised Developer ID certificate.
+
+Generate the desktop updater keypair once, from `frontend`, with `npm run tauri -- signer generate`
+writing to a path outside the repository, and choose no password. The private key becomes
+`TAURI_SIGNING_PRIVATE_KEY`; the matching public key is committed as `plugins.updater.pubkey` in
+`frontend/src-tauri/tauri.conf.json` and the two must stay paired. Installed clients accept only
+updates signed by that key, so losing it breaks automatic updates for every shipped client and is
+recoverable only by publishing a build carrying a new public key. Keep a secure backup.
 
 The application identifier is permanently `io.419labs.hive`. The distributed desktop supports
 Apple Silicon and macOS 14 or later.
@@ -91,12 +99,21 @@ Expected draft assets:
 ```text
 Hive-<version>-macos-arm64.dmg
 Hive-<version>-macos-arm64.dmg.sha256
+Hive-<version>-macos-arm64.app.tar.gz
+Hive-<version>-macos-arm64.app.tar.gz.sig
+Hive-<version>-macos-arm64.app.tar.gz.sha256
+latest.json
 hive-backend-<version>-linux-x64.tar.gz
 hive-backend-<version>-linux-x64.tar.gz.sha256
 hive-backend-<version>-linux-arm64.tar.gz
 hive-backend-<version>-linux-arm64.tar.gz.sha256
 provision.sh
 ```
+
+The `.app.tar.gz` bundle, its `.sig` signature, and `latest.json` serve the desktop updater.
+Installed apps poll `releases/latest/download/latest.json`, which GitHub resolves only to the
+newest stable release, so prereleases are never offered as automatic updates even though they
+publish the same assets.
 
 GitHub also exposes source `.zip` and `.tar.gz` archives for the release tag.
 
@@ -106,7 +123,7 @@ Before publishing the draft:
 
 1. confirm the tag and target commit match the intended `main` commit;
 2. review the generated notes and labels;
-3. confirm all seven assets exist;
+3. confirm all eleven assets exist;
 4. compare the published checksums with locally calculated SHA-256 values;
 5. install the DMG on a clean Apple Silicon Mac;
 6. confirm Gatekeeper shows only the normal downloaded-from-Internet confirmation;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,8 @@
     "@streamdown/mermaid": "^1.0.2",
     "@tanstack/react-query": "^5.101.4",
     "@tauri-apps/api": "^2.11.1",
+    "@tauri-apps/plugin-process": "^2.3.1",
+    "@tauri-apps/plugin-updater": "^2.10.1",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/xterm": "^6.0.0",
     "ai": "^6.0.81",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -65,6 +65,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,6 +702,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,6 +1030,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1546,6 +1576,8 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-log",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -1628,6 +1660,21 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -2133,6 +2180,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2424,6 +2477,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2558,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2506,6 +2577,20 @@ checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
 dependencies = [
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3118,15 +3203,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3136,6 +3226,20 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3167,6 +3271,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3356,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3237,6 +3423,29 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.0",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3629,6 +3838,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,6 +3969,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -3933,6 +4159,49 @@ dependencies = [
  "url",
  "windows",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
 ]
 
 [[package]]
@@ -4166,6 +4435,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4462,6 +4741,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
@@ -4766,6 +5051,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4993,6 +5287,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5415,6 +5718,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5540,6 +5853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5570,6 +5889,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.13.0",
+ "memchr",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -30,3 +30,5 @@ log = "0.4"
 tauri = { version = "2.10.0", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2.5.3"
+tauri-plugin-process = "2"
+tauri-plugin-updater = "2"

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -10,6 +10,8 @@
     "core:window:allow-start-dragging",
     "core:window:allow-start-resize-dragging",
     "opener:default",
+    "process:default",
+    "updater:default",
     {
       "identifier": "opener:allow-open-url",
       "allow": [

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -55,6 +55,7 @@ fn open_terminal_ssh(terminal_id: String, command: String) -> Result<(), String>
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
             detect_terminals,
             open_terminal_ssh,
@@ -66,6 +67,10 @@ pub fn run() {
         ])
         .setup(|app| {
             app.manage(provision::ProvisionState::default());
+            // The updater ships installers, which only exist on desktop.
+            #[cfg(desktop)]
+            app.handle()
+                .plugin(tauri_plugin_updater::Builder::new().build())?;
             if cfg!(debug_assertions) {
                 app.handle().plugin(
                     tauri_plugin_log::Builder::default()

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -27,6 +27,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "createUpdaterArtifacts": true,
     "resources": {
       "../../LICENSE": "LICENSE"
     },
@@ -40,5 +41,13 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "endpoints": [
+        "https://github.com/unfence-labs/hive/releases/latest/download/latest.json"
+      ],
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEYwM0U0NDU0RjIwMzc5MjkKUldRcGVRUHlWRVErOEhTbmZrZ25aNGxzaVc2YmNmNm9TTWZ3NmFMWG1taXlDMnZ0TVc5TWNvLzIK"
+    }
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -38,7 +38,6 @@ const Installer = lazy(() => import("@/pages/installer/Installer"));
 
 function NotificationToastsBridge({ projects }: { projects: Project[] }) {
   useNotificationToasts(projects);
-  useDesktopUpdate();
   return null;
 }
 
@@ -72,20 +71,26 @@ export default function App() {
   }, [requiresSetup]);
   const closeInstaller = useCallback(() => setInstaller(null), []);
 
-  if (installer === "gate") {
-    return (
-      <Suspense fallback={<BootScreen />}>
-        <Installer onClose={closeInstaller} />
-      </Suspense>
-    );
-  }
+  // App-level, not ConfiguredApp-level: an installed build stuck on the
+  // installer gate must still be offered updates — that gate is exactly where
+  // a broken old build would strand its user.
+  useDesktopUpdate();
 
   return (
-    <ConfiguredApp
-      installerOpen={installer === "overlay"}
-      onOpenInstaller={() => setInstaller("overlay")}
-      onCloseInstaller={closeInstaller}
-    />
+    <>
+      <HiveToaster />
+      {installer === "gate" ? (
+        <Suspense fallback={<BootScreen />}>
+          <Installer onClose={closeInstaller} />
+        </Suspense>
+      ) : (
+        <ConfiguredApp
+          installerOpen={installer === "overlay"}
+          onOpenInstaller={() => setInstaller("overlay")}
+          onCloseInstaller={closeInstaller}
+        />
+      )}
+    </>
   );
 }
 
@@ -134,7 +139,6 @@ function ConfiguredApp({
   return (
     <BrowserRouter>
       <WorkspaceLiveDataProvider workspaceIds={workspaceIds}>
-        <HiveToaster />
         <WorkspaceLauncher
           pickerOpen={workspaceFrom.open}
           pickerProjectId={workspaceFrom.projectId}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { WorkspaceLiveDataProvider } from "@/contexts/WorkspaceLiveDataContext";
 import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
 import { useActiveSessionPrewarm } from "@/hooks/useActiveSessionPrewarm";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
+import { useDesktopUpdate } from "@/hooks/useDesktopUpdate";
 import { wsTransport } from "@/lib/ws-transport";
 import { HiveToaster } from "@/components/ui/toaster";
 
@@ -37,6 +38,7 @@ const Installer = lazy(() => import("@/pages/installer/Installer"));
 
 function NotificationToastsBridge({ projects }: { projects: Project[] }) {
   useNotificationToasts(projects);
+  useDesktopUpdate();
   return null;
 }
 

--- a/frontend/src/hooks/useDesktopUpdate.tsx
+++ b/frontend/src/hooks/useDesktopUpdate.tsx
@@ -1,0 +1,161 @@
+import { useEffect, useRef } from "react";
+import { toast } from "sonner";
+import { isDesktopShell } from "@/lib/is-desktop";
+import { TOAST_DURATIONS } from "@/lib/toast-config";
+import { HiveToast, type HiveToastVariant } from "@/components/ui/toaster";
+
+/** The update handle returned by the updater plugin, minus the "no update" case. */
+type Update = NonNullable<Awaited<ReturnType<typeof import("@tauri-apps/plugin-updater").check>>>;
+
+/** One toast for the whole flow: available → downloading → installing → failed. */
+const UPDATE_TOAST_ID = "hive-app-update";
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+/**
+ * Update checks only make sense for an installed desktop build: the web app is
+ * served fresh on every load, and a dev build runs off the Vite server with no
+ * installer to replace. Exported so tests can drive the gate.
+ */
+export function shouldCheckForUpdates(): boolean {
+  return isDesktopShell() && import.meta.env.PROD;
+}
+
+function showUpdateToast(args: {
+  variant: HiveToastVariant;
+  status: string;
+  description: string;
+  actionLabel?: string;
+  duration: number;
+  onAction?: () => void;
+  onDismiss?: () => void;
+}): void {
+  toast.custom(
+    (id) => (
+      <HiveToast
+        variant={args.variant}
+        title="Hive"
+        status={args.status}
+        description={args.description}
+        actionLabel={args.actionLabel}
+        onAction={args.onAction}
+        onClose={() => toast.dismiss(id)}
+      />
+    ),
+    {
+      id: UPDATE_TOAST_ID,
+      duration: args.duration,
+      onDismiss: args.onDismiss,
+    },
+  );
+}
+
+function describeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 120 ? `${message.slice(0, 117)}…` : message;
+}
+
+/**
+ * Watches for desktop releases and offers the install as a sticky toast.
+ *
+ * The toast is the only surface: a failed background check is the normal state
+ * of an offline app, so it never reaches the user. Acting on the toast
+ * downloads the installer in place, then relaunches into the new version.
+ */
+export function useDesktopUpdate(): void {
+  const dismissedVersionRef = useRef<string | null>(null);
+  const checkingRef = useRef(false);
+  const installingRef = useRef(false);
+
+  useEffect(() => {
+    if (!shouldCheckForUpdates()) return;
+
+    let active = true;
+
+    /** Re-renders the sticky toast in place; no action while it runs. */
+    const showProgress = (description: string) => {
+      showUpdateToast({
+        variant: "success",
+        status: "UPDATE",
+        description,
+        duration: TOAST_DURATIONS.actionRequired,
+      });
+    };
+
+    const install = async (update: Update) => {
+      if (installingRef.current) return;
+      installingRef.current = true;
+      showProgress("Downloading update…");
+
+      try {
+        let contentLength = 0;
+        let downloaded = 0;
+        let lastPercent = -1;
+        await update.downloadAndInstall((event) => {
+          if (event.event === "Started") {
+            contentLength = event.data.contentLength ?? 0;
+          } else if (event.event === "Progress") {
+            downloaded += event.data.chunkLength;
+            if (contentLength <= 0) return;
+            const percent = Math.min(100, Math.round((downloaded / contentLength) * 100));
+            if (percent === lastPercent) return;
+            lastPercent = percent;
+            showProgress(`Downloading update… ${percent}%`);
+          } else if (event.event === "Finished") {
+            showProgress("Installing update…");
+          }
+        });
+
+        const { relaunch } = await import("@tauri-apps/plugin-process");
+        await relaunch();
+      } catch (error) {
+        console.warn("Failed to install update:", error);
+        installingRef.current = false;
+        showUpdateToast({
+          variant: "error",
+          status: "FAILED",
+          description: `Update failed: ${describeError(error)}`,
+          actionLabel: "Retry",
+          duration: TOAST_DURATIONS.error,
+          onAction: () => void install(update),
+        });
+      }
+    };
+
+    const runCheck = async () => {
+      // An install in flight owns the toast; a new check must not steal it.
+      if (checkingRef.current || installingRef.current) return;
+      checkingRef.current = true;
+
+      try {
+        const { check } = await import("@tauri-apps/plugin-updater");
+        const update = await check();
+        if (!active || !update) return;
+        if (dismissedVersionRef.current === update.version) return;
+        showUpdateToast({
+          variant: "success",
+          status: "UPDATE",
+          description: `Version ${update.version} is available`,
+          actionLabel: "Restart & update",
+          duration: TOAST_DURATIONS.actionRequired,
+          onAction: () => void install(update),
+          // Closing it answers "not this version"; a later release asks again.
+          onDismiss: () => {
+            dismissedVersionRef.current = update.version;
+          },
+        });
+      } catch (error) {
+        console.warn("Update check failed:", error);
+      } finally {
+        checkingRef.current = false;
+      }
+    };
+
+    void runCheck();
+    const timer = window.setInterval(() => void runCheck(), CHECK_INTERVAL_MS);
+
+    return () => {
+      active = false;
+      window.clearInterval(timer);
+    };
+  }, []);
+}

--- a/frontend/tests/App.test.tsx
+++ b/frontend/tests/App.test.tsx
@@ -27,6 +27,7 @@ const mocks = vi.hoisted(() => ({
   disconnectAll: vi.fn(),
   onMessage: vi.fn(() => ({ unsubscribe: vi.fn(), hadBufferedMessages: false })),
   onGlobalMessage: vi.fn(() => vi.fn()),
+  useDesktopUpdate: vi.fn(),
   projects: [] as Array<{
     id: string;
     name: string;
@@ -70,6 +71,10 @@ vi.mock("@/hooks/useProjects", () => ({
     deleteProject: mocks.deleteProject,
     archiveWorkspace: mocks.archiveWorkspace,
   }),
+}));
+
+vi.mock("@/hooks/useDesktopUpdate", () => ({
+  useDesktopUpdate: mocks.useDesktopUpdate,
 }));
 
 vi.mock("@/lib/ws-transport", () => ({
@@ -394,6 +399,9 @@ describe("App", () => {
     expect(mocks.syncWorkspaces).not.toHaveBeenCalled();
     // With no server there is no way out but the welcome screen's own paths.
     expect(screen.queryByRole("button", { name: "cancel installer" })).not.toBeInTheDocument();
+    // The one exception to "nothing else mounts": update checks. A broken old
+    // build stranded on this gate must still be able to update itself.
+    expect(mocks.useDesktopUpdate).toHaveBeenCalled();
   });
 
   it("keeps the gate up once the install stores its connection", async () => {

--- a/frontend/tests/hooks/useDesktopUpdate.test.tsx
+++ b/frontend/tests/hooks/useDesktopUpdate.test.tsx
@@ -1,0 +1,221 @@
+import { act, renderHook } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useDesktopUpdate } from "@/hooks/useDesktopUpdate";
+import type { HiveToastProps } from "@/components/ui/toaster";
+
+type CustomRender = (id: string | number) => ReactElement<HiveToastProps>;
+type ToastOptions = { id?: string | number; duration?: number; onDismiss?: () => void };
+type DownloadEvent =
+  | { event: "Started"; data: { contentLength?: number } }
+  | { event: "Progress"; data: { chunkLength: number } }
+  | { event: "Finished" };
+
+const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
+
+const mocks = vi.hoisted(() => ({
+  check: vi.fn(),
+  relaunch: vi.fn(),
+  custom: vi.fn(),
+  dismiss: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: mocks.check }));
+vi.mock("@tauri-apps/plugin-process", () => ({ relaunch: mocks.relaunch }));
+
+vi.mock("sonner", () => ({
+  // HiveToaster is never rendered in these tests, only HiveToast is read.
+  Toaster: () => null,
+  toast: {
+    custom: mocks.custom,
+    dismiss: mocks.dismiss,
+  },
+}));
+
+function setDesktopShell(enabled: boolean) {
+  const globals = window as unknown as Record<string, unknown>;
+  if (enabled) globals.__TAURI_INTERNALS__ = {};
+  else delete globals.__TAURI_INTERNALS__;
+}
+
+/** Drains the hook's dynamic imports and awaited plugin calls. */
+async function settle() {
+  await act(async () => {
+    for (let i = 0; i < 10; i++) await Promise.resolve();
+  });
+}
+
+async function renderUpdateHook() {
+  const rendered = renderHook(() => useDesktopUpdate());
+  await settle();
+  return rendered;
+}
+
+/** Read the props of the most recently emitted <HiveToast> custom toast. */
+function lastToast(): { props: HiveToastProps; options: ToastOptions } {
+  const calls = mocks.custom.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  const [render, options] = calls[calls.length - 1] as [CustomRender, ToastOptions];
+  return { props: render(options?.id ?? "auto-id").props, options: options ?? {} };
+}
+
+function makeUpdate(version: string, downloadAndInstall = defaultDownload()) {
+  return { version, downloadAndInstall };
+}
+
+function defaultDownload() {
+  return vi.fn(async (onEvent?: (event: DownloadEvent) => void) => {
+    onEvent?.({ event: "Started", data: { contentLength: 100 } });
+    onEvent?.({ event: "Progress", data: { chunkLength: 40 } });
+    onEvent?.({ event: "Finished" });
+  });
+}
+
+describe("useDesktopUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    setDesktopShell(true);
+    // The hook only checks release builds; vitest runs in dev mode.
+    vi.stubEnv("PROD", true);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.custom.mockImplementation((_render, options) => options?.id ?? "toast-custom");
+    mocks.check.mockResolvedValue(null);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+    setDesktopShell(false);
+  });
+
+  it("does not check for updates outside the desktop shell", async () => {
+    setDesktopShell(false);
+
+    await renderUpdateHook();
+
+    expect(mocks.check).not.toHaveBeenCalled();
+    expect(mocks.custom).not.toHaveBeenCalled();
+  });
+
+  it("does not check for updates in dev builds", async () => {
+    vi.stubEnv("PROD", false);
+
+    await renderUpdateHook();
+
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when no update is available", async () => {
+    await renderUpdateHook();
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(mocks.custom).not.toHaveBeenCalled();
+  });
+
+  it("shows a sticky toast when an update is available", async () => {
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+
+    await renderUpdateHook();
+
+    const { props, options } = lastToast();
+    expect(options.id).toBe("hive-app-update");
+    expect(options.duration).toBe(Infinity);
+    expect(props).toMatchObject({
+      variant: "success",
+      title: "Hive",
+      status: "UPDATE",
+      description: "Version 1.2.3 is available",
+      actionLabel: "Restart & update",
+    });
+  });
+
+  it("downloads, reports progress and relaunches when the action is clicked", async () => {
+    const update = makeUpdate("1.2.3");
+    mocks.check.mockResolvedValue(update);
+
+    await renderUpdateHook();
+    act(() => lastToast().props.onAction?.());
+    await settle();
+
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1);
+    const descriptions = mocks.custom.mock.calls.map(
+      ([render, options]) => (render as CustomRender)((options as ToastOptions)?.id ?? "").props.description,
+    );
+    expect(descriptions).toContain("Downloading update… 40%");
+    expect(descriptions).toContain("Installing update…");
+    // The progress toast drops its CTA so a second download cannot start.
+    expect(lastToast().props.actionLabel).toBeUndefined();
+  });
+
+  it("shows a retryable error toast when the install fails", async () => {
+    const update = makeUpdate(
+      "1.2.3",
+      vi.fn(async () => {
+        throw new Error("network down");
+      }),
+    );
+    mocks.check.mockResolvedValue(update);
+
+    await renderUpdateHook();
+    act(() => lastToast().props.onAction?.());
+    await settle();
+
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+    const { props, options } = lastToast();
+    expect(options.duration).toBe(10000);
+    expect(props).toMatchObject({
+      variant: "error",
+      status: "FAILED",
+      description: "Update failed: network down",
+      actionLabel: "Retry",
+    });
+
+    act(() => props.onAction?.());
+    await settle();
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(2);
+  });
+
+  it("swallows check failures without a toast", async () => {
+    mocks.check.mockRejectedValue(new Error("no latest.json"));
+
+    await renderUpdateHook();
+
+    expect(mocks.custom).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("does not re-show a dismissed version, but announces a newer one", async () => {
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+    await renderUpdateHook();
+
+    act(() => lastToast().options.onDismiss?.());
+    mocks.custom.mockClear();
+
+    await act(async () => {
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+    });
+    await settle();
+    expect(mocks.custom).not.toHaveBeenCalled();
+
+    mocks.check.mockResolvedValue(makeUpdate("1.3.0"));
+    await act(async () => {
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+    });
+    await settle();
+    expect(lastToast().props.description).toBe("Version 1.3.0 is available");
+  });
+
+  it("stops checking after unmount", async () => {
+    const { unmount } = await renderUpdateHook();
+
+    unmount();
+    await act(async () => {
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+    });
+    await settle();
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/tests/tauri/Capabilities.test.ts
+++ b/frontend/tests/tauri/Capabilities.test.ts
@@ -54,6 +54,14 @@ describe("Tauri default capability", () => {
     expect(stringPermissions).toContain("opener:default");
   });
 
+  it("includes the permissions the auto-updater needs to install and relaunch", async () => {
+    await loadCapability();
+
+    const stringPermissions = capability.permissions.filter((p) => typeof p === "string");
+    expect(stringPermissions).toContain("updater:default");
+    expect(stringPermissions).toContain("process:default");
+  });
+
   it("includes core:window drag permissions", async () => {
     await loadCapability();
 

--- a/frontend/tests/tauri/Updater.test.ts
+++ b/frontend/tests/tauri/Updater.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+
+describe("Tauri updater configuration", () => {
+  let config: {
+    bundle: { createUpdaterArtifacts?: boolean };
+    plugins: { updater?: { endpoints?: string[]; pubkey?: string } };
+  };
+
+  // Load the Tauri config file once
+  async function loadConfig() {
+    if (config) return;
+    const configRaw = await readFile(join(process.cwd(), "src-tauri", "tauri.conf.json"), "utf-8");
+    config = JSON.parse(configRaw);
+  }
+
+  it("emits updater artifacts when bundling", async () => {
+    await loadConfig();
+
+    expect(config.bundle.createUpdaterArtifacts).toBe(true);
+  });
+
+  it("points at the latest stable release manifest", async () => {
+    await loadConfig();
+
+    expect(config.plugins.updater?.endpoints).toEqual([
+      "https://github.com/unfence-labs/hive/releases/latest/download/latest.json",
+    ]);
+  });
+
+  it("carries the public key that verifies release signatures", async () => {
+    await loadConfig();
+
+    expect(typeof config.plugins.updater?.pubkey).toBe("string");
+    expect(config.plugins.updater?.pubkey).not.toBe("");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,6 +68,8 @@
         "@streamdown/mermaid": "^1.0.2",
         "@tanstack/react-query": "^5.101.4",
         "@tauri-apps/api": "^2.11.1",
+        "@tauri-apps/plugin-process": "^2.3.1",
+        "@tauri-apps/plugin-updater": "^2.10.1",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/xterm": "^6.0.0",
         "ai": "^6.0.81",
@@ -6258,6 +6260,24 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-process": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+      "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-updater": {
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-updater/-/plugin-updater-2.10.1.tgz",
+      "integrity": "sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.10.1"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/test/release/release-workflow.test.mjs
+++ b/test/release/release-workflow.test.mjs
@@ -47,6 +47,17 @@ test("release builds the frontend before Tauri", () => {
   assert.ok(frontendBuild < tauriBuild);
 });
 
+test("release signs and publishes the desktop updater artifacts", () => {
+  for (const expected of [
+    "TAURI_SIGNING_PRIVATE_KEY",
+    "macos-arm64.app.tar.gz.sig",
+    "macos-arm64.app.tar.gz.sha256",
+    "latest.json",
+  ]) {
+    assert.ok(workflow.includes(expected), `missing ${expected}`);
+  }
+});
+
 test("release notarizes and staples the DMG", () => {
   assert.match(workflow, /xcrun notarytool submit "\$dmg"[\s\S]*--wait/);
   assert.match(workflow, /xcrun stapler staple "\$dmg"/);


### PR DESCRIPTION
## Summary

The desktop app now updates itself. When a newer stable release is published, installed clients show a sticky toast offering the update; accepting downloads it in place (with progress), installs, and relaunches into the new version.

### Client (Tauri + React)
- Register `tauri-plugin-updater` (desktop-only, in `setup`) and `tauri-plugin-process`; add `updater:default` / `process:default` capabilities, enable `createUpdaterArtifacts`, and resolve both plugins into `Cargo.lock` (the desktop CI job builds `--locked`).
- New `useDesktopUpdate` hook mounted at the `App` root — together with `HiveToaster` — so update checks also run on the first-run installer gate, not just the configured app: a broken old build stranded on setup can still rescue itself. Checks on startup and every 4 hours, only in installed desktop builds (`isDesktopShell()` + prod gate). Failed background checks stay silent; install failures show a retryable error toast; dismissing a version suppresses it until a newer one appears.
- Updater endpoint: `releases/latest/download/latest.json`, so only stable releases are auto-offered — prerelease (beta) users keep updating via DMG.

### Release pipeline
- The macOS job signs updater artifacts with the new `TAURI_SIGNING_PRIVATE_KEY` release-environment secret (checked with the existing missing-secret guard) and builds with `--bundles app,dmg`.
- Publishes `Hive-<version>-macos-arm64.app.tar.gz`, `.sig`, `.sha256`, and a `jq`-generated `latest.json`; the draft-release asset guard grows from 7 to 11 files.
- The updater public key is committed in `tauri.conf.json`; docs (`releasing.md`, `getting-started.md`) cover key generation, backup, and the new update behavior.

## Before the next release (action required)

Add the `TAURI_SIGNING_PRIVATE_KEY` secret to the `release` GitHub environment (the maintainer holds the generated key; it was created without a password). Without it the release build now fails fast at the secret check.

## Test plan

- `npm run test:release` — 9/9 pass (new workflow assertions for signing + updater assets)
- Frontend `lint`, `typecheck`, full `npm test` — 145 files / 1768 tests pass (new `useDesktopUpdate` hook tests, new `Updater.test.ts` config tests, extended capabilities test, gate-mode update-check assertion in `App.test.tsx`)
- `cargo metadata --locked` passes after the lockfile update that fixes the previously red `desktop` CI job
- Not verifiable locally (Linux, no macOS toolchain): the actual `tauri build` producing `Hive.app.tar.gz(.sig)` — exercised by the workflow's own `test` guards on the first real release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
