### PR TITLE
chore: prepare release 0.1.1

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.0"
+version = "0.1.1"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the canonical Hive release version from `0.1.0` to `0.1.1`
- keep `Cargo.toml` and `Cargo.lock` aligned for desktop and release artifacts

## Validation

- `npm run release:version:check -- 0.1.1`
- `npm run lint`
- `npm run typecheck`
- `npm run test`
- `npm run test:release`
- `npm run test:provision`
- `git diff --check`
