### PR TITLE
fix(ios): polish conversations and Hub refresh

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -414,7 +414,7 @@ private struct EffortMenu: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 1) {
-            ForEach(levels, id: \.self) { level in
+            ForEach(levels.reversed(), id: \.self) { level in
                 Button {
                     onSelect(level)
                 } label: {

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -104,12 +104,13 @@ struct ConversationsSection<Header: View>: View {
                 Text(actionErrorMessage)
             }
         }
-        .alert(
+        .confirmationDialog(
             "Delete conversation?",
             isPresented: Binding(
                 get: { sessionToDelete != nil },
                 set: { if !$0 { sessionToDelete = nil } }
             ),
+            titleVisibility: .visible,
             presenting: sessionToDelete
         ) { session in
             Button("Delete", role: .destructive) {
@@ -159,7 +160,10 @@ struct ConversationsSection<Header: View>: View {
                 .listRowSeparator(.hidden)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                     Button(role: .destructive) {
-                        sessionToDelete = session
+                        // Let the swipe close before presenting the confirmation dialog.
+                        DispatchQueue.main.async {
+                            sessionToDelete = session
+                        }
                     } label: {
                         Image(systemName: "trash")
                             .imageScale(.small)

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -104,13 +104,12 @@ struct ConversationsSection<Header: View>: View {
                 Text(actionErrorMessage)
             }
         }
-        .confirmationDialog(
+        .alert(
             "Delete conversation?",
             isPresented: Binding(
                 get: { sessionToDelete != nil },
                 set: { if !$0 { sessionToDelete = nil } }
             ),
-            titleVisibility: .visible,
             presenting: sessionToDelete
         ) { session in
             Button("Delete", role: .destructive) {
@@ -159,11 +158,8 @@ struct ConversationsSection<Header: View>: View {
                 .listRowBackground(WhisperColor.appBackground)
                 .listRowSeparator(.hidden)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button(role: .destructive) {
-                        // Let the swipe close before presenting the confirmation dialog.
-                        DispatchQueue.main.async {
-                            sessionToDelete = session
-                        }
+                    Button {
+                        sessionToDelete = session
                     } label: {
                         Image(systemName: "trash")
                             .imageScale(.small)

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -158,9 +158,13 @@ struct ConversationsSection<Header: View>: View {
                 .listRowBackground(WhisperColor.appBackground)
                 .listRowSeparator(.hidden)
                 .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                    Button("Delete", role: .destructive) {
+                    Button(role: .destructive) {
                         sessionToDelete = session
+                    } label: {
+                        Image(systemName: "trash")
                     }
+                    .tint(WhisperColor.danger)
+                    .accessibilityLabel("Delete conversation")
                 }
             }
         }

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -162,6 +162,7 @@ struct ConversationsSection<Header: View>: View {
                         sessionToDelete = session
                     } label: {
                         Image(systemName: "trash")
+                            .imageScale(.small)
                     }
                     .tint(WhisperColor.danger)
                     .accessibilityLabel("Delete conversation")

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -29,7 +29,7 @@ struct HubView: View {
             WhisperColor.appBackground
                 .ignoresSafeArea()
 
-            ScrollView {
+            List {
                 VStack(alignment: .leading, spacing: HiveSpacing.md) {
                     if store.projects.isEmpty {
                         emptyState
@@ -40,9 +40,16 @@ struct HubView: View {
                         denseHubContent(sections: displayedSections)
                     }
                 }
-                .padding(.horizontal, HiveSpacing.lg)
-                .padding(.vertical, HiveSpacing.md)
+                .listRowInsets(EdgeInsets(
+                    top: HiveSpacing.md,
+                    leading: HiveSpacing.lg,
+                    bottom: HiveSpacing.md,
+                    trailing: HiveSpacing.lg
+                ))
+                .listRowBackground(WhisperColor.appBackground)
+                .listRowSeparator(.hidden)
             }
+            .listStyle(.plain)
             .scrollBounceBehavior(.always)
             .scrollContentBackground(.hidden)
             .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -54,7 +54,7 @@ struct HubView: View {
             .listStyle(.plain)
             .scrollBounceBehavior(.always)
             .scrollContentBackground(.hidden)
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
+            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
             .refreshable {
                 // Unstructured Task shields refresh from SwiftUI prematurely
                 // cancelling the .refreshable task on ScrollView (known iOS 26 regression).

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -30,20 +30,22 @@ struct HubView: View {
                 .ignoresSafeArea()
 
             List {
-                VStack(alignment: .leading, spacing: HiveSpacing.md) {
+                Group {
                     if store.projects.isEmpty {
                         emptyState
                     } else if !searchText.isEmpty, displayedSections.isEmpty {
                         ContentUnavailableView.search(text: searchText)
                             .padding(.top, 40)
                     } else {
-                        denseHubContent(sections: displayedSections)
+                        ForEach(displayedSections) { section in
+                            sectionView(section)
+                        }
                     }
                 }
                 .listRowInsets(EdgeInsets(
                     top: HiveSpacing.md,
                     leading: HiveSpacing.lg,
-                    bottom: HiveSpacing.md,
+                    bottom: 0,
                     trailing: HiveSpacing.lg
                 ))
                 .listRowBackground(WhisperColor.appBackground)
@@ -201,14 +203,6 @@ struct HubView: View {
     }
 
     // MARK: - Dense Hub
-
-    private func denseHubContent(sections: [HubSection]) -> some View {
-        LazyVStack(alignment: .leading, spacing: HiveSpacing.md) {
-            ForEach(sections) { section in
-                sectionView(section)
-            }
-        }
-    }
 
     private var baseSections: [HubSection] {
         HubOrganization.sections(


### PR DESCRIPTION
## Summary

- display conversation thinking levels from highest to lowest, matching the web app
- replace the conversation swipe action with a compact red trash icon and preserve its accessibility label
- keep the existing delete confirmation alert without triggering SwiftUI’s premature destructive-row animation
- use native `List` refresh behavior in the Hub to prevent stale spacing after pull-to-refresh
- render Hub sections as stable list rows so initial loading does not preserve a full-screen placeholder offset
- keep the Hub search drawer visible during refresh to avoid the search field jumping when the spinner appears

## Testing

- manually verified the conversation thinking selector and delete flow on iOS
- manually verified Hub launch and pull-to-refresh behavior on iOS
- `git diff --check`
- not run: `swift test` (Swift toolchain unavailable in this environment)