### PR TITLE
chore(release): prepare 0.1.0-beta.2

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1536,7 +1536,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.0-beta.1"
+version = "0.1.0-beta.2"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the canonical Hive release version from `0.1.0-beta.1` to `0.1.0-beta.2`
- synchronize the Hive package entry in `Cargo.lock`

## Validation

- `npm run release:version:check`
- `npm run lint`
- `npm run typecheck`
- `npm test`
- `npm run test:release`
- `npm run test:provision`
- `git diff --check`