### PR TITLE
refactor(settings): flatten the nested card chrome, fix two Updates defects

### DIFF
--- a/frontend/src/components/settings/SettingsSection.tsx
+++ b/frontend/src/components/settings/SettingsSection.tsx
@@ -1,0 +1,66 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * The body of a settings page: a single column of sections laid directly on the
+ * {@link CenterCard} surface.
+ *
+ * The card already provides the border, background and elevation, so sections
+ * inside it carry no chrome of their own — drawing a second bordered box on top
+ * of the card only doubles the frame. Sections are told apart by a hairline
+ * rule and whitespace instead.
+ */
+export function SettingsPanel({
+  children,
+  className,
+  wide = false,
+}: {
+  children: ReactNode;
+  className?: string;
+  /** Wider column for dense, table-like pages (e.g. a project's details). */
+  wide?: boolean;
+  }) {
+  return (
+    <div className={cn("px-6 py-3", wide ? "max-w-4xl" : "max-w-2xl", className)}>{children}</div>
+  );
+}
+
+/**
+ * One titled block inside a {@link SettingsPanel}. The rule belongs to the
+ * section rather than the panel so conditionally rendered sections cannot leave
+ * a dangling divider behind.
+ */
+export function SettingsSection({
+  title,
+  description,
+  action,
+  children,
+  role,
+}: {
+  /** Accepts a node so a section can inline a badge next to its heading. */
+  title?: ReactNode;
+  description?: ReactNode;
+  /** Trailing control on the heading row, e.g. a button or a toggle. */
+  action?: ReactNode;
+  children?: ReactNode;
+  role?: string;
+}) {
+  return (
+    <section className="border-b border-border/50 py-6 last:border-b-0" role={role}>
+      {(title || action) && (
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            {typeof title === "string" ? (
+              <h2 className="text-sm font-medium text-foreground">{title}</h2>
+            ) : (
+              title
+            )}
+            {description && <p className="mt-1 text-xs text-muted-foreground">{description}</p>}
+          </div>
+          {action && <div className="shrink-0">{action}</div>}
+        </div>
+      )}
+      {children}
+    </section>
+  );
+}

--- a/frontend/src/pages/settings/AccountSettings.tsx
+++ b/frontend/src/pages/settings/AccountSettings.tsx
@@ -1,6 +1,7 @@
 import { Github, Loader2, LogOut, ExternalLink, AlertCircle, CheckCircle2, Terminal, XCircle } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { cn } from "@/lib/utils";
 import { openExternal } from "@/lib/open-external";
 import { SignInPrompt } from "@/components/setup/SignInPrompt";
@@ -17,169 +18,168 @@ export default function AccountSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-      {state.kind === "loading" ? (
-        <div className="flex flex-1 items-center justify-center">
-          <Loader2 className="h-5 w-5 motion-safe:animate-spin text-muted-foreground" />
-        </div>
-      ) : (
-        <div className="max-w-2xl space-y-6 px-4 py-5">
-          {state.kind === "no-gh" && (
-            <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-              <div className="flex items-start gap-3">
-                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-warning-foreground" />
-                <div>
-                  <h2 className="text-sm font-medium">GitHub CLI not found</h2>
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    The GitHub CLI (<code className="rounded bg-muted px-1 py-0.5 text-[11px]">gh</code>) is required but was not found on the server.
+        {state.kind === "loading" ? (
+          <div className="flex flex-1 items-center justify-center">
+            <Loader2 className="h-5 w-5 motion-safe:animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <SettingsPanel>
+            {state.kind === "no-gh" && (
+              <SettingsSection>
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-warning-foreground" />
+                  <div>
+                    <h2 className="text-sm font-medium">GitHub CLI not found</h2>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      The GitHub CLI (<code className="rounded bg-muted px-1 py-0.5 text-[11px]">gh</code>) is required but was not found on the server.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => void openExternal("https://cli.github.com")}
+                      className="mt-3 inline-flex cursor-pointer items-center gap-1.5 text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                    >
+                      Install GitHub CLI
+                      <ExternalLink className="h-3 w-3" />
+                    </button>
+                  </div>
+                </div>
+              </SettingsSection>
+            )}
+
+            {state.kind === "disconnected" && (
+              <SettingsSection>
+                <div className="flex flex-col items-center py-4">
+                  <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
+                    <Github className="h-6 w-6 text-muted-foreground" />
+                  </div>
+                  <h2 className="mt-3 text-sm font-medium">Not connected</h2>
+                  <p className="mt-1 text-center text-xs text-muted-foreground">
+                    Connect your GitHub account to enable PR tracking and automatic git credentials.
                   </p>
                   <button
                     type="button"
-                    onClick={() => void openExternal("https://cli.github.com")}
-                    className="mt-3 inline-flex cursor-pointer items-center gap-1.5 text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                    onClick={connect}
+                    className="mt-4 inline-flex cursor-pointer items-center gap-2 rounded-md bg-[#24292f] px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[#24292f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                   >
-                    Install GitHub CLI
-                    <ExternalLink className="h-3 w-3" />
+                    <Github className="h-3.5 w-3.5" />
+                    Connect with GitHub
                   </button>
                 </div>
-              </div>
-            </section>
-          )}
+              </SettingsSection>
+            )}
 
-          {state.kind === "disconnected" && (
-            <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-              <div className="flex flex-col items-center py-4">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted/50">
-                  <Github className="h-6 w-6 text-muted-foreground" />
-                </div>
-                <h2 className="mt-3 text-sm font-medium">Not connected</h2>
-                <p className="mt-1 text-center text-xs text-muted-foreground">
-                  Connect your GitHub account to enable PR tracking and automatic git credentials.
-                </p>
-                <button
-                  type="button"
-                  onClick={connect}
-                  className="mt-4 inline-flex cursor-pointer items-center gap-2 rounded-md bg-[#24292f] px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-[#24292f]/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                >
-                  <Github className="h-3.5 w-3.5" />
-                  Connect with GitHub
-                </button>
-              </div>
-            </section>
-          )}
+            {state.kind === "connecting" && (
+              <SettingsSection
+                title="Enter this code on GitHub"
+                description="Copy the code below and enter it at the GitHub verification page."
+              >
+                <SignInPrompt
+                  verificationUri={state.verificationUri}
+                  userCode={state.userCode}
+                  onCancel={cancelConnect}
+                />
+              </SettingsSection>
+            )}
 
-          {state.kind === "connecting" && (
-            <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-              <h2 className="text-sm font-medium">Enter this code on GitHub</h2>
-              <p className="mt-1 text-xs text-muted-foreground">
-                Copy the code below and enter it at the GitHub verification page.
-              </p>
-              <SignInPrompt
-                verificationUri={state.verificationUri}
-                userCode={state.userCode}
-                onCancel={cancelConnect}
-              />
-            </section>
-          )}
-
-          {state.kind === "connected" && (
-            <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-              <div className="flex items-center gap-4">
-                {state.user.avatarUrl ? (
-                  <img
-                    src={state.user.avatarUrl}
-                    alt={`${state.user.login}'s avatar`}
-                    className="h-16 w-16 rounded-full"
-                  />
-                ) : (
-                  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
-                    <Github className="h-8 w-8 text-muted-foreground" />
+            {state.kind === "connected" && (
+              <SettingsSection>
+                <div className="flex items-center gap-4">
+                  {state.user.avatarUrl ? (
+                    <img
+                      src={state.user.avatarUrl}
+                      alt={`${state.user.login}'s avatar`}
+                      className="h-16 w-16 rounded-full"
+                    />
+                  ) : (
+                    <div className="flex h-16 w-16 items-center justify-center rounded-full bg-muted">
+                      <Github className="h-8 w-8 text-muted-foreground" />
+                    </div>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <h2 className="text-base font-semibold">
+                      {state.user.name || state.user.login}
+                    </h2>
+                    {state.user.email && (
+                      <p className="mt-0.5 text-xs text-muted-foreground">{state.user.email}</p>
+                    )}
+                    <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                      <Github className="h-3 w-3" />
+                      {state.user.login}
+                    </p>
                   </div>
-                )}
-                <div className="min-w-0 flex-1">
-                  <h2 className="text-base font-semibold">
-                    {state.user.name || state.user.login}
-                  </h2>
-                  {state.user.email && (
-                    <p className="mt-0.5 text-xs text-muted-foreground">{state.user.email}</p>
-                  )}
-                  <p className="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
-                    <Github className="h-3 w-3" />
-                    {state.user.login}
-                  </p>
                 </div>
-              </div>
-              <div className="mt-4 border-t border-border/50 pt-4">
-                <button
-                  type="button"
-                  onClick={disconnect}
-                  disabled={disconnecting}
-                  className={cn(
-                    "inline-flex cursor-pointer items-center gap-2 rounded-md border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-                    disconnecting && "pointer-events-none opacity-60",
-                  )}
-                >
-                  {disconnecting
-                    ? <Loader2 className="h-3 w-3 motion-safe:animate-spin" />
-                    : <LogOut className="h-3 w-3" />}
-                  Disconnect
-                </button>
-              </div>
-            </section>
-          )}
+                <div className="mt-4">
+                  <button
+                    type="button"
+                    onClick={disconnect}
+                    disabled={disconnecting}
+                    className={cn(
+                      "inline-flex cursor-pointer items-center gap-2 rounded-md border border-border/50 px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted/40 hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                      disconnecting && "pointer-events-none opacity-60",
+                    )}
+                  >
+                    {disconnecting
+                      ? <Loader2 className="h-3 w-3 motion-safe:animate-spin" />
+                      : <LogOut className="h-3 w-3" />}
+                    Disconnect
+                  </button>
+                </div>
+              </SettingsSection>
+            )}
 
-          {state.kind === "error" && (
-            <section className="rounded-lg border border-border/50 bg-card/50 p-5" role="alert">
+            {state.kind === "error" && (
+              <SettingsSection role="alert">
+                <div className="flex items-start gap-3">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                  <div>
+                    <h2 className="text-sm font-medium">Something went wrong</h2>
+                    <p className="mt-1 text-xs text-muted-foreground">{state.message}</p>
+                    {state.retryable && (
+                      <button
+                        type="button"
+                        onClick={retry}
+                        className="mt-3 inline-flex cursor-pointer items-center gap-1.5 text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
+                      >
+                        Try again
+                      </button>
+                    )}
+                  </div>
+                </div>
+              </SettingsSection>
+            )}
+
+            {/* GitHub CLI integration status */}
+            <SettingsSection>
               <div className="flex items-start gap-3">
-                <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                {state.kind === "connected" ? (
+                  <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success-foreground" />
+                ) : state.kind === "no-gh" ? (
+                  <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
+                ) : (
+                  <Terminal className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+                )}
                 <div>
-                  <h2 className="text-sm font-medium">Something went wrong</h2>
-                  <p className="mt-1 text-xs text-muted-foreground">{state.message}</p>
-                  {state.retryable && (
-                    <button
-                      type="button"
-                      onClick={retry}
-                      className="mt-3 inline-flex cursor-pointer items-center gap-1.5 text-xs text-primary hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-sm"
-                    >
-                      Try again
-                    </button>
+                  <h2 className="text-sm font-medium">GitHub CLI integration</h2>
+                  {state.kind === "connected" && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Authenticated and ready.
+                    </p>
+                  )}
+                  {state.kind === "no-gh" && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      GitHub CLI (<code className="rounded bg-muted px-1 py-0.5 text-[11px]">gh</code>) is not installed.
+                    </p>
+                  )}
+                  {(state.kind === "disconnected" || state.kind === "connecting" || state.kind === "error") && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      GitHub CLI is installed but not authenticated.
+                    </p>
                   )}
                 </div>
               </div>
-            </section>
-          )}
-
-          {/* GitHub CLI integration status */}
-          <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <div className="flex items-start gap-3">
-              {state.kind === "connected" ? (
-                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-success-foreground" />
-              ) : state.kind === "no-gh" ? (
-                <XCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
-              ) : (
-                <Terminal className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
-              )}
-              <div>
-                <h2 className="text-sm font-medium">GitHub CLI integration</h2>
-                {state.kind === "connected" && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Authenticated and ready.
-                  </p>
-                )}
-                {state.kind === "no-gh" && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    GitHub CLI (<code className="rounded bg-muted px-1 py-0.5 text-[11px]">gh</code>) is not installed.
-                  </p>
-                )}
-                {(state.kind === "disconnected" || state.kind === "connecting" || state.kind === "error") && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    GitHub CLI is installed but not authenticated.
-                  </p>
-                )}
-              </div>
-            </div>
-          </section>
-        </div>
-      )}
+            </SettingsSection>
+          </SettingsPanel>
+        )}
       </CenterCard>
     </div>
   );

--- a/frontend/src/pages/settings/AgentSettings.tsx
+++ b/frontend/src/pages/settings/AgentSettings.tsx
@@ -1,5 +1,6 @@
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel } from "@/components/settings/SettingsSection";
 import { ToolsPanel } from "@/components/setup/ToolsPanel";
 
 /**
@@ -15,7 +16,7 @@ export default function AgentSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-        <div className="max-w-2xl space-y-4 px-4 py-5">
+        <SettingsPanel className="space-y-4 py-6">
           <ToolsPanel />
           {/*
             The note lives here, not in ToolsPanel: the installer reuses that
@@ -24,7 +25,7 @@ export default function AgentSettings() {
             disabled for want of the second harness.
           */}
           <p className="text-xs text-muted-foreground">At least one harness needed to run Hive</p>
-        </div>
+        </SettingsPanel>
       </CenterCard>
     </div>
   );

--- a/frontend/src/pages/settings/AppearanceSettings.tsx
+++ b/frontend/src/pages/settings/AppearanceSettings.tsx
@@ -4,6 +4,7 @@ import { useThemeMode, type ThemeMode } from "@/hooks/useThemeMode";
 import { TOAST_POSITIONS, useToastPosition } from "@/hooks/useToastPosition";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { cn } from "@/lib/utils";
 
 const THEME_OPTIONS: { id: ThemeMode; label: string; Icon: typeof Sun }[] = [
@@ -24,17 +25,15 @@ export default function AppearanceSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-      <div className="max-w-2xl space-y-5 px-4 py-5">
-        <section>
-          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <h2 className="text-sm font-medium text-foreground">Theme</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Choose how Hive looks. System follows your OS preference.
-            </p>
+        <SettingsPanel>
+          <SettingsSection
+            title="Theme"
+            description="Choose how Hive looks. System follows your OS preference."
+          >
             <div
               role="radiogroup"
               aria-label="Theme mode"
-              className="mt-5 grid grid-cols-3 gap-2"
+              className="mt-4 grid grid-cols-3 gap-2"
             >
               {THEME_OPTIONS.map(({ id, label, Icon }) => {
                 const isActive = id === mode;
@@ -64,16 +63,13 @@ export default function AppearanceSettings() {
                 );
               })}
             </div>
-          </div>
-        </section>
+          </SettingsSection>
 
-        <section>
-          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <h2 className="text-sm font-medium text-foreground">Accent color</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Applies to active states, badges, focus rings, and highlights.
-            </p>
-            <div className="mt-5 flex flex-wrap gap-2">
+          <SettingsSection
+            title="Accent color"
+            description="Applies to active states, badges, focus rings, and highlights."
+          >
+            <div className="mt-4 flex flex-wrap gap-2">
               {options.map((option) => {
                 const isActive = option.id === accentId;
                 return (
@@ -116,19 +112,16 @@ export default function AppearanceSettings() {
                 );
               })}
             </div>
-          </div>
-        </section>
+          </SettingsSection>
 
-        <section>
-          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <h2 className="text-sm font-medium text-foreground">Toast position</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Choose where notifications appear in the app.
-            </p>
+          <SettingsSection
+            title="Toast position"
+            description="Choose where notifications appear in the app."
+          >
             <div
               role="radiogroup"
               aria-label="Toast position"
-              className="mt-5 grid h-28 w-48 grid-cols-3 grid-rows-2 overflow-hidden rounded-lg border border-border bg-background shadow-inner"
+              className="mt-4 grid h-28 w-48 grid-cols-3 grid-rows-2 overflow-hidden rounded-lg border border-border bg-background shadow-inner"
             >
               {TOAST_POSITIONS.map((option) => (
                 <label
@@ -157,9 +150,8 @@ export default function AppearanceSettings() {
                 </label>
               ))}
             </div>
-          </div>
-        </section>
-      </div>
+          </SettingsSection>
+        </SettingsPanel>
       </CenterCard>
     </div>
   );

--- a/frontend/src/pages/settings/ConnectionSettings.tsx
+++ b/frontend/src/pages/settings/ConnectionSettings.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { RefreshCw } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { TransportSecurityWarning } from "@/components/setup/TransportSecurityWarning";
 import { useConnection } from "@/hooks/useConnection";
 import type { ConnectionStatus } from "@/hooks/useConnectionStatus";
@@ -143,17 +144,13 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
       </SettingsHeader>
 
       <CenterCard scroll>
-        <div className="max-w-2xl space-y-6 px-4 py-5">
-          <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <div className="flex items-start justify-between">
-              <div>
-                <h2 className="text-sm font-medium text-foreground">Server</h2>
-                {!connection && (
-                  <p className="mt-1 text-xs text-muted-foreground">
-                    Enter the address and access token of your Hive server.
-                  </p>
-                )}
-              </div>
+        <SettingsPanel>
+          <SettingsSection
+            title="Server"
+            description={
+              !connection ? "Enter the address and access token of your Hive server." : undefined
+            }
+            action={
               <span
                 className={cn(
                   "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[11px] font-medium",
@@ -163,15 +160,15 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
                 <span className={cn("h-1.5 w-1.5 rounded-full", cfg.dot)} />
                 {cfg.label}
               </span>
-            </div>
-
+            }
+          >
             {cfg.hint && connection && (
               <p role="status" className="mt-3 text-xs text-destructive">
                 {cfg.hint}
               </p>
             )}
 
-            <div className="mt-5 space-y-4">
+            <div className="mt-4 space-y-4">
               <TransportSecurityWarning />
               <div className="grid grid-cols-[1fr_120px] gap-3">
                 <div>
@@ -274,8 +271,8 @@ export default function ConnectionSettings({ onRefreshConnection }: ConnectionSe
                 )}
               </div>
             </div>
-          </section>
-        </div>
+          </SettingsSection>
+        </SettingsPanel>
       </CenterCard>
     </div>
   );

--- a/frontend/src/pages/settings/ModelsSettings.tsx
+++ b/frontend/src/pages/settings/ModelsSettings.tsx
@@ -3,6 +3,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Check, Eye, EyeOff, Loader2, Save } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { ProviderIcon } from "@/components/chat/ProviderIcon";
 import { groupModelsByProvider } from "@/components/chat/ModelSelector";
 import { Input } from "@/components/ui/input";
@@ -40,15 +41,11 @@ export default function ModelsSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-      <div className="max-w-2xl space-y-5 px-4 py-5">
-        <section>
-          <div className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <h2 className="text-sm font-medium text-foreground">Default model</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Used when starting a new conversation. You can still switch models
-              from the composer at any time.
-            </p>
-
+        <SettingsPanel>
+          <SettingsSection
+            title="Default model"
+            description="Used when starting a new conversation. You can still switch models from the composer at any time."
+          >
             {isLoading && (
               <div className="flex items-center gap-2 py-6 text-xs text-muted-foreground">
                 <Loader2 className="h-4 w-4 animate-spin" />
@@ -103,11 +100,10 @@ export default function ModelsSettings() {
                 Could not save the default model. Please try again.
               </p>
             )}
-          </div>
-        </section>
+          </SettingsSection>
 
-        <KimiSection />
-      </div>
+          <KimiSection />
+        </SettingsPanel>
       </CenterCard>
     </div>
   );
@@ -154,10 +150,10 @@ function KimiSection() {
   };
 
   return (
-    <section>
-      <div className="rounded-lg border border-border/50 bg-card/50 p-5">
-        <h2 className="text-sm font-medium text-foreground">Kimi</h2>
-        <p className="mt-1 text-xs text-muted-foreground">
+    <SettingsSection
+      title="Kimi"
+      description={
+        <>
           API key from the{" "}
           <a
             href="https://www.kimi.com/code/console"
@@ -168,76 +164,76 @@ function KimiSection() {
             Kimi Code console
           </a>
           , used to enable the Kimi provider.
+        </>
+      }
+    >
+      {loadState === "loading" && (
+        <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading saved key…
+        </div>
+      )}
+
+      {loadState === "error" && (
+        <p className="py-4 text-xs text-destructive">
+          Could not load the saved API key. Reload the page to try again.
         </p>
+      )}
 
-        {loadState === "loading" && (
-          <div className="flex items-center gap-2 py-4 text-xs text-muted-foreground">
-            <Loader2 className="h-4 w-4 animate-spin" />
-            Loading saved key…
-          </div>
-        )}
-
-        {loadState === "error" && (
-          <p className="py-4 text-xs text-destructive">
-            Could not load the saved API key. Reload the page to try again.
-          </p>
-        )}
-
-        {loadState === "loaded" && (
-          <>
-            <div className="mt-4">
-              <label htmlFor="kimi-api-key" className="mb-1.5 block text-xs font-medium text-muted-foreground">
-                Kimi API key
-              </label>
-              <div className="relative">
-                <Input
-                  id="kimi-api-key"
-                  type={showKey ? "text" : "password"}
-                  value={apiKey}
-                  onChange={(e) => { setApiKey(e.target.value); setFeedback(null); }}
-                  placeholder="sk-..."
-                  className="pr-9 font-mono text-xs"
-                />
-                <button
-                  type="button"
-                  onClick={() => setShowKey(!showKey)}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  {showKey
-                    ? <EyeOff className="h-3.5 w-3.5" />
-                    : <Eye className="h-3.5 w-3.5" />}
-                </button>
-              </div>
-            </div>
-
-            <div className="mt-4 flex items-center gap-2">
+      {loadState === "loaded" && (
+        <>
+          <div className="mt-4">
+            <label htmlFor="kimi-api-key" className="mb-1.5 block text-xs font-medium text-muted-foreground">
+              Kimi API key
+            </label>
+            <div className="relative">
+              <Input
+                id="kimi-api-key"
+                type={showKey ? "text" : "password"}
+                value={apiKey}
+                onChange={(e) => { setApiKey(e.target.value); setFeedback(null); }}
+                placeholder="sk-..."
+                className="pr-9 font-mono text-xs"
+              />
               <button
                 type="button"
-                onClick={() => void save()}
-                disabled={saving}
-                className={cn(
-                  "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
-                  saving && "pointer-events-none opacity-60",
-                )}
+                onClick={() => setShowKey(!showKey)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground transition-colors hover:text-foreground"
               >
-                {saving
-                  ? <Loader2 className="h-3 w-3 animate-spin" />
-                  : <Save className="h-3 w-3" />}
-                Save
+                {showKey
+                  ? <EyeOff className="h-3.5 w-3.5" />
+                  : <Eye className="h-3.5 w-3.5" />}
               </button>
-
-              {feedback && (
-                <span className={cn(
-                  "text-xs font-medium",
-                  feedback === "saved" ? "text-success-foreground" : "text-destructive",
-                )}>
-                  {feedback === "saved" ? "Saved" : "Failed to save"}
-                </span>
-              )}
             </div>
-          </>
-        )}
-      </div>
-    </section>
+          </div>
+
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => void save()}
+              disabled={saving}
+              className={cn(
+                "inline-flex cursor-pointer items-center gap-2 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90",
+                saving && "pointer-events-none opacity-60",
+              )}
+            >
+              {saving
+                ? <Loader2 className="h-3 w-3 animate-spin" />
+                : <Save className="h-3 w-3" />}
+              Save
+            </button>
+
+            {feedback && (
+              <span className={cn(
+                "text-xs font-medium",
+                feedback === "saved" ? "text-success-foreground" : "text-destructive",
+              )}>
+                {feedback === "saved" ? "Saved" : "Failed to save"}
+              </span>
+            )}
+          </div>
+        </>
+      )}
+    </SettingsSection>
   );
 }

--- a/frontend/src/pages/settings/NotificationSettings.tsx
+++ b/frontend/src/pages/settings/NotificationSettings.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Eye, EyeOff, Send, Save, Loader2 } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
@@ -39,10 +40,10 @@ export default function NotificationSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-      <div className="max-w-2xl space-y-6 px-4 py-5">
-        <LocalToastsSection />
-        <TelegramForm initial={telegram} />
-      </div>
+        <SettingsPanel>
+          <LocalToastsSection />
+          <TelegramForm initial={telegram} />
+        </SettingsPanel>
       </CenterCard>
     </div>
   );
@@ -153,14 +154,12 @@ function LocalToastsSection() {
       description="Show toast notifications when agents finish in background workspaces."
       enabled={enabled}
       onToggle={setLocalToastsEnabled}
-    >
-      <div />
-    </NotificationSection>
+    />
   );
 }
 
 // ---------------------------------------------------------------------------
-// Shared section wrapper (toggle header + card chrome)
+// Shared section wrapper (toggle header)
 // ---------------------------------------------------------------------------
 
 function NotificationSection({ id, title, description, enabled, onToggle, children }: {
@@ -169,19 +168,20 @@ function NotificationSection({ id, title, description, enabled, onToggle, childr
   description: string;
   enabled: boolean;
   onToggle: (v: boolean) => void;
-  children: ReactNode;
+  children?: ReactNode;
 }) {
   return (
-    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-      <div className="flex items-start justify-between">
-        <div>
-          <h2 id={`${id}-toggle-label`} className="text-sm font-medium text-foreground">{title}</h2>
-          <p className="mt-1 text-xs text-muted-foreground">{description}</p>
-        </div>
-        <Toggle id={`${id}-toggle-label`} enabled={enabled} onChange={onToggle} />
-      </div>
+    <SettingsSection
+      // Rendered here rather than passed as a string so the toggle can point at
+      // the heading it controls.
+      title={
+        <h2 id={`${id}-toggle-label`} className="text-sm font-medium text-foreground">{title}</h2>
+      }
+      description={description}
+      action={<Toggle id={`${id}-toggle-label`} enabled={enabled} onChange={onToggle} />}
+    >
       {children}
-    </section>
+    </SettingsSection>
   );
 }
 
@@ -239,7 +239,7 @@ function TelegramForm({ initial }: { initial: TelegramConfig }) {
       enabled={channel.enabled}
       onToggle={channel.handleToggle}
     >
-      <div className={cn("mt-5 space-y-4 transition-opacity", !channel.enabled && "pointer-events-none opacity-50")}>
+      <div className={cn("mt-4 space-y-4 transition-opacity", !channel.enabled && "pointer-events-none opacity-50")}>
         <div>
           <label htmlFor="tg-token" className="mb-1.5 block text-xs font-medium text-muted-foreground">
             Bot Token

--- a/frontend/src/pages/settings/ProjectDetail.tsx
+++ b/frontend/src/pages/settings/ProjectDetail.tsx
@@ -3,6 +3,7 @@ import { useParams, useNavigate } from "react-router-dom";
 import { Trash2, ExternalLink, Save, Pencil, Plus, X, Eye } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { EnvEditor } from "@/components/EnvEditor";
 import { ProjectEnvStructuredEditor } from "@/components/ProjectEnvStructuredEditor";
 import {
@@ -83,103 +84,107 @@ export default function ProjectDetail() {
       </SettingsHeader>
 
       <CenterCard scroll>
-      <div className="max-w-4xl space-y-4 px-4 py-5">
-        <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-          <div className="mb-4 flex items-center justify-between gap-3">
-            <h2 className="text-sm font-medium text-foreground">Overview</h2>
-            <span className="rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium tabular-nums text-primary">
-              {workspaceCount} workspace{workspaceCount !== 1 ? "s" : ""}
-            </span>
-          </div>
-
-          <div className="space-y-3">
-            <InfoRow label="Repository" mono>
-              {project.url ? (
-                <span className="inline-flex max-w-full items-center gap-1.5">
-                  <span className="truncate">{project.url}</span>
-                  <a
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-                    aria-label="Open repository URL"
-                  >
-                    <ExternalLink className="h-3 w-3" />
-                  </a>
-                </span>
-              ) : (
-                <span className="text-muted-foreground">Local only</span>
-              )}
-            </InfoRow>
-            <InfoRow label="Bare repo" mono>
-              {project.repoPath ?? "\u2014"}
-            </InfoRow>
-            <InfoRow label="Workspaces" mono>
-              {project.workspacesPath ?? "\u2014"}
-            </InfoRow>
-            {envConfigured && envPath && (
-              <InfoRow label="Env config" mono>
-                {envPath}
+        <SettingsPanel wide>
+          <SettingsSection
+            title="Overview"
+            action={
+              <span className="rounded-md bg-primary/10 px-2 py-0.5 text-[11px] font-medium tabular-nums text-primary">
+                {workspaceCount} workspace{workspaceCount !== 1 ? "s" : ""}
+              </span>
+            }
+          >
+            <div className="mt-4 space-y-3">
+              <InfoRow label="Repository" mono>
+                {project.url ? (
+                  <span className="inline-flex max-w-full items-center gap-1.5">
+                    <span className="truncate">{project.url}</span>
+                    <a
+                      href={project.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+                      aria-label="Open repository URL"
+                    >
+                      <ExternalLink className="h-3 w-3" />
+                    </a>
+                  </span>
+                ) : (
+                  <span className="text-muted-foreground">Local only</span>
+                )}
               </InfoRow>
-            )}
-          </div>
-        </section>
-
-        <ProjectEnvSection
-          project={project}
-          envConfigured={envConfigured}
-          envConfig={envConfig}
-          envRevision={envRevision}
-          envLoading={envQuery.isLoading}
-          editorOpen={envEditorOpen}
-          onOpenEditor={() => setEditingEnvProjectId(project.id)}
-          onCloseEditor={() => setEditingEnvProjectId(null)}
-        />
-
-        <section className="rounded-lg border border-destructive/20 bg-destructive/5 p-5">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-            <div>
-              <h2 className="text-sm font-medium text-destructive">Danger zone</h2>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {hasWorkspaces
-                  ? "Cannot delete a project with active workspaces. Archive all workspaces first."
-                  : "This will permanently delete the bare repository and all associated data."}
-              </p>
-            </div>
-            <button
-              type="button"
-              disabled={hasWorkspaces}
-              onClick={() => setShowDeleteConfirm(true)}
-              className={cn(
-                "inline-flex cursor-pointer items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
-                hasWorkspaces
-                  ? "cursor-not-allowed border-border/30 text-muted-foreground/50"
-                  : "border-destructive/40 text-destructive hover:bg-destructive/10",
+              <InfoRow label="Bare repo" mono>
+                {project.repoPath ?? "\u2014"}
+              </InfoRow>
+              <InfoRow label="Workspaces" mono>
+                {project.workspacesPath ?? "\u2014"}
+              </InfoRow>
+              {envConfigured && envPath && (
+                <InfoRow label="Env config" mono>
+                  {envPath}
+                </InfoRow>
               )}
-            >
-              <Trash2 className="h-3.5 w-3.5" />
-              Delete project
-            </button>
-          </div>
-        </section>
-      </div>
+            </div>
+          </SettingsSection>
 
-      <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete project</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete <strong>{project.name}</strong> and all its data. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => void handleDelete()}>
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
+          <ProjectEnvSection
+            project={project}
+            envConfigured={envConfigured}
+            envConfig={envConfig}
+            envRevision={envRevision}
+            envLoading={envQuery.isLoading}
+            editorOpen={envEditorOpen}
+            onOpenEditor={() => setEditingEnvProjectId(project.id)}
+            onCloseEditor={() => setEditingEnvProjectId(null)}
+          />
+
+          {/*
+            The one place that keeps a box of its own: the tint is the warning,
+            not decoration, and it only reads as one against flat siblings.
+          */}
+          <section className="my-6 rounded-lg border border-destructive/20 bg-destructive/5 p-5">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-sm font-medium text-destructive">Danger zone</h2>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {hasWorkspaces
+                    ? "Cannot delete a project with active workspaces. Archive all workspaces first."
+                    : "This will permanently delete the bare repository and all associated data."}
+                </p>
+              </div>
+              <button
+                type="button"
+                disabled={hasWorkspaces}
+                onClick={() => setShowDeleteConfirm(true)}
+                className={cn(
+                  "inline-flex cursor-pointer items-center gap-2 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors",
+                  hasWorkspaces
+                    ? "cursor-not-allowed border-border/30 text-muted-foreground/50"
+                    : "border-destructive/40 text-destructive hover:bg-destructive/10",
+                )}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete project
+              </button>
+            </div>
+          </section>
+        </SettingsPanel>
+
+        <AlertDialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete project</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will permanently delete <strong>{project.name}</strong> and all its data. This action cannot be undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => void handleDelete()}>
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
       </CenterCard>
     </div>
   );
@@ -216,66 +221,64 @@ function ProjectEnvSection({
   };
 
   return (
-    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <h2 className="text-sm font-medium text-foreground">Environment</h2>
-            {envConfigured && !envLoading ? (
-              <Button
-                type="button"
-                variant="ghost"
-                size="xs"
-                onClick={() => setViewerOpen(true)}
-                className="h-6 border border-primary/20 bg-primary/10 px-2 text-[11px] text-primary hover:bg-primary/15 hover:text-primary"
-                aria-label="View generated .env"
-                title="View generated .env"
-              >
-                {envStatusLabel}
-                <Eye className="h-3 w-3" aria-hidden="true" />
-              </Button>
-            ) : (
-              <Badge variant="secondary" className="h-6 rounded-md px-2 text-[11px] text-muted-foreground">
-                {envStatusLabel}
-              </Badge>
-            )}
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {envDescription}
-          </p>
+    <SettingsSection
+      title={
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-medium text-foreground">Environment</h2>
+          {envConfigured && !envLoading ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="xs"
+              onClick={() => setViewerOpen(true)}
+              className="h-6 border border-primary/20 bg-primary/10 px-2 text-[11px] text-primary hover:bg-primary/15 hover:text-primary"
+              aria-label="View generated .env"
+              title="View generated .env"
+            >
+              {envStatusLabel}
+              <Eye className="h-3 w-3" aria-hidden="true" />
+            </Button>
+          ) : (
+            <Badge variant="secondary" className="h-6 rounded-md px-2 text-[11px] text-muted-foreground">
+              {envStatusLabel}
+            </Badge>
+          )}
         </div>
-        <div className="flex shrink-0 items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon-sm"
-            disabled={envLoading}
-            onClick={editorOpen ? onCloseEditor : onOpenEditor}
-            title={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
-            aria-label={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
-            className="border-border/50 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
-          >
-            {envLoading ? (
-              <span className="h-3.5 w-3.5" />
-            ) : editorOpen ? (
-              <X className="h-3.5 w-3.5" />
-            ) : envConfigured ? (
-              <Pencil className="h-3.5 w-3.5" />
-            ) : (
-              <Plus className="h-3.5 w-3.5" />
-            )}
-          </Button>
-        </div>
-      </div>
-
+      }
+      description={envDescription}
+      action={
+        <Button
+          type="button"
+          variant="outline"
+          size="icon-sm"
+          disabled={envLoading}
+          onClick={editorOpen ? onCloseEditor : onOpenEditor}
+          title={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
+          aria-label={getEnvToggleTitle(envLoading, editorOpen, envConfigured)}
+          className="border-border/50 text-muted-foreground hover:bg-muted/40 hover:text-foreground"
+        >
+          {envLoading ? (
+            <span className="h-3.5 w-3.5" />
+          ) : editorOpen ? (
+            <X className="h-3.5 w-3.5" />
+          ) : envConfigured ? (
+            <Pencil className="h-3.5 w-3.5" />
+          ) : (
+            <Plus className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      }
+    >
       {editorOpen && (
-        <ProjectEnvEditor
-          key={`${project.id}:${envRevision}`}
-          initialConfig={envConfig}
-          loading={envLoading}
-          saving={updateEnv.isPending}
-          onSave={(config) => void handleSaveEnv(config)}
-        />
+        <div className="mt-4">
+          <ProjectEnvEditor
+            key={`${project.id}:${envRevision}`}
+            initialConfig={envConfig}
+            loading={envLoading}
+            saving={updateEnv.isPending}
+            onSave={(config) => void handleSaveEnv(config)}
+          />
+        </div>
       )}
 
       <ProjectEnvViewer
@@ -283,7 +286,7 @@ function ProjectEnvSection({
         onOpenChange={setViewerOpen}
         config={envConfig}
       />
-    </section>
+    </SettingsSection>
   );
 }
 

--- a/frontend/src/pages/settings/ServerSettings.tsx
+++ b/frontend/src/pages/settings/ServerSettings.tsx
@@ -1,5 +1,6 @@
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { Button } from "@/components/ui/button";
 
 interface ServerSettingsProps {
@@ -20,17 +21,16 @@ export default function ServerSettings({ onOpenInstaller }: ServerSettingsProps)
       </SettingsHeader>
 
       <CenterCard scroll>
-        <div className="max-w-2xl space-y-6 px-4 py-5">
-          <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-            <h2 className="text-sm font-medium text-foreground">Install Hive on a server</h2>
-            <p className="mt-1 text-xs text-muted-foreground">
-              Opens the installer over the app. Nothing changes here unless you finish it.
-            </p>
-            <Button size="sm" variant="outline" className="mt-3" onClick={onOpenInstaller}>
+        <SettingsPanel>
+          <SettingsSection
+            title="Install Hive on a server"
+            description="Opens the installer over the app. Nothing changes here unless you finish it."
+          >
+            <Button size="sm" variant="outline" className="mt-4" onClick={onOpenInstaller}>
               Open the installer
             </Button>
-          </section>
-        </div>
+          </SettingsSection>
+        </SettingsPanel>
       </CenterCard>
     </div>
   );

--- a/frontend/src/pages/settings/UpdatesSettings.tsx
+++ b/frontend/src/pages/settings/UpdatesSettings.tsx
@@ -3,6 +3,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Check, Copy, KeyRound, Loader2, RefreshCw } from "lucide-react";
 import { SettingsHeader } from "@/components/AppLayout";
 import { CenterCard } from "@/components/CenterCard";
+import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSection";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -30,7 +31,12 @@ import { useWorkspaceLiveDataContext } from "@/contexts/WorkspaceLiveDataContext
 import { isDesktopShell } from "@/lib/is-desktop";
 import { copyToClipboard } from "@/lib/clipboard";
 import { createTauriProvisionClient, type SshKey } from "@/lib/provision-client";
-import { runServerUpdate, serverVersionDiffersFromApp, useServerUpdateState } from "@/lib/server-update";
+import {
+  runServerUpdate,
+  serverVersionDiffersFromApp,
+  useServerUpdateState,
+  type ServerUpdateState,
+} from "@/lib/server-update";
 import {
   checkForUpdatesNow,
   installCurrentUpdate,
@@ -53,14 +59,14 @@ export default function UpdatesSettings() {
       </SettingsHeader>
 
       <CenterCard scroll>
-        <div className="max-w-2xl space-y-6 px-4 py-5">
+        <SettingsPanel>
           {isDesktopShell() && <AppSection appVersion={appVersion} />}
           <ServerSection
             appVersion={appVersion}
             backendVersion={backendQuery.data?.version ?? null}
             unreachable={backendQuery.isError}
           />
-        </div>
+        </SettingsPanel>
       </CenterCard>
     </div>
   );
@@ -68,17 +74,16 @@ export default function UpdatesSettings() {
 
 function AppSection({ appVersion }: { appVersion: string | null }) {
   const update = useDesktopUpdateState();
+  const canCheck = shouldCheckForUpdates();
   const busy =
     update.phase === "checking" || update.phase === "downloading" || update.phase === "installing";
 
   return (
-    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-      <div className="flex items-center justify-between gap-3">
-        <div>
-          <h2 className="text-sm font-medium text-foreground">Application</h2>
-          <p className="mt-1 text-xs text-muted-foreground">Version {appVersion ?? "—"}</p>
-        </div>
-        {shouldCheckForUpdates() && (
+    <SettingsSection
+      title="Application"
+      description={`Version ${appVersion ?? "—"}`}
+      action={
+        canCheck && (
           <Button size="sm" variant="outline" onClick={checkForUpdatesNow} disabled={busy}>
             {update.phase === "checking" ? (
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -87,16 +92,17 @@ function AppSection({ appVersion }: { appVersion: string | null }) {
             )}
             Check for updates
           </Button>
-        )}
-      </div>
-      {shouldCheckForUpdates() ? (
+        )
+      }
+    >
+      {canCheck ? (
         <UpdateStatus update={update} />
       ) : (
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-3 text-xs text-muted-foreground">
           Update checks run in installed builds only.
         </p>
       )}
-    </section>
+    </SettingsSection>
   );
 }
 
@@ -105,14 +111,14 @@ function UpdateStatus({ update }: { update: DesktopUpdateState }) {
   const serverBusy = useServerUpdateState().phase === "running";
   switch (update.phase) {
     case "upToDate":
-      return <p className="mt-2 text-xs text-muted-foreground">You're on the latest version.</p>;
+      return <p className="mt-3 text-xs text-muted-foreground">You're on the latest version.</p>;
     case "checkFailed":
       return (
-        <p className="mt-2 text-xs text-destructive">Update check failed: {update.error}</p>
+        <p className="mt-3 text-xs text-destructive">Update check failed: {update.error}</p>
       );
     case "available":
       return (
-        <div className="mt-3 flex items-center justify-between gap-3 rounded-md border border-border/50 bg-muted/40 px-3 py-2">
+        <div className="mt-3 flex items-center justify-between gap-3">
           <p className="text-xs text-foreground">Version {update.version} is available.</p>
           <Button size="sm" onClick={installCurrentUpdate} disabled={serverBusy}>
             Restart & update
@@ -121,12 +127,12 @@ function UpdateStatus({ update }: { update: DesktopUpdateState }) {
       );
     case "downloading":
       return (
-        <p className="mt-2 text-xs text-muted-foreground">
+        <p className="mt-3 text-xs text-muted-foreground">
           Downloading {update.version}…{update.percent !== null ? ` ${update.percent}%` : ""}
         </p>
       );
     case "installing":
-      return <p className="mt-2 text-xs text-muted-foreground">Installing {update.version}…</p>;
+      return <p className="mt-3 text-xs text-muted-foreground">Installing {update.version}…</p>;
     case "failed":
       return (
         <div className="mt-3 flex items-center justify-between gap-3">
@@ -154,14 +160,13 @@ function ServerSection({
   const outdated = appVersion !== null && serverVersionDiffersFromApp(appVersion, backendVersion);
 
   return (
-    <section className="rounded-lg border border-border/50 bg-card/50 p-5">
-      <h2 className="text-sm font-medium text-foreground">Server</h2>
-      <p className="mt-1 text-xs text-muted-foreground">
-        Version {unreachable ? "unavailable" : (backendVersion ?? "—")}
-      </p>
+    <SettingsSection
+      title="Server"
+      description={`Version ${unreachable ? "unavailable" : (backendVersion ?? "—")}`}
+    >
       {/* `outdated` needs the app version, so this is desktop-only by construction. */}
       {outdated && <ServerUpdateFlow targetVersion={appVersion} />}
-    </section>
+    </SettingsSection>
   );
 }
 
@@ -249,117 +254,204 @@ function ServerUpdateFlow({ targetVersion }: { targetVersion: string }) {
 
   return (
     <>
-      {updateState.phase === "running" ? (
+      <ServerUpdateStatus
+        targetVersion={targetVersion}
+        state={updateState}
+        onUpdate={requestUpdate}
+      />
+
+      <AgentsRunningDialog
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        busyWorkspaces={busyWorkspaces}
+        onConfirm={() => void begin()}
+      />
+
+      <SshKeyPickerDialog
+        open={keyPicker.open}
+        onOpenChange={(open) => !open && setKeyPicker({ open: false, keys: [] })}
+        keys={keyPicker.keys}
+        onPick={pickKey}
+      />
+
+      <EscalationPasswordDialog
+        open={passwordOpen}
+        onOpenChange={setPasswordOpen}
+        adminUser={connection.adminUser}
+        password={password}
+        onPasswordChange={setPassword}
+        onSubmit={submitPassword}
+      />
+    </>
+  );
+}
+
+/** Presentation only: the run itself stays in {@link ServerUpdateFlow} above. */
+function ServerUpdateStatus({
+  targetVersion,
+  state,
+  onUpdate,
+}: {
+  targetVersion: string;
+  state: ServerUpdateState;
+  onUpdate: () => void;
+}) {
+  return (
+    <>
+      {state.phase === "running" ? (
         <p className="mt-3 flex items-center gap-2 text-xs text-muted-foreground">
           <Loader2 className="h-3.5 w-3.5 animate-spin" />
-          {updateState.step}
+          {state.step}
         </p>
-      ) : updateState.phase === "done" ? (
-        <p className="mt-2 text-xs text-muted-foreground">Server updated.</p>
+      ) : state.phase === "done" ? (
+        <p className="mt-3 text-xs text-muted-foreground">Server updated.</p>
       ) : (
         <div className="mt-3 flex items-center justify-between gap-3">
           <p className="text-xs text-muted-foreground">
             The server is not on the app's version.
           </p>
-          <Button size="sm" onClick={requestUpdate}>
+          <Button size="sm" onClick={onUpdate}>
             Update server to {targetVersion}
           </Button>
         </div>
       )}
-      {updateState.phase === "failed" && !updateState.passwordRequired && (
+      {state.phase === "failed" && !state.passwordRequired && (
         <>
-          <p className="mt-2 text-xs text-destructive">Update failed: {updateState.error}</p>
+          <p className="mt-2 text-xs text-destructive">Update failed: {state.error}</p>
           <p className="mt-2 text-xs text-muted-foreground">
             Fallback, from a server shell:
           </p>
           <UpdateCommand version={targetVersion} />
         </>
       )}
-
-      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
-        <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Agents are running</AlertDialogTitle>
-            <AlertDialogDescription>
-              {busyWorkspaces} workspace{busyWorkspaces === 1 ? " has" : "s have"} agents running.
-              Updating restarts the server and stops them.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={() => void begin()}>Update anyway</AlertDialogAction>
-          </AlertDialogFooter>
-        </AlertDialogContent>
-      </AlertDialog>
-
-      <Dialog
-        open={keyPicker.open}
-        onOpenChange={(open) => !open && setKeyPicker({ open: false, keys: [] })}
-      >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Select an SSH key</DialogTitle>
-            <DialogDescription>
-              The key used to install this server. It is remembered for future updates.
-            </DialogDescription>
-          </DialogHeader>
-          {keyPicker.keys.length === 0 ? (
-            <p className="text-xs text-muted-foreground">No usable SSH key found in ~/.ssh.</p>
-          ) : (
-            <div className="space-y-1">
-              {keyPicker.keys.map((key) => (
-                <button
-                  key={key.path}
-                  type="button"
-                  onClick={() => pickKey(key)}
-                  className="flex w-full items-center gap-2 rounded-md border border-border/50 px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
-                >
-                  <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
-                  <span className="min-w-0 flex-1 truncate">{key.label}</span>
-                  {key.keyType && (
-                    <span className="text-xs text-muted-foreground">{key.keyType}</span>
-                  )}
-                </button>
-              ))}
-            </div>
-          )}
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={passwordOpen} onOpenChange={setPasswordOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>Escalation password</DialogTitle>
-            <DialogDescription>
-              {connection.adminUser ?? "root"} needs a password to escalate on the server. It is
-              used for this run only and never stored.
-            </DialogDescription>
-          </DialogHeader>
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              submitPassword();
-            }}
-          >
-            <Input
-              type="password"
-              value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              autoFocus
-              aria-label="Password"
-            />
-            <DialogFooter className="mt-4">
-              <Button type="button" variant="outline" onClick={() => setPasswordOpen(false)}>
-                Cancel
-              </Button>
-              <Button type="submit" disabled={!password}>
-                Update server
-              </Button>
-            </DialogFooter>
-          </form>
-        </DialogContent>
-      </Dialog>
     </>
+  );
+}
+
+function AgentsRunningDialog({
+  open,
+  onOpenChange,
+  busyWorkspaces,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  busyWorkspaces: number;
+  onConfirm: () => void;
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Agents are running</AlertDialogTitle>
+          <AlertDialogDescription>
+            {busyWorkspaces} workspace{busyWorkspaces === 1 ? " has" : "s have"} agents running.
+            Updating restarts the server and stops them.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Update anyway</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+function SshKeyPickerDialog({
+  open,
+  onOpenChange,
+  keys,
+  onPick,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  keys: SshKey[];
+  onPick: (key: SshKey) => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Select an SSH key</DialogTitle>
+          <DialogDescription>
+            The key used to install this server. It is remembered for future updates.
+          </DialogDescription>
+        </DialogHeader>
+        {keys.length === 0 ? (
+          <p className="text-xs text-muted-foreground">No usable SSH key found in ~/.ssh.</p>
+        ) : (
+          <div className="space-y-1">
+            {keys.map((key) => (
+              <button
+                key={key.path}
+                type="button"
+                onClick={() => onPick(key)}
+                className="flex w-full items-center gap-2 rounded-md border border-border/50 px-3 py-2 text-left text-sm transition-colors hover:bg-accent"
+              >
+                <KeyRound className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="min-w-0 flex-1 truncate">{key.label}</span>
+                {key.keyType && (
+                  <span className="text-xs text-muted-foreground">{key.keyType}</span>
+                )}
+              </button>
+            ))}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EscalationPasswordDialog({
+  open,
+  onOpenChange,
+  adminUser,
+  password,
+  onPasswordChange,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  adminUser: string | undefined;
+  password: string;
+  onPasswordChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Escalation password</DialogTitle>
+          <DialogDescription>
+            {adminUser ?? "root"} needs a password to escalate on the server. It is used for this
+            run only and never stored.
+          </DialogDescription>
+        </DialogHeader>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            onSubmit();
+          }}
+        >
+          <Input
+            type="password"
+            value={password}
+            onChange={(event) => onPasswordChange(event.target.value)}
+            autoFocus
+            aria-label="Password"
+          />
+          <DialogFooter className="mt-4">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!password}>
+              Update server
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
   );
 }
 

--- a/frontend/src/pages/settings/UpdatesSettings.tsx
+++ b/frontend/src/pages/settings/UpdatesSettings.tsx
@@ -83,7 +83,11 @@ function AppSection({ appVersion }: { appVersion: string | null }) {
       title="Application"
       description={`Version ${appVersion ?? "—"}`}
       action={
-        canCheck && (
+        // Withdrawn once an update is found: re-checking cannot answer
+        // anything new, and it would stack a secondary button above the
+        // primary "Restart & update" that replaces it below.
+        canCheck &&
+        update.phase !== "available" && (
           <Button size="sm" variant="outline" onClick={checkForUpdatesNow} disabled={busy}>
             {update.phase === "checking" ? (
               <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
@@ -315,13 +319,23 @@ function ServerUpdateStatus({
           </Button>
         </div>
       )}
-      {state.phase === "failed" && !state.passwordRequired && (
+      {state.phase === "failed" && (
         <>
+          {/*
+            Shown even when a password is required: that opens a dialog, and
+            dismissing it would otherwise leave the page identical to a run
+            that never happened. The prompt above is the way back in.
+          */}
           <p className="mt-2 text-xs text-destructive">Update failed: {state.error}</p>
-          <p className="mt-2 text-xs text-muted-foreground">
-            Fallback, from a server shell:
-          </p>
-          <UpdateCommand version={targetVersion} />
+          {/* A password prompt is retryable in the app, so no shell detour. */}
+          {!state.passwordRequired && (
+            <>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Fallback, from a server shell:
+              </p>
+              <UpdateCommand version={targetVersion} />
+            </>
+          )}
         </>
       )}
     </>

--- a/frontend/tests/pages/UpdatesSettings.test.tsx
+++ b/frontend/tests/pages/UpdatesSettings.test.tsx
@@ -246,4 +246,41 @@ describe("UpdatesSettings", () => {
     ).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Update server/ })).toBeInTheDocument();
   });
+
+  it("keeps the failure visible when the password prompt is dismissed", async () => {
+    seedMismatch();
+    mocks.install.mockRejectedValue({ code: "SSH_PASSWORD_REQUIRED", detail: "password needed" });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: /Update server/ }));
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    // Dismissing the dialog used to leave the page identical to a run that
+    // never happened, so the failure was invisible.
+    expect(await screen.findByText("Update failed: password needed")).toBeInTheDocument();
+    // A password prompt is retryable in the app, so no shell detour.
+    expect(screen.queryByText("Fallback, from a server shell:")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Update server/ })).toBeInTheDocument();
+  });
+
+  it("withdraws the check button once an app update is available", async () => {
+    setDesktopShell(true);
+    seedConnection();
+    vi.stubEnv("PROD", true);
+    mocks.check.mockResolvedValue({
+      version: "1.4.0",
+      downloadAndInstall: vi.fn(),
+      close: vi.fn(async () => {}),
+    });
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(await screen.findByRole("button", { name: "Check for updates" }));
+
+    // Re-checking cannot answer anything new, and it would stack a secondary
+    // button above the primary one that replaces it.
+    expect(await screen.findByRole("button", { name: "Restart & update" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Check for updates" })).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Why

Every settings page drew a bordered box *inside* `CenterCard`, which already paints the card surface. Since `bg-card/50` sits on `bg-card`, the fill was invisible — the inner box contributed a border ring and nothing else. The Updates page went one further and boxed the "update available" row inside that: three frames for one sentence and a button.

The string `rounded-lg border border-border/50 bg-card/50 p-5` was duplicated across eight pages. It is now zero.

## What changed

Sections sit flat on the card, separated by a hairline rule. The chrome that remains signals interactivity (radio rows, inputs) instead of nesting.

- New `SettingsPanel` / `SettingsSection` in `components/settings/SettingsSection.tsx` — the column and one titled block, with an `action` slot for the trailing control (button, toggle, status badge).
- Applied to Account, Agent, Appearance, Connection, Models, Notification, ProjectDetail, Server and Updates.
- Account: dropped the inner `border-t` above the Disconnect button, which stacked a second rule ~15px from the section divider. Caught in a live screenshot, not by reading.
- ProjectDetail: the Danger zone **keeps** its box. Its tint is a warning rather than decoration, and it only reads as one against flat siblings. Commented so it does not get "harmonized" later.
- Updates: extracted `AgentsRunningDialog`, `SshKeyPickerDialog`, `EscalationPasswordDialog` and `ServerUpdateStatus` out of `ServerUpdateFlow`, which had grown to ~190 lines with three dialogs' markup inline.

## Two defects the new layout exposed

Laying every state out side by side made two real problems obvious, both fixed here:

1. **A password-blocked server update rendered nothing.** The error line sat inside the `!passwordRequired` guard next to the shell fallback, so a run that failed needing an escalation password opened the dialog and, once dismissed, left the page pixel-identical to a run that never happened. The error is now always shown; only the fallback command stays behind the guard, since a password prompt is retryable in-app and does not need a shell detour.
2. **Inverted button hierarchy on an available update.** The section offered "Check for updates" next to an update it had already found, stacking a secondary button above the primary "Restart & update". It is now withdrawn once an update is available, leaving the primary action alone beside the line it acts on — the shape the Server section already used.

Both are covered by tests verified to fail without the fix.

## Testing

`lint`, `typecheck` and the full frontend suite (1817 tests, 152 files) pass. Verified live against a dev backend in light and dark mode: Appearance, Notifications, Connection, Models, Account and Project detail.

The desktop-only **Application** section on Updates is gated behind `isDesktopShell()`, so it cannot render in a browser and was not visually checked. Its structure is identical to the Server section that was, and `tests/pages/UpdatesSettings.test.tsx` covers its states.

Unrelated flake worth noting: `tests/pages/AccountSettings.test.tsx` → "copies device code with clipboard helper and toggles copy label" failed once under full-suite load, then passed in isolation and on three consecutive full runs. It is a fake-timer test over `SignInPrompt`, which this branch does not touch.
