### PR TITLE
fix: compare updater against Cargo version

### DIFF
--- a/.github/workflows/updater-smoke.yml
+++ b/.github/workflows/updater-smoke.yml
@@ -111,6 +111,7 @@ jobs:
           test -s "$APPLE_API_KEY_PATH"
 
           rustup target add aarch64-apple-darwin
+          node ../scripts/release/release-version.mjs set 0.0.0
           macos_build="$(git rev-list --count HEAD)"
           smoke_config="$(jq -cn \
             --arg endpoint "$UPDATE_ENDPOINT" \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -150,11 +150,11 @@ After publishing a beta, run the `updater smoke test` workflow from `main`, ente
 and approve the `release` environment. It uploads a signed and notarized test DMG as an Actions
 artifact retained for seven days; it does not create or modify a GitHub release.
 
-Install that DMG on a test Mac. Its embedded version is `0.0.0` and its updater points directly to
-the selected release, including a prerelease. Open Hive, accept the update notification, and confirm
-that the app downloads the update, restarts successfully, and does not offer the same update again.
-On a separate pass, dismiss the notification and confirm that release stays dismissed after an app
-restart; a newer release should still be offered.
+Install that DMG on a test Mac. The workflow sets its Cargo and macOS bundle versions to `0.0.0` and
+points its updater directly to the selected release, including a prerelease. Open Hive, accept the
+update notification, and confirm that the app downloads the update, restarts successfully, and does
+not offer the same update again. On a separate pass, dismiss the notification and confirm that
+release stays dismissed after an app restart; a newer release should still be offered.
 
 Creating the draft also creates its tag. If a draft is wrong, correct the code through another pull
 request and use a new prerelease version. If a published release is wrong, document the issue and

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,7 @@ GitHub marks versions containing a prerelease suffix as prereleases. They do not
 
 Cargo is the canonical source of the full release version. Private npm workspace versions are not
 product versions. The macOS bundle uses the numeric core version required by Apple while the app's
-embedded provisioning code retains the full Cargo version.
+embedded provisioning and updater comparison retain the full Cargo version.
 
 ## One-time GitHub and Apple setup
 

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1570,6 +1570,7 @@ version = "0.1.0-beta.5"
 dependencies = [
  "dirs",
  "log",
+ "semver",
  "serde",
  "serde_json",
  "tauri",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -27,6 +27,7 @@ dirs = "6"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
+semver = "1"
 tauri = { version = "2.10.0", features = [] }
 tauri-plugin-log = "2"
 tauri-plugin-opener = "2.5.3"

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -5,6 +5,13 @@ use std::path::Path;
 use std::process::Command;
 use tauri::Manager;
 
+#[cfg(desktop)]
+fn update_is_newer_than(current_version: &str, update_version: &semver::Version) -> bool {
+    let current_version = semver::Version::parse(current_version)
+        .expect("Cargo package version must be valid SemVer");
+    update_version > &current_version
+}
+
 #[derive(Serialize)]
 pub struct TerminalApp {
     id: String,
@@ -69,8 +76,14 @@ pub fn run() {
             app.manage(provision::ProvisionState::default());
             // The updater ships installers, which only exist on desktop.
             #[cfg(desktop)]
-            app.handle()
-                .plugin(tauri_plugin_updater::Builder::new().build())?;
+            app.handle().plugin(
+                tauri_plugin_updater::Builder::new()
+                    .default_version_comparator(|_, update| {
+                        // The macOS bundle uses a numeric version; Cargo keeps the full SemVer.
+                        update_is_newer_than(env!("CARGO_PKG_VERSION"), &update.version)
+                    })
+                    .build(),
+            )?;
             if cfg!(debug_assertions) {
                 app.handle().plugin(
                     tauri_plugin_log::Builder::default()
@@ -82,4 +95,23 @@ pub fn run() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(all(test, desktop))]
+mod tests {
+    use super::update_is_newer_than;
+    use semver::Version;
+
+    #[test]
+    fn compares_updates_against_the_cargo_prerelease_version() {
+        let stable = Version::parse("0.1.0").unwrap();
+        let newer_prerelease = Version::parse("0.1.0-beta.6").unwrap();
+        let current_prerelease = Version::parse("0.1.0-beta.5").unwrap();
+        let older_prerelease = Version::parse("0.1.0-beta.4").unwrap();
+
+        assert!(update_is_newer_than("0.1.0-beta.5", &stable));
+        assert!(update_is_newer_than("0.1.0-beta.5", &newer_prerelease));
+        assert!(!update_is_newer_than("0.1.0-beta.5", &current_prerelease));
+        assert!(!update_is_newer_than("0.1.0-beta.5", &older_prerelease));
+    }
 }

--- a/test/release/release-workflow.test.mjs
+++ b/test/release/release-workflow.test.mjs
@@ -79,9 +79,17 @@ test("updater smoke test is manual, main-only, and cannot publish", () => {
 });
 
 test("updater smoke test builds a protected disposable baseline", () => {
+  const cargoVersionOverride = updaterSmokeWorkflow.indexOf(
+    "node ../scripts/release/release-version.mjs set 0.0.0",
+  );
+  const tauriBuild = updaterSmokeWorkflow.indexOf("npm run tauri build");
+
   assert.match(updaterSmokeWorkflow, /environment:\s*\n\s+name: release/);
   assert.match(updaterSmokeWorkflow, /version: "0\.0\.0"/);
   assert.match(updaterSmokeWorkflow, /createUpdaterArtifacts: false/);
   assert.match(updaterSmokeWorkflow, /releases\/download\/v\$TARGET_VERSION\/latest\.json/);
   assert.doesNotMatch(updaterSmokeWorkflow, /TAURI_SIGNING_PRIVATE_KEY/);
+  assert.notEqual(cargoVersionOverride, -1);
+  assert.notEqual(tauriBuild, -1);
+  assert.ok(cargoVersionOverride < tauriBuild);
 });


### PR DESCRIPTION
## Summary

- compare updater manifests against the full Cargo SemVer instead of the numeric macOS bundle version
- preserve correct prerelease-to-stable ordering
- document the distinct macOS bundle and updater versions

## Validation

- `cargo fmt --manifest-path frontend/src-tauri/Cargo.toml -- --check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:release`

The GitHub `desktop` job provides the GTK dependencies required for the Rust test suite.