### PR TITLE
fix: authenticate Claude branch naming

### DIFF
--- a/backend/src/agents/naming.test.ts
+++ b/backend/src/agents/naming.test.ts
@@ -143,6 +143,38 @@ describe("generateNames", () => {
     expect(proc._stdinEnd).toHaveBeenCalledTimes(1);
   });
 
+  it("passes Hive's Claude OAuth token to the naming command", async () => {
+    const previousToken = process.env.CLAUDE_CODE_OAUTH_TOKEN;
+    process.env.CLAUDE_CODE_OAUTH_TOKEN = "synthetic-oauth-token";
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+
+    try {
+      queueMicrotask(() => {
+        proc._stdout.emit("data", Buffer.from("{}"));
+        proc.emit("close", 0);
+      });
+
+      await generateNames(baseContext("claude"));
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "claude",
+        expect.any(Array),
+        expect.objectContaining({
+          env: expect.objectContaining({
+            CLAUDE_CODE_OAUTH_TOKEN: "synthetic-oauth-token",
+          }),
+        }),
+      );
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAUDE_CODE_OAUTH_TOKEN;
+      } else {
+        process.env.CLAUDE_CODE_OAUTH_TOKEN = previousToken;
+      }
+    }
+  });
+
   it("accepts fenced JSON output", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/naming.ts
+++ b/backend/src/agents/naming.ts
@@ -1,5 +1,6 @@
 import { spawn } from "node:child_process";
 import { basename } from "node:path";
+import { getClaudeOAuthToken } from "../services/setup/auth/secrets.js";
 import { git } from "../utils/git.js";
 import { buildWorkspaceEnv, DEBUG_AGENT_LOGS } from "../utils/env.js";
 
@@ -110,6 +111,7 @@ function extractJson(text: string): NamingResult {
 export async function generateNames(ctx: NamingContext): Promise<NamingResult> {
   const command = ctx.command ?? "claude";
   const prompt = buildNamingPrompt(ctx.userMessage);
+  const oauthToken = getClaudeOAuthToken();
 
   return new Promise<NamingResult>((resolve) => {
     const args = [
@@ -125,7 +127,9 @@ export async function generateNames(ctx: NamingContext): Promise<NamingResult> {
     const proc = spawn(command, args, {
       cwd: ctx.cwd,
       stdio: ["pipe", "pipe", "pipe"],
-      env: buildWorkspaceEnv(),
+      env: buildWorkspaceEnv(
+        oauthToken ? { CLAUDE_CODE_OAUTH_TOKEN: oauthToken } : undefined,
+      ),
     });
 
     proc.stdin?.end();


### PR DESCRIPTION
## Summary

- pass Hive-managed Claude OAuth credentials to the Haiku naming subprocess
- preserve workspace environment isolation while explicitly re-injecting the provisioned token
- add regression coverage for the naming subprocess environment

## Root cause

The onboarding flow stores the Claude token in `CLAUDE_CODE_OAUTH_TOKEN`. `buildWorkspaceEnv()` intentionally strips all `CLAUDE_CODE_*` variables, and normal Claude conversations re-inject the managed token through the provider. The standalone Haiku naming subprocess did not, so it ran unauthenticated and returned no branch or session names.

## Validation

- `cd backend && npm test -- --run src/agents/naming.test.ts`
- `cd backend && npm run lint`
- `cd backend && npm run typecheck`
- `git diff --check`