### PR TITLE
fix(provision): ignore generated nftables rules

### DIFF
--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -74,8 +74,8 @@ to a second one.
 ### Firewall handling
 
 There is no firewall question. If `ufw` is active, the installer opens only Hive's configured TCP
-port automatically. If no firewall is active, no rule is needed. An active `firewalld` or raw
-`nftables` ruleset blocks the install because Hive cannot configure its policy safely and must not
+port automatically. If no firewall is active, no rule is needed. An active `firewalld` or
+`nftables` service blocks the install because Hive cannot configure its policy safely and must not
 claim success while its port may be closed.
 
 ## What the installer changes
@@ -110,7 +110,7 @@ claim success while its port may be closed.
   checksum pinned in the script before anything is unpacked.
 - **Your firewall policy.** The installer never enables a firewall and never changes its default
   policy. If `ufw` is already active it opens only the configured TCP port. If no firewall is active
-  it does nothing and says so. An active `firewalld` or raw `nftables` ruleset blocks the install
+  it does nothing and says so. An active `firewalld` or `nftables` service blocks the install
   rather than being modified or silently ignored.
 - **Your SSH configuration.** `sshd` is not reconfigured. The only SSH file written on the server is
   `authorized_keys` on the service account the installer created. On your own machine, approving a

--- a/scripts/provision/steps.sh
+++ b/scripts/provision/steps.sh
@@ -208,17 +208,17 @@ firewalld_is_active() {
 
 nftables_is_active() {
   command -v nft >/dev/null 2>&1 &&
-    [ -n "$(nft list ruleset 2>/dev/null || true)" ]
+    systemctl is-active --quiet nftables 2>/dev/null
 }
 
 # Which firewall manager governs the server. Active managers win over merely
 # installed ones, so an inactive ufw package cannot hide an enforcing
-# firewalld or raw nftables ruleset.
+# firewalld or nftables service.
 firewall_backend() {
   if firewalld_is_active; then printf firewalld
   elif ufw_is_active; then printf ufw
   # ufw and firewalld commonly use nftables underneath, so only treat the
-  # ruleset as raw nftables after both managers have been ruled out.
+  # system nftables service as the manager after both have been ruled out.
   elif nftables_is_active; then printf nftables
   elif command -v ufw >/dev/null 2>&1; then printf ufw
   elif command -v firewall-cmd >/dev/null 2>&1; then printf firewalld
@@ -1084,7 +1084,7 @@ title_firewall_rule() { echo "Check the firewall"; }
 # session running the install, with no way back in. Hive only opens its own port
 # when ufw is already enforcing one.
 #
-# Only ufw is modified. An active firewalld or raw nftables ruleset blocks the
+# Only ufw is modified. An active firewalld or nftables service blocks the
 # install because their runtime/permanent and zone semantics cannot be guessed
 # safely, and succeeding with a closed port would leave Hive unusable.
 # Every rule this install added, one per line, appended and never rewritten.

--- a/test/provision/contract.sh
+++ b/test/provision/contract.sh
@@ -547,6 +547,31 @@ fw_open="$(HIVE_LOG_FILE="$WORK/preflight.log.ndjson" bash -c '
 expect "an active ufw reports the automatic port rule" \
   grep -q '"check":"firewall","status":"ok".*"ruleToApply":"ufw allow 9999/tcp"' <<<"$fw_open"
 
+nft_service_detection="$(bash -c '
+  # shellcheck disable=SC1090
+  source "$1"; source "$2"
+  mkdir -p "$3/bin"
+  LOG_FILE="$3/preflight.log"
+  printf "#!/bin/sh\nprintf \"table ip filter {}\\\\n\"\n" >"$3/bin/nft"
+  chmod +x "$3/bin/nft"
+  PATH="$3/bin:$PATH"
+  OPT_PORT=9420
+  firewalld_is_active() { return 1; }
+  ufw_is_active() { return 1; }
+  sudo_nopasswd() { return 0; }
+  systemctl() { return 1; }
+  nftables_is_active && echo inactive-ruleset-active || echo inactive-ruleset-ignored
+  preflight_firewall
+  systemctl() { [ "$1:$2:$3" = "is-active:--quiet:nftables" ]; }
+  nftables_is_active && echo active-service-detected
+' _ "$PROV/lib.sh" "$PROV/steps.sh" "$WORK/nft-service")"
+expect "generated nftables rules are ignored when the nftables service is inactive" \
+  grep -qx inactive-ruleset-ignored <<<"$nft_service_detection"
+expect "preflight accepts generated rules when the nftables service is inactive" \
+  grep -q '"check":"firewall","status":"ok".*"active":false' <<<"$nft_service_detection"
+expect "the active nftables system service is detected" \
+  grep -qx active-service-detected <<<"$nft_service_detection"
+
 raw_nft="$(bash -c '
   # shellcheck disable=SC1090
   source "$1"; source "$2"
@@ -555,7 +580,7 @@ raw_nft="$(bash -c '
   nftables_is_active() { return 0; }
   firewall_backend
 ' _ "$PROV/lib.sh" "$PROV/steps.sh")"
-expect "an inactive ufw installation cannot hide active raw nftables rules" \
+expect "an inactive ufw installation cannot hide the active nftables service" \
   [ "$raw_nft" = nftables ]
 
 fw_unsupported="$(HIVE_LOG_FILE="$WORK/preflight.log.ndjson" bash -c '


### PR DESCRIPTION
## Summary

- detect raw nftables as active only when the system `nftables.service` is active
- ignore non-empty rulesets generated by container and private-network tooling when that service is inactive
- keep active ufw, firewalld, and nftables service handling unchanged
- document the service-based boundary

## Why

A VPS running Docker and private-network tooling can have a non-empty iptables-nft ruleset while `nftables.service` is disabled and the input policy already accepts the private interface. Treating any rule as an operator-managed firewall blocks a valid Hive install. Parsing arbitrary rule ownership would be brittle; the system service is the minimal deterministic boundary.

## Validation

- `npm run test:provision`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`

The provision contract reproduces a non-empty generated ruleset with an inactive nftables service, verifies preflight accepts it, and still verifies that an active nftables service is detected.