### PR TITLE
fix(ios): drop the forced opaque navigation bar appearance

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -278,8 +278,6 @@ struct ChatView: View {
                 composerStack
             }
         }
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .navigationTitle(navigationTitle)
         .navigationSubtitle(Text(navigationSubtitle))
         .navigationBarTitleDisplayMode(.inline)

--- a/ios/HiveMobile/Views/Chat/ConversationsSection.swift
+++ b/ios/HiveMobile/Views/Chat/ConversationsSection.swift
@@ -61,8 +61,6 @@ struct ConversationsSection<Header: View>: View {
         .navigationDestination(for: SessionMetadata.self) { session in
             ChatView(workspace: workspace, session: session, store: store)
         }
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 ToolbarAddButton(

--- a/ios/HiveMobile/Views/Chat/ScriptLogView.swift
+++ b/ios/HiveMobile/Views/Chat/ScriptLogView.swift
@@ -61,8 +61,6 @@ struct ScriptLogView: View {
         .hiveScreenBackground()
         .navigationTitle(scriptId)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: triggerAction) {

--- a/ios/HiveMobile/Views/Chat/ToolInputSheet.swift
+++ b/ios/HiveMobile/Views/Chat/ToolInputSheet.swift
@@ -21,8 +21,6 @@ struct ToolInputSheet: View {
             }
             .hiveScreenBackground()
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
         }
         .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)

--- a/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
+++ b/ios/HiveMobile/Views/Hub/AddProjectSheet.swift
@@ -88,8 +88,6 @@ struct AddProjectSheet: View {
             .hiveScreenBackground()
             .navigationTitle(mode == .clone ? "Add Project" : "Create Project")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-            .toolbarBackground(.visible, for: .navigationBar)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }

--- a/ios/HiveMobile/Views/Hub/HubView.swift
+++ b/ios/HiveMobile/Views/Hub/HubView.swift
@@ -67,8 +67,6 @@ struct HubView: View {
         }
         .navigationTitle("Hub")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar { toolbarContent }
         .task {
             // Always safe: existing data stays visible while refresh runs.

--- a/ios/HiveMobile/Views/Settings/AutomationDetailView.swift
+++ b/ios/HiveMobile/Views/Settings/AutomationDetailView.swift
@@ -72,8 +72,6 @@ struct AutomationDetailView: View {
         .hiveScreenBackground()
         .navigationTitle(automation.name)
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .navigationDestination(item: $selectedRun) { run in
             AutomationRunLogView(automation: automation, run: run)
         }

--- a/ios/HiveMobile/Views/Settings/AutomationRunLogView.swift
+++ b/ios/HiveMobile/Views/Settings/AutomationRunLogView.swift
@@ -59,8 +59,6 @@ struct AutomationRunLogView: View {
         .hiveScreenBackground()
         .navigationTitle("Run log")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .task { await load() }
     }
 

--- a/ios/HiveMobile/Views/Settings/AutomationsListView.swift
+++ b/ios/HiveMobile/Views/Settings/AutomationsListView.swift
@@ -36,8 +36,6 @@ struct AutomationsListView: View {
         .hiveScreenBackground()
         .navigationTitle("Automations")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .navigationDestination(item: $selectedAutomation) { automation in
             AutomationDetailView(automation: automation)
         }

--- a/ios/HiveMobile/Views/Settings/SettingsView.swift
+++ b/ios/HiveMobile/Views/Settings/SettingsView.swift
@@ -69,8 +69,6 @@ struct SettingsView: View {
         .onDisappear { stopConnectionPolling() }
         .navigationTitle("Settings")
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(WhisperColor.appBackground, for: .navigationBar)
-        .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()


### PR DESCRIPTION
## Problem

Pushing a workspace from the Hub left the top of the destination covered for the length of the transition, with the Hub search field floating unstyled over it. The pop replayed the artifact in reverse.

Every screen installed its own `UINavigationBarAppearance` through `toolbarBackground(WhisperColor.appBackground, for: .navigationBar)` plus `toolbarBackground(.visible, for: .navigationBar)`. Two distinct appearance objects on the two sides of a push are not something UIKit crossfades: it applies the incoming one immediately, so the bar background snapped to the destination height at the start of the animation while the search drawer was still fading out inside the old one.

The search drawer was a red herring. Switching it to `hidesSearchBarWhenScrolling` changed nothing on device, which makes sense since the search bar is always a subview of the shared `UINavigationBar` and that flag only gates its collapse.

## Fix

Remove the pair from all ten screens. The bar goes back to the iOS 26 default, a Liquid Glass bar shared by both sides of the transition, so the appearance no longer changes mid-push.

## Visual change

Bars now blur the content scrolling underneath instead of painting a flat `WhisperColor.appBackground` band. This matches the glass cards and pills the rest of the app already uses, and it was confirmed as the wanted look on device.

## Testing

Bisected on device across two builds: with both the opaque bar and the search drawer removed the animation was clean, and putting the search drawer back kept it clean, which pins the cause on the bar appearance.

Verified on device for the Hub to workspace push and pop. The other eight screens carry the same one-line removal and have not been walked through individually yet, so the Settings, Automations, Chat, and sheet bars are worth a look.

Known remaining nit, not addressed here: on the pop back to the Hub the search field renders as bare placeholder text for the length of the animation, then settles correctly. It is the search field's own Liquid Glass material, not the bar.