### PR TITLE
feat: one-button server update from the app

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,8 +109,10 @@ the generated uninstall script are all covered in **[Prerequisites](prerequisite
 
 ### Update the backend
 
-Wait for active agents, terminals, and automations to finish, then run the provisioner from the
-exact release you want:
+The desktop app offers this flow from Settings > Updates once the app itself is current: it runs
+the same update over SSH, warns when agents are still running, and asks for the escalation
+password only when the server requires one. To run it by hand instead, wait for active agents,
+terminals, and automations to finish, then run the provisioner from the exact release you want:
 
 ```bash
 curl -fsSL https://github.com/unfence-labs/hive/releases/download/v0.1.0-beta.2/provision.sh \

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -109,10 +109,11 @@ the generated uninstall script are all covered in **[Prerequisites](prerequisite
 
 ### Update the backend
 
-The desktop app offers this flow from Settings > Updates once the app itself is current: it runs
-the same update over SSH, warns when agents are still running, and asks for the escalation
-password only when the server requires one. To run it by hand instead, wait for active agents,
-terminals, and automations to finish, then run the provisioner from the exact release you want:
+The desktop app offers this flow from Settings > Updates: it converges the server to the app's
+version, whether that means an upgrade or a visible downgrade. It runs the update over SSH, warns
+when agents are still running, and asks for the escalation password only when the server requires
+one. To run it by hand instead, wait for active agents, terminals, and automations to finish, then
+run the provisioner from the exact release you want:
 
 ```bash
 curl -fsSL https://github.com/unfence-labs/hive/releases/download/v0.1.0-beta.2/provision.sh \

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
     "@testing-library/user-event": "^14.6.3",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react": "^6.0.5",
     "jsdom": "^30.0.1",
     "tailwindcss": "^4.1.18",
     "tw-animate-css": "^1.4.0",

--- a/frontend/src-tauri/src/provision.rs
+++ b/frontend/src-tauri/src/provision.rs
@@ -345,6 +345,10 @@ pub struct ProvisionOptions {
     /// Authorized on the hive service account, so an editor or terminal session
     /// connects as hive rather than as the install account.
     ssh_public_key: Option<String>,
+    /// Update an existing completed install to this build's version. The script
+    /// reads port and directories from the server's install manifest, and
+    /// rejects `--allowed-host` and `--ssh-public-key` in this mode.
+    update: bool,
 }
 
 impl ProvisionOptions {
@@ -374,6 +378,10 @@ impl ProvisionOptions {
         let mut args = Vec::new();
         if preflight {
             args.push("--preflight".to_string());
+        }
+        if self.update {
+            args.push("--update".into());
+            return Ok(args);
         }
         args.push("--allowed-host".into());
         args.push(allowed_host.to_string());
@@ -1654,6 +1662,7 @@ mod tests {
             install_dir: Some("/opt/hive".into()),
             data_dir: Some("/srv/hive".into()),
             ssh_public_key: Some(format!("ssh-ed25519 {ED25519_BLOB} lenny@box")),
+            update: false,
         };
         let command = remote_command(PrivilegeMode::Root, &args(&options, false));
         assert!(command.contains(&format!("'--ssh-public-key' 'ssh-ed25519 {ED25519_BLOB}'")));
@@ -1663,6 +1672,18 @@ mod tests {
 
         let preflight = args(&options, true);
         assert_eq!(preflight.first().map(String::as_str), Some("--preflight"));
+    }
+
+    #[test]
+    fn update_mode_sends_only_the_update_flag() {
+        // The script rejects --allowed-host and --ssh-public-key during an
+        // update, and reads everything else from the install manifest.
+        let options = ProvisionOptions {
+            update: true,
+            ..ProvisionOptions::default()
+        };
+        assert_eq!(args(&options, false), vec!["--update"]);
+        assert_eq!(args(&options, true), vec!["--preflight", "--update"]);
     }
 
     // ── dev release upload ───────────────────────────────────────────────────

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ import { useWsCacheInvalidation } from "@/hooks/useWsCacheInvalidation";
 import { useActiveSessionPrewarm } from "@/hooks/useActiveSessionPrewarm";
 import { useNotificationToasts } from "@/hooks/useNotificationToasts";
 import { useDesktopUpdate } from "@/hooks/useDesktopUpdate";
+import { ServerUpdatePrompt } from "@/components/ServerUpdatePrompt";
 import { wsTransport } from "@/lib/ws-transport";
 import { HiveToaster } from "@/components/ui/toaster";
 
@@ -148,6 +149,7 @@ function ConfiguredApp({
           }
         />
         <NotificationToastsBridge projects={projects} />
+        <ServerUpdatePrompt />
         <AddProjectDialog
           open={showAddProject}
           onOpenChange={setShowAddProject}

--- a/frontend/src/components/ServerUpdatePrompt.tsx
+++ b/frontend/src/components/ServerUpdatePrompt.tsx
@@ -1,0 +1,59 @@
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { HiveToast } from "@/components/ui/toaster";
+import { TOAST_DURATIONS } from "@/lib/toast-config";
+import { api } from "@/hooks/useApi";
+import { useAppVersion } from "@/hooks/useAppVersion";
+import { useConnection } from "@/hooks/useConnection";
+import { isDesktopShell } from "@/lib/is-desktop";
+import { markServerUpdatePrompted, shouldPromptServerUpdate } from "@/lib/server-update";
+
+const SERVER_UPDATE_TOAST_ID = "hive-server-update";
+
+/**
+ * Nudges once per launch when the server lags the app — the ordinary state
+ * right after a desktop auto-update, since the app must update first (its
+ * bundled provisioner installs its own version). The action only navigates:
+ * the update itself runs from Settings > Updates, which can host the dialogs
+ * the run may need.
+ */
+export function ServerUpdatePrompt() {
+  const navigate = useNavigate();
+  const { connection } = useConnection();
+  const appVersion = useAppVersion();
+  const enabled = isDesktopShell() && Boolean(connection);
+  const serverQuery = useQuery({
+    queryKey: ["server", "version"],
+    queryFn: () => api.get<{ version: string }>("/api/server/version"),
+    enabled,
+  });
+  const backendVersion = serverQuery.data?.version ?? null;
+
+  useEffect(() => {
+    if (!enabled || !appVersion || !backendVersion) return;
+    if (backendVersion === "dev" || backendVersion === appVersion) return;
+    if (!shouldPromptServerUpdate()) return;
+    markServerUpdatePrompted();
+    toast.custom(
+      (id) => (
+        <HiveToast
+          variant="success"
+          title="Hive"
+          status="SERVER"
+          description={`The server is on ${backendVersion}; the app is on ${appVersion}`}
+          actionLabel="Review"
+          onAction={() => {
+            toast.dismiss(id);
+            navigate("/settings/updates");
+          }}
+          onClose={() => toast.dismiss(id)}
+        />
+      ),
+      { id: SERVER_UPDATE_TOAST_ID, duration: TOAST_DURATIONS.actionRequired },
+    );
+  }, [enabled, appVersion, backendVersion, navigate]);
+
+  return null;
+}

--- a/frontend/src/components/ServerUpdatePrompt.tsx
+++ b/frontend/src/components/ServerUpdatePrompt.tsx
@@ -8,14 +8,18 @@ import { api } from "@/hooks/useApi";
 import { useAppVersion } from "@/hooks/useAppVersion";
 import { useConnection } from "@/hooks/useConnection";
 import { isDesktopShell } from "@/lib/is-desktop";
-import { markServerUpdatePrompted, shouldPromptServerUpdate } from "@/lib/server-update";
+import {
+  markServerUpdatePrompted,
+  serverVersionDiffersFromApp,
+  shouldPromptServerUpdate,
+} from "@/lib/server-update";
 
 const SERVER_UPDATE_TOAST_ID = "hive-server-update";
 
 /**
- * Nudges once per launch when the server lags the app — the ordinary state
- * right after a desktop auto-update, since the app must update first (its
- * bundled provisioner installs its own version). The action only navigates:
+ * Nudges once per launch when the server is not on the app's version — the
+ * ordinary state right after a desktop auto-update, since the app must update
+ * first (its bundled provisioner installs its own version). The action only navigates:
  * the update itself runs from Settings > Updates, which can host the dialogs
  * the run may need.
  */
@@ -32,8 +36,7 @@ export function ServerUpdatePrompt() {
   const backendVersion = serverQuery.data?.version ?? null;
 
   useEffect(() => {
-    if (!enabled || !appVersion || !backendVersion) return;
-    if (backendVersion === "dev" || backendVersion === appVersion) return;
+    if (!enabled || !serverVersionDiffersFromApp(appVersion, backendVersion)) return;
     if (!shouldPromptServerUpdate()) return;
     markServerUpdatePrompted();
     toast.custom(

--- a/frontend/src/hooks/useAppVersion.ts
+++ b/frontend/src/hooks/useAppVersion.ts
@@ -1,0 +1,25 @@
+import { useEffect, useState } from "react";
+import { isDesktopShell } from "@/lib/is-desktop";
+
+/**
+ * The desktop build's own version; the web app has none of its own. Asked from
+ * Rust because the JS-side `getVersion()` reports the numeric macOS bundle
+ * version, which drops prerelease suffixes like `-beta.5`.
+ */
+export function useAppVersion(): string | null {
+  const [version, setVersion] = useState<string | null>(null);
+  useEffect(() => {
+    if (!isDesktopShell()) return;
+    let active = true;
+    void import("@tauri-apps/api/core")
+      .then(({ invoke }) => invoke<string>("app_version"))
+      .then((v) => {
+        if (active) setVersion(v);
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, []);
+  return version;
+}

--- a/frontend/src/hooks/useConnection.ts
+++ b/frontend/src/hooks/useConnection.ts
@@ -24,6 +24,12 @@ export interface ServerConnection {
   sshUser?: string;
   /** Admin account used to log in over SSH and run the install. */
   adminUser?: string;
+  /**
+   * Path of the private key the install authenticated with — the path only,
+   * never key material. Lets the in-app server update reconnect without
+   * re-asking; absent for connections stored before it existed.
+   */
+  sshKeyPath?: string;
 }
 
 export const CONNECTION_STORAGE_KEY = "hive-connection";
@@ -59,6 +65,7 @@ function normalizeConnection(value: unknown): ServerConnection | null {
   const authToken = trimmedString(candidate.authToken);
   const sshUser = trimmedString(candidate.sshUser);
   const adminUser = trimmedString(candidate.adminUser);
+  const sshKeyPath = trimmedString(candidate.sshKeyPath);
   return {
     host,
     port,
@@ -67,6 +74,7 @@ function normalizeConnection(value: unknown): ServerConnection | null {
     ...(authToken ? { authToken } : {}),
     ...(sshUser ? { sshUser } : {}),
     ...(adminUser ? { adminUser } : {}),
+    ...(sshKeyPath ? { sshKeyPath } : {}),
   };
 }
 

--- a/frontend/src/hooks/useDesktopUpdate.tsx
+++ b/frontend/src/hooks/useDesktopUpdate.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useSyncExternalStore } from "react";
 import { toast } from "sonner";
 import { isDesktopShell } from "@/lib/is-desktop";
+import { serverUpdateInProgress } from "@/lib/server-update";
 import { TOAST_DURATIONS } from "@/lib/toast-config";
 import { HiveToast, type HiveToastVariant } from "@/components/ui/toaster";
 
@@ -120,7 +121,9 @@ function releaseUpdate(update: Update): void {
 }
 
 async function install(update: Update): Promise<void> {
-  if (installInProgress()) return;
+  // The install ends in relaunch(), which kills the SSH sidecar — never under
+  // a provisioning run that is updating the server through it.
+  if (installInProgress() || serverUpdateInProgress()) return;
   setState({ phase: "downloading", version: update.version, percent: null });
   showProgressToast("Downloading update…");
 

--- a/frontend/src/lib/provision-client.ts
+++ b/frontend/src/lib/provision-client.ts
@@ -74,6 +74,12 @@ export interface ProvisionOptions {
   dataDir?: string;
   /** Authorized on the hive service account by the install. */
   sshPublicKey?: string;
+  /**
+   * Update an existing completed install to the app's version instead of
+   * installing. The script reads everything else from the server's install
+   * manifest, so no other option applies.
+   */
+  update?: boolean;
 }
 
 /** The sidecar's rejection shape: a taxonomy code plus a raw diagnostic. */

--- a/frontend/src/lib/server-connection.ts
+++ b/frontend/src/lib/server-connection.ts
@@ -1,7 +1,7 @@
 import type { ServerConnection } from "@/hooks/useConnection";
 import { replaceConnection, serverUrlFor } from "@/hooks/useConnection";
 import { queryClient } from "@/lib/query-client";
-import { resetServerUpdate } from "@/lib/server-update";
+import { resetServerUpdate, serverUpdateInProgress } from "@/lib/server-update";
 import { wsTransport } from "@/lib/ws-transport";
 
 /**
@@ -105,6 +105,16 @@ export async function switchServer(
   connection: ServerConnection | null,
   options: { verify?: boolean } = {},
 ): Promise<void> {
+  // The client talks to exactly one server, and a provisioning run belongs to
+  // it. The sidecar cannot be cancelled, so switching mid-run would leave a
+  // run whose progress and terminal state describe a server this client no
+  // longer points at. Refusing is the whole answer.
+  if (serverUpdateInProgress()) {
+    throw new ServerConnectionError(
+      "invalid",
+      "A server update is running. Wait for it to finish before switching servers.",
+    );
+  }
   if (connection) {
     validateServerConnection(connection);
     if (options.verify) await probeServerConnection(connection);
@@ -112,7 +122,7 @@ export async function switchServer(
 
   replaceConnection(connection);
   wsTransport.disconnectAll();
-  // A done or failed server-update run describes the previous server.
+  // A done or failed run describes the server this client is leaving.
   resetServerUpdate();
   // Not clear(): mounted observers (e.g. the health badge) are not refetched
   // after a cache teardown and would freeze on their pending state.

--- a/frontend/src/lib/server-connection.ts
+++ b/frontend/src/lib/server-connection.ts
@@ -1,6 +1,7 @@
 import type { ServerConnection } from "@/hooks/useConnection";
 import { replaceConnection, serverUrlFor } from "@/hooks/useConnection";
 import { queryClient } from "@/lib/query-client";
+import { resetServerUpdate } from "@/lib/server-update";
 import { wsTransport } from "@/lib/ws-transport";
 
 /**
@@ -111,6 +112,8 @@ export async function switchServer(
 
   replaceConnection(connection);
   wsTransport.disconnectAll();
+  // A done or failed server-update run describes the previous server.
+  resetServerUpdate();
   // Not clear(): mounted observers (e.g. the health badge) are not refetched
   // after a cache teardown and would freeze on their pending state.
   await queryClient.resetQueries();

--- a/frontend/src/lib/server-update.ts
+++ b/frontend/src/lib/server-update.ts
@@ -1,0 +1,109 @@
+import { useSyncExternalStore } from "react";
+import type { ProvisionClient } from "@/lib/provision-client";
+import { toProvisionError } from "@/lib/provision-client";
+
+/**
+ * The in-app server update: `provision.sh --update` over the SSH sidecar,
+ * driven from the Updates settings page. Module-level for the same reason as
+ * the desktop-update store — the run outlives the page that started it.
+ */
+export type ServerUpdateState =
+  | { phase: "idle" }
+  | { phase: "running"; step: string }
+  | { phase: "failed"; error: string; passwordRequired: boolean }
+  | { phase: "done" };
+
+let state: ServerUpdateState = { phase: "idle" };
+const listeners = new Set<() => void>();
+
+/** Shown at most once per app launch; the Updates page is the durable surface. */
+let mismatchPrompted = false;
+
+function setState(next: ServerUpdateState): void {
+  state = next;
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function useServerUpdateState(): ServerUpdateState {
+  return useSyncExternalStore(subscribe, () => state);
+}
+
+export function shouldPromptServerUpdate(): boolean {
+  return !mismatchPrompted;
+}
+
+export function markServerUpdatePrompted(): void {
+  mismatchPrompted = true;
+}
+
+/**
+ * Back to a clean slate: called when the client switches servers (a done or
+ * failed run describes the previous server) and between tests.
+ */
+export function resetServerUpdate(): void {
+  state = { phase: "idle" };
+  mismatchPrompted = false;
+}
+
+/** A provisioning run owns the backend; a desktop relaunch would kill it. */
+export function serverUpdateInProgress(): boolean {
+  return state.phase === "running";
+}
+
+/** `probe_os` -> `Probe os`, for a step the script has not titled yet. */
+function humanize(id: string): string {
+  const words = id.replace(/[_-]+/g, " ");
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+export interface ServerUpdateTarget {
+  host: string;
+  /** SSH login. Undefined means root. */
+  user?: string;
+  keyPath: string;
+  /** Escalation password, only when a previous attempt asked for one. */
+  password?: string;
+}
+
+/**
+ * Run the update and resolve with the terminal state. The provisioner owns
+ * correctness on the server side (identity checks, health check, rollback);
+ * this side only narrates the stream. A failure with `passwordRequired` means
+ * the account escalates with a password and the caller should collect one.
+ */
+export async function runServerUpdate(
+  client: ProvisionClient,
+  target: ServerUpdateTarget,
+): Promise<ServerUpdateState> {
+  if (state.phase === "running") return state;
+  setState({ phase: "running", step: "Connecting to the server…" });
+
+  try {
+    await client.install(
+      {
+        connection: { host: target.host, user: target.user, keyPath: target.keyPath },
+        options: { update: true },
+        password: target.password,
+      },
+      (record) => {
+        if (typeof record.step === "string" && record.status === "start") {
+          setState({ phase: "running", step: record.title ?? humanize(record.step) });
+        }
+      },
+    );
+    setState({ phase: "done" });
+  } catch (error) {
+    const { code, detail } = toProvisionError(error);
+    setState({
+      phase: "failed",
+      error: detail,
+      passwordRequired: code === "SSH_PASSWORD_REQUIRED",
+    });
+  }
+  return state;
+}

--- a/frontend/src/lib/server-update.ts
+++ b/frontend/src/lib/server-update.ts
@@ -55,6 +55,24 @@ export function serverUpdateInProgress(): boolean {
   return state.phase === "running";
 }
 
+/**
+ * The one mismatch rule, shared by the Updates page and the boot prompt: any
+ * comparable difference — behind OR ahead — offers convergence to the app's
+ * version, which is the authority (the button names its target, so a downgrade
+ * is a visible, supported choice). A "dev" backend is never comparable.
+ */
+export function serverVersionDiffersFromApp(
+  appVersion: string | null,
+  backendVersion: string | null,
+): boolean {
+  return (
+    appVersion !== null &&
+    backendVersion !== null &&
+    backendVersion !== "dev" &&
+    backendVersion !== appVersion
+  );
+}
+
 /** `probe_os` -> `Probe os`, for a step the script has not titled yet. */
 function humanize(id: string): string {
   const words = id.replace(/[_-]+/g, " ");

--- a/frontend/src/pages/installer/Installer.tsx
+++ b/frontend/src/pages/installer/Installer.tsx
@@ -132,12 +132,13 @@ export default function Installer({
         authToken: result.accessToken,
         sshUser: result.serviceUser,
         adminUser: user ?? "root",
+        ...(inputs.sshKeyPath ? { sshKeyPath: inputs.sshKeyPath } : {}),
         setupPending: true,
       });
       clearInstallRuns();
       advance();
     },
-    [inputs.address, inputs.port, advance],
+    [inputs.address, inputs.port, inputs.sshKeyPath, advance],
   );
 
   let screen: React.ReactNode = null;

--- a/frontend/src/pages/settings/ConnectionSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionSettings.tsx
@@ -6,7 +6,12 @@ import { TransportSecurityWarning } from "@/components/setup/TransportSecurityWa
 import { useConnection } from "@/hooks/useConnection";
 import type { ConnectionStatus } from "@/hooks/useConnectionStatus";
 import { useConnectionStatus } from "@/hooks/useConnectionStatus";
-import { DEFAULT_BACKEND_PORT, isValidPort, switchServer } from "@/lib/server-connection";
+import {
+  DEFAULT_BACKEND_PORT,
+  isValidPort,
+  normalizeHost,
+  switchServer,
+} from "@/lib/server-connection";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
@@ -101,10 +106,12 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
           // would silently disconnect a client whose token was never shown.
           authToken: tokenDraft.trim() || connection?.authToken,
           sshUser: sshUserDraft.trim() || undefined,
-          // Install-owned; the operator never edits them here, but replacing
-          // the record must not silently drop them.
-          adminUser: connection?.adminUser,
-          sshKeyPath: connection?.sshKeyPath,
+          // Install-owned; a reconnect to the same server must not silently
+          // drop them, but they describe that server only — pointing the app
+          // at a different host must not carry the old identity along.
+          ...(normalizeHost(hostDraft.trim()) === connection?.host
+            ? { adminUser: connection?.adminUser, sshKeyPath: connection?.sshKeyPath }
+            : {}),
         },
         { verify: true },
       );

--- a/frontend/src/pages/settings/ConnectionSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionSettings.tsx
@@ -101,9 +101,10 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
           // would silently disconnect a client whose token was never shown.
           authToken: tokenDraft.trim() || connection?.authToken,
           sshUser: sshUserDraft.trim() || undefined,
-          // Install-owned; the operator never edits it here, but replacing the
-          // record must not silently drop it.
+          // Install-owned; the operator never edits them here, but replacing
+          // the record must not silently drop them.
           adminUser: connection?.adminUser,
+          sshKeyPath: connection?.sshKeyPath,
         },
         { verify: true },
       );

--- a/frontend/src/pages/settings/UpdatesSettings.tsx
+++ b/frontend/src/pages/settings/UpdatesSettings.tsx
@@ -26,11 +26,11 @@ import {
 import { api } from "@/hooks/useApi";
 import { useAppVersion } from "@/hooks/useAppVersion";
 import { replaceConnection, useConnection } from "@/hooks/useConnection";
-import { useProjects } from "@/hooks/useProjects";
+import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext";
 import { isDesktopShell } from "@/lib/is-desktop";
 import { copyToClipboard } from "@/lib/clipboard";
 import { createTauriProvisionClient, type SshKey } from "@/lib/provision-client";
-import { runServerUpdate, useServerUpdateState } from "@/lib/server-update";
+import { runServerUpdate, serverVersionDiffersFromApp, useServerUpdateState } from "@/lib/server-update";
 import {
   checkForUpdatesNow,
   installCurrentUpdate,
@@ -150,13 +150,8 @@ function ServerSection({
   backendVersion: string | null;
   unreachable: boolean;
 }) {
-  // The desktop version is the reference: releases version both artifacts
-  // together, so a differing backend is one an operator has not updated yet.
-  const outdated =
-    appVersion !== null &&
-    backendVersion !== null &&
-    backendVersion !== "dev" &&
-    backendVersion !== appVersion;
+  // The null re-check narrows appVersion for the JSX below.
+  const outdated = appVersion !== null && serverVersionDiffersFromApp(appVersion, backendVersion);
 
   return (
     <section className="rounded-lg border border-border/50 bg-card/50 p-5">
@@ -179,7 +174,7 @@ function ServerUpdateFlow({ targetVersion }: { targetVersion: string }) {
   const desktopUpdate = useDesktopUpdateState();
   const updateState = useServerUpdateState();
   const { connection } = useConnection();
-  const { projects } = useProjects();
+  const liveData = useWorkspaceLiveDataContext();
   const queryClient = useQueryClient();
   const client = useMemo(() => createTauriProvisionClient(), []);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -200,9 +195,11 @@ function ServerUpdateFlow({ targetVersion }: { targetVersion: string }) {
   if (!connection) return null;
   if (appUpdatePending && updateState.phase !== "running") return null;
 
-  const busyWorkspaces = projects
-    .flatMap((project) => project.workspaces ?? [])
-    .filter((workspace) => workspace.status === "busy").length;
+  // Live WS state, not the projects query: status transitions do not
+  // invalidate the projects list, whose snapshot can miss a running agent.
+  const busyWorkspaces = Object.values(liveData).filter(
+    (workspace) => workspace.status === "busy",
+  ).length;
 
   const launch = async (keyPath: string, escalationPassword?: string) => {
     const result = await runServerUpdate(client, {

--- a/frontend/src/pages/settings/UpdatesSettings.tsx
+++ b/frontend/src/pages/settings/UpdatesSettings.tsx
@@ -1,12 +1,36 @@
-import { useEffect, useState } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { Check, Copy, Loader2, RefreshCw } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, Copy, KeyRound, Loader2, RefreshCw } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { api } from "@/hooks/useApi";
+import { useAppVersion } from "@/hooks/useAppVersion";
+import { replaceConnection, useConnection } from "@/hooks/useConnection";
+import { useProjects } from "@/hooks/useProjects";
 import { isDesktopShell } from "@/lib/is-desktop";
 import { copyToClipboard } from "@/lib/clipboard";
+import { createTauriProvisionClient, type SshKey } from "@/lib/provision-client";
+import { runServerUpdate, useServerUpdateState } from "@/lib/server-update";
 import {
   checkForUpdatesNow,
   installCurrentUpdate,
@@ -14,29 +38,6 @@ import {
   useDesktopUpdateState,
   type DesktopUpdateState,
 } from "@/hooks/useDesktopUpdate";
-
-/**
- * The desktop build's own version; the web app has none of its own. Asked from
- * Rust because the JS-side `getVersion()` reports the numeric macOS bundle
- * version, which drops prerelease suffixes like `-beta.5`.
- */
-function useAppVersion(): string | null {
-  const [version, setVersion] = useState<string | null>(null);
-  useEffect(() => {
-    if (!isDesktopShell()) return;
-    let active = true;
-    void import("@tauri-apps/api/core")
-      .then(({ invoke }) => invoke<string>("app_version"))
-      .then((v) => {
-        if (active) setVersion(v);
-      })
-      .catch(() => {});
-    return () => {
-      active = false;
-    };
-  }, []);
-  return version;
-}
 
 export default function UpdatesSettings() {
   const appVersion = useAppVersion();
@@ -100,6 +101,8 @@ function AppSection({ appVersion }: { appVersion: string | null }) {
 }
 
 function UpdateStatus({ update }: { update: DesktopUpdateState }) {
+  // Installing ends in relaunch(), which would kill a provisioning run's SSH.
+  const serverBusy = useServerUpdateState().phase === "running";
   switch (update.phase) {
     case "upToDate":
       return <p className="mt-2 text-xs text-muted-foreground">You're on the latest version.</p>;
@@ -111,7 +114,7 @@ function UpdateStatus({ update }: { update: DesktopUpdateState }) {
       return (
         <div className="mt-3 flex items-center justify-between gap-3 rounded-md border border-border/50 bg-muted/40 px-3 py-2">
           <p className="text-xs text-foreground">Version {update.version} is available.</p>
-          <Button size="sm" onClick={installCurrentUpdate}>
+          <Button size="sm" onClick={installCurrentUpdate} disabled={serverBusy}>
             Restart & update
           </Button>
         </div>
@@ -128,7 +131,7 @@ function UpdateStatus({ update }: { update: DesktopUpdateState }) {
       return (
         <div className="mt-3 flex items-center justify-between gap-3">
           <p className="text-xs text-destructive">Update failed: {update.error}</p>
-          <Button size="sm" variant="outline" onClick={installCurrentUpdate}>
+          <Button size="sm" variant="outline" onClick={installCurrentUpdate} disabled={serverBusy}>
             Retry
           </Button>
         </div>
@@ -161,15 +164,205 @@ function ServerSection({
       <p className="mt-1 text-xs text-muted-foreground">
         Version {unreachable ? "unavailable" : (backendVersion ?? "—")}
       </p>
-      {outdated && (
-        <>
-          <p className="mt-2 text-xs text-muted-foreground">
-            The server is not on the app's version. Update it from a server shell:
+      {/* `outdated` needs the app version, so this is desktop-only by construction. */}
+      {outdated && <ServerUpdateFlow targetVersion={appVersion} />}
+    </section>
+  );
+}
+
+/**
+ * The in-app path: `provision.sh --update` over the SSH sidecar, using the key
+ * the install stored (or asking for it once on older connections) and asking
+ * for the escalation password only when the server's sudo mode requires it.
+ */
+function ServerUpdateFlow({ targetVersion }: { targetVersion: string }) {
+  const desktopUpdate = useDesktopUpdateState();
+  const updateState = useServerUpdateState();
+  const { connection } = useConnection();
+  const { projects } = useProjects();
+  const queryClient = useQueryClient();
+  const client = useMemo(() => createTauriProvisionClient(), []);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [keyPicker, setKeyPicker] = useState<{ open: boolean; keys: SshKey[] }>({
+    open: false,
+    keys: [],
+  });
+  const [passwordOpen, setPasswordOpen] = useState(false);
+  const [password, setPassword] = useState("");
+
+  // The app update comes first: the bundled provisioner installs the app's own
+  // version, so updating the server before the app would converge on the old
+  // one. A run already in flight keeps its progress visible regardless.
+  const appUpdatePending =
+    desktopUpdate.phase === "available" ||
+    desktopUpdate.phase === "downloading" ||
+    desktopUpdate.phase === "installing";
+  if (!connection) return null;
+  if (appUpdatePending && updateState.phase !== "running") return null;
+
+  const busyWorkspaces = projects
+    .flatMap((project) => project.workspaces ?? [])
+    .filter((workspace) => workspace.status === "busy").length;
+
+  const launch = async (keyPath: string, escalationPassword?: string) => {
+    const result = await runServerUpdate(client, {
+      host: connection.host,
+      user: connection.adminUser,
+      keyPath,
+      password: escalationPassword,
+    });
+    if (result.phase === "failed" && result.passwordRequired) {
+      setPasswordOpen(true);
+      return;
+    }
+    if (result.phase === "done") {
+      void queryClient.invalidateQueries({ queryKey: ["server", "version"] });
+    }
+  };
+
+  const begin = async (escalationPassword?: string) => {
+    if (connection.sshKeyPath) {
+      void launch(connection.sshKeyPath, escalationPassword);
+      return;
+    }
+    // Connections stored before the key path existed: ask once, then keep it.
+    // No password can reach this branch: the password prompt only follows a
+    // launch, and a launch requires a key — which pickKey persists first.
+    const keys = (await client.listKeys().catch(() => [])).filter((key) => key.usable);
+    setKeyPicker({ open: true, keys });
+  };
+
+  const requestUpdate = () => {
+    if (busyWorkspaces > 0) setConfirmOpen(true);
+    else void begin();
+  };
+
+  const pickKey = (key: SshKey) => {
+    setKeyPicker({ open: false, keys: [] });
+    replaceConnection({ ...connection, sshKeyPath: key.path });
+    void launch(key.path);
+  };
+
+  const submitPassword = () => {
+    setPasswordOpen(false);
+    const submitted = password;
+    setPassword("");
+    void begin(submitted);
+  };
+
+  return (
+    <>
+      {updateState.phase === "running" ? (
+        <p className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+          {updateState.step}
+        </p>
+      ) : updateState.phase === "done" ? (
+        <p className="mt-2 text-xs text-muted-foreground">Server updated.</p>
+      ) : (
+        <div className="mt-3 flex items-center justify-between gap-3">
+          <p className="text-xs text-muted-foreground">
+            The server is not on the app's version.
           </p>
-          <UpdateCommand version={appVersion} />
+          <Button size="sm" onClick={requestUpdate}>
+            Update server to {targetVersion}
+          </Button>
+        </div>
+      )}
+      {updateState.phase === "failed" && !updateState.passwordRequired && (
+        <>
+          <p className="mt-2 text-xs text-destructive">Update failed: {updateState.error}</p>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Fallback, from a server shell:
+          </p>
+          <UpdateCommand version={targetVersion} />
         </>
       )}
-    </section>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Agents are running</AlertDialogTitle>
+            <AlertDialogDescription>
+              {busyWorkspaces} workspace{busyWorkspaces === 1 ? " has" : "s have"} agents running.
+              Updating restarts the server and stops them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void begin()}>Update anyway</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <Dialog
+        open={keyPicker.open}
+        onOpenChange={(open) => !open && setKeyPicker({ open: false, keys: [] })}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Select an SSH key</DialogTitle>
+            <DialogDescription>
+              The key used to install this server. It is remembered for future updates.
+            </DialogDescription>
+          </DialogHeader>
+          {keyPicker.keys.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No usable SSH key found in ~/.ssh.</p>
+          ) : (
+            <div className="space-y-1">
+              {keyPicker.keys.map((key) => (
+                <button
+                  key={key.path}
+                  type="button"
+                  onClick={() => pickKey(key)}
+                  className="flex w-full items-center gap-2 rounded-md border border-border/50 px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+                >
+                  <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{key.label}</span>
+                  {key.keyType && (
+                    <span className="text-xs text-muted-foreground">{key.keyType}</span>
+                  )}
+                </button>
+              ))}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={passwordOpen} onOpenChange={setPasswordOpen}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>Escalation password</DialogTitle>
+            <DialogDescription>
+              {connection.adminUser ?? "root"} needs a password to escalate on the server. It is
+              used for this run only and never stored.
+            </DialogDescription>
+          </DialogHeader>
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitPassword();
+            }}
+          >
+            <Input
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              autoFocus
+              aria-label="Password"
+            />
+            <DialogFooter className="mt-4">
+              <Button type="button" variant="outline" onClick={() => setPasswordOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!password}>
+                Update server
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
 

--- a/frontend/tests/components/ServerUpdatePrompt.test.tsx
+++ b/frontend/tests/components/ServerUpdatePrompt.test.tsx
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { render, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { ServerUpdatePrompt } from "@/components/ServerUpdatePrompt";
+import { resetServerUpdate } from "@/lib/server-update";
+import { replaceConnection } from "@/hooks/useConnection";
+import { createWrapper } from "../test-utils";
+
+const mocks = vi.hoisted(() => ({
+  get: vi.fn(),
+  invoke: vi.fn(),
+  custom: vi.fn(),
+  dismiss: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({ api: { get: mocks.get } }));
+vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
+vi.mock("sonner", () => ({
+  Toaster: () => null,
+  toast: { custom: mocks.custom, dismiss: mocks.dismiss },
+}));
+
+function setDesktopShell(enabled: boolean) {
+  const globals = window as unknown as Record<string, unknown>;
+  if (enabled) globals.__TAURI_INTERNALS__ = {};
+  else delete globals.__TAURI_INTERNALS__;
+}
+
+function renderPrompt() {
+  const { wrapper: Wrapper } = createWrapper();
+  return render(
+    <Wrapper>
+      <MemoryRouter>
+        <ServerUpdatePrompt />
+      </MemoryRouter>
+    </Wrapper>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  resetServerUpdate();
+  setDesktopShell(true);
+  replaceConnection({ host: "203.0.113.10", port: 9420, authToken: "token" });
+  mocks.get.mockResolvedValue({ version: "1.2.3" });
+  mocks.invoke.mockResolvedValue("1.3.0");
+});
+
+afterEach(() => {
+  setDesktopShell(false);
+});
+
+describe("ServerUpdatePrompt", () => {
+  it("prompts once per launch when the server lags the app", async () => {
+    const first = renderPrompt();
+    await waitFor(() => expect(mocks.custom).toHaveBeenCalledTimes(1));
+
+    first.unmount();
+    renderPrompt();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mocks.custom).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays silent when versions match, on dev backends, and on the web", async () => {
+    mocks.invoke.mockResolvedValue("1.2.3");
+    renderPrompt();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.custom).not.toHaveBeenCalled();
+
+    mocks.get.mockResolvedValue({ version: "dev" });
+    mocks.invoke.mockResolvedValue("1.3.0");
+    renderPrompt();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.custom).not.toHaveBeenCalled();
+
+    setDesktopShell(false);
+    renderPrompt();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(mocks.custom).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/ServerUpdatePrompt.test.tsx
+++ b/frontend/tests/components/ServerUpdatePrompt.test.tsx
@@ -52,7 +52,7 @@ afterEach(() => {
 });
 
 describe("ServerUpdatePrompt", () => {
-  it("prompts once per launch when the server lags the app", async () => {
+  it("prompts once per launch when the server differs from the app", async () => {
     const first = renderPrompt();
     await waitFor(() => expect(mocks.custom).toHaveBeenCalledTimes(1));
 

--- a/frontend/tests/hooks/useDesktopUpdate.test.tsx
+++ b/frontend/tests/hooks/useDesktopUpdate.test.tsx
@@ -8,6 +8,7 @@ import {
   useDesktopUpdate,
   useDesktopUpdateState,
 } from "@/hooks/useDesktopUpdate";
+import { resetServerUpdate } from "@/lib/server-update";
 import type { HiveToastProps } from "@/components/ui/toaster";
 
 type CustomRender = (id: string | number) => ReactElement<HiveToastProps>;
@@ -83,6 +84,7 @@ describe("useDesktopUpdate", () => {
     vi.useFakeTimers();
     localStorage.clear();
     resetDesktopUpdateForTests();
+    resetServerUpdate();
     setDesktopShell(true);
     // The hook only checks release builds; vitest runs in dev mode.
     vi.stubEnv("PROD", true);
@@ -276,6 +278,29 @@ describe("useDesktopUpdate", () => {
     expect(mocks.check).toHaveBeenCalledTimes(1);
   });
 
+  it("refuses to install while a server update is provisioning", async () => {
+    const { runServerUpdate } = await import("@/lib/server-update");
+    const update = makeUpdate("1.2.3");
+    mocks.check.mockResolvedValue(update);
+    await renderUpdateHook();
+
+    // A provisioning run holds the SSH sidecar; relaunch() would kill it.
+    const client = {
+      listKeys: vi.fn(),
+      testConnection: vi.fn(),
+      trustHost: vi.fn(),
+      preflight: vi.fn(),
+      install: vi.fn(() => new Promise<void>(() => {})),
+    };
+    void runServerUpdate(client, { host: "203.0.113.10", keyPath: "/k" });
+
+    act(() => lastToast().props.onAction?.());
+    await settle();
+
+    expect(update.downloadAndInstall).not.toHaveBeenCalled();
+    expect(mocks.relaunch).not.toHaveBeenCalled();
+  });
+
   it("dismissing the toast keeps the update available to the Updates page", async () => {
     mocks.check.mockResolvedValue(makeUpdate("1.2.3"));
     const { result } = renderHook(() => {
@@ -355,6 +380,7 @@ describe("manual checks from the Updates page", () => {
     vi.clearAllMocks();
     localStorage.clear();
     resetDesktopUpdateForTests();
+    resetServerUpdate();
     setDesktopShell(true);
     vi.stubEnv("PROD", true);
     vi.spyOn(console, "warn").mockImplementation(() => {});

--- a/frontend/tests/installer/Installer.test.tsx
+++ b/frontend/tests/installer/Installer.test.tsx
@@ -755,6 +755,8 @@ describe("Installer", () => {
       sshUser: "hive",
       // …and the install login is kept only for a future reinstall.
       adminUser: "ops",
+      // The key path (never the key) is kept for the in-app server update.
+      sshKeyPath: "/home/lenny/.ssh/id_ed25519",
     });
     // Storing the connection is not the end of the flow: the accounts screen
     // still has to run, so the installer is still up.
@@ -1046,6 +1048,7 @@ describe("Installer", () => {
       authToken: ACCESS_TOKEN,
       sshUser: "hive",
       adminUser: "root",
+      sshKeyPath: "/home/lenny/.ssh/id_ed25519",
     });
     // Nothing of the run survives to be resumed.
     expect(localStorage.getItem(INSTALLER_STORAGE_KEY)).toBe(

--- a/frontend/tests/lib/server-connection.test.ts
+++ b/frontend/tests/lib/server-connection.test.ts
@@ -3,11 +3,30 @@ import { getConnection } from "@/hooks/useConnection";
 import { queryClient } from "@/lib/query-client";
 import { wsTransport } from "@/lib/ws-transport";
 import { ServerConnectionError, switchServer } from "@/lib/server-connection";
+import {
+  markServerUpdatePrompted,
+  resetServerUpdate,
+  runServerUpdate,
+  serverUpdateInProgress,
+  shouldPromptServerUpdate,
+} from "@/lib/server-update";
+import type { ProvisionClient } from "@/lib/provision-client";
+
+function provisionClientWith(install: ProvisionClient["install"]): ProvisionClient {
+  return {
+    listKeys: vi.fn(),
+    testConnection: vi.fn(),
+    trustHost: vi.fn(),
+    preflight: vi.fn(),
+    install,
+  };
+}
 
 describe("switchServer", () => {
   beforeEach(() => {
     localStorage.clear();
     vi.restoreAllMocks();
+    resetServerUpdate();
   });
 
   it("probes with the proposed token before replacing the connection", async () => {
@@ -41,6 +60,31 @@ describe("switchServer", () => {
     await expect(
       switchServer({ host: "server.example.com", port: 3000 }, { verify: true }),
     ).rejects.toMatchObject<Partial<ServerConnectionError>>({ reason: "unreachable" });
+  });
+
+  it("clears a finished server-update run and refuses to switch during one", async () => {
+    // A terminal state describes the server being left: switching resets it.
+    // The prompt flag only flips back through resetServerUpdate, so it proves
+    // the reset ran (a failed phase alone would also read as "not running").
+    await runServerUpdate(
+      provisionClientWith(vi.fn(() => Promise.reject({ code: "HEALTH_TIMEOUT", detail: "x" }))),
+      { host: "203.0.113.10", keyPath: "/k" },
+    );
+    markServerUpdatePrompted();
+    await switchServer({ host: "new.example.com", port: 3000, authToken: "token" });
+    expect(shouldPromptServerUpdate()).toBe(true);
+
+    // A run in flight owns the connection: the sidecar cannot be cancelled,
+    // and its terminal state must never describe a different server.
+    void runServerUpdate(
+      provisionClientWith(vi.fn(() => new Promise<void>(() => {}))),
+      { host: "new.example.com", keyPath: "/k" },
+    );
+    await expect(
+      switchServer({ host: "other.example.com", port: 3000, authToken: "token" }),
+    ).rejects.toMatchObject<Partial<ServerConnectionError>>({ reason: "invalid" });
+    expect(serverUpdateInProgress()).toBe(true);
+    expect(getConnection()).toMatchObject({ host: "new.example.com" });
   });
 
   it("keeps the current connection when the proposed one is rejected", async () => {

--- a/frontend/tests/lib/server-update.test.ts
+++ b/frontend/tests/lib/server-update.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import {
+  markServerUpdatePrompted,
+  resetServerUpdate,
+  runServerUpdate,
+  shouldPromptServerUpdate,
+  useServerUpdateState,
+  type ServerUpdateState,
+} from "@/lib/server-update";
+import type { ProvisionClient, ProvisionRecord } from "@/lib/provision-client";
+
+const TARGET = { host: "203.0.113.10", user: "root", keyPath: "/home/lenny/.ssh/id_ed25519" };
+
+function clientWith(install: ProvisionClient["install"]): ProvisionClient {
+  return {
+    listKeys: vi.fn(),
+    testConnection: vi.fn(),
+    trustHost: vi.fn(),
+    preflight: vi.fn(),
+    install,
+  };
+}
+
+beforeEach(() => {
+  resetServerUpdate();
+});
+
+describe("runServerUpdate", () => {
+  it("narrates step records and ends done", async () => {
+    let emit: (record: ProvisionRecord) => void = () => {};
+    let finish: () => void = () => {};
+    const install = vi.fn(
+      (_request, onRecord: (record: ProvisionRecord) => void) =>
+        new Promise<void>((resolve) => {
+          emit = onRecord;
+          finish = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useServerUpdateState());
+
+    let run: Promise<ServerUpdateState>;
+    act(() => {
+      run = runServerUpdate(clientWith(install), TARGET);
+    });
+    expect(result.current).toEqual({ phase: "running", step: "Connecting to the server…" });
+
+    act(() => emit({ step: "stop_service", status: "start" }));
+    expect(result.current).toEqual({ phase: "running", step: "Stop service" });
+
+    act(() => emit({ step: "health_check", status: "start", title: "Waiting for the backend" }));
+    expect(result.current).toEqual({ phase: "running", step: "Waiting for the backend" });
+
+    await act(async () => {
+      finish();
+      await run;
+    });
+    expect(result.current).toEqual({ phase: "done" });
+    expect(install).toHaveBeenCalledWith(
+      {
+        connection: { host: TARGET.host, user: TARGET.user, keyPath: TARGET.keyPath },
+        options: { update: true },
+        password: undefined,
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("flags a missing escalation password as recoverable", async () => {
+    const install = vi.fn(() =>
+      Promise.reject({ code: "SSH_PASSWORD_REQUIRED", detail: "a password is needed" }),
+    );
+
+    const result = await runServerUpdate(clientWith(install), TARGET);
+
+    expect(result).toEqual({
+      phase: "failed",
+      error: "a password is needed",
+      passwordRequired: true,
+    });
+  });
+
+  it("reports other failures as terminal", async () => {
+    const install = vi.fn(() => Promise.reject({ code: "HEALTH_TIMEOUT", detail: "no health" }));
+
+    const result = await runServerUpdate(clientWith(install), TARGET);
+
+    expect(result).toEqual({ phase: "failed", error: "no health", passwordRequired: false });
+  });
+
+  it("refuses to start a second run while one is in flight", async () => {
+    let finish: () => void = () => {};
+    const install = vi.fn(() => new Promise<void>((resolve) => (finish = resolve)));
+    const client = clientWith(install);
+
+    const first = runServerUpdate(client, TARGET);
+    const second = await runServerUpdate(client, TARGET);
+
+    expect(second.phase).toBe("running");
+    expect(install).toHaveBeenCalledTimes(1);
+    finish();
+    await first;
+  });
+});
+
+describe("mismatch prompt gate", () => {
+  it("prompts once per launch", () => {
+    expect(shouldPromptServerUpdate()).toBe(true);
+    markServerUpdatePrompted();
+    expect(shouldPromptServerUpdate()).toBe(false);
+    resetServerUpdate();
+    expect(shouldPromptServerUpdate()).toBe(true);
+  });
+});

--- a/frontend/tests/lib/server-update.test.ts
+++ b/frontend/tests/lib/server-update.test.ts
@@ -4,6 +4,7 @@ import {
   markServerUpdatePrompted,
   resetServerUpdate,
   runServerUpdate,
+  serverVersionDiffersFromApp,
   shouldPromptServerUpdate,
   useServerUpdateState,
   type ServerUpdateState,
@@ -100,6 +101,20 @@ describe("runServerUpdate", () => {
     expect(install).toHaveBeenCalledTimes(1);
     finish();
     await first;
+  });
+});
+
+describe("serverVersionDiffersFromApp", () => {
+  it("flags only a comparable, differing backend", () => {
+    expect(serverVersionDiffersFromApp("1.3.0", "1.2.3")).toBe(true);
+    // A newer backend also differs: the button converges to the app's version
+    // and names its target, so the downgrade is a visible choice.
+    expect(serverVersionDiffersFromApp("1.2.3", "1.3.0")).toBe(true);
+    expect(serverVersionDiffersFromApp("1.3.0", "1.3.0")).toBe(false);
+    // A source checkout has no comparable version.
+    expect(serverVersionDiffersFromApp("1.3.0", "dev")).toBe(false);
+    expect(serverVersionDiffersFromApp(null, "1.2.3")).toBe(false);
+    expect(serverVersionDiffersFromApp("1.3.0", null)).toBe(false);
   });
 });
 

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -157,7 +157,12 @@ describe("ConnectionSettings", () => {
   });
 
   it("keeps the stored token when reconnecting with the field left blank", async () => {
-    replaceConnection({ host: "100.64.0.10", port: 3000, authToken: "good" });
+    replaceConnection({
+      host: "100.64.0.10",
+      port: 3000,
+      authToken: "good",
+      sshKeyPath: "/home/lenny/.ssh/id_ed25519",
+    });
     const fetchMock = mockProbe(new Response("[]", { status: 200 }));
     const user = userEvent.setup();
     render(<ConnectionSettings />);
@@ -165,7 +170,13 @@ describe("ConnectionSettings", () => {
     await user.click(screen.getByRole("button", { name: "Connect" }));
 
     await waitFor(() =>
-      expect(getConnection()).toMatchObject({ host: "100.64.0.10", authToken: "good" }),
+      expect(getConnection()).toMatchObject({
+        host: "100.64.0.10",
+        authToken: "good",
+        // Install-owned like adminUser: a reconnect must not drop the key
+        // path the in-app server update depends on.
+        sshKeyPath: "/home/lenny/.ssh/id_ed25519",
+      }),
     );
     // The probe authenticated with the stored token, not with an empty one.
     expect(fetchMock).toHaveBeenCalledWith(

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -185,6 +185,29 @@ describe("ConnectionSettings", () => {
     );
   });
 
+  it("drops the install-owned identity when pointing at a different host", async () => {
+    replaceConnection({
+      host: "100.64.0.10",
+      port: 3000,
+      authToken: "good",
+      adminUser: "ops",
+      sshKeyPath: "/home/lenny/.ssh/id_ed25519",
+    });
+    mockProbe(new Response("[]", { status: 200 }));
+    const user = userEvent.setup();
+    render(<ConnectionSettings />);
+
+    const host = screen.getByPlaceholderText("203.0.113.10");
+    await user.clear(host);
+    await user.type(host, "100.64.0.20");
+    await user.click(screen.getByRole("button", { name: "Connect" }));
+
+    await waitFor(() => expect(getConnection()?.host).toBe("100.64.0.20"));
+    // The key and admin login describe the old server, not the new one.
+    expect(getConnection()?.sshKeyPath).toBeUndefined();
+    expect(getConnection()?.adminUser).toBeUndefined();
+  });
+
   it("keeps the working connection when a new attempt is rejected", async () => {
     replaceConnection({ host: "old.example.com", port: 3000, authToken: "good" });
     mockProbe(new Response("", { status: 401 }));

--- a/frontend/tests/pages/UpdatesSettings.test.tsx
+++ b/frontend/tests/pages/UpdatesSettings.test.tsx
@@ -1,19 +1,36 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import UpdatesSettings from "@/pages/settings/UpdatesSettings";
 import { resetDesktopUpdateForTests } from "@/hooks/useDesktopUpdate";
+import { resetServerUpdate } from "@/lib/server-update";
+import { getConnection, replaceConnection } from "@/hooks/useConnection";
+import type { ProvisionClient } from "@/lib/provision-client";
 import { createWrapper } from "../test-utils";
 
 const mocks = vi.hoisted(() => ({
   get: vi.fn(),
   invoke: vi.fn(),
   check: vi.fn(),
+  install: vi.fn(),
+  listKeys: vi.fn(),
+  projects: [] as unknown[],
 }));
 
 vi.mock("@/hooks/useApi", () => ({ api: { get: mocks.get } }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
 vi.mock("@tauri-apps/plugin-updater", () => ({ check: mocks.check }));
+vi.mock("@/hooks/useProjects", () => ({ useProjects: () => ({ projects: mocks.projects }) }));
+vi.mock("@/lib/provision-client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/lib/provision-client")>()),
+  createTauriProvisionClient: (): ProvisionClient => ({
+    listKeys: mocks.listKeys,
+    testConnection: vi.fn(),
+    trustHost: vi.fn(),
+    preflight: vi.fn(),
+    install: mocks.install,
+  }),
+}));
 
 function setDesktopShell(enabled: boolean) {
   const globals = window as unknown as Record<string, unknown>;
@@ -30,12 +47,37 @@ function renderPage() {
   );
 }
 
+function seedConnection(overrides: Record<string, unknown> = {}) {
+  replaceConnection({
+    host: "203.0.113.10",
+    port: 9420,
+    authToken: "token",
+    adminUser: "root",
+    sshKeyPath: "/home/lenny/.ssh/id_ed25519",
+    ...overrides,
+  });
+}
+
+/** A desktop app on 1.3.0-beta.2 talking to a backend still on 1.2.3. */
+function seedMismatch() {
+  setDesktopShell(true);
+  seedConnection();
+  mocks.invoke.mockResolvedValue("1.3.0-beta.2");
+}
+
 beforeEach(() => {
-  vi.clearAllMocks();
+  // reset, not clear: a test that aborts mid-flow leaves unconsumed
+  // mock*Once implementations behind, and clear would keep them queued.
+  vi.resetAllMocks();
+  localStorage.clear();
   resetDesktopUpdateForTests();
+  resetServerUpdate();
+  mocks.projects = [];
   mocks.get.mockResolvedValue({ version: "1.2.3" });
   mocks.invoke.mockResolvedValue("1.2.3");
   mocks.check.mockResolvedValue(null);
+  mocks.install.mockResolvedValue(undefined);
+  mocks.listKeys.mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -58,38 +100,30 @@ describe("UpdatesSettings", () => {
     expect(await screen.findByText("Version unavailable")).toBeInTheDocument();
   });
 
-  it("shows the app version on desktop without an update hint when versions match", async () => {
+  it("shows no server action when versions match", async () => {
     setDesktopShell(true);
+    seedConnection();
     renderPage();
 
     expect(await screen.findByRole("heading", { name: "Application" })).toBeInTheDocument();
     expect(await screen.findAllByText("Version 1.2.3")).toHaveLength(2);
-    expect(screen.queryByText(/provision\.sh/)).not.toBeInTheDocument();
-  });
-
-  it("offers the server update command when the backend lags the app", async () => {
-    setDesktopShell(true);
-    mocks.invoke.mockResolvedValue("1.3.0-beta.2");
-    renderPage();
-
-    expect(
-      await screen.findByText(/releases\/download\/v1\.3\.0-beta\.2\/provision\.sh/),
-    ).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Copy update command" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Update server/ })).not.toBeInTheDocument();
   });
 
   it("never suggests updating a dev backend", async () => {
     setDesktopShell(true);
+    seedConnection();
     mocks.get.mockResolvedValue({ version: "dev" });
     mocks.invoke.mockResolvedValue("1.3.0");
     renderPage();
 
     expect(await screen.findByText("Version dev")).toBeInTheDocument();
-    expect(screen.queryByText(/provision\.sh/)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Update server/ })).not.toBeInTheDocument();
   });
 
   it("runs a manual check from the button and reports up to date", async () => {
     setDesktopShell(true);
+    seedConnection();
     vi.stubEnv("PROD", true);
     const user = userEvent.setup();
     renderPage();
@@ -98,5 +132,117 @@ describe("UpdatesSettings", () => {
 
     expect(mocks.check).toHaveBeenCalledTimes(1);
     expect(await screen.findByText("You're on the latest version.")).toBeInTheDocument();
+  });
+
+  it("updates the server in place when the backend lags the app", async () => {
+    seedMismatch();
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Update server to 1.3.0-beta.2" }));
+
+    await waitFor(() => expect(screen.getByText("Server updated.")).toBeInTheDocument());
+    expect(mocks.install).toHaveBeenCalledWith(
+      {
+        connection: {
+          host: "203.0.113.10",
+          user: "root",
+          keyPath: "/home/lenny/.ssh/id_ed25519",
+        },
+        options: { update: true },
+        password: undefined,
+      },
+      expect.any(Function),
+    );
+  });
+
+  it("hides the server update while an app update is pending", async () => {
+    seedMismatch();
+    vi.stubEnv("PROD", true);
+    mocks.check.mockResolvedValue({
+      version: "1.4.0",
+      downloadAndInstall: vi.fn(),
+      close: vi.fn(async () => {}),
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(await screen.findByRole("button", { name: /Update server/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Check for updates" }));
+
+    expect(await screen.findByText("Version 1.4.0 is available.")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Update server/ })).not.toBeInTheDocument();
+  });
+
+  it("warns before restarting a server with busy workspaces", async () => {
+    seedMismatch();
+    mocks.projects = [
+      { id: "p1", workspaces: [{ id: "w1", status: "busy" }, { id: "w2", status: "idle" }] },
+    ];
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Update server/ }));
+    expect(mocks.install).not.toHaveBeenCalled();
+    expect(screen.getByText(/1 workspace has agents running/)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Update anyway" }));
+    await waitFor(() => expect(mocks.install).toHaveBeenCalledTimes(1));
+  });
+
+  it("asks for the SSH key once when the stored connection has none", async () => {
+    seedMismatch();
+    seedConnection({ sshKeyPath: undefined });
+    mocks.listKeys.mockResolvedValue([
+      { path: "/home/lenny/.ssh/id_ed25519", label: "id_ed25519", encrypted: false, agentLoaded: false, usable: true },
+      { path: "/home/lenny/.ssh/id_rsa", label: "id_rsa", encrypted: true, agentLoaded: false, usable: false },
+    ]);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Update server/ }));
+    expect(await screen.findByText("Select an SSH key")).toBeInTheDocument();
+    // Passphrase-protected keys cannot authenticate non-interactively.
+    expect(screen.queryByText("id_rsa")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /id_ed25519/ }));
+
+    await waitFor(() => expect(mocks.install).toHaveBeenCalledTimes(1));
+    expect(mocks.install.mock.calls[0][0].connection.keyPath).toBe("/home/lenny/.ssh/id_ed25519");
+    expect(getConnection()?.sshKeyPath).toBe("/home/lenny/.ssh/id_ed25519");
+  });
+
+  it("collects the escalation password when the server requires one", async () => {
+    seedMismatch();
+    mocks.install
+      .mockRejectedValueOnce({ code: "SSH_PASSWORD_REQUIRED", detail: "password needed" })
+      .mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Update server/ }));
+    expect(await screen.findByRole("heading", { name: "Escalation password" })).toBeInTheDocument();
+
+    await user.type(screen.getByLabelText("Password"), "hunter2");
+    await user.click(screen.getByRole("button", { name: "Update server" }));
+
+    await waitFor(() => expect(screen.getByText("Server updated.")).toBeInTheDocument());
+    expect(mocks.install).toHaveBeenCalledTimes(2);
+    expect(mocks.install.mock.calls[1][0].password).toBe("hunter2");
+  });
+
+  it("offers the manual command as a fallback after a failed run", async () => {
+    seedMismatch();
+    mocks.install.mockRejectedValue({ code: "HEALTH_TIMEOUT", detail: "no health" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Update server/ }));
+
+    expect(await screen.findByText("Update failed: no health")).toBeInTheDocument();
+    expect(
+      screen.getByText(/releases\/download\/v1\.3\.0-beta\.2\/provision\.sh/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Update server/ })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/pages/UpdatesSettings.test.tsx
+++ b/frontend/tests/pages/UpdatesSettings.test.tsx
@@ -14,13 +14,15 @@ const mocks = vi.hoisted(() => ({
   check: vi.fn(),
   install: vi.fn(),
   listKeys: vi.fn(),
-  projects: [] as unknown[],
+  liveData: {} as Record<string, { status?: "idle" | "busy" }>,
 }));
 
 vi.mock("@/hooks/useApi", () => ({ api: { get: mocks.get } }));
 vi.mock("@tauri-apps/api/core", () => ({ invoke: mocks.invoke }));
 vi.mock("@tauri-apps/plugin-updater", () => ({ check: mocks.check }));
-vi.mock("@/hooks/useProjects", () => ({ useProjects: () => ({ projects: mocks.projects }) }));
+vi.mock("@/contexts/WorkspaceLiveDataContext", () => ({
+  useWorkspaceLiveDataContext: () => mocks.liveData,
+}));
 vi.mock("@/lib/provision-client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@/lib/provision-client")>()),
   createTauriProvisionClient: (): ProvisionClient => ({
@@ -72,7 +74,7 @@ beforeEach(() => {
   localStorage.clear();
   resetDesktopUpdateForTests();
   resetServerUpdate();
-  mocks.projects = [];
+  mocks.liveData = {};
   mocks.get.mockResolvedValue({ version: "1.2.3" });
   mocks.invoke.mockResolvedValue("1.2.3");
   mocks.check.mockResolvedValue(null);
@@ -134,7 +136,7 @@ describe("UpdatesSettings", () => {
     expect(await screen.findByText("You're on the latest version.")).toBeInTheDocument();
   });
 
-  it("updates the server in place when the backend lags the app", async () => {
+  it("updates the server in place when the backend differs from the app", async () => {
     seedMismatch();
     const user = userEvent.setup();
     renderPage();
@@ -176,9 +178,8 @@ describe("UpdatesSettings", () => {
 
   it("warns before restarting a server with busy workspaces", async () => {
     seedMismatch();
-    mocks.projects = [
-      { id: "p1", workspaces: [{ id: "w1", status: "busy" }, { id: "w2", status: "idle" }] },
-    ];
+    // Live WS state, not the projects query — the query snapshot can be stale.
+    mocks.liveData = { w1: { status: "busy" }, w2: { status: "idle" } };
     const user = userEvent.setup();
     renderPage();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,7 +100,7 @@
         "@testing-library/user-event": "^14.6.3",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react": "^6.0.5",
         "jsdom": "^30.0.1",
         "tailwindcss": "^4.1.18",
         "tw-animate-css": "^1.4.0",
@@ -134,6 +134,39 @@
       "license": "MIT",
       "engines": {
         "vscode": "^1.0.0"
+      }
+    },
+    "frontend/node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "frontend/node_modules/@vitejs/plugin-react": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.5.tgz",
+      "integrity": "sha512-BOVzne/NL162sMdResB25mUv+vWMF5NoAjNf09TeGlE7ZpszZWSD3winycicLJw72yeVsoCn/2kOhEuCvEShMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rolldown/pluginutils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "peerDependencies": {
+        "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
+        "babel-plugin-react-compiler": "^1.0.0",
+        "vite": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@rolldown/plugin-babel": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        }
       }
     },
     "frontend/node_modules/lightningcss": {
@@ -769,16 +802,6 @@
         "@babel/core": "^7.0.0"
       }
     },
-    "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
@@ -837,38 +860,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-self": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
-      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-react-jsx-source": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
-      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.27.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -5724,13 +5715,6 @@
         "node": "^20.19.0 || >=22.12.0"
       }
     },
-    "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.3",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.3.tgz",
-      "integrity": "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -6934,51 +6918,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/@types/babel__core": {
-      "version": "7.20.5",
-      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.20.7",
-        "@babel/types": "^7.20.7",
-        "@types/babel__generator": "*",
-        "@types/babel__template": "*",
-        "@types/babel__traverse": "*"
-      }
-    },
-    "node_modules/@types/babel__generator": {
-      "version": "7.27.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__template": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/parser": "^7.1.0",
-        "@babel/types": "^7.0.0"
-      }
-    },
-    "node_modules/@types/babel__traverse": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.28.2"
-      }
-    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -7630,27 +7569,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">= 20"
-      }
-    },
-    "node_modules/@vitejs/plugin-react": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-5.1.4.tgz",
-      "integrity": "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/core": "^7.29.0",
-        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
-        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
-        "@rolldown/pluginutils": "1.0.0-rc.3",
-        "@types/babel__core": "^7.20.5",
-        "react-refresh": "^0.18.0"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "peerDependencies": {
-        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/@vitest/expect": {
@@ -12688,16 +12606,6 @@
       "dev": true,
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/react-refresh": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.2",


### PR DESCRIPTION
## Summary

Iteration B of the update flow: the app can now update the backend itself. With PR #433's version surfaces plus this, the full loop is: desktop auto-updates → app detects the differing server → one click runs `provision.sh --update` over SSH.

### Ordering (the structural decision)
The provisioner is compiled into the desktop binary at the app's version, so **the app updates first, the server second** — the bundled script always installs the app's own version. The UI encodes this: while an app update is pending, the server button is hidden (a run already in flight keeps its progress visible). After the relaunch, a once-per-launch toast nudges toward Settings > Updates. No persisted orchestration state: mismatch detection is the orchestrator.

### What's in
- **Rust sidecar**: `ProvisionOptions.update` flag → sends `--update` alone (the script rejects `--allowed-host`/`--ssh-public-key` in that mode and reads identity from the install manifest). Privilege preflight, streaming, and redaction reuse the install path unchanged.
- **SSH identity**: the installer persists the key *path* on the stored connection (never key material); pre-existing connections get a one-time key picker. The sudo password is prompted per run only on `SSH_PASSWORD_REQUIRED` and never stored. ConnectionSettings carries the install-owned identity (`adminUser`, `sshKeyPath`) through a reconnect only when the host is unchanged.
- **`server-update.ts`**: small module store (idle/running/failed/done), same pattern as the desktop-update store. The mismatch rule is one shared helper, `serverVersionDiffersFromApp`: any comparable difference offers convergence to the app's version — the button names its target, so a downgrade is a visible, supported choice.
- **Updates page**: converge button ("Update server to X"), inline step progress, failure + retry with the manual command as fallback, and a warning dialog when workspaces are busy — counted from the **live WS status map** (status transitions never invalidate the projects query, whose snapshot could miss an agent started from another client; the Brain counts too).
- **Single-server semantics**: `switchServer` refuses while a server update is provisioning — the sidecar cannot be cancelled, and a run's state must never describe a server the client no longer points at. Desktop `install()` and the provisioning run also guard against each other (relaunch would kill the SSH run; the Rust `RunGuard` serializes sidecar runs).
- Server-side rollback/health-check untouched — the provisioner already owns correctness there.
- Also carries a small unrelated fix: React plugin aligned with Vite 8.

### Review & audit
Adversarially reviewed by agent (2 real bugs + 2 risks fixed and re-verified), then a 3-pass external audit, now closed: live busy source, refuse-switch-during-run, host-scoped SSH identity, and the helper rename all came out of it. Accepted cosmetic nits: transient "Server updated." flash, "workspace" wording for a busy Brain, case-sensitive host comparison.

## Testing
- `frontend`: lint, typecheck, full suite — 1807 tests, covering the store, the page flow (busy dialog, key picker, password retry, fallback command), the boot prompt, both cross-guards, and the switch refusal.
- Rust: new `script_args` update-mode test; `cargo` unavailable on this Linux host (GTK deps) — CI's macOS build covers it.
- Live e2e validated on an OrbStack VM: fresh install → mismatch toast → one-click update with local tarball sideload, including the sudo-password dialog path.