### PR TITLE
feat: expose backend version and add Updates settings page

### DIFF
--- a/backend/src/api/server.test.ts
+++ b/backend/src/api/server.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import Fastify, { type FastifyInstance } from "fastify";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { pathToFileURL } from "node:url";
+import { serverRoutes, readBackendVersion } from "./server.js";
+
+let app: ReturnType<typeof Fastify>;
+
+beforeEach(async () => {
+  app = Fastify();
+  await app.register((instance: FastifyInstance) => serverRoutes(instance));
+  await app.ready();
+});
+
+afterEach(async () => {
+  await app.close();
+});
+
+describe("GET /api/server/version", () => {
+  it("reports dev when running from a source checkout", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/server/version" });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual({ version: "dev" });
+  });
+});
+
+describe("readBackendVersion", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(join(tmpdir(), "hive-server-version-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("returns the trimmed VERSION file contents", async () => {
+    const file = join(tempDir, "VERSION");
+    await writeFile(file, "0.1.0-beta.6\n");
+
+    expect(await readBackendVersion(pathToFileURL(file))).toBe("0.1.0-beta.6");
+  });
+
+  it("falls back to dev when the file is missing or empty", async () => {
+    expect(await readBackendVersion(pathToFileURL(join(tempDir, "VERSION")))).toBe("dev");
+
+    const empty = join(tempDir, "VERSION");
+    await writeFile(empty, "\n");
+    expect(await readBackendVersion(pathToFileURL(empty))).toBe("dev");
+  });
+});

--- a/backend/src/api/server.ts
+++ b/backend/src/api/server.ts
@@ -1,0 +1,23 @@
+import { readFile } from "node:fs/promises";
+import type { FastifyInstance } from "fastify";
+
+/**
+ * The release tarball carries a VERSION file at its root, written by
+ * scripts/release/build-backend-tarball.sh next to dist/. A source checkout
+ * has no such file and reports "dev".
+ */
+export async function readBackendVersion(
+  versionFile: URL = new URL("../../VERSION", import.meta.url),
+): Promise<string> {
+  try {
+    return (await readFile(versionFile, "utf8")).trim() || "dev";
+  } catch {
+    return "dev";
+  }
+}
+
+export async function serverRoutes(app: FastifyInstance): Promise<void> {
+  app.get("/api/server/version", async () => ({
+    version: await readBackendVersion(),
+  }));
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,7 @@ import { ensureDataDir, getDataDir, loadAllProjects, saveProject } from "./state
 import { type SessionOptions, rebuildNotifier, stopAllSessions } from "./agents/agent-manager.js";
 import { GitSyncService } from "./services/git-sync.js";
 import { settingsRoutes } from "./api/settings.js";
+import { serverRoutes } from "./api/server.js";
 import { setupRoutes } from "./api/setup.js";
 import { providerUsageRoutes } from "./api/provider-usage.js";
 import { stopProviderUsagePolling } from "./services/provider-usage.js";
@@ -373,6 +374,7 @@ export async function buildApp(opts: BuildAppOptions = {}) {
     }),
   );
   await app.register((instance: FastifyInstance) => settingsRoutes(instance));
+  await app.register((instance: FastifyInstance) => serverRoutes(instance));
   await app.register((instance: FastifyInstance) => setupRoutes(instance));
   await app.register((instance: FastifyInstance) => providerUsageRoutes(instance));
   await app.register((instance: FastifyInstance) => accountRoutes(instance));

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,6 +74,7 @@ Public backend surface exposed by route modules under `backend/src/api/`.
 | Team agents | `GET/POST /api/agents`, `PATCH/DELETE /api/agents/:id` |
 | Prompts | `GET/POST /api/prompt-templates`, `PUT/DELETE /api/prompt-templates/:id`, `GET/PUT/DELETE /api/prompts/base`, `GET/PUT/DELETE /api/prompts/brain`, `GET/PUT/DELETE /api/prompts/issue-draft` |
 | Settings | `GET/PUT /api/settings/defaults`, `GET/PUT /api/settings/notifications`, `POST /api/settings/notifications/test`, `GET/PUT/DELETE /api/settings/instructions`, `POST /api/settings/instructions/sync`, `GET/POST /api/settings/skills`, `GET/PUT/DELETE /api/settings/skills/:id`, `POST /api/settings/skills/:id/sync`, `POST /api/settings/skills/sync-missing`, `GET/POST /api/settings/subagents`, `GET /api/settings/subagents/:id`, `PUT/DELETE /api/settings/subagents/:id/providers/:provider`, `POST /api/settings/subagents/:id/providers/:provider/counterpart` |
+| Server | `GET /api/server/version` |
 | Account | `GET /api/account/status`, `POST /api/account/disconnect` |
 | Tool setup | `GET /api/setup/tools`, `GET /api/setup/status`, `POST /api/setup/tools/:tool/:kind` (`kind` = `install` \| `update`) |
 | Tool sign-in | `POST /api/setup/auth/:tool/start` (`tool` = `claude` \| `codex` \| `gh`), `POST /api/setup/auth/:tool/code`, `POST /api/setup/auth/:tool/cancel` |

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -18,6 +18,13 @@ pub struct TerminalApp {
     name: String,
 }
 
+/// The full Cargo SemVer. The macOS bundle version is numeric-only, so the
+/// JS-side `getVersion()` drops prerelease suffixes and cannot be used.
+#[tauri::command]
+fn app_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
 #[tauri::command]
 fn detect_terminals() -> Vec<TerminalApp> {
     let mut terminals = vec![TerminalApp {
@@ -64,6 +71,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .invoke_handler(tauri::generate_handler![
+            app_version,
             detect_terminals,
             open_terminal_ssh,
             provision::provision_list_keys,

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,6 +33,7 @@ const PromptTemplatesSettings = lazy(() => import("@/pages/settings/PromptTempla
 const SkillsSettings = lazy(() => import("@/pages/settings/SkillsSettings"));
 const InstructionsSettings = lazy(() => import("@/pages/settings/InstructionsSettings"));
 const SubagentsSettings = lazy(() => import("@/pages/settings/SubagentsSettings"));
+const UpdatesSettings = lazy(() => import("@/pages/settings/UpdatesSettings"));
 const CreateAutomationDialog = lazy(() => import("@/components/CreateAutomationDialog"));
 const Installer = lazy(() => import("@/pages/installer/Installer"));
 
@@ -204,6 +205,7 @@ function ConfiguredApp({
                 />
               )}
               <Route path="settings/notifications" element={<NotificationSettings />} />
+              <Route path="settings/updates" element={<UpdatesSettings />} />
               <Route path="settings/cli" element={<AgentSettings />} />
               <Route path="settings/models" element={<ModelsSettings />} />
               <Route path="settings/instructions" element={<InstructionsSettings />} />

--- a/frontend/src/components/SettingsSidebar.tsx
+++ b/frontend/src/components/SettingsSidebar.tsx
@@ -7,6 +7,7 @@ import {
   ChevronRight,
   CircleUser,
   Cpu,
+  Download,
   FileCode2,
   FileText,
   Folder,
@@ -98,6 +99,12 @@ export default function SettingsSidebar() {
               label="Notifications"
               icon={<Bell className="h-4 w-4" />}
               active={pathname === "/settings/notifications"}
+            />
+            <NavItem
+              to="/settings/updates"
+              label="Updates"
+              icon={<Download className="h-4 w-4" />}
+              active={pathname === "/settings/updates"}
             />
           </SidebarSection>
 

--- a/frontend/src/hooks/useDesktopUpdate.tsx
+++ b/frontend/src/hooks/useDesktopUpdate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import { isDesktopShell } from "@/lib/is-desktop";
 import { TOAST_DURATIONS } from "@/lib/toast-config";
@@ -19,6 +19,47 @@ const CHECK_INTERVAL_MS = 4 * 60 * 60 * 1000;
  */
 export function shouldCheckForUpdates(): boolean {
   return isDesktopShell() && import.meta.env.PROD;
+}
+
+/**
+ * One state machine shared by two surfaces: the sticky toast (passive channel,
+ * mounted app-wide) and the Updates settings page (active channel). Both render
+ * the same flow, so an install started from either is visible on both.
+ */
+export type DesktopUpdateState =
+  | { phase: "idle" }
+  | { phase: "checking" }
+  | { phase: "upToDate" }
+  | { phase: "checkFailed"; error: string }
+  | { phase: "available"; version: string }
+  | { phase: "downloading"; version: string; percent: number | null }
+  | { phase: "installing"; version: string }
+  | { phase: "failed"; version: string; error: string };
+
+let state: DesktopUpdateState = { phase: "idle" };
+const listeners = new Set<() => void>();
+let currentUpdate: Update | null = null;
+let watcherActive = false;
+
+function setState(next: DesktopUpdateState): void {
+  state = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useDesktopUpdateState(): DesktopUpdateState {
+  return useSyncExternalStore(subscribe, () => state);
+}
+
+/** Test-only: the module store outlives each test's mount. */
+export function resetDesktopUpdateForTests(): void {
+  state = { phase: "idle" };
+  currentUpdate = null;
+  watcherActive = false;
 }
 
 function showUpdateToast(args: {
@@ -53,128 +94,163 @@ function showUpdateToast(args: {
   );
 }
 
+/** Re-renders the sticky toast in place; no action while it runs. */
+function showProgressToast(description: string): void {
+  showUpdateToast({
+    variant: "success",
+    status: "UPDATE",
+    description,
+    duration: TOAST_DURATIONS.actionRequired,
+  });
+}
+
 function describeError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   return message.length > 120 ? `${message.slice(0, 117)}…` : message;
 }
 
+/** Read `state` fresh: async flows re-check it after every await. */
+function installInProgress(): boolean {
+  return state.phase === "downloading" || state.phase === "installing";
+}
+
+function releaseUpdate(update: Update): void {
+  if (currentUpdate === update) currentUpdate = null;
+  void update.close().catch((error) => console.warn("Failed to release update:", error));
+}
+
+async function install(update: Update): Promise<void> {
+  if (installInProgress()) return;
+  setState({ phase: "downloading", version: update.version, percent: null });
+  showProgressToast("Downloading update…");
+
+  try {
+    let contentLength = 0;
+    let downloaded = 0;
+    let lastPercent = -1;
+    await update.downloadAndInstall((event) => {
+      if (event.event === "Started") {
+        contentLength = event.data.contentLength ?? 0;
+      } else if (event.event === "Progress") {
+        downloaded += event.data.chunkLength;
+        if (contentLength <= 0) return;
+        const percent = Math.min(100, Math.round((downloaded / contentLength) * 100));
+        if (percent === lastPercent) return;
+        lastPercent = percent;
+        setState({ phase: "downloading", version: update.version, percent });
+        showProgressToast(`Downloading update… ${percent}%`);
+      } else if (event.event === "Finished") {
+        setState({ phase: "installing", version: update.version });
+        showProgressToast("Installing update…");
+      }
+    });
+
+    const { relaunch } = await import("@tauri-apps/plugin-process");
+    await relaunch();
+  } catch (error) {
+    console.warn("Failed to install update:", error);
+    setState({ phase: "failed", version: update.version, error: describeError(error) });
+    showUpdateToast({
+      variant: "error",
+      status: "FAILED",
+      description: `Update failed: ${describeError(error)}`,
+      actionLabel: "Retry",
+      duration: TOAST_DURATIONS.error,
+      onAction: () => void install(update),
+    });
+  }
+}
+
+/**
+ * A manual check answers on the Updates page instead of toasting, and ignores
+ * the dismissed version: it exists precisely to recover a dismissed update.
+ */
+async function runCheck(opts: { manual: boolean }): Promise<void> {
+  if (state.phase === "checking" || installInProgress()) return;
+  setState({ phase: "checking" });
+
+  try {
+    const { check } = await import("@tauri-apps/plugin-updater");
+    const update = await check();
+    // An install may have started from a live toast while the check was in
+    // flight; it owns the state and its handle must not be closed under it.
+    if (installInProgress()) {
+      if (update) releaseUpdate(update);
+      return;
+    }
+    if (!update) {
+      if (currentUpdate) releaseUpdate(currentUpdate);
+      setState(opts.manual ? { phase: "upToDate" } : { phase: "idle" });
+      return;
+    }
+    if (!opts.manual && !watcherActive) {
+      releaseUpdate(update);
+      setState({ phase: "idle" });
+      return;
+    }
+    if (currentUpdate && currentUpdate !== update) releaseUpdate(currentUpdate);
+    currentUpdate = update;
+    setState({ phase: "available", version: update.version });
+
+    if (opts.manual) return;
+    const dismissed = window.localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY);
+    if (dismissed === update.version) return;
+    showUpdateToast({
+      variant: "success",
+      status: "UPDATE",
+      description: `Version ${update.version} is available`,
+      actionLabel: "Restart & update",
+      duration: TOAST_DURATIONS.actionRequired,
+      onAction: () => void install(update),
+      // Closing it answers "not this version": the toast stays away until a
+      // later release, but the Updates page still offers the install.
+      onDismiss: () => {
+        window.localStorage.setItem(DISMISSED_UPDATE_VERSION_KEY, update.version);
+      },
+    });
+  } catch (error) {
+    console.warn("Update check failed:", error);
+    if (installInProgress()) return;
+    if (currentUpdate) {
+      // A failed check (offline is normal) must not retract an offered update.
+      setState({ phase: "available", version: currentUpdate.version });
+      return;
+    }
+    setState(opts.manual ? { phase: "checkFailed", error: describeError(error) } : { phase: "idle" });
+  }
+}
+
+export function checkForUpdatesNow(): void {
+  if (!shouldCheckForUpdates()) return;
+  void runCheck({ manual: true });
+}
+
+export function installCurrentUpdate(): void {
+  if (currentUpdate) void install(currentUpdate);
+}
+
 /**
  * Watches for desktop releases and offers the install as a sticky toast.
  *
- * The toast is the only surface: a failed background check is the normal state
- * of an offline app, so it never reaches the user. Acting on the toast
- * downloads the installer in place, then relaunches into the new version.
+ * The toast is the only passive surface: a failed background check is the
+ * normal state of an offline app, so it never reaches the user. Acting on the
+ * toast downloads the installer in place, then relaunches into the new version.
  */
 export function useDesktopUpdate(): void {
-  const dismissedVersionRef = useRef<string | null>(null);
-  const checkingRef = useRef(false);
-  const installingRef = useRef(false);
-  const updateRef = useRef<Update | null>(null);
-
   useEffect(() => {
     if (!shouldCheckForUpdates()) return;
 
-    let active = true;
-    dismissedVersionRef.current = window.localStorage.getItem(DISMISSED_UPDATE_VERSION_KEY);
-
-    const releaseUpdate = (update: Update) => {
-      if (updateRef.current === update) updateRef.current = null;
-      void update.close().catch((error) => console.warn("Failed to release update:", error));
-    };
-
-    /** Re-renders the sticky toast in place; no action while it runs. */
-    const showProgress = (description: string) => {
-      showUpdateToast({
-        variant: "success",
-        status: "UPDATE",
-        description,
-        duration: TOAST_DURATIONS.actionRequired,
-      });
-    };
-
-    const install = async (update: Update) => {
-      if (installingRef.current) return;
-      installingRef.current = true;
-      showProgress("Downloading update…");
-
-      try {
-        let contentLength = 0;
-        let downloaded = 0;
-        let lastPercent = -1;
-        await update.downloadAndInstall((event) => {
-          if (event.event === "Started") {
-            contentLength = event.data.contentLength ?? 0;
-          } else if (event.event === "Progress") {
-            downloaded += event.data.chunkLength;
-            if (contentLength <= 0) return;
-            const percent = Math.min(100, Math.round((downloaded / contentLength) * 100));
-            if (percent === lastPercent) return;
-            lastPercent = percent;
-            showProgress(`Downloading update… ${percent}%`);
-          } else if (event.event === "Finished") {
-            showProgress("Installing update…");
-          }
-        });
-
-        const { relaunch } = await import("@tauri-apps/plugin-process");
-        await relaunch();
-      } catch (error) {
-        console.warn("Failed to install update:", error);
-        installingRef.current = false;
-        showUpdateToast({
-          variant: "error",
-          status: "FAILED",
-          description: `Update failed: ${describeError(error)}`,
-          actionLabel: "Retry",
-          duration: TOAST_DURATIONS.error,
-          onAction: () => void install(update),
-        });
-      }
-    };
-
-    const runCheck = async () => {
-      // An install in flight owns the toast; a new check must not steal it.
-      if (checkingRef.current || installingRef.current) return;
-      checkingRef.current = true;
-
-      try {
-        const { check } = await import("@tauri-apps/plugin-updater");
-        const update = await check();
-        if (!update) return;
-        if (!active || dismissedVersionRef.current === update.version) {
-          releaseUpdate(update);
-          return;
-        }
-        if (updateRef.current) releaseUpdate(updateRef.current);
-        updateRef.current = update;
-        showUpdateToast({
-          variant: "success",
-          status: "UPDATE",
-          description: `Version ${update.version} is available`,
-          actionLabel: "Restart & update",
-          duration: TOAST_DURATIONS.actionRequired,
-          onAction: () => void install(update),
-          // Closing it answers "not this version"; a later release asks again.
-          onDismiss: () => {
-            dismissedVersionRef.current = update.version;
-            window.localStorage.setItem(DISMISSED_UPDATE_VERSION_KEY, update.version);
-            releaseUpdate(update);
-          },
-        });
-      } catch (error) {
-        console.warn("Update check failed:", error);
-      } finally {
-        checkingRef.current = false;
-      }
-    };
-
-    void runCheck();
-    const timer = window.setInterval(() => void runCheck(), CHECK_INTERVAL_MS);
+    watcherActive = true;
+    void runCheck({ manual: false });
+    const timer = window.setInterval(() => void runCheck({ manual: false }), CHECK_INTERVAL_MS);
 
     return () => {
-      active = false;
+      watcherActive = false;
       window.clearInterval(timer);
-      if (updateRef.current && !installingRef.current) releaseUpdate(updateRef.current);
+      if (currentUpdate && !installInProgress()) {
+        releaseUpdate(currentUpdate);
+        setState({ phase: "idle" });
+      }
     };
   }, []);
 }

--- a/frontend/src/pages/settings/UpdatesSettings.tsx
+++ b/frontend/src/pages/settings/UpdatesSettings.tsx
@@ -1,0 +1,199 @@
+import { useEffect, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, Copy, Loader2, RefreshCw } from "lucide-react";
+import { SettingsHeader } from "@/components/AppLayout";
+import { CenterCard } from "@/components/CenterCard";
+import { Button } from "@/components/ui/button";
+import { api } from "@/hooks/useApi";
+import { isDesktopShell } from "@/lib/is-desktop";
+import { copyToClipboard } from "@/lib/clipboard";
+import {
+  checkForUpdatesNow,
+  installCurrentUpdate,
+  shouldCheckForUpdates,
+  useDesktopUpdateState,
+  type DesktopUpdateState,
+} from "@/hooks/useDesktopUpdate";
+
+/**
+ * The desktop build's own version; the web app has none of its own. Asked from
+ * Rust because the JS-side `getVersion()` reports the numeric macOS bundle
+ * version, which drops prerelease suffixes like `-beta.5`.
+ */
+function useAppVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isDesktopShell()) return;
+    let active = true;
+    void import("@tauri-apps/api/core")
+      .then(({ invoke }) => invoke<string>("app_version"))
+      .then((v) => {
+        if (active) setVersion(v);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+  return version;
+}
+
+export default function UpdatesSettings() {
+  const appVersion = useAppVersion();
+  const backendQuery = useQuery({
+    queryKey: ["server", "version"],
+    queryFn: () => api.get<{ version: string }>("/api/server/version"),
+  });
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-hidden">
+      <SettingsHeader>
+        <h1 className="text-sm font-medium">Updates</h1>
+      </SettingsHeader>
+
+      <CenterCard scroll>
+        <div className="max-w-2xl space-y-6 px-4 py-5">
+          {isDesktopShell() && <AppSection appVersion={appVersion} />}
+          <ServerSection
+            appVersion={appVersion}
+            backendVersion={backendQuery.data?.version ?? null}
+            unreachable={backendQuery.isError}
+          />
+        </div>
+      </CenterCard>
+    </div>
+  );
+}
+
+function AppSection({ appVersion }: { appVersion: string | null }) {
+  const update = useDesktopUpdateState();
+  const busy =
+    update.phase === "checking" || update.phase === "downloading" || update.phase === "installing";
+
+  return (
+    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-sm font-medium text-foreground">Application</h2>
+          <p className="mt-1 text-xs text-muted-foreground">Version {appVersion ?? "—"}</p>
+        </div>
+        {shouldCheckForUpdates() && (
+          <Button size="sm" variant="outline" onClick={checkForUpdatesNow} disabled={busy}>
+            {update.phase === "checking" ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            Check for updates
+          </Button>
+        )}
+      </div>
+      {shouldCheckForUpdates() ? (
+        <UpdateStatus update={update} />
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Update checks run in installed builds only.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function UpdateStatus({ update }: { update: DesktopUpdateState }) {
+  switch (update.phase) {
+    case "upToDate":
+      return <p className="mt-2 text-xs text-muted-foreground">You're on the latest version.</p>;
+    case "checkFailed":
+      return (
+        <p className="mt-2 text-xs text-destructive">Update check failed: {update.error}</p>
+      );
+    case "available":
+      return (
+        <div className="mt-3 flex items-center justify-between gap-3 rounded-md border border-border/50 bg-muted/40 px-3 py-2">
+          <p className="text-xs text-foreground">Version {update.version} is available.</p>
+          <Button size="sm" onClick={installCurrentUpdate}>
+            Restart & update
+          </Button>
+        </div>
+      );
+    case "downloading":
+      return (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Downloading {update.version}…{update.percent !== null ? ` ${update.percent}%` : ""}
+        </p>
+      );
+    case "installing":
+      return <p className="mt-2 text-xs text-muted-foreground">Installing {update.version}…</p>;
+    case "failed":
+      return (
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <p className="text-xs text-destructive">Update failed: {update.error}</p>
+          <Button size="sm" variant="outline" onClick={installCurrentUpdate}>
+            Retry
+          </Button>
+        </div>
+      );
+    default:
+      return null;
+  }
+}
+
+function ServerSection({
+  appVersion,
+  backendVersion,
+  unreachable,
+}: {
+  appVersion: string | null;
+  backendVersion: string | null;
+  unreachable: boolean;
+}) {
+  // The desktop version is the reference: releases version both artifacts
+  // together, so a differing backend is one an operator has not updated yet.
+  const outdated =
+    appVersion !== null &&
+    backendVersion !== null &&
+    backendVersion !== "dev" &&
+    backendVersion !== appVersion;
+
+  return (
+    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
+      <h2 className="text-sm font-medium text-foreground">Server</h2>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Version {unreachable ? "unavailable" : (backendVersion ?? "—")}
+      </p>
+      {outdated && (
+        <>
+          <p className="mt-2 text-xs text-muted-foreground">
+            The server is not on the app's version. Update it from a server shell:
+          </p>
+          <UpdateCommand version={appVersion} />
+        </>
+      )}
+    </section>
+  );
+}
+
+function UpdateCommand({ version }: { version: string }) {
+  const [copied, setCopied] = useState(false);
+  const command = `curl -fsSL https://github.com/unfence-labs/hive/releases/download/v${version}/provision.sh | sudo bash -s -- --update`;
+
+  return (
+    <div className="mt-2 flex items-center gap-2">
+      <code className="min-w-0 flex-1 truncate rounded bg-muted px-2 py-1.5 font-mono text-[11px] text-muted-foreground">
+        {command}
+      </code>
+      <Button
+        size="sm"
+        variant="ghost"
+        aria-label="Copy update command"
+        onClick={() => {
+          void copyToClipboard(command);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 2000);
+        }}
+      >
+        {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+      </Button>
+    </div>
+  );
+}

--- a/frontend/tests/hooks/useDesktopUpdate.test.tsx
+++ b/frontend/tests/hooks/useDesktopUpdate.test.tsx
@@ -1,7 +1,13 @@
 import { act, renderHook } from "@testing-library/react";
 import type { ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useDesktopUpdate } from "@/hooks/useDesktopUpdate";
+import {
+  checkForUpdatesNow,
+  installCurrentUpdate,
+  resetDesktopUpdateForTests,
+  useDesktopUpdate,
+  useDesktopUpdateState,
+} from "@/hooks/useDesktopUpdate";
 import type { HiveToastProps } from "@/components/ui/toaster";
 
 type CustomRender = (id: string | number) => ReactElement<HiveToastProps>;
@@ -76,6 +82,7 @@ describe("useDesktopUpdate", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     localStorage.clear();
+    resetDesktopUpdateForTests();
     setDesktopShell(true);
     // The hook only checks release builds; vitest runs in dev mode.
     vi.stubEnv("PROD", true);
@@ -194,7 +201,8 @@ describe("useDesktopUpdate", () => {
 
     act(() => lastToast().props.onClose());
     expect(mocks.dismiss).toHaveBeenCalledWith("hive-app-update");
-    expect(dismissedUpdate.close).toHaveBeenCalledTimes(1);
+    // The handle stays open: the Updates page can still install a dismissed version.
+    expect(dismissedUpdate.close).not.toHaveBeenCalled();
     mocks.custom.mockClear();
 
     await act(async () => {
@@ -210,6 +218,7 @@ describe("useDesktopUpdate", () => {
     });
     await settle();
     expect(lastToast().props.description).toBe("Version 1.3.0 is available");
+    expect(dismissedUpdate.close).toHaveBeenCalledTimes(1);
   });
 
   it("remembers a dismissed version after remounting", async () => {
@@ -226,7 +235,8 @@ describe("useDesktopUpdate", () => {
     await renderUpdateHook();
 
     expect(mocks.custom).not.toHaveBeenCalled();
-    expect(repeatedUpdate.close).toHaveBeenCalledTimes(1);
+    // Kept open so the Updates page can still offer the dismissed install.
+    expect(repeatedUpdate.close).not.toHaveBeenCalled();
   });
 
   it("releases the active update when the hook unmounts", async () => {
@@ -264,5 +274,150 @@ describe("useDesktopUpdate", () => {
     await settle();
 
     expect(mocks.check).toHaveBeenCalledTimes(1);
+  });
+
+  it("dismissing the toast keeps the update available to the Updates page", async () => {
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+    const { result } = renderHook(() => {
+      useDesktopUpdate();
+      return useDesktopUpdateState();
+    });
+    await settle();
+
+    act(() => lastToast().props.onClose());
+
+    expect(result.current).toEqual({ phase: "available", version: "1.2.3" });
+  });
+
+  it("does not clobber an install started while a check was in flight", async () => {
+    const installedUpdate = makeUpdate(
+      "1.2.3",
+      vi.fn(() => new Promise<void>(() => {})), // download never settles
+    );
+    mocks.check.mockResolvedValue(installedUpdate);
+    const { result } = renderHook(() => {
+      useDesktopUpdate();
+      return useDesktopUpdateState();
+    });
+    await settle();
+
+    let resolveCheck: (update: unknown) => void = () => {};
+    mocks.check.mockReturnValue(new Promise((resolve) => (resolveCheck = resolve)));
+    await act(async () => {
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+    });
+    act(() => lastToast().props.onAction?.());
+    await settle();
+
+    const lateUpdate = makeUpdate("1.2.4");
+    act(() => resolveCheck(lateUpdate));
+    await settle();
+
+    expect(result.current).toEqual({ phase: "downloading", version: "1.2.3", percent: null });
+    expect(installedUpdate.close).not.toHaveBeenCalled();
+    expect(lateUpdate.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an offered update available when a later check fails", async () => {
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+    const { result } = renderHook(() => {
+      useDesktopUpdate();
+      return useDesktopUpdateState();
+    });
+    await settle();
+
+    mocks.check.mockRejectedValue(new Error("offline"));
+    await act(async () => {
+      vi.advanceTimersByTime(CHECK_INTERVAL_MS);
+    });
+    await settle();
+
+    expect(result.current).toEqual({ phase: "available", version: "1.2.3" });
+  });
+
+  it("reflects a toast-driven install in the shared state", async () => {
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+    const { result } = renderHook(() => {
+      useDesktopUpdate();
+      return useDesktopUpdateState();
+    });
+    await settle();
+
+    act(() => lastToast().props.onAction?.());
+    await settle();
+
+    expect(result.current).toEqual({ phase: "installing", version: "1.2.3" });
+  });
+});
+
+describe("manual checks from the Updates page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    resetDesktopUpdateForTests();
+    setDesktopShell(true);
+    vi.stubEnv("PROD", true);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    mocks.custom.mockImplementation((_render, options) => options?.id ?? "toast-custom");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    setDesktopShell(false);
+  });
+
+  it("surfaces a dismissed version without a toast", async () => {
+    localStorage.setItem("hive-dismissed-update-version", "1.2.3");
+    mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
+    const { result } = renderHook(() => useDesktopUpdateState());
+
+    act(() => checkForUpdatesNow());
+    await settle();
+
+    expect(result.current).toEqual({ phase: "available", version: "1.2.3" });
+    expect(mocks.custom).not.toHaveBeenCalled();
+  });
+
+  it("reports up to date when there is no update", async () => {
+    mocks.check.mockResolvedValue(null);
+    const { result } = renderHook(() => useDesktopUpdateState());
+
+    act(() => checkForUpdatesNow());
+    await settle();
+
+    expect(result.current).toEqual({ phase: "upToDate" });
+  });
+
+  it("reports a failed check", async () => {
+    mocks.check.mockRejectedValue(new Error("no latest.json"));
+    const { result } = renderHook(() => useDesktopUpdateState());
+
+    act(() => checkForUpdatesNow());
+    await settle();
+
+    expect(result.current).toEqual({ phase: "checkFailed", error: "no latest.json" });
+  });
+
+  it("does not check outside installed desktop builds", async () => {
+    vi.stubEnv("PROD", false);
+
+    act(() => checkForUpdatesNow());
+    await settle();
+
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it("installs the update found by a manual check", async () => {
+    const update = makeUpdate("1.2.3");
+    mocks.check.mockResolvedValue(update);
+    renderHook(() => useDesktopUpdateState());
+
+    act(() => checkForUpdatesNow());
+    await settle();
+    act(() => installCurrentUpdate());
+    await settle();
+
+    expect(update.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(mocks.relaunch).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/tests/pages/UpdatesSettings.test.tsx
+++ b/frontend/tests/pages/UpdatesSettings.test.tsx
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import UpdatesSettings from "@/pages/settings/UpdatesSettings";
+import { resetDesktopUpdateForTests } from "@/hooks/useDesktopUpdate";
+import { createWrapper } from "../test-utils";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  invoke: vi.fn(),
+  check: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({ api: { get: mocks.get } }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("@tauri-apps/plugin-updater", () => ({ check: mocks.check }));
+
+function setDesktopShell(enabled: boolean) {
+  const globals = window as unknown as Record<string, unknown>;
+  if (enabled) globals.__TAURI_INTERNALS__ = {};
+  else delete globals.__TAURI_INTERNALS__;
+}
+
+function renderPage() {
+  const { wrapper: Wrapper } = createWrapper();
+  render(
+    <Wrapper>
+      <UpdatesSettings />
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetDesktopUpdateForTests();
+  mocks.get.mockResolvedValue({ version: "1.2.3" });
+  mocks.invoke.mockResolvedValue("1.2.3");
+  mocks.check.mockResolvedValue(null);
+});
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  setDesktopShell(false);
+});
+
+describe("UpdatesSettings", () => {
+  it("shows only the server version on the web", async () => {
+    renderPage();
+
+    expect(await screen.findByText("Version 1.2.3")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "Application" })).not.toBeInTheDocument();
+  });
+
+  it("reports an unreachable server", async () => {
+    mocks.get.mockRejectedValue(new Error("down"));
+    renderPage();
+
+    expect(await screen.findByText("Version unavailable")).toBeInTheDocument();
+  });
+
+  it("shows the app version on desktop without an update hint when versions match", async () => {
+    setDesktopShell(true);
+    renderPage();
+
+    expect(await screen.findByRole("heading", { name: "Application" })).toBeInTheDocument();
+    expect(await screen.findAllByText("Version 1.2.3")).toHaveLength(2);
+    expect(screen.queryByText(/provision\.sh/)).not.toBeInTheDocument();
+  });
+
+  it("offers the server update command when the backend lags the app", async () => {
+    setDesktopShell(true);
+    mocks.invoke.mockResolvedValue("1.3.0-beta.2");
+    renderPage();
+
+    expect(
+      await screen.findByText(/releases\/download\/v1\.3\.0-beta\.2\/provision\.sh/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Copy update command" })).toBeInTheDocument();
+  });
+
+  it("never suggests updating a dev backend", async () => {
+    setDesktopShell(true);
+    mocks.get.mockResolvedValue({ version: "dev" });
+    mocks.invoke.mockResolvedValue("1.3.0");
+    renderPage();
+
+    expect(await screen.findByText("Version dev")).toBeInTheDocument();
+    expect(screen.queryByText(/provision\.sh/)).not.toBeInTheDocument();
+  });
+
+  it("runs a manual check from the button and reports up to date", async () => {
+    setDesktopShell(true);
+    vi.stubEnv("PROD", true);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Check for updates" }));
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("You're on the latest version.")).toBeInTheDocument();
+  });
+});

--- a/scripts/release/build-backend-tarball.sh
+++ b/scripts/release/build-backend-tarball.sh
@@ -90,6 +90,9 @@ mkdir -p "$pkg"
 cp -R "$ROOT/backend/dist" "$pkg/dist"
 cp -R "$install_root/node_modules" "$pkg/node_modules"
 cp "$ROOT/LICENSE" "$pkg/"
+# The runtime reads this file to answer GET /api/server/version; a checkout
+# without it reports "dev".
+printf '%s\n' "$VERSION" >"$pkg/VERSION"
 
 # The manifest carries the release version and the build facts an installer
 # needs to reject a tarball its runtime cannot load.
@@ -136,6 +139,10 @@ mkdir -p "$unpacked"
 tar -xzf "$OUT_DIR/$NAME.tar.gz" -C "$unpacked"
 [ -f "$unpacked/dist/index.js" ] || { echo "archive has no dist/index.js" >&2; exit 1; }
 [ -f "$unpacked/LICENSE" ] || { echo "archive has no LICENSE" >&2; exit 1; }
+[ "$(cat "$unpacked/VERSION" 2>/dev/null)" = "$VERSION" ] || {
+  echo "archive VERSION mismatch: expected $VERSION" >&2
+  exit 1
+}
 artifact_version="$(node -p 'require(process.argv[1]).version' "$unpacked/package.json")"
 [ "$artifact_version" = "$VERSION" ] || {
   echo "archive version mismatch: expected $VERSION, got $artifact_version" >&2


### PR DESCRIPTION
## Summary

First iteration of the update-flow polish now that all the release bricks exist: make versions visible everywhere and give a dismissed desktop update a recovery path. No backend-update trigger from the app yet — that is a follow-up iteration.

### Backend
- The release tarball now carries a `VERSION` file at its root (written and verified by `build-backend-tarball.sh`); the provisioning-owned `.hive-version` is untouched.
- New authenticated route `GET /api/server/version` reads it, falling back to `"dev"` for source checkouts.

### Frontend
- `useDesktopUpdate` refactored from a toast-only effect hook into a module-level shared state machine (`idle / checking / upToDate / checkFailed / available / downloading / installing / failed`) consumed by both the sticky toast (passive channel) and the new **Settings > Updates** page (active channel). An install started on either surface is visible on both.
- New Updates page (web + desktop): server version everywhere; on desktop also the app version, a **Check for updates** button, and inline install with progress.
- A manual check bypasses the localStorage-dismissed version — the recovery path for a dismissed toast. Dismissing the toast now keeps the update handle open so the page can still install it; the handle is released when a newer release supersedes it or on unmount.
- When the server lags the app, the page shows a copyable `provision.sh --update` command pinned to the app's release tag.
- New `app_version` Tauri command exposing the full Cargo SemVer: the JS-side `getVersion()` reports the numeric macOS bundle version, which drops prerelease suffixes (same trap as #432) and would have produced false mismatches and 404 release URLs.
- Check/install races hardened: a check resolving after an install started no longer closes the handle under it or clobbers the state, and a failed background check no longer retracts an already-offered update.

## Testing

- `backend`: lint, typecheck, full suite (1922 tests) ✅
- `frontend`: lint, typecheck, full suite (1791 tests, incl. new page + race coverage) ✅
- `cargo check` unavailable on this Linux host (GTK dev libs missing); the Rust change is a one-line const command — CI's macOS build covers it.