### PR TITLE
feat(web): optimistic workspace archive

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -312,10 +312,11 @@ export default function Sidebar({ onAddProject, onAddAutomation, onNewWorkspaceF
         });
         uncommittedCount = stats.uncommitted.length;
       } catch {
-        uncommittedCount = 0;
+        // Fail closed: archiving destroys the worktree, so an unknown dirty
+        // state must go through the confirm dialog.
       }
     }
-    if (uncommittedCount > 0) {
+    if (uncommittedCount === undefined || uncommittedCount > 0) {
       setArchiveTarget(wsId);
     } else {
       doArchive(wsId);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -184,7 +184,6 @@ export default function Sidebar({ onAddProject, onAddAutomation, onNewWorkspaceF
   const [expandedProjects, setExpandedProjects] = useState<Record<string, boolean>>({});
   const [creatingProjectId, setCreatingProjectId] = useState<string | null>(null);
   const [archiveTarget, setArchiveTarget] = useState<string | null>(null);
-  const [archivingWsId, setArchivingWsId] = useState<string | null>(null);
   const [isCreatingFolder, setIsCreatingFolder] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
@@ -319,19 +318,13 @@ export default function Sidebar({ onAddProject, onAddAutomation, onNewWorkspaceF
     if (uncommittedCount > 0) {
       setArchiveTarget(wsId);
     } else {
-      await doArchive(wsId);
+      doArchive(wsId);
     }
   };
 
-  const doArchive = async (wsId: string) => {
-    setArchivingWsId(wsId);
-    try {
-      const wasActive = activeWsId === wsId;
-      await archiveWorkspace(wsId);
-      if (wasActive) navigate("/home");
-    } finally {
-      setArchivingWsId(null);
-    }
+  const doArchive = (wsId: string) => {
+    if (activeWsId === wsId) navigate("/home");
+    archiveWorkspace(wsId);
   };
 
   const handleProjectDragStart = (
@@ -517,7 +510,6 @@ export default function Sidebar({ onAddProject, onAddAutomation, onNewWorkspaceF
         liveData={liveData}
         prStatuses={prStatuses}
         creatingProjectId={creatingProjectId}
-        archivingWsId={archivingWsId}
         canReorder={hasInitialHydration}
         draggingProjectId={draggingProjectId}
         projectInsertIndicator={projectInsertIndicator}
@@ -835,7 +827,7 @@ export default function Sidebar({ onAddProject, onAddAutomation, onNewWorkspaceF
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction
               onClick={() => {
-                if (archiveTarget) void doArchive(archiveTarget);
+                if (archiveTarget) doArchive(archiveTarget);
                 setArchiveTarget(null);
               }}
             >

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -27,7 +27,6 @@ interface SidebarProjectItemProps {
   liveData: Record<string, WorkspaceLiveData>;
   prStatuses: Record<string, PrStatusResponse>;
   creatingProjectId: string | null;
-  archivingWsId: string | null;
   draggingProjectId: string | null;
   projectInsertIndicator: ProjectInsertIndicator;
   onAddWorkspace: (projectId: string) => void;
@@ -61,7 +60,6 @@ export function SidebarProjectItem({
   liveData,
   prStatuses,
   creatingProjectId,
-  archivingWsId,
   draggingProjectId,
   projectInsertIndicator,
   onAddWorkspace,
@@ -148,7 +146,6 @@ export function SidebarProjectItem({
                   wsLive={liveData[ws.id]}
                   prStatus={prStatuses[ws.id]}
                   isActive={activeWsId === ws.id}
-                  isArchiving={archivingWsId === ws.id}
                   onArchive={onArchiveWorkspace}
                 />
               ))}

--- a/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
+++ b/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ArchiveIcon, Loader2 } from "lucide-react";
+import { ArchiveIcon } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
@@ -18,7 +18,6 @@ interface SidebarWorkspaceItemProps {
   wsLive: WorkspaceLiveData | undefined;
   prStatus: PrStatusResponse | undefined;
   isActive: boolean;
-  isArchiving: boolean;
   onArchive: (wsId: string) => void;
 }
 
@@ -39,7 +38,6 @@ export function SidebarWorkspaceItem({
   wsLive,
   prStatus,
   isActive,
-  isArchiving,
   onArchive,
 }: SidebarWorkspaceItemProps) {
   const streaming = wsLive?.streaming ?? false;
@@ -52,7 +50,7 @@ export function SidebarWorkspaceItem({
 
   // A running script must never be archived from under itself; while it runs we
   // keep showing the metadata on hover instead of swapping in the archive action.
-  const canArchive = !scriptRunning && !isArchiving;
+  const canArchive = !scriptRunning;
 
   const branchClass = streaming
     ? "sidebar-stream-text"
@@ -63,12 +61,7 @@ export function SidebarWorkspaceItem({
         : "text-muted-foreground";
 
   return (
-    <div
-      className={cn(
-        "group/ws relative transition-opacity",
-        isArchiving && "pointer-events-none opacity-40",
-      )}
-    >
+    <div className="group/ws relative transition-opacity">
       <Tooltip>
         <TooltipTrigger asChild>
           <Link
@@ -99,9 +92,7 @@ export function SidebarWorkspaceItem({
             <span
               className={cn(
                 "flex shrink-0 items-center gap-2 transition-opacity",
-                // While archiving, the spinner takes over the trailing slot — hide
-                // the metadata entirely so it doesn't show through underneath.
-                isArchiving ? "opacity-0" : canArchive && "group-hover/ws:opacity-0",
+                canArchive && "group-hover/ws:opacity-0",
               )}
             >
               {diffTotals && (
@@ -136,31 +127,25 @@ export function SidebarWorkspaceItem({
         </TooltipContent>
       </Tooltip>
 
-      {/* Center the archive overlay (loader + trash) on the PR-dot column, which sits
+      {/* Center the archive button on the PR-dot column, which sits
           13px from the row's right edge (px-2 = 8px + half the dot's w-2.5 cell = 5px).
           A w-3.5 (14px) box at right-1.5 (6px) centers there (6 + 7 = 13px); the box must
-          be wider than the ~13px icons, since Chromium start-aligns oversized grid items
+          be wider than the ~13px icon, since Chromium start-aligns oversized grid items
           rather than centering them. */}
-      {isArchiving ? (
-        <div className="absolute right-1.5 top-1/2 grid w-3.5 -translate-y-1/2 place-items-center">
-          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
-        </div>
-      ) : (
-        canArchive && (
-          <button
-            type="button"
-            className="absolute right-1.5 top-1/2 grid w-3.5 -translate-y-1/2 place-items-center rounded text-muted-foreground opacity-0 transition-[opacity,color] duration-150 hover:text-destructive group-hover/ws:opacity-100"
-            onClick={(event) => {
-              event.preventDefault();
-              event.stopPropagation();
-              onArchive(ws.id);
-            }}
-            aria-label={`Archive workspace ${ws.name}`}
-            title="Archive workspace"
-          >
-            <ArchiveIcon className="size-[13px]" />
-          </button>
-        )
+      {canArchive && (
+        <button
+          type="button"
+          className="absolute right-1.5 top-1/2 grid w-3.5 -translate-y-1/2 place-items-center rounded text-muted-foreground opacity-0 transition-[opacity,color] duration-150 hover:text-destructive group-hover/ws:opacity-100"
+          onClick={(event) => {
+            event.preventDefault();
+            event.stopPropagation();
+            onArchive(ws.id);
+          }}
+          aria-label={`Archive workspace ${ws.name}`}
+          title="Archive workspace"
+        >
+          <ArchiveIcon className="size-[13px]" />
+        </button>
       )}
     </div>
   );

--- a/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
+++ b/frontend/src/components/sidebar/SidebarWorkspaceItem.tsx
@@ -61,7 +61,7 @@ export function SidebarWorkspaceItem({
         : "text-muted-foreground";
 
   return (
-    <div className="group/ws relative transition-opacity">
+    <div className="group/ws relative">
       <Tooltip>
         <TooltipTrigger asChild>
           <Link

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -261,8 +261,8 @@ export function useProjects() {
   });
 
   // A background ["projects"] refetch landing while the archive POST is still
-  // in flight would resurrect the optimistically removed row — filter pending
-  // archives out of whatever the cache holds.
+  // in flight would resurrect the optimistically removed row, so filter
+  // pending archives out of whatever the cache holds.
   const pendingArchiveIds = useMutationState({
     filters: { mutationKey: ["archive-workspace"], status: "pending" },
     select: (m) => m.state.variables as string,

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useMutationState, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
 import { api } from "./useApi";
 import type { CreateWorkspaceSource, Project, Workspace } from "@/types";
 
@@ -179,8 +180,18 @@ export function useProjects() {
   });
 
   const archiveWorkspace = useMutation({
+    mutationKey: ["archive-workspace"],
     mutationFn: (wsId: string) =>
       api.post(`/api/workspaces/${wsId}/archive`),
+    onMutate: async (wsId) => {
+      await queryClient.cancelQueries({ queryKey: ["projects"] });
+      queryClient.setQueryData<Project[]>(["projects"], (prev) =>
+        prev?.map((p) => ({
+          ...p,
+          workspaces: p.workspaces.filter((ws) => ws.id !== wsId),
+        })) ?? [],
+      );
+    },
     onSuccess: (_, wsId) => {
       queryClient.setQueryData<Project[]>(["projects"], (prev) =>
         prev?.map((p) => ({
@@ -190,10 +201,32 @@ export function useProjects() {
       );
       invalidateWorkspaceSources();
     },
+    onError: (err) => {
+      toast.error(
+        err instanceof Error && err.message ? err.message : "Failed to archive workspace",
+      );
+      // Server is truth: refetch so the workspace row reappears.
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+    },
   });
 
+  // A background ["projects"] refetch landing while the archive POST is still
+  // in flight would resurrect the optimistically removed row — filter pending
+  // archives out of whatever the cache holds.
+  const pendingArchiveIds = useMutationState({
+    filters: { mutationKey: ["archive-workspace"], status: "pending" },
+    select: (m) => m.state.variables as string,
+  });
+  const rawProjects = query.data ?? [];
+  const projects = pendingArchiveIds.length === 0
+    ? rawProjects
+    : rawProjects.map((p) => ({
+      ...p,
+      workspaces: p.workspaces.filter((ws) => !pendingArchiveIds.includes(ws.id)),
+    }));
+
   return {
-    projects: query.data ?? [],
+    projects,
     loading: query.isLoading,
     recovering: query.isFetching && query.isError && !query.data,
     unavailable: query.isError && !query.data,
@@ -212,6 +245,6 @@ export function useProjects() {
     createWorkspace: (projectId: string, source?: CreateWorkspaceSource) =>
       createWorkspace.mutateAsync({ projectId, source }),
     deleteProject: (id: string) => deleteProject.mutateAsync(id),
-    archiveWorkspace: (wsId: string) => archiveWorkspace.mutateAsync(wsId),
+    archiveWorkspace: (wsId: string) => archiveWorkspace.mutate(wsId),
   };
 }

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -185,12 +185,33 @@ export function useProjects() {
       api.post(`/api/workspaces/${wsId}/archive`),
     onMutate: async (wsId) => {
       await queryClient.cancelQueries({ queryKey: ["projects"] });
+      let removed: {
+        projectId: string;
+        workspace: Workspace;
+        workspaceIndex: number;
+        previousWorkspaceId?: string;
+        nextWorkspaceId?: string;
+      } | undefined;
       queryClient.setQueryData<Project[]>(["projects"], (prev) =>
-        prev?.map((p) => ({
-          ...p,
-          workspaces: p.workspaces.filter((ws) => ws.id !== wsId),
-        })) ?? [],
+        prev?.map((p) => {
+          const workspaceIndex = p.workspaces.findIndex((ws) => ws.id === wsId);
+          const workspace = p.workspaces[workspaceIndex];
+          if (workspace) {
+            removed = {
+              projectId: p.id,
+              workspace,
+              workspaceIndex,
+              previousWorkspaceId: p.workspaces[workspaceIndex - 1]?.id,
+              nextWorkspaceId: p.workspaces[workspaceIndex + 1]?.id,
+            };
+          }
+          return {
+            ...p,
+            workspaces: p.workspaces.filter((ws) => ws.id !== wsId),
+          };
+        }) ?? [],
       );
+      return removed;
     },
     onSuccess: (_, wsId) => {
       queryClient.setQueryData<Project[]>(["projects"], (prev) =>
@@ -201,11 +222,40 @@ export function useProjects() {
       );
       invalidateWorkspaceSources();
     },
-    onError: (err) => {
+    onError: (err, _wsId, removed) => {
       toast.error(
         err instanceof Error && err.message ? err.message : "Failed to archive workspace",
       );
-      // Server is truth: refetch so the workspace row reappears.
+      // Re-insert locally: the failure is often an outage, in which case the
+      // reconciling refetch below fails too and nothing else refetches
+      // ["projects"] (focus/reconnect refetches are disabled globally).
+      if (removed) {
+        const {
+          projectId,
+          workspace,
+          workspaceIndex,
+          previousWorkspaceId,
+          nextWorkspaceId,
+        } = removed;
+        queryClient.setQueryData<Project[]>(["projects"], (prev) =>
+          prev?.map((p) => {
+            if (p.id !== projectId || p.workspaces.some((ws) => ws.id === workspace.id)) {
+              return p;
+            }
+            const workspaces = [...p.workspaces];
+            const nextIndex = workspaces.findIndex((ws) => ws.id === nextWorkspaceId);
+            const previousIndex = workspaces.findIndex((ws) => ws.id === previousWorkspaceId);
+            const insertAt = nextIndex >= 0
+              ? nextIndex
+              : previousIndex >= 0
+                ? previousIndex + 1
+                : Math.min(workspaceIndex, workspaces.length);
+            workspaces.splice(insertAt, 0, workspace);
+            return { ...p, workspaces };
+          }) ?? [],
+        );
+      }
+      // Server is truth: reconcile when it is reachable.
       void queryClient.invalidateQueries({ queryKey: ["projects"] });
     },
   });

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -1651,7 +1651,7 @@ describe("Sidebar", () => {
     expect(api.get).not.toHaveBeenCalledWith(expect.stringContaining("/diff/stat"));
   });
 
-  it("falls back to direct API call when diffStats not cached and API fails", async () => {
+  it("fails closed to the confirm dialog when diff stats cannot be loaded", async () => {
     const user = userEvent.setup();
     mockPostWithBulkFallback({
       "/api/workspaces/w1/archive": undefined,
@@ -1665,7 +1665,14 @@ describe("Sidebar", () => {
     const archiveBtn = screen.getByRole("button", { name: /archive workspace/i });
     await user.click(archiveBtn);
 
-    // When API fails, uncommittedCount falls back to 0 -> archives directly
+    // Unknown dirty state must not archive silently: the worktree is destroyed.
+    await waitFor(() => {
+      expect(screen.getByText("Archive workspace")).toBeInTheDocument();
+    });
+    expect(api.post).not.toHaveBeenCalledWith("/api/workspaces/w1/archive");
+
+    await user.click(screen.getByRole("button", { name: "Archive" }));
+
     await waitFor(() => {
       expect(api.post).toHaveBeenCalledWith("/api/workspaces/w1/archive");
     });

--- a/frontend/tests/hooks/useProjects.test.ts
+++ b/frontend/tests/hooks/useProjects.test.ts
@@ -226,10 +226,14 @@ describe("useProjects", () => {
     expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w2"]);
   });
 
-  it("archive rolls back via refetch and toasts once when the POST fails", async () => {
+  it("archive restores the row locally and toasts once when the POST fails", async () => {
     const project = makeProject("p1");
     project.workspaces = [makeWorkspace("w1")];
-    vi.mocked(api.get).mockResolvedValue([project]);
+    // Outage scenario: the reconciling refetch fails along with the POST, so
+    // the rollback must come from the local re-insert, not the server.
+    vi.mocked(api.get)
+      .mockResolvedValueOnce([project])
+      .mockRejectedValue(new Error("offline"));
     vi.mocked(api.post).mockRejectedValueOnce(new Error("archive failed"));
 
     const { wrapper } = createWrapper();
@@ -242,9 +246,48 @@ describe("useProjects", () => {
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
     expect(toast.error).toHaveBeenCalledWith("archive failed");
-    // The invalidated ["projects"] refetch restores the row from the server.
     await waitFor(() =>
       expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w1"]),
+    );
+  });
+
+  it("preserves workspace order when concurrent archives fail", async () => {
+    const project = makeProject("p1");
+    project.workspaces = [makeWorkspace("w1"), makeWorkspace("w2"), makeWorkspace("w3")];
+    vi.mocked(api.get)
+      .mockResolvedValueOnce([project])
+      .mockRejectedValue(new Error("offline"));
+    let rejectW1!: (reason?: unknown) => void;
+    let rejectW2!: (reason?: unknown) => void;
+    vi.mocked(api.post).mockImplementation((url) => new Promise((_, reject) => {
+      if (url === "/api/workspaces/w1/archive") rejectW1 = reject;
+      if (url === "/api/workspaces/w2/archive") rejectW2 = reject;
+    }));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => {
+      result.current.archiveWorkspace("w1");
+      result.current.archiveWorkspace("w2");
+    });
+
+    await waitFor(() =>
+      expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w3"]),
+    );
+
+    act(() => {
+      rejectW1(new Error("archive failed"));
+      rejectW2(new Error("archive failed"));
+    });
+
+    await waitFor(() =>
+      expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual([
+        "w1",
+        "w2",
+        "w3",
+      ]),
     );
   });
 

--- a/frontend/tests/hooks/useProjects.test.ts
+++ b/frontend/tests/hooks/useProjects.test.ts
@@ -1,5 +1,6 @@
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
 import { useProjects } from "@/hooks/useProjects";
 import { api } from "@/hooks/useApi";
 import { createWrapper } from "../test-utils";
@@ -12,6 +13,8 @@ vi.mock("@/hooks/useApi", () => ({
     delete: vi.fn(),
   },
 }));
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn() } }));
 
 function makeProject(id: string): Project {
   return {
@@ -178,7 +181,7 @@ describe("useProjects", () => {
     expect(cached?.[1]?.workspaces).toEqual([createdWorkspace]);
   });
 
-  it("archives workspace and removes it from project cache", async () => {
+  it("archives workspace and keeps it out of the cache once the POST resolves", async () => {
     const project = makeProject("p1");
     project.workspaces = [makeWorkspace("w1"), makeWorkspace("w2")];
     vi.mocked(api.get).mockResolvedValueOnce([project]);
@@ -189,13 +192,60 @@ describe("useProjects", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.archiveWorkspace("w1");
+      result.current.archiveWorkspace("w1");
     });
 
-    expect(api.post).toHaveBeenCalledWith("/api/workspaces/w1/archive");
-    const cached = queryClient.getQueryData<Project[]>(["projects"]);
-    expect(cached?.[0]?.workspaces).toHaveLength(1);
-    expect(cached?.[0]?.workspaces[0]?.id).toBe("w2");
+    await waitFor(() =>
+      expect(api.post).toHaveBeenCalledWith("/api/workspaces/w1/archive"),
+    );
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Project[]>(["projects"]);
+      expect(cached?.[0]?.workspaces).toHaveLength(1);
+      expect(cached?.[0]?.workspaces[0]?.id).toBe("w2");
+    });
+    expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w2"]);
+  });
+
+  it("archive optimistically removes the workspace while the POST is in flight", async () => {
+    const project = makeProject("p1");
+    project.workspaces = [makeWorkspace("w1"), makeWorkspace("w2")];
+    vi.mocked(api.get).mockResolvedValueOnce([project]);
+    vi.mocked(api.post).mockImplementation(() => new Promise(() => {}));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.archiveWorkspace("w1");
+      // React Query batches cache notifications on a macrotask; flush it so the
+      // optimistic removal is observable without the POST ever resolving.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+
+    expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w2"]);
+  });
+
+  it("archive rolls back via refetch and toasts once when the POST fails", async () => {
+    const project = makeProject("p1");
+    project.workspaces = [makeWorkspace("w1")];
+    vi.mocked(api.get).mockResolvedValue([project]);
+    vi.mocked(api.post).mockRejectedValueOnce(new Error("archive failed"));
+
+    const { wrapper } = createWrapper();
+    const { result } = renderHook(() => useProjects(), { wrapper });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      result.current.archiveWorkspace("w1");
+    });
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledTimes(1));
+    expect(toast.error).toHaveBeenCalledWith("archive failed");
+    // The invalidated ["projects"] refetch restores the row from the server.
+    await waitFor(() =>
+      expect(result.current.projects[0]?.workspaces.map((ws) => ws.id)).toEqual(["w1"]),
+    );
   });
 
   it("archive only removes workspace from its parent project", async () => {
@@ -211,12 +261,14 @@ describe("useProjects", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.archiveWorkspace("w1");
+      result.current.archiveWorkspace("w1");
     });
 
-    const cached = queryClient.getQueryData<Project[]>(["projects"]);
-    expect(cached?.[0]?.workspaces).toHaveLength(0);
-    expect(cached?.[1]?.workspaces).toHaveLength(1);
+    await waitFor(() => {
+      const cached = queryClient.getQueryData<Project[]>(["projects"]);
+      expect(cached?.[0]?.workspaces).toHaveLength(0);
+      expect(cached?.[1]?.workspaces).toHaveLength(1);
+    });
   });
 
   it("rolls back project when workspace creation fails", async () => {
@@ -302,11 +354,13 @@ describe("useProjects", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     await act(async () => {
-      await result.current.archiveWorkspace("w1");
+      result.current.archiveWorkspace("w1");
     });
 
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project-branches"] });
-    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project-pulls"] });
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project-branches"] });
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["project-pulls"] });
+    });
   });
 
   it("invalidates projects query when fetchProjects is called", async () => {


### PR DESCRIPTION
## What

Archiving a workspace is now optimistic on web:

- The sidebar row disappears instantly on click; the archive POST (multi-second worktree removal) runs in the background.
- Navigation to `/home` happens immediately at click time, and only when the archived workspace is the active one. From anywhere else in the app, the current page never moves.
- On failure: one generic error toast, and the workspace is re-inserted locally at its original position (sibling-anchored, tolerant of concurrent archives), then `["projects"]` is invalidated as best-effort reconciliation. The local re-insert matters because during an outage the refetch fails too and nothing else refetches the projects list (focus/reconnect refetches are disabled globally).
- A `useMutationState` filter on `useProjects().projects` prevents a background refetch from resurrecting the row mid-flight (covers Sidebar, HomeView, and the WS subscription sync in `App.tsx`).
- The pre-archive uncommitted-changes check now fails closed: if the diff-stat fetch fails, the confirm dialog is shown instead of assuming a clean worktree before a destructive archive.
- The `archivingWsId` spinner state and prop chain are removed (the row is gone instantly, the spinner has nothing to attach to).

No backend or iOS changes; iOS parity is tracked in #453.

## Testing

- `npm run lint`, `npm run typecheck`: clean (frontend and backend).
- `npm run test`: 152 files, 1821 tests, green. New coverage: optimistic removal with a never-resolving POST, local rollback + single toast when both the POST and the reconciling refetch fail, order preservation under concurrent failed archives, workspace stays gone once the POST resolves, fail-closed confirm dialog when diff stats cannot be loaded.

## Review

Externally audited in two passes; all accepted findings are applied (local rollback re-insert, order-preserving rollback, fail-closed dirty check). The "navigate only after success" suggestion was rejected by design: immediate navigation is the purpose of the change, and a failed archive intentionally leaves the user where they are with the row restored and a toast.