### PR TITLE
fix(ios): stop the Hub search bar from overlapping pushed workspaces

### DIFF
--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -26,45 +26,44 @@ struct HubView: View {
         let displayedSections = filteredSections(sections)
         let prIds = visiblePrWorkspaceIds(in: displayedSections)
 
-        ZStack {
-            WhisperColor.appBackground
-                .ignoresSafeArea()
-
-            List {
-                Group {
-                    if store.projects.isEmpty {
-                        emptyState
-                    } else if !searchText.isEmpty, displayedSections.isEmpty {
-                        ContentUnavailableView.search(text: searchText)
-                            .padding(.top, 40)
-                    } else {
-                        ForEach(displayedSections) { section in
-                            sectionView(section)
-                        }
+        List {
+            Group {
+                if store.projects.isEmpty {
+                    emptyState
+                } else if !searchText.isEmpty, displayedSections.isEmpty {
+                    ContentUnavailableView.search(text: searchText)
+                        .padding(.top, 40)
+                } else {
+                    ForEach(displayedSections) { section in
+                        sectionView(section)
                     }
                 }
-                .listRowInsets(EdgeInsets(
-                    top: HiveSpacing.md,
-                    leading: HiveSpacing.lg,
-                    bottom: 0,
-                    trailing: HiveSpacing.lg
-                ))
-                .listRowBackground(WhisperColor.appBackground)
-                .listRowSeparator(.hidden)
             }
-            .listStyle(.plain)
-            .scrollBounceBehavior(.always)
-            .scrollContentBackground(.hidden)
-            .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
-            .refreshable {
-                // Unstructured Task shields refresh from SwiftUI prematurely
-                // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
-                await Task { @MainActor in
-                    store.statusMonitor.forceRefresh()
-                    await store.refresh(force: true, userInitiated: true)
-                }.value
-            }
+            .listRowInsets(EdgeInsets(
+                top: HiveSpacing.md,
+                leading: HiveSpacing.lg,
+                bottom: 0,
+                trailing: HiveSpacing.lg
+            ))
+            .listRowBackground(WhisperColor.appBackground)
+            .listRowSeparator(.hidden)
         }
+        .listStyle(.plain)
+        .scrollBounceBehavior(.always)
+        .scrollContentBackground(.hidden)
+        // Drawer must hide when scrolling: a pinned search bar lives in the shared
+        // navigation bar, so it lingers unstyled over the pushed workspace during
+        // the transition instead of sliding away with the list.
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .automatic))
+        .refreshable {
+            // Unstructured Task shields refresh from SwiftUI prematurely
+            // cancelling the .refreshable task on ScrollView (known iOS 26 regression).
+            await Task { @MainActor in
+                store.statusMonitor.forceRefresh()
+                await store.refresh(force: true, userInitiated: true)
+            }.value
+        }
+        .hiveScreenBackground()
         .navigationTitle("Hub")
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)


### PR DESCRIPTION
## Problem

Pushing a workspace from the Hub left the top of the destination covered during the transition, and the pop showed an unstyled search bar floating over the animation.

The Hub pinned its search bar with `navigationBarDrawer(displayMode: .always)`, which maps to UIKit's `hidesSearchBarWhenScrolling = false`. A pinned search bar lives in the navigation bar, chrome that both screens of the stack share, so on push it stayed behind and cross-faded over the incoming workspace instead of leaving with the list. The taller bar is what clipped the top of the workspace dashboard.

## Fix

Switch the drawer to `.automatic`. The search bar goes back to being part of the list's scroll content, so it travels out with the outgoing view and the bar height stays constant across the transition. This is the standard behaviour in Mail and Notes, and `AutomationsListView` already uses `.automatic`.

The background `ZStack` goes away too: it duplicated the `hiveScreenBackground()` the `NavigationStack` already applies in `HiveApp`, and it kept `.searchable` one container away from the scroll view it attaches to.

## Behaviour change

The Hub search bar now hides on scroll and comes back when you pull down, instead of staying visible at all times.

## Testing

Not compiled: no Swift toolchain on the machine this was written on. Needs a device check on the Hub to workspace push and pop.