### PR TITLE
fix(web): PR status stuck in sidebar after hub disconnect

### DIFF
--- a/backend/src/services/git-sync.test.ts
+++ b/backend/src/services/git-sync.test.ts
@@ -22,7 +22,7 @@ vi.mock("../utils/github.js", async (importOriginal) => {
   };
 });
 
-function makePr(number: number): PullRequestInfo {
+function makePr(number: number, overrides: Partial<PullRequestInfo> = {}): PullRequestInfo {
   return {
     number,
     url: `https://github.com/o/r/pull/${number}`,
@@ -33,6 +33,7 @@ function makePr(number: number): PullRequestInfo {
     checksPassed: null,
     checksTotal: null,
     reviewStatus: null,
+    ...overrides,
   };
 }
 
@@ -154,6 +155,41 @@ describe("GitSyncService", () => {
     expect(events).toEqual([ws.id]);
 
     prService._clearForTests();
+  });
+
+  it("emits a merged PR status after the cache TTL expires", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    vi.mocked(fetchPrForBranch).mockClear();
+    const prStatus = new PrStatusService(dataDir);
+    const prService = new GitSyncService(dataDir, prStatus, (id) => id === ws.id);
+    const events: PullRequestInfo[] = [];
+    let now = 100_000;
+    const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    prService.onPrStatusChange((_wsId, status) => {
+      if (status.pr) events.push(status.pr);
+    });
+
+    vi.mocked(fetchPrForBranch)
+      .mockResolvedValueOnce({ pr: makePr(42) })
+      .mockResolvedValueOnce({
+        pr: makePr(42, {
+          state: "merged",
+          mergeable: null,
+          mergeableState: "unknown",
+        }),
+      });
+
+    try {
+      await prService.poll();
+      now += 15_001;
+      await prService.poll();
+
+      expect(events.map((pr) => pr.state)).toEqual(["open", "merged"]);
+      expect(fetchPrForBranch).toHaveBeenCalledTimes(2);
+    } finally {
+      nowSpy.mockRestore();
+      prService._clearForTests();
+    }
   });
 
   it("clears cached PR status for a workspace when its branch changes", async () => {

--- a/frontend/src/hooks/usePrStatus.ts
+++ b/frontend/src/hooks/usePrStatus.ts
@@ -89,9 +89,10 @@ export function useSyncPrWorkspaces(wsIds: string[]): void {
   useEffect(() => {
     const next = new Set(wsIds);
     const changed = next.size !== prWorkspaceIds.size || [...next].some((wsId) => !prWorkspaceIds.has(wsId));
-    if (!changed) return;
     prWorkspaceIds = next;
+    // Rehydrate transport state on every mount: disconnectAll clears it while
+    // this module-level interest set survives remounts.
     wsTransport.syncPrWorkspaces([...next]);
-    notifyPrInterestListeners();
+    if (changed) notifyPrInterestListeners();
   }, [stableKey, wsIds]);
 }

--- a/frontend/tests/hooks/usePrStatus.test.ts
+++ b/frontend/tests/hooks/usePrStatus.test.ts
@@ -164,3 +164,27 @@ describe("usePrStatusMap", () => {
     expect(result.current["ws-2"]?.error).toBe("Failed to fetch PR status");
   });
 });
+
+describe("useSyncPrWorkspaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    renderHook(() => useSyncPrWorkspaces([]), { wrapper: createWrapper().wrapper });
+  });
+
+  it("resends unchanged PR interest when the hook remounts", () => {
+    const first = renderHook(() => useSyncPrWorkspaces(["ws-1"]), {
+      wrapper: createWrapper().wrapper,
+    });
+    expect(wsTransport.syncPrWorkspaces).toHaveBeenLastCalledWith(["ws-1"]);
+
+    first.unmount();
+    vi.mocked(wsTransport.syncPrWorkspaces).mockClear();
+
+    renderHook(() => useSyncPrWorkspaces(["ws-1"]), {
+      wrapper: createWrapper().wrapper,
+    });
+
+    expect(wsTransport.syncPrWorkspaces).toHaveBeenCalledOnce();
+    expect(wsTransport.syncPrWorkspaces).toHaveBeenCalledWith(["ws-1"]);
+  });
+});


### PR DESCRIPTION
## Problem

PR merge status stopped updating in the sidebar (and everywhere else consuming `usePrStatus`) after a hub disconnect.

`wsTransport.disconnectAll()` (server connection switch, connection refresh) clears the transport's `prWorkspaceIds` set, but the module-level interest set in `usePrStatus.ts` survives remounts. The `if (!changed) return` early exit in `useSyncPrWorkspaces` then saw an unchanged set and never called `wsTransport.syncPrWorkspaces()` again, so the backend never resumed pushing `pr_status` frames.

## Fix

Resync the transport on every effect run (mirroring the `syncWorkspaces` pattern in `App.tsx`, which never had an early return), while keeping React listener notifications gated on actual set changes.

## Tests

- `frontend/tests/hooks/usePrStatus.test.ts`: regression test — remounting the hook with an unchanged workspace set resends PR interest to the transport.
- `backend/src/services/git-sync.test.ts`: characterization test — a merged PR state is emitted once the 15s `PrStatusService` cache TTL expires (spy cleanup wrapped in `try/finally`).