### PR TITLE
fix(backend): workspace creation intermittently fails on archived city branches

### DIFF
--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -134,6 +134,24 @@ describe("createWorkspace", () => {
     expect(second.name).toBe(free);
   });
 
+  it("reserves cities despite same-named tags and nested workspace refs", async () => {
+    const bare = bareRepoPath(dataDir, projectId);
+    // A tag sharing the branch name makes %(refname:short) ambiguous, and a
+    // nested ref blocks its whole workspace/<city> namespace: both cities
+    // must stay excluded from the pick.
+    const [taggedCity, nestedCity, free] = CITIES;
+    await git(["update-ref", `refs/heads/workspace/${taggedCity}`, "HEAD"], bare);
+    await git(["update-ref", `refs/tags/workspace/${taggedCity}`, "HEAD"], bare);
+    await git(["update-ref", `refs/heads/workspace/${nestedCity}/topic`, "HEAD"], bare);
+    for (const city of CITIES) {
+      if (city === taggedCity || city === nestedCity || city === free) continue;
+      await git(["update-ref", `refs/heads/workspace/${city}`, "HEAD"], bare);
+    }
+
+    const ws = await createWorkspace(projectId, dataDir);
+    expect(ws.name).toBe(free);
+  });
+
   it("throws for non-existent project", async () => {
     await expect(createWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
   });

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -16,6 +16,7 @@ import {
   mergeWorkspace,
 } from "./workspace-manager.js";
 import { git } from "../utils/git.js";
+import { CITIES } from "../utils/city-names.js";
 import { _resetDefaultBranchRefreshCache } from "../utils/git-default-branch.js";
 import { loadProject, saveProject } from "../state/state.js";
 import * as stateStore from "../state/state.js";
@@ -114,6 +115,23 @@ describe("createWorkspace", () => {
     const ws1 = await createWorkspace(projectId, dataDir);
     const ws2 = await createWorkspace(projectId, dataDir);
     expect(ws1.name).not.toBe(ws2.name);
+  });
+
+  it("skips city names whose branches survive from archived workspaces", async () => {
+    const first = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(first.id, dataDir);
+
+    // Occupy every city except the archived one and a single free one, so the
+    // picker can only succeed by excluding the archived branch.
+    const bare = bareRepoPath(dataDir, projectId);
+    const free = CITIES.find((city) => city !== first.name);
+    for (const city of CITIES) {
+      if (city === first.name || city === free) continue;
+      await git(["update-ref", `refs/heads/workspace/${city}`, "HEAD"], bare);
+    }
+
+    const second = await createWorkspace(projectId, dataDir);
+    expect(second.name).toBe(free);
   });
 
   it("throws for non-existent project", async () => {

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -148,8 +148,16 @@ describe("createWorkspace", () => {
       await git(["update-ref", `refs/heads/workspace/${city}`, "HEAD"], bare);
     }
 
-    const ws = await createWorkspace(projectId, dataDir);
-    expect(ws.name).toBe(free);
+    // Pin the pick to the first available city: broken parsing leaves
+    // taggedCity and nestedCity as candidates ahead of free, so any
+    // regression fails deterministically instead of one run in three.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const ws = await createWorkspace(projectId, dataDir);
+      expect(ws.name).toBe(free);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("throws for non-existent project", async () => {

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -217,15 +217,17 @@ export async function createWorkspace(
       const bare = bareRepoPath(dataDir, projectId);
 
       // Archived workspaces keep their workspace/<city> branch for restore;
-      // exclude those cities too or `worktree add -b` collides.
+      // exclude those cities too or `worktree add -b` collides. Full refnames
+      // (%(refname:short) is ambiguous next to a same-named tag), first path
+      // segment only (a nested workspace/<city>/x ref blocks workspace/<city>).
       const { stdout: branchRefs } = await git(
-        ["for-each-ref", "--format=%(refname:short)", "refs/heads/workspace/"],
+        ["for-each-ref", "--format=%(refname)", "refs/heads/workspace/"],
         bare,
       );
       const branchCities = branchRefs
         .split("\n")
         .filter(Boolean)
-        .map((ref) => ref.slice("workspace/".length));
+        .map((ref) => ref.slice("refs/heads/workspace/".length).split("/")[0]);
       const usedNames = [...state.workspaces.map((ws) => ws.name), ...branchCities];
       const cityName = pickCityName(usedNames);
       const wsPath = join(workspacesDir(dataDir, projectId), cityName);

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -214,10 +214,21 @@ export async function createWorkspace(
       const state = await loadProject(projectId, dataDir);
       if (!state) throw new NotFoundError(`Project ${projectId} not found`);
 
-      const usedNames = state.workspaces.map((ws) => ws.name);
+      const bare = bareRepoPath(dataDir, projectId);
+
+      // Archived workspaces keep their workspace/<city> branch for restore;
+      // exclude those cities too or `worktree add -b` collides.
+      const { stdout: branchRefs } = await git(
+        ["for-each-ref", "--format=%(refname:short)", "refs/heads/workspace/"],
+        bare,
+      );
+      const branchCities = branchRefs
+        .split("\n")
+        .filter(Boolean)
+        .map((ref) => ref.slice("workspace/".length));
+      const usedNames = [...state.workspaces.map((ws) => ws.name), ...branchCities];
       const cityName = pickCityName(usedNames);
       const wsPath = join(workspacesDir(dataDir, projectId), cityName);
-      const bare = bareRepoPath(dataDir, projectId);
 
       const defaultBranch = await resolveDefaultBranch(bare);
 


### PR DESCRIPTION
## Problem

Clicking "+" next to a project sometimes did nothing. The backend was returning a 500: archived workspaces intentionally keep their `workspace/<city>` branch for potential restore, but `pickCityName()` only excluded the names of *active* workspaces. When the random pick landed on an archived city, `git worktree add -b workspace/<city>` failed with "a branch named ... already exists".

With 18 orphaned `workspace/*` branches on a real project, that's roughly a 9% silent failure per click. Confirmed via two 500s on `POST /api/projects/:id/workspaces` in the backend logs (~30-40ms responses, consistent with an immediate local git failure).

## Fix

Before picking a city, list `refs/heads/workspace/*` in the bare repo and merge those cities into the used-names set passed to `pickCityName()`. The picker can no longer collide with a surviving archive branch. PR and branch source flows don't go through the city picker and are unaffected.

The frontend swallows the rejection (no catch/toast in `handleAddWorkspace`), which is why the failure was invisible; surfacing errors in the UI is intentionally out of scope here.

## Test

New deterministic regression test: create a workspace, archive it (branch survives), occupy every other city via `update-ref`, then assert the next creation picks the single genuinely free city. Backend lint, typecheck, and the full `workspace-manager.test.ts` suite (59 tests) pass.