### PR TITLE
fix: allow digit-prefixed SSH users

### DIFF
--- a/frontend/src-tauri/src/provision.rs
+++ b/frontend/src-tauri/src/provision.rs
@@ -233,7 +233,7 @@ fn validate_user(user: &str) -> Result<(), ProvisionError> {
     let mut bytes = user.bytes();
     let first_ok = bytes
         .next()
-        .is_some_and(|c| c.is_ascii_alphabetic() || c == b'_');
+        .is_some_and(|c| c.is_ascii_alphanumeric() || c == b'_');
     let rest_ok = bytes.all(|c| c.is_ascii_alphanumeric() || matches!(c, b'.' | b'_' | b'-'));
     if first_ok && rest_ok {
         Ok(())
@@ -1599,10 +1599,10 @@ mod tests {
             assert!(validate_host(host).is_err(), "{host}");
         }
 
-        for user in ["root", "_service", "hive.admin-2"] {
+        for user in ["root", "_service", "hive.admin-2", "2root"] {
             assert!(validate_user(user).is_ok(), "{user}");
         }
-        for user in ["", "-root", "2root", "root name", "root@host", "a$b"] {
+        for user in ["", "-root", "root name", "root@host", "a$b"] {
             assert!(validate_user(user).is_err(), "{user}");
         }
 

--- a/frontend/src/lib/server-connection.ts
+++ b/frontend/src/lib/server-connection.ts
@@ -46,7 +46,7 @@ export function isValidPort(port: number): boolean {
 }
 
 export function isValidUserName(user: string): boolean {
-  return /^[A-Za-z_][A-Za-z0-9._-]*$/.test(user);
+  return /^[A-Za-z0-9_][A-Za-z0-9._-]*$/.test(user);
 }
 
 export function validateServerConnection(connection: ServerConnection): void {

--- a/frontend/tests/installer/machine.test.ts
+++ b/frontend/tests/installer/machine.test.ts
@@ -185,11 +185,12 @@ describe("installer machine", () => {
   it("refuses addresses and directories the sidecar would refuse", () => {
     expect(isUsableAddress("203.0.113.10")).toBe(true);
     expect(isUsableAddress("ops_2@server.example.com")).toBe(true);
+    expect(isUsableAddress("2root@server.example.com")).toBe(true);
     expect(isUsableAddress("root@[2001:db8::1]")).toBe(true);
     expect(isUsableAddress("")).toBe(false);
     expect(isUsableAddress("-oProxyCommand=bad")).toBe(false);
     expect(isUsableAddress("host name")).toBe(false);
-    expect(isUsableAddress("2root@host")).toBe(false);
+    expect(isUsableAddress("-root@host")).toBe(false);
 
     expect(isUsableDirectory("/opt/hive")).toBe(true);
     expect(isUsableDirectory("opt/hive")).toBe(false);

--- a/frontend/tests/lib/server-connection.test.ts
+++ b/frontend/tests/lib/server-connection.test.ts
@@ -71,6 +71,12 @@ describe("switchServer", () => {
     expect(getConnection()).toBeNull();
   });
 
+  it("accepts SSH users that start with a digit", async () => {
+    await switchServer({ host: "server.example.com", port: 3000, sshUser: "2root" });
+
+    expect(getConnection()).toMatchObject({ sshUser: "2root" });
+  });
+
   it("clears the connection and tears down live transports", async () => {
     await switchServer({ host: "old.example.com", port: 3000 });
     const disconnect = vi.spyOn(wsTransport, "disconnectAll");


### PR DESCRIPTION
## Summary
- accept SSH usernames that start with an ASCII digit
- keep option and metacharacter protections unchanged
- cover installer, saved connections, and Tauri validation with regression tests

## Validation
- `npm test -- --run tests/installer/machine.test.ts tests/lib/server-connection.test.ts`
- `npm run lint`
- `npm run typecheck`
- `cargo fmt --check`

## Note
The targeted Rust test could not run in this Linux environment because Tauri requires the missing GDK 3 system library.