### PR TITLE
chore(release): prepare 0.1.0-beta.5

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1566,7 +1566,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.0-beta.4"
+version = "0.1.0-beta.5"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the Hive Cargo version to `0.1.0-beta.5`
- keep `Cargo.toml` and `Cargo.lock` aligned

## Validation

- `npm run release:version:check -- 0.1.0-beta.5`
- `npm run lint`
- `npm run typecheck`
- `npm run test:release`