### PR TITLE
feat: improve toast placement, styling, and interactions

### DIFF
--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -1,8 +1,10 @@
 import { X } from "lucide-react";
+import type { PointerEvent } from "react";
 import { Toaster } from "sonner";
 import "sonner/dist/styles.css";
 
 import { useThemeType } from "@/hooks/useThemeType";
+import { useToastPosition } from "@/hooks/useToastPosition";
 
 export type HiveToastVariant = "success" | "error" | "warning";
 
@@ -33,9 +35,13 @@ export interface HiveToastProps {
   onClose: () => void;
 }
 
+function stopSwipeGesture(event: PointerEvent<HTMLButtonElement>) {
+  event.stopPropagation();
+}
+
 /**
  * Refined Minimal toast — flat surface, status dot with a soft ring, a mono
- * status word, a quiet ghost action, and a hover/focus-revealed close button.
+ * status word, a quiet ghost action, and a discreet close button.
  */
 export function HiveToast({
   variant,
@@ -49,7 +55,7 @@ export function HiveToast({
   const colors = VARIANT_COLORS[variant];
 
   return (
-    <div className="group pointer-events-auto relative flex w-[min(380px,calc(100vw-2rem))] items-start gap-3 rounded-lg border border-border bg-popover px-4 py-3.5 text-popover-foreground shadow-[var(--center-card-shadow)]">
+    <div className="pointer-events-auto flex w-[min(380px,calc(100vw-2rem))] items-start gap-3 rounded-lg border border-border bg-popover px-4 py-3.5 text-popover-foreground shadow-[var(--center-card-shadow)]">
       <span
         className="mt-1.5 size-2 shrink-0 rounded-full"
         style={{
@@ -57,7 +63,7 @@ export function HiveToast({
           boxShadow: `0 0 0 3px color-mix(in oklch, ${colors.accent} 18%, transparent)`,
         }}
       />
-      <div className="min-w-0 flex-1 pr-5">
+      <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <span className="truncate text-sm font-medium leading-5 text-foreground">{title}</span>
           <span
@@ -69,29 +75,34 @@ export function HiveToast({
         </div>
         <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">{description}</p>
       </div>
-      {actionLabel ? (
+      <div className="flex shrink-0 items-center gap-1">
+        {actionLabel ? (
+          <button
+            type="button"
+            onPointerDown={stopSwipeGesture}
+            onClick={onAction}
+            className="cursor-pointer rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          >
+            {actionLabel}
+          </button>
+        ) : null}
         <button
           type="button"
-          onClick={onAction}
-          className="shrink-0 cursor-pointer rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          onPointerDown={stopSwipeGesture}
+          onClick={onClose}
+          aria-label="Dismiss"
+          className="flex size-7 cursor-pointer items-center justify-center rounded text-muted-foreground opacity-60 transition-[color,background-color,opacity] hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
         >
-          {actionLabel}
+          <X className="size-3" />
         </button>
-      ) : null}
-      <button
-        type="button"
-        onClick={onClose}
-        aria-label="Dismiss"
-        className="absolute right-1.5 top-1.5 flex size-5 cursor-pointer items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity pointer-events-none hover:bg-accent hover:text-foreground focus-visible:pointer-events-auto focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 group-hover:pointer-events-auto group-hover:opacity-100"
-      >
-        <X className="size-3" />
-      </button>
+      </div>
     </div>
   );
 }
 
 export function HiveToaster() {
   const theme = useThemeType();
+  const { position } = useToastPosition();
 
   return (
     <Toaster
@@ -99,10 +110,9 @@ export function HiveToaster() {
       gap={10}
       mobileOffset={16}
       offset={18}
-      position="top-left"
+      position={position}
       theme={theme}
       visibleToasts={3}
-      swipeDirections={["left"]}
       // Toasts are rendered as fully custom <HiveToast> nodes, so the sonner
       // wrapper must stay bare (no default card chrome around our component).
       toastOptions={{ unstyled: true }}

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -11,15 +11,15 @@ export type HiveToastVariant = "success" | "error" | "warning";
 const VARIANT_COLORS: Record<HiveToastVariant, { accent: string; statusText: string }> = {
   success: {
     accent: "var(--success)",
-    statusText: "color-mix(in oklch, var(--success) 50%, var(--background))",
+    statusText: "var(--success-foreground)",
   },
   error: {
     accent: "var(--destructive)",
-    statusText: "color-mix(in oklch, var(--destructive) 50%, var(--background))",
+    statusText: "var(--destructive)",
   },
   warning: {
     accent: "var(--warning)",
-    statusText: "color-mix(in oklch, var(--warning) 50%, var(--background))",
+    statusText: "var(--warning-foreground)",
   },
 };
 

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -11,15 +11,15 @@ export type HiveToastVariant = "success" | "error" | "warning";
 const VARIANT_COLORS: Record<HiveToastVariant, { accent: string; statusText: string }> = {
   success: {
     accent: "var(--success)",
-    statusText: "var(--success-foreground)",
+    statusText: "color-mix(in oklch, var(--success) 50%, var(--background))",
   },
   error: {
     accent: "var(--destructive)",
-    statusText: "var(--destructive)",
+    statusText: "color-mix(in oklch, var(--destructive) 50%, var(--background))",
   },
   warning: {
     accent: "var(--warning)",
-    statusText: "var(--warning-foreground)",
+    statusText: "color-mix(in oklch, var(--warning) 50%, var(--background))",
   },
 };
 
@@ -55,7 +55,7 @@ export function HiveToast({
   const colors = VARIANT_COLORS[variant];
 
   return (
-    <div className="pointer-events-auto flex w-[min(380px,calc(100vw-2rem))] items-start gap-3 rounded-lg border border-border bg-popover px-4 py-3.5 text-popover-foreground shadow-[var(--center-card-shadow)]">
+    <div className="pointer-events-auto flex w-[min(380px,calc(100vw-2rem))] items-start gap-3 rounded-lg border border-background/15 bg-foreground px-4 py-3.5 text-background shadow-xl transition-colors duration-200">
       <span
         className="mt-1.5 size-2 shrink-0 rounded-full"
         style={{
@@ -65,7 +65,7 @@ export function HiveToast({
       />
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <span className="truncate text-sm font-medium leading-5 text-foreground">{title}</span>
+          <span className="truncate text-sm font-medium leading-5 text-background">{title}</span>
           <span
             className="shrink-0 font-mono text-[10px] font-medium uppercase tracking-wider"
             style={{ color: colors.statusText }}
@@ -73,7 +73,7 @@ export function HiveToast({
             {status}
           </span>
         </div>
-        <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-muted-foreground">{description}</p>
+        <p className="mt-0.5 line-clamp-2 text-xs leading-5 text-background/70">{description}</p>
       </div>
       <div className="flex shrink-0 items-center gap-1">
         {actionLabel ? (
@@ -81,7 +81,7 @@ export function HiveToast({
             type="button"
             onPointerDown={stopSwipeGesture}
             onClick={onAction}
-            className="cursor-pointer rounded-md px-2 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            className="cursor-pointer rounded-md px-2 py-1 text-xs font-medium text-background/70 transition-colors hover:bg-background/10 hover:text-background focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-background/40"
           >
             {actionLabel}
           </button>
@@ -91,7 +91,7 @@ export function HiveToast({
           onPointerDown={stopSwipeGesture}
           onClick={onClose}
           aria-label="Dismiss"
-          className="flex size-7 cursor-pointer items-center justify-center rounded text-muted-foreground opacity-60 transition-[color,background-color,opacity] hover:bg-accent hover:text-foreground hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          className="flex size-7 cursor-pointer items-center justify-center rounded text-background opacity-60 transition-[color,background-color,opacity] hover:bg-background/10 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-background/40"
         >
           <X className="size-3" />
         </button>

--- a/frontend/src/components/ui/toaster.tsx
+++ b/frontend/src/components/ui/toaster.tsx
@@ -10,16 +10,16 @@ export type HiveToastVariant = "success" | "error" | "warning";
 
 const VARIANT_COLORS: Record<HiveToastVariant, { accent: string; statusText: string }> = {
   success: {
-    accent: "var(--success)",
-    statusText: "var(--success-foreground)",
+    accent: "var(--toast-success)",
+    statusText: "var(--toast-success)",
   },
   error: {
-    accent: "var(--destructive)",
-    statusText: "var(--destructive)",
+    accent: "var(--toast-error)",
+    statusText: "var(--toast-error)",
   },
   warning: {
-    accent: "var(--warning)",
-    statusText: "var(--warning-foreground)",
+    accent: "var(--toast-warning)",
+    statusText: "var(--toast-warning)",
   },
 };
 
@@ -36,6 +36,8 @@ export interface HiveToastProps {
 }
 
 function stopSwipeGesture(event: PointerEvent<HTMLButtonElement>) {
+  // Sonner guards direct button targets, but nested elements such as the
+  // close icon bypass that check and can start a swipe gesture.
   event.stopPropagation();
 }
 

--- a/frontend/src/hooks/useNotificationToasts.tsx
+++ b/frontend/src/hooks/useNotificationToasts.tsx
@@ -186,8 +186,8 @@ export function useNotificationToasts(projects: Project[]): void {
       } else if (msg.type === "tool_input_required" && msg.sessionId) {
         if (!getLocalToastsEnabled()) return;
         const { label, go } = getToastContext();
-        // Sticky: stays visible (even while viewing the conversation) until
-        // the question is answered, the turn ends, or the user closes it.
+        // Sticky until the question is resolved or the turn ends. Following
+        // the CTA opens the response surface and dismisses the reminder.
         const sid = msg.sessionId;
         const isPlan = msg.toolName === "ExitPlanMode";
         const actionToastKey = getActionToastKey(workspaceId, sid);

--- a/frontend/src/hooks/useNotificationToasts.tsx
+++ b/frontend/src/hooks/useNotificationToasts.tsx
@@ -54,8 +54,6 @@ function showWorkspaceToast(args: {
   actionLabel: string;
   duration: number;
   id?: ToastId;
-  /** Sticky action toasts must outlive their CTA click (default true). */
-  dismissOnAction?: boolean;
   onAction: () => void;
   onDismiss?: ExternalToast["onDismiss"];
 }): ToastId {
@@ -69,7 +67,7 @@ function showWorkspaceToast(args: {
         actionLabel={args.actionLabel}
         onAction={() => {
           args.onAction();
-          if (args.dismissOnAction !== false) toast.dismiss(id);
+          toast.dismiss(id);
         }}
         onClose={() => toast.dismiss(id)}
       />
@@ -201,7 +199,6 @@ export function useNotificationToasts(projects: Project[]): void {
           description: isPlan ? "Plan ready for review" : "Agent needs input",
           actionLabel: isPlan ? "Review" : "Respond",
           duration: TOAST_DURATIONS.actionRequired,
-          dismissOnAction: false,
           onAction: () => go(sid),
           onDismiss: () => {
             if (actionToastsRef.current.get(actionToastKey) === toastId) {

--- a/frontend/src/hooks/useToastPosition.ts
+++ b/frontend/src/hooks/useToastPosition.ts
@@ -1,0 +1,41 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+export const TOAST_POSITIONS = [
+  { id: "top-left", label: "Top left" },
+  { id: "top-center", label: "Top center" },
+  { id: "top-right", label: "Top right" },
+  { id: "bottom-left", label: "Bottom left" },
+  { id: "bottom-center", label: "Bottom center" },
+  { id: "bottom-right", label: "Bottom right" },
+] as const;
+
+export type ToastPosition = (typeof TOAST_POSITIONS)[number]["id"];
+
+const STORAGE_KEY = "hive-toast-position";
+const DEFAULT_POSITION: ToastPosition = "bottom-left";
+const listeners = new Set<() => void>();
+
+function isToastPosition(value: string | null): value is ToastPosition {
+  return TOAST_POSITIONS.some((option) => option.id === value);
+}
+
+function getSnapshot(): ToastPosition {
+  const value = typeof localStorage !== "undefined" ? localStorage.getItem(STORAGE_KEY) : null;
+  return isToastPosition(value) ? value : DEFAULT_POSITION;
+}
+
+function subscribe(callback: () => void): () => void {
+  listeners.add(callback);
+  return () => listeners.delete(callback);
+}
+
+export function useToastPosition() {
+  const position = useSyncExternalStore(subscribe, getSnapshot, () => DEFAULT_POSITION);
+
+  const setPosition = useCallback((next: ToastPosition) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    for (const listener of listeners) listener();
+  }, []);
+
+  return { position, setPosition };
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -141,6 +141,11 @@
   --warning-border: color-mix(in oklch, var(--warning) 30%, transparent);
   --warning-contrast: #000000;
 
+  /* Semantic colors tuned for the inverted toast surface. */
+  --toast-success: #34d399;
+  --toast-error: #f87171;
+  --toast-warning: #facc15;
+
   /* PR status — GitHub Primer state palette (light) */
   --pr-open: #1a7f37;
   --pr-draft: #6e7781;
@@ -230,6 +235,11 @@
   --warning-muted: color-mix(in oklch, var(--warning) 10%, transparent);
   --warning-border: color-mix(in oklch, var(--warning) 25%, transparent);
   --warning-contrast: #000000;
+
+  /* Dark mode uses a light toast surface, so status colors need deeper tones. */
+  --toast-success: #166534;
+  --toast-error: #b91c1c;
+  --toast-warning: #854d0e;
 
   /* PR status — GitHub Primer state palette (dark) */
   --pr-open: #3fb950;

--- a/frontend/src/pages/settings/AppearanceSettings.tsx
+++ b/frontend/src/pages/settings/AppearanceSettings.tsx
@@ -1,6 +1,7 @@
 import { Check, Monitor, Moon, Sun } from "lucide-react";
 import { useAccentColor } from "@/hooks/useAccentColor";
 import { useThemeMode, type ThemeMode } from "@/hooks/useThemeMode";
+import { TOAST_POSITIONS, useToastPosition } from "@/hooks/useToastPosition";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
 import { cn } from "@/lib/utils";
@@ -14,6 +15,7 @@ const THEME_OPTIONS: { id: ThemeMode; label: string; Icon: typeof Sun }[] = [
 export default function AppearanceSettings() {
   const { accentId, setAccent, options } = useAccentColor();
   const { mode, setMode } = useThemeMode();
+  const { position, setPosition } = useToastPosition();
 
   return (
     <div className="flex h-full min-h-0 flex-col overflow-hidden">
@@ -113,6 +115,47 @@ export default function AppearanceSettings() {
                   </button>
                 );
               })}
+            </div>
+          </div>
+        </section>
+
+        <section>
+          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
+            <h2 className="text-sm font-medium text-foreground">Toast position</h2>
+            <p className="mt-1 text-xs text-muted-foreground">
+              Choose where notifications appear in the app.
+            </p>
+            <div
+              role="radiogroup"
+              aria-label="Toast position"
+              className="mt-5 grid h-28 w-48 grid-cols-3 grid-rows-2 overflow-hidden rounded-lg border border-border bg-background shadow-inner"
+            >
+              {TOAST_POSITIONS.map((option) => (
+                <label
+                  key={option.id}
+                  title={option.label}
+                  className="group relative flex min-h-11 cursor-pointer items-center justify-center border-border transition-colors has-checked:bg-primary/8 has-focus-visible:z-10 has-focus-visible:ring-[3px] has-focus-visible:ring-inset has-focus-visible:ring-ring/50 [&:nth-child(-n+3)]:border-b [&:not(:nth-child(3n))]:border-r"
+                >
+                  <input
+                    type="radio"
+                    name="toast-position"
+                    value={option.id}
+                    checked={position === option.id}
+                    onChange={() => setPosition(option.id)}
+                    className="sr-only"
+                  />
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      "h-2 w-8 rounded-sm border transition-colors",
+                      position === option.id
+                        ? "border-primary bg-primary"
+                        : "border-muted-foreground/40 bg-muted group-hover:border-muted-foreground/70",
+                    )}
+                  />
+                  <span className="sr-only">{option.label}</span>
+                </label>
+              ))}
             </div>
           </div>
         </section>

--- a/frontend/tests/components/ToastInteractions.test.tsx
+++ b/frontend/tests/components/ToastInteractions.test.tsx
@@ -1,0 +1,32 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, describe, expect, it } from "vitest";
+import { Toaster, toast } from "sonner";
+import { HiveToast } from "@/components/ui/toaster";
+
+describe("toast interactions", () => {
+  beforeEach(() => toast.dismiss());
+
+  it("dismisses a custom toast from its close button", async () => {
+    const user = userEvent.setup();
+    render(<Toaster toastOptions={{ unstyled: true }} />);
+
+    act(() => {
+      toast.custom((id) => (
+        <HiveToast
+          variant="success"
+          title="Hive"
+          status="Done"
+          description="Task completed"
+          onClose={() => toast.dismiss(id)}
+        />
+      ));
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Dismiss" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Dismiss" })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/tests/components/ToastInteractions.test.tsx
+++ b/frontend/tests/components/ToastInteractions.test.tsx
@@ -1,6 +1,6 @@
-import { act, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Toaster, toast } from "sonner";
 import { HiveToast } from "@/components/ui/toaster";
 
@@ -28,5 +28,60 @@ describe("toast interactions", () => {
     await waitFor(() => {
       expect(screen.queryByRole("button", { name: "Dismiss" })).not.toBeInTheDocument();
     });
+  });
+
+  it("runs a custom toast action and dismisses the toast", async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(<Toaster toastOptions={{ unstyled: true }} />);
+
+    act(() => {
+      toast.custom((id) => (
+        <HiveToast
+          variant="warning"
+          title="Hive"
+          status="Input"
+          description="Agent needs input"
+          actionLabel="Respond"
+          onAction={() => {
+            onAction();
+            toast.dismiss(id);
+          }}
+          onClose={() => toast.dismiss(id)}
+        />
+      ));
+    });
+
+    await user.click(await screen.findByRole("button", { name: "Respond" }));
+
+    expect(onAction).toHaveBeenCalledOnce();
+    await waitFor(() => {
+      expect(screen.queryByRole("button", { name: "Respond" })).not.toBeInTheDocument();
+    });
+  });
+
+  it("keeps control pointer events out of the swipe container", () => {
+    const onPointerDown = vi.fn();
+    render(
+      <div onPointerDown={onPointerDown}>
+        <HiveToast
+          variant="warning"
+          title="Hive"
+          status="Input"
+          description="Agent needs input"
+          actionLabel="Respond"
+          onAction={() => {}}
+          onClose={() => {}}
+        />
+      </div>,
+    );
+
+    fireEvent.pointerDown(screen.getByRole("button", { name: "Respond" }));
+
+    const closeIcon = screen.getByRole("button", { name: "Dismiss" }).querySelector("svg");
+    expect(closeIcon).not.toBeNull();
+    fireEvent.pointerDown(closeIcon as SVGSVGElement);
+
+    expect(onPointerDown).not.toHaveBeenCalled();
   });
 });

--- a/frontend/tests/components/Toaster.test.tsx
+++ b/frontend/tests/components/Toaster.test.tsx
@@ -1,0 +1,27 @@
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HiveToaster } from "@/components/ui/toaster";
+
+const mocks = vi.hoisted(() => ({
+  toaster: vi.fn(() => null),
+  useToastPosition: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({ Toaster: mocks.toaster }));
+vi.mock("@/hooks/useThemeType", () => ({ useThemeType: () => "dark" }));
+vi.mock("@/hooks/useToastPosition", () => ({ useToastPosition: mocks.useToastPosition }));
+
+describe("HiveToaster", () => {
+  beforeEach(() => {
+    mocks.toaster.mockClear();
+    mocks.useToastPosition.mockReturnValue({ position: "bottom-center" });
+  });
+
+  it("uses the local position and Sonner's default swipe behavior", () => {
+    render(<HiveToaster />);
+
+    const props = mocks.toaster.mock.calls[0]?.[0];
+    expect(props).toEqual(expect.objectContaining({ position: "bottom-center", theme: "dark" }));
+    expect(props).not.toHaveProperty("swipeDirections");
+  });
+});

--- a/frontend/tests/hooks/useNotificationToasts.test.tsx
+++ b/frontend/tests/hooks/useNotificationToasts.test.tsx
@@ -289,7 +289,7 @@ describe("useNotificationToasts", () => {
     expect(mocks.dismiss).not.toHaveBeenCalled();
   });
 
-  it("keeps sticky action toasts when their CTA is clicked", () => {
+  it("dismisses sticky action toasts when their CTA is clicked", () => {
     renderHook(() => useNotificationToasts(makeProjects()));
 
     emit("ws-1", {
@@ -306,7 +306,7 @@ describe("useNotificationToasts", () => {
 
     expect(mocks.setSavedSession).toHaveBeenCalledWith("ws-1", "sess-9");
     expect(mocks.navigate).toHaveBeenCalledWith("/workspaces/ws-1");
-    expect(mocks.dismiss).not.toHaveBeenCalled();
+    expect(mocks.dismiss).toHaveBeenCalledWith("hive-action-toast:ws-1:sess-9");
   });
 
   it("shows sticky action toasts even while viewing the workspace", () => {

--- a/frontend/tests/hooks/useToastPosition.test.tsx
+++ b/frontend/tests/hooks/useToastPosition.test.tsx
@@ -1,0 +1,24 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useToastPosition } from "@/hooks/useToastPosition";
+
+describe("useToastPosition", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("defaults to bottom left when no valid preference exists", () => {
+    localStorage.setItem("hive-toast-position", "middle");
+
+    const { result } = renderHook(() => useToastPosition());
+
+    expect(result.current.position).toBe("bottom-left");
+  });
+
+  it("persists position changes", () => {
+    const { result } = renderHook(() => useToastPosition());
+
+    act(() => result.current.setPosition("top-right"));
+
+    expect(result.current.position).toBe("top-right");
+    expect(localStorage.getItem("hive-toast-position")).toBe("top-right");
+  });
+});

--- a/frontend/tests/pages/SettingsView.test.tsx
+++ b/frontend/tests/pages/SettingsView.test.tsx
@@ -9,9 +9,11 @@ import { getConnection, replaceConnection } from "@/hooks/useConnection";
 const mocks = vi.hoisted(() => ({
   setAccent: vi.fn(),
   setThemeMode: vi.fn(),
+  setToastPosition: vi.fn(),
   useConnectionStatus: vi.fn(),
   useAccentColor: vi.fn(),
   useThemeMode: vi.fn(),
+  useToastPosition: vi.fn(),
 }));
 
 vi.mock("@/hooks/useConnectionStatus", () => ({
@@ -25,6 +27,18 @@ vi.mock("@/hooks/useAccentColor", () => ({
 vi.mock("@/hooks/useThemeMode", () => ({
   useThemeMode: mocks.useThemeMode,
   THEME_MODES: ["system", "light", "dark"],
+}));
+
+vi.mock("@/hooks/useToastPosition", () => ({
+  TOAST_POSITIONS: [
+    { id: "top-left", label: "Top left" },
+    { id: "top-center", label: "Top center" },
+    { id: "top-right", label: "Top right" },
+    { id: "bottom-left", label: "Bottom left" },
+    { id: "bottom-center", label: "Bottom center" },
+    { id: "bottom-right", label: "Bottom right" },
+  ],
+  useToastPosition: mocks.useToastPosition,
 }));
 
 const TRANSPORT_SECURITY_WARNING =
@@ -349,6 +363,13 @@ describe("AppearanceSettings", () => {
       setMode: mocks.setThemeMode,
       options: ["system", "light", "dark"],
     });
+
+    mocks.setToastPosition.mockReset();
+    mocks.useToastPosition.mockReset();
+    mocks.useToastPosition.mockReturnValue({
+      position: "bottom-left",
+      setPosition: mocks.setToastPosition,
+    });
   });
 
   it("updates accent color from accent option buttons", async () => {
@@ -383,5 +404,15 @@ describe("AppearanceSettings", () => {
     expect(screen.getByRole("radio", { name: "Dark" })).toHaveAttribute("aria-checked", "true");
     expect(screen.getByRole("radio", { name: "Light" })).toHaveAttribute("aria-checked", "false");
     expect(screen.getByRole("radio", { name: "System" })).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("changes the toast position from the spatial selector", async () => {
+    const user = userEvent.setup();
+    render(<AppearanceSettings />);
+
+    expect(screen.getByRole("radio", { name: "Bottom left" })).toBeChecked();
+    await user.click(screen.getByRole("radio", { name: "Top right" }));
+
+    expect(mocks.setToastPosition).toHaveBeenCalledWith("top-right");
   });
 });


### PR DESCRIPTION
## Summary
- default app toasts to the bottom-left and add a six-position appearance preference
- persist the preference locally and let Sonner derive swipe directions from placement
- make close and navigation actions reliably dismiss toasts while preserving update progress flows
- use a smooth tooltip-inspired inverse surface while preserving green, red, and yellow semantic status colors

## Verification
- npm test (frontend: 1,813 tests)
- npm run lint (frontend)
- npm run typecheck (frontend)
- targeted toast interaction tests
- browser verification in light and dark themes for position, close, and action interactions