### PR TITLE
fix(web): avoid native composer reset

### DIFF
--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -373,7 +373,12 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
             planMode={planMode && supportsPlanMode}
           />
         )}
-        <PromptInput onSubmit={handleSubmit} accept="image/*" multiple>
+        <PromptInput
+          onSubmit={handleSubmit}
+          accept="image/*"
+          multiple
+          resetOnSubmit={false}
+        >
         <PromptInputBody>
           <ChatInputAttachments onFileCountChange={setFileCount} attachmentsRef={attachmentsRef} />
           <MentionHighlightOverlay

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -388,7 +388,7 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
           />
           <PromptInputTextarea
             ref={textareaRef}
-            className="min-h-[100px] max-h-40 bg-transparent text-sm placeholder:text-muted-foreground/40"
+            className="chat-input-textarea min-h-[100px] max-h-40 bg-transparent text-sm placeholder:text-muted-foreground/40"
             placeholder={isDisconnected ? "Reconnecting..." : (customPlaceholder ?? "Send message, #mention files, @call agents, run /commands")}
             autoCapitalize="off"
             autoComplete="off"

--- a/frontend/src/components/ai-elements/prompt-input.tsx
+++ b/frontend/src/components/ai-elements/prompt-input.tsx
@@ -384,6 +384,8 @@ export type PromptInputProps = Omit<
   globalDrop?: boolean;
   // Render a hidden input with given name and keep it in sync for native form posts. Default false.
   syncHiddenInput?: boolean;
+  // Reset uncontrolled form fields before submission. Default true.
+  resetOnSubmit?: boolean;
   // Minimal constraints
   maxFiles?: number;
   // bytes
@@ -404,6 +406,7 @@ export const PromptInput = ({
   multiple,
   globalDrop,
   syncHiddenInput,
+  resetOnSubmit = true,
   maxFiles,
   maxFileSize,
   onError,
@@ -751,9 +754,9 @@ export const PromptInput = ({
             return (formData.get("message") as string) || "";
           })();
 
-      // Reset form immediately after capturing text to avoid race condition
-      // where user input during async blob conversion would be lost
-      if (!usingProvider) {
+      // Uncontrolled consumers reset immediately so input entered during async
+      // blob conversion is not cleared afterward.
+      if (!usingProvider && resetOnSubmit) {
         form.reset();
       }
 
@@ -797,7 +800,7 @@ export const PromptInput = ({
         // Don't clear on error - user may want to retry
       }
     },
-    [usingProvider, controller, files, onSubmit, clear]
+    [usingProvider, controller, files, onSubmit, clear, resetOnSubmit]
   );
 
   // Render with or without local provider

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -358,6 +358,15 @@
     background: color-mix(in oklch, var(--muted-foreground) 25%, transparent);
   }
 
+  .chat-input-textarea,
+  .chat-input-textarea:hover {
+    scrollbar-color: var(--input) transparent;
+  }
+  .chat-input-textarea::-webkit-scrollbar-thumb,
+  .chat-input-textarea:hover::-webkit-scrollbar-thumb {
+    background: var(--input);
+  }
+
   html,
   body {
     @apply bg-background font-sans text-foreground;

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -102,6 +102,7 @@ describe("ChatInput", () => {
     expect(input).toHaveAttribute("autocomplete", "off");
     expect(input).toHaveAttribute("autocorrect", "off");
     expect(input).toHaveAttribute("spellcheck", "false");
+    expect(input).toHaveClass("chat-input-textarea");
   });
 
   it("appends text through the imperative ref API", () => {

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -330,6 +330,7 @@ describe("ChatInput", () => {
 
   it("clears text input after successful send", async () => {
     const user = userEvent.setup();
+    const resetSpy = vi.spyOn(HTMLFormElement.prototype, "reset");
     renderChatInput();
 
     const input = screen.getByPlaceholderText("Send message, #mention files, @call agents, run /commands");
@@ -337,6 +338,8 @@ describe("ChatInput", () => {
     await user.click(screen.getByRole("button", { name: "Send" }));
 
     expect(input).toHaveValue("");
+    expect(resetSpy).not.toHaveBeenCalled();
+    resetSpy.mockRestore();
   });
 
   it("keeps input enabled when connecting (only disconnected disables)", () => {


### PR DESCRIPTION
## Summary

- let controlled prompt inputs opt out of the native form reset
- disable the native reset for `ChatInput` so React remains the single source of truth
- keep the composer scrollbar styling stable across hover to avoid a WKWebView native-control repaint glitch
- verify successful sends still clear the composer without calling `form.reset()`

## Context

On macOS, Tauri uses WKWebView. When a send clears the focused textarea while the pointer remains over it, the placeholder can be clipped to a few characters until the pointer leaves. The composer combines native content sizing with global hover-dependent scrollbar styling, causing WKWebView to recompose the native textarea differently on pointer entry and exit. This patch removes the redundant native reset and prevents that textarea’s scrollbar paint from changing on hover.

## Validation

- `cd frontend && npm run lint`
- `cd frontend && npm run typecheck`
- `cd frontend && npm test -- tests/components/ChatInput.test.tsx`

Manual verification in Tauri on macOS is still required: send while leaving the pointer inside the composer, then move it outside and back in; also verify multiline overflow.