### PR TITLE
fix(ios): prevent stacked workspace navigation

### DIFF
--- a/ios/HiveMobile/HiveApp.swift
+++ b/ios/HiveMobile/HiveApp.swift
@@ -92,7 +92,10 @@ struct HiveApp: App {
             }
             Tab("Hub", systemImage: "square.grid.2x2.fill", value: .hub) {
                 NavigationStack(path: $hubPath) {
-                    HubView(openSettings: { switchTab(to: .settings) })
+                    HubView(
+                        navigationPath: $hubPath,
+                        openSettings: { switchTab(to: .settings) }
+                    )
                         .navigationDestination(for: Workspace.self) { workspace in
                             WorkspaceConversationsView(
                                 workspace: workspace,

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -9,6 +9,7 @@ private enum HubLayout {
 
 struct HubView: View {
     @Environment(ProjectStore.self) private var store
+    @Binding var navigationPath: NavigationPath
     var openSettings: (() -> Void)?
     @State private var showAddProject = false
     @State private var workspaceToArchive: Workspace?
@@ -299,11 +300,20 @@ struct HubView: View {
         } else {
             VStack(spacing: HiveSpacing.xs) {
                 ForEach(sortedWorkspaces(project.workspaces)) { workspace in
-                    NavigationLink(value: workspace) {
-                        HubWorkspaceRow(
-                            workspace: workspace,
-                            monitor: store.statusMonitor
-                        )
+                    // NavigationLinks nested in this shared List row activate together.
+                    Button {
+                        navigationPath.append(workspace)
+                    } label: {
+                        HStack(spacing: HiveSpacing.xs) {
+                            HubWorkspaceRow(
+                                workspace: workspace,
+                                monitor: store.statusMonitor
+                            )
+                            Image(systemName: "chevron.right")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(WhisperColor.textMuted)
+                                .accessibilityHidden(true)
+                        }
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
@@ -545,7 +555,7 @@ private extension View {
 
 #Preview {
     NavigationStack {
-        HubView()
+        HubView(navigationPath: .constant(NavigationPath()))
     }
     .environment(ProjectStore(storeCache: ConversationStoreCache()))
     .preferredColorScheme(.dark)


### PR DESCRIPTION
## Summary

- keep the Hub `List` refresh and scroll behavior
- replace nested workspace `NavigationLink` values with an explicit single-path append
- preserve the disclosure chevron, archive context menu, and preview setup

## Why

Each expanded Hub section is one logical `List` row. SwiftUI activates every nested `NavigationLink` in that row, which stacked all visible workspaces when the user tapped one. Plain buttons already isolate actions elsewhere in the same row, so workspace taps now append only the selected workspace to the shared Hub path.

## Testing

- `git diff --check`
- Not run: `cd ios && swift test` (`swift` is unavailable in this environment)

Manual iOS verification recommended: tap a project with several workspaces and confirm one Back action returns directly to the Hub.