### PR TITLE
feat(ios): optimistic workspace archive

### DIFF
--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -40,6 +40,11 @@ final class ProjectStore {
     private let archiveWorkspaceClosure: @MainActor (String) async throws -> Void
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
+    /// Session-lifetime tombstones for successfully archived workspaces. There
+    /// is no restore path and ids are never reused, so an archived id can never
+    /// legitimately reappear; stripping these from refresh results guards
+    /// against a stale snapshot fetched before the archive completed.
+    private var archivedIds: Set<String> = []
 
     init(
         storeCache: ConversationStoreCache,
@@ -198,6 +203,7 @@ final class ProjectStore {
         do {
             try await archiveWorkspaceClosure(id)
             pendingArchiveIds.remove(id)
+            archivedIds.insert(id)
             syncMonitoredWorkspaces()
         } catch {
             pendingArchiveIds.remove(id)
@@ -266,11 +272,13 @@ final class ProjectStore {
                     fresh[i].workspaces[j].hasFavicon = fresh[i].hasFavicon
                 }
             }
-            // A refresh landing mid-archive must not resurrect an optimistically
-            // removed workspace.
-            if !pendingArchiveIds.isEmpty {
+            // A refresh must not resurrect an archived workspace: neither one
+            // whose archive is still in flight, nor one from a stale snapshot
+            // fetched before an archive completed.
+            let hiddenIds = pendingArchiveIds.union(archivedIds)
+            if !hiddenIds.isEmpty {
                 for i in fresh.indices {
-                    fresh[i].workspaces.removeAll { pendingArchiveIds.contains($0.id) }
+                    fresh[i].workspaces.removeAll { hiddenIds.contains($0.id) }
                 }
             }
             statusMonitor.seedLastActivityDates(from: fresh.flatMap(\.workspaces))

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -23,6 +23,8 @@ final class ProjectStore {
     private(set) var fetchFailure: FetchFailure?
     private(set) var refreshFailedWithCachedData = false
     private(set) var creatingWorkspaceProjectIds: Set<String> = []
+    private(set) var pendingArchiveIds: Set<String> = []
+    private(set) var archiveFailed = false
     private(set) var isCreatingProject = false
     private(set) var cloningRepoName: String?
     private(set) var uiPreferences: UiPreferencesPayload = .empty
@@ -35,6 +37,7 @@ final class ProjectStore {
     private let api: APIClient
     private let fetchProjectsClosure: @MainActor () async throws -> [Project]
     private let fetchPreferencesClosure: @MainActor () async throws -> UiPreferencesPayload
+    private let archiveWorkspaceClosure: @MainActor (String) async throws -> Void
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
 
@@ -42,13 +45,15 @@ final class ProjectStore {
         storeCache: ConversationStoreCache,
         statusMonitor: HubStatusMonitor? = nil,
         fetchProjects: (@MainActor () async throws -> [Project])? = nil,
-        fetchPreferences: (@MainActor () async throws -> UiPreferencesPayload)? = nil
+        fetchPreferences: (@MainActor () async throws -> UiPreferencesPayload)? = nil,
+        archiveWorkspace: (@MainActor (String) async throws -> Void)? = nil
     ) {
         let client = APIClient()
         self.api = client
         self.statusMonitor = statusMonitor ?? HubStatusMonitor(storeCache: storeCache)
         self.fetchProjectsClosure = fetchProjects ?? { try await client.fetchProjects() }
         self.fetchPreferencesClosure = fetchPreferences ?? { try await client.fetchUiPreferences() }
+        self.archiveWorkspaceClosure = archiveWorkspace ?? { try await client.archiveWorkspace(workspaceId: $0) }
     }
 
     /// Whether the store has never successfully loaded data yet.
@@ -60,9 +65,10 @@ final class ProjectStore {
 
     /// Sync the hub monitor with every workspace plus the synthetic Brain id, so
     /// the Brain always stays subscribed (streaming/done events, send wiring) and
-    /// is never evicted by `sync`.
+    /// is never evicted by `sync`. Workspaces with an in-flight archive stay
+    /// subscribed so their ConversationStore survives until the outcome is known.
     private func syncMonitoredWorkspaces() {
-        let ids = projects.flatMap(\.workspaces).map(\.id) + [BRAIN_WORKSPACE_ID]
+        let ids = projects.flatMap(\.workspaces).map(\.id) + pendingArchiveIds + [BRAIN_WORKSPACE_ID]
         statusMonitor.sync(workspaceIds: ids)
     }
 
@@ -170,17 +176,72 @@ final class ProjectStore {
     }
 
     func archiveWorkspace(id: String) async {
+        guard !pendingArchiveIds.contains(id) else { return }
+        guard
+            let projectIndex = projects.firstIndex(where: { project in
+                project.workspaces.contains(where: { $0.id == id })
+            }),
+            let workspaceIndex = projects[projectIndex].workspaces.firstIndex(where: { $0.id == id })
+        else { return }
+
+        // Capture removal context, then remove optimistically before the request.
+        let projectId = projects[projectIndex].id
+        let siblings = projects[projectIndex].workspaces
+        let workspace = siblings[workspaceIndex]
+        let previousId = workspaceIndex > 0 ? siblings[workspaceIndex - 1].id : nil
+        let nextId = workspaceIndex < siblings.count - 1 ? siblings[workspaceIndex + 1].id : nil
+
+        projects[projectIndex].workspaces.remove(at: workspaceIndex)
+        pendingArchiveIds.insert(id)
+        archiveFailed = false
+
         do {
-            try await api.archiveWorkspace(workspaceId: id)
-            for i in projects.indices {
-                projects[i].workspaces.removeAll { $0.id == id }
-            }
+            try await archiveWorkspaceClosure(id)
+            pendingArchiveIds.remove(id)
             syncMonitoredWorkspaces()
-        } catch is CancellationError {
-            // Ignore
         } catch {
-            errorMessage = error.localizedDescription
+            pendingArchiveIds.remove(id)
+            restoreWorkspace(
+                workspace,
+                inProject: projectId,
+                previousId: previousId,
+                nextId: nextId,
+                originalIndex: workspaceIndex
+            )
+            if !(error is CancellationError) {
+                archiveFailed = true
+            }
         }
+    }
+
+    /// Re-insert a workspace after a failed archive. Anchoring on siblings
+    /// (rather than a raw index) keeps concurrent failed archives converging
+    /// to the original order.
+    private func restoreWorkspace(
+        _ workspace: Workspace,
+        inProject projectId: String,
+        previousId: String?,
+        nextId: String?,
+        originalIndex: Int
+    ) {
+        guard let projectIndex = projects.firstIndex(where: { $0.id == projectId }) else { return }
+        guard !projects[projectIndex].workspaces.contains(where: { $0.id == workspace.id }) else { return }
+
+        let workspaces = projects[projectIndex].workspaces
+        let insertionIndex: Int
+        if let nextId, let nextIndex = workspaces.firstIndex(where: { $0.id == nextId }) {
+            insertionIndex = nextIndex
+        } else if let previousId, let previousIndex = workspaces.firstIndex(where: { $0.id == previousId }) {
+            insertionIndex = previousIndex + 1
+        } else {
+            insertionIndex = min(originalIndex, workspaces.count)
+        }
+        projects[projectIndex].workspaces.insert(workspace, at: insertionIndex)
+    }
+
+    /// Dismiss the transient archive failure notice.
+    func acknowledgeArchiveFailure() {
+        archiveFailed = false
     }
 
     /// Refresh projects from the API. Shows existing data while loading.
@@ -203,6 +264,13 @@ final class ProjectStore {
                 for j in fresh[i].workspaces.indices {
                     fresh[i].workspaces[j].projectId = fresh[i].id
                     fresh[i].workspaces[j].hasFavicon = fresh[i].hasFavicon
+                }
+            }
+            // A refresh landing mid-archive must not resurrect an optimistically
+            // removed workspace.
+            if !pendingArchiveIds.isEmpty {
+                for i in fresh.indices {
+                    fresh[i].workspaces.removeAll { pendingArchiveIds.contains($0.id) }
                 }
             }
             statusMonitor.seedLastActivityDates(from: fresh.flatMap(\.workspaces))

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -98,9 +98,23 @@ struct HubView: View {
                             store.acknowledgeRefreshFailure()
                         }
                     }
+            } else if store.archiveFailed {
+                archiveFailedNotice
+                    .task {
+                        try? await Task.sleep(for: .seconds(3))
+                        if !Task.isCancelled {
+                            store.acknowledgeArchiveFailure()
+                        }
+                    }
             }
         }
         .animation(.default, value: store.refreshFailedWithCachedData)
+        .animation(.default, value: store.archiveFailed)
+        .onChange(of: store.archiveFailed) { _, failed in
+            if failed {
+                Haptics.notify(.error)
+            }
+        }
         .safeAreaInset(edge: .top, spacing: 0) {
             if let repoName = store.cloningRepoName {
                 HStack(spacing: HiveSpacing.sm) {
@@ -138,7 +152,7 @@ struct HubView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: { ws in
-            Text("\"\(ws.name)\" will be archived and removed from this list. Archived workspaces can be restored from the desktop app.")
+            Text("\"\(ws.name)\" will be archived and removed from this list. Any uncommitted changes will be lost.")
         }
     }
 
@@ -175,9 +189,17 @@ struct HubView: View {
     }
 
     private var refreshFailedNotice: some View {
+        transientNotice(icon: "exclamationmark.triangle", message: "Couldn't refresh. Showing cached data.")
+    }
+
+    private var archiveFailedNotice: some View {
+        transientNotice(icon: "exclamationmark.triangle", message: "Failed to archive workspace")
+    }
+
+    private func transientNotice(icon: String, message: String) -> some View {
         HStack(spacing: HiveSpacing.sm) {
-            Image(systemName: "exclamationmark.triangle")
-            Text("Couldn't refresh. Showing cached data.")
+            Image(systemName: icon)
+            Text(message)
                 .font(.footnote)
         }
         .foregroundStyle(WhisperColor.textSecondary)

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
@@ -20,8 +20,13 @@ private final class ArchiveFakeHubConnection: HubConnectionClient {
 private final class ArchiveGate {
     private var continuation: CheckedContinuation<Void, any Error>?
     private var pendingResult: Result<Void, any Error>?
+    private var enteredContinuation: CheckedContinuation<Void, Never>?
+    private var hasEntered = false
 
     func wait() async throws {
+        hasEntered = true
+        enteredContinuation?.resume()
+        enteredContinuation = nil
         try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
             if let result = pendingResult {
                 pendingResult = nil
@@ -32,6 +37,13 @@ private final class ArchiveGate {
         }
     }
 
+    /// Suspends until `wait()` has been entered, so tests assert in-flight
+    /// state against a guaranteed interleaving instead of arbitrary yields.
+    func entered() async {
+        if hasEntered { return }
+        await withCheckedContinuation { enteredContinuation = $0 }
+    }
+
     func resume(_ result: Result<Void, any Error> = .success(())) {
         if let cont = continuation {
             continuation = nil
@@ -40,6 +52,11 @@ private final class ArchiveGate {
             pendingResult = result
         }
     }
+}
+
+@MainActor
+private final class Counter {
+    var value = 0
 }
 
 @MainActor
@@ -75,14 +92,15 @@ struct ProjectStoreArchiveTests {
     }
 
     private func makeStore(
-        archiveWorkspace: @escaping @MainActor (String) async throws -> Void
+        archiveWorkspace: @escaping @MainActor (String) async throws -> Void,
+        fetchProjects: (@MainActor () async throws -> [Project])? = nil
     ) -> (store: ProjectStore, cache: ConversationStoreCache) {
         let cache = ConversationStoreCache()
         let monitor = HubStatusMonitor(storeCache: cache) { _ in ArchiveFakeHubConnection() }
         let store = ProjectStore(
             storeCache: cache,
             statusMonitor: monitor,
-            fetchProjects: { [self.sampleProject()] },
+            fetchProjects: fetchProjects ?? { [self.sampleProject()] },
             fetchPreferences: { .empty },
             archiveWorkspace: archiveWorkspace
         )
@@ -101,7 +119,7 @@ struct ProjectStoreArchiveTests {
         #expect(workspaceIds(store) == ["w1", "w2", "w3"])
 
         let task = Task { await store.archiveWorkspace(id: "w2") }
-        for _ in 0..<5 { await Task.yield() }
+        await gate.entered()
 
         #expect(workspaceIds(store) == ["w1", "w3"])
         #expect(store.pendingArchiveIds == ["w2"])
@@ -147,7 +165,7 @@ struct ProjectStoreArchiveTests {
         await store.refresh()
 
         let task = Task { await store.archiveWorkspace(id: "w2") }
-        for _ in 0..<5 { await Task.yield() }
+        await gate.entered()
         #expect(workspaceIds(store) == ["w1", "w3"])
 
         await store.refresh(force: true)
@@ -159,6 +177,53 @@ struct ProjectStoreArchiveTests {
         #expect(workspaceIds(store) == ["w1", "w3"])
         #expect(store.pendingArchiveIds.isEmpty)
         #expect(store.archiveFailed == false)
+    }
+
+    @Test
+    func staleRefreshResolvingAfterArchiveSuccessDoesNotResurrect() async {
+        let fetchGate = ArchiveGate()
+        let fetchCount = Counter()
+        let staleProjects = [sampleProject()]
+        let (store, _) = makeStore(
+            archiveWorkspace: { _ in },
+            fetchProjects: {
+                fetchCount.value += 1
+                if fetchCount.value > 1 {
+                    try await fetchGate.wait()
+                }
+                return staleProjects
+            }
+        )
+        await store.refresh()
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+
+        // Second refresh suspends on a fetch whose snapshot still contains w2,
+        // while the archive completes and clears its pending id underneath.
+        let refreshTask = Task { await store.refresh(force: true) }
+        await fetchGate.entered()
+
+        await store.archiveWorkspace(id: "w2")
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        fetchGate.resume()
+        await refreshTask.value
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.pendingArchiveIds.isEmpty)
+    }
+
+    @Test
+    func failedArchiveIsNotTombstonedByLaterRefresh() async {
+        let (store, _) = makeStore(archiveWorkspace: { _ in throw ArchiveError() })
+        await store.refresh()
+
+        await store.archiveWorkspace(id: "w2")
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+
+        // A failed archive leaves the workspace alive server-side; it must
+        // survive subsequent refreshes, not be treated as archived.
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
     }
 
     @Test

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
@@ -1,0 +1,175 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+private struct ArchiveError: Error {}
+
+@MainActor
+private final class ArchiveFakeHubConnection: HubConnectionClient {
+    func connect() {}
+    func cancel() {}
+    func forceReconnect() {}
+    func send(_ message: HubIncoming) async -> Bool { true }
+    func sendSync(_ payload: HubSyncPayload, forceBootstrap: Bool) {}
+    func probeLiveness() {}
+}
+
+/// Holds an archive request open until the test resolves it, so mid-flight
+/// state can be asserted deterministically.
+@MainActor
+private final class ArchiveGate {
+    private var continuation: CheckedContinuation<Void, any Error>?
+    private var pendingResult: Result<Void, any Error>?
+
+    func wait() async throws {
+        try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+            if let result = pendingResult {
+                pendingResult = nil
+                cont.resume(with: result)
+            } else {
+                continuation = cont
+            }
+        }
+    }
+
+    func resume(_ result: Result<Void, any Error> = .success(())) {
+        if let cont = continuation {
+            continuation = nil
+            cont.resume(with: result)
+        } else {
+            pendingResult = result
+        }
+    }
+}
+
+@MainActor
+struct ProjectStoreArchiveTests {
+    private func sampleWorkspace(id: String) -> Workspace {
+        Workspace(
+            id: id,
+            name: "Workspace \(id)",
+            branch: "hive/\(id)",
+            status: .idle,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            activeSessionId: nil,
+            projectName: "Project p1",
+            defaultBranch: "main",
+            sessionCount: 0,
+            projectId: "p1",
+            hasFavicon: nil
+        )
+    }
+
+    private func sampleProject() -> Project {
+        Project(
+            id: "p1",
+            name: "Project p1",
+            url: nil,
+            createdAt: "2026-01-01T00:00:00.000Z",
+            workspaces: [
+                sampleWorkspace(id: "w1"),
+                sampleWorkspace(id: "w2"),
+                sampleWorkspace(id: "w3")
+            ]
+        )
+    }
+
+    private func makeStore(
+        archiveWorkspace: @escaping @MainActor (String) async throws -> Void
+    ) -> (store: ProjectStore, cache: ConversationStoreCache) {
+        let cache = ConversationStoreCache()
+        let monitor = HubStatusMonitor(storeCache: cache) { _ in ArchiveFakeHubConnection() }
+        let store = ProjectStore(
+            storeCache: cache,
+            statusMonitor: monitor,
+            fetchProjects: { [self.sampleProject()] },
+            fetchPreferences: { .empty },
+            archiveWorkspace: archiveWorkspace
+        )
+        return (store, cache)
+    }
+
+    private func workspaceIds(_ store: ProjectStore) -> [String] {
+        store.projects.first?.workspaces.map(\.id) ?? []
+    }
+
+    @Test
+    func optimisticRemovalHidesWorkspaceWhileRequestInFlight() async {
+        let gate = ArchiveGate()
+        let (store, _) = makeStore(archiveWorkspace: { _ in try await gate.wait() })
+        await store.refresh()
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+
+        let task = Task { await store.archiveWorkspace(id: "w2") }
+        for _ in 0..<5 { await Task.yield() }
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.pendingArchiveIds == ["w2"])
+
+        gate.resume()
+        await task.value
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.pendingArchiveIds.isEmpty)
+    }
+
+    @Test
+    func successfulArchiveKeepsRemovalAndEvictsConversationStore() async {
+        let (store, cache) = makeStore(archiveWorkspace: { _ in })
+        await store.refresh()
+        _ = cache.getOrCreate("w2")
+        #expect(cache.stores["w2"] != nil)
+
+        await store.archiveWorkspace(id: "w2")
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.pendingArchiveIds.isEmpty)
+        #expect(store.archiveFailed == false)
+        #expect(cache.stores["w2"] == nil)
+    }
+
+    @Test
+    func failedArchiveRestoresWorkspaceBetweenSiblings() async {
+        let (store, _) = makeStore(archiveWorkspace: { _ in throw ArchiveError() })
+        await store.refresh()
+
+        await store.archiveWorkspace(id: "w2")
+
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+        #expect(store.pendingArchiveIds.isEmpty)
+        #expect(store.archiveFailed == true)
+    }
+
+    @Test
+    func refreshMidFlightDoesNotResurrectPendingArchive() async {
+        let gate = ArchiveGate()
+        let (store, _) = makeStore(archiveWorkspace: { _ in try await gate.wait() })
+        await store.refresh()
+
+        let task = Task { await store.archiveWorkspace(id: "w2") }
+        for _ in 0..<5 { await Task.yield() }
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        gate.resume()
+        await task.value
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.pendingArchiveIds.isEmpty)
+        #expect(store.archiveFailed == false)
+    }
+
+    @Test
+    func acknowledgeArchiveFailureClearsFlag() async {
+        let (store, _) = makeStore(archiveWorkspace: { _ in throw ArchiveError() })
+        await store.refresh()
+
+        await store.archiveWorkspace(id: "w2")
+        #expect(store.archiveFailed == true)
+
+        store.acknowledgeArchiveFailure()
+        #expect(store.archiveFailed == false)
+    }
+}


### PR DESCRIPTION
Closes #453. iOS parity with the web's optimistic archive (#454).

## What

- **Optimistic removal**: `ProjectStore.archiveWorkspace` removes the workspace from `projects` before the POST (which takes seconds server-side for the worktree removal). The API call sits behind an injectable closure, following the existing `fetchProjects` pattern.
- **Anti-resurrection**: `pendingArchiveIds` (in-flight archives) and `archivedIds` (session-lifetime tombstones recorded on success) are both stripped from `refresh()` results. The tombstones close a race where a refresh suspended on its fetch publishes a stale snapshot after the archive completed; since no restore path exists and ids are never reused, an archived id can never legitimately reappear.
- **Deferred eviction**: the monitor sync (which evicts the workspace's `ConversationStore` and drops its subscription) runs only after the POST succeeds. In-flight archive ids stay in the monitored set, so a rollback restores the row with its conversation store intact instead of an empty shell.
- **Rollback on failure**: sibling-anchored re-insert at the original position (same convergence semantics as web under concurrent failures), transient `archiveFailed` flag surfaced as a 3s auto-dismiss pill on the Hub (shared `transientNotice` helper with the refresh-failed notice, refresh wins if both are active) plus an error haptic. Cancellation rolls back silently. The archive path no longer writes to the sticky `errorMessage` banner.
- **Alert copy fix**: drops the false "can be restored from the desktop app" claim; now warns that uncommitted changes will be lost. The confirm alert stays unconditional (mobile convention for a destructive context-menu action).

## Scope notes

- The navigation-pop requirement from #453 was dropped: archive is only reachable from the Hub root context menu, so "inside the archived workspace" is an unreachable state (details in the issue comment).
- No backend or web changes; no new WS event (multi-client sync stays refresh-based, same as web).
- Externally audited in two passes; accepted findings applied (stale-refresh tombstone, failure-path test, deterministic test handshake). The concurrent-double-failure ordering edge case was accepted as a known degenerate case (identical behavior in the merged web code, self-heals on next refresh).

## Testing

`ProjectStoreArchiveTests` (swift-testing, fake `HubConnectionClient` so no real socket, gate-based deterministic interleavings via `ArchiveGate.entered()`): optimistic removal while the POST is held open, success keeps the row out and evicts the conversation store, failure restores the row between its original siblings, a forced refresh mid-flight does not resurrect the row, a stale refresh resolving after archive success does not resurrect the row (tombstone), a failed archive is never tombstoned, and `acknowledgeArchiveFailure` clears the flag.

**Caveat**: the Swift toolchain is not available in the authoring environment, so `swift test` has not been run yet. Code was line-by-line reviewed against the real APIs (protocol isolation, memberwise inits, Haptics signature). Please run `cd ios && swift test` before merging.