### PR TITLE
chore(release): prepare 0.1.0

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0-beta.6"
+version = "0.1.0"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.0-beta.6"
+version = "0.1.0"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Bumps the release version to **0.1.0** — the first stable release (Cargo.toml + Cargo.lock via `npm run release:version -- set`).

Ships since 0.1.0-beta.6:
- #435 — one-button server update from the app (SSH-driven `provision.sh --update`, busy-workspace warning, escalation-password flow, single-server guards), hardened by a closed 3-pass external audit.
- #436 — allow digit-prefixed SSH users.
- #437 — toast placement, styling, and interaction improvements.

A stable version carries no prerelease suffix, so `release.yml` publishes it as a normal GitHub release (`prerelease=false`) and it becomes the repo's **latest**. That un-breaks two paths that were dead while every release was a prerelease:
- the desktop updater endpoint (`releases/latest/download/latest.json`) — desktops on beta.6 will see 0.1.0 as an available update (the SemVer comparator orders `0.1.0 > 0.1.0-beta.6`);
- the documented install one-liner (`releases/latest/download/provision.sh`).

After merge:
1. Wait for CI green on `main`, then dispatch the release workflow from `main` to tag `v0.1.0`.
2. The desktop app (beta.6) should offer 0.1.0 via toast or Settings > Updates > Check for updates.
3. After the app relaunches into 0.1.0, the server-update prompt converges the backend — the first full one-click update loop in production.