### PR TITLE
chore(release): prepare 0.1.0-beta.6

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.0-beta.5"
+version = "0.1.0-beta.6"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Bumps the release version to 0.1.0-beta.6 (Cargo.toml + Cargo.lock via `npm run release:version -- set`).

Ships since 0.1.0-beta.5:
- #433 — backend version exposure (`GET /api/server/version`, `VERSION` file in the backend tarball) and the Settings > Updates page with manual check recovery for dismissed updates.
- #430 — consolidated Dependabot updates.
- #432 — updater comparison against the full Cargo version.

After merge: dispatch the release workflow from `main` to tag `v0.1.0-beta.6`, then update the server with the target release's `provision.sh --update`.