### PR TITLE
chore(deps): consolidate safe Dependabot updates

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,13 +20,13 @@
     "tauri": "tauri"
   },
   "dependencies": {
-    "@codemirror/lang-markdown": "^6.5.1",
+    "@codemirror/lang-markdown": "^6.5.2",
     "@codemirror/language": "^6.12.4",
     "@codemirror/language-data": "^6.5.2",
     "@codemirror/legacy-modes": "^6.5.3",
     "@codemirror/state": "^6.7.1",
     "@codemirror/theme-one-dark": "^6.1.3",
-    "@codemirror/view": "^6.43.7",
+    "@codemirror/view": "^6.43.8",
     "@hive/shared": "^0.1.0",
     "@pierre/diffs": "1.2.8",
     "@react-symbols/icons": "^1.4.1",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -3488,9 +3488,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@eslint/js": "^10.0.1",
         "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
-        "globals": "^16.0.0",
+        "globals": "^17.9.0",
         "knip": "^6.31.0",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.66.0"
@@ -52,13 +52,13 @@
       "version": "0.1.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@codemirror/lang-markdown": "^6.5.1",
+        "@codemirror/lang-markdown": "^6.5.2",
         "@codemirror/language": "^6.12.4",
         "@codemirror/language-data": "^6.5.2",
         "@codemirror/legacy-modes": "^6.5.3",
         "@codemirror/state": "^6.7.1",
         "@codemirror/theme-one-dark": "^6.1.3",
-        "@codemirror/view": "^6.43.7",
+        "@codemirror/view": "^6.43.8",
         "@hive/shared": "^0.1.0",
         "@pierre/diffs": "1.2.8",
         "@react-symbols/icons": "^1.4.1",
@@ -1114,9 +1114,9 @@
       }
     },
     "node_modules/@codemirror/lang-markdown": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.1.tgz",
-      "integrity": "sha512-6re5avCNfyRMIoi3XNjbEfQM1vTeVD3JS3g/Fyegyso/eoANFM71Cyvbb66LDyYtQLMEcRFlzioywCqDo9SlLA==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.5.2.tgz",
+      "integrity": "sha512-AwBOdkWYuA//WcM0xO5PfHPUcmz/O2i5o0Nsg1U69SII/loCJlFI1Romd9xp2HYb1kYJRGZotyqRghuHH5n8Kw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/autocomplete": "^6.7.1",
@@ -1344,9 +1344,9 @@
       }
     },
     "node_modules/@codemirror/view": {
-      "version": "6.43.7",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.7.tgz",
-      "integrity": "sha512-FZsExxkoxnAN+d9TgqXLg5g4A1oQwzX9WlkOT5i2PKkcW7xx3Bmu0vs90g6fo9Mpdsb/l96dnAraQ8932aO4/g==",
+      "version": "6.43.8",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.8.tgz",
+      "integrity": "sha512-qtItTDssZ/5GFfi94hrILu9j/VUeFPDPkhovEfmWFj2ipTxnzPB8DdHgfbb8HYTzLTYhrndKmyQxXUz/PDLenw==",
       "license": "MIT",
       "dependencies": {
         "@codemirror/state": "^6.7.0",
@@ -9696,9 +9696,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+      "version": "17.9.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
+      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@eslint/js": "^10.0.1",
     "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
-    "globals": "^16.0.0",
+    "globals": "^17.9.0",
     "knip": "^6.31.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.66.0"


### PR DESCRIPTION
## Summary

Consolidates the low-risk updates from the current Dependabot batch:

- `globals` 16.5.0 → 17.9.0
- `@codemirror/lang-markdown` 6.5.1 → 6.5.2
- `@codemirror/view` 6.43.7 → 6.43.8
- `semver` 1.0.27 → 1.0.28

This supersedes #441, the safe CodeMirror portion of #442, and #446.

`globals` 17 only splits the `audioWorklet` environment out of the browser globals; Hive does not use that environment, the Node requirement is unchanged, and the original update passed CI. The CodeMirror releases are targeted bug fixes. `semver` is a documentation-only patch release.

## Deliberately excluded

- `@pierre/diffs` 1.2.8 → 1.3.5 from #442: its theme/dependency changes break the production build because `@shikijs/themes/horizon-bright` is no longer exported.
- `@testing-library/jest-dom` 6.9.1 → 7.0.0 from #443: it raises the minimum Node version to 22 and adds a required peer dependency, while Hive still documents Node 20+ support.
- TypeScript 5.9.3 → 7.0.2 from #444: `typescript-eslint` currently declares support only below TypeScript 6.1, so `npm ci` fails. TypeScript 7 also removes compiler options used by the frontend configuration, including `baseUrl`.
- `lucide-react` 0.563.0 → 1.30.0 from #445: it removes the `Github` and `GithubIcon` exports used by the UI, breaking typecheck and build.

## Verification

- `npm run lint`
- `npm run typecheck`
- `npm run test` — 1,922 backend and 1,817 frontend tests passed
- `npm run build --workspace @hive/frontend`
- `git diff --check`
- `npm ls` confirms excluded packages remain pinned
- `cargo tree --manifest-path frontend/src-tauri/Cargo.toml -i semver`

A local `cargo test` reaches the native Tauri dependency build but cannot complete in this environment because `gdk-3.0` is not installed. The original isolated `semver` update in #441 passed the CI, desktop, and iOS jobs.