### PR TITLE
fix(backend): create workspaces from the latest default branch

### DIFF
--- a/backend/src/api/workspace-create-from.test.ts
+++ b/backend/src/api/workspace-create-from.test.ts
@@ -7,6 +7,7 @@ import { projectRoutes } from "./projects.js";
 import { workspaceRoutes } from "./workspaces.js";
 import { workspaceSourceRoutes } from "./workspace-sources.js";
 import { git } from "../utils/git.js";
+import { refreshDefaultBranchFromOrigin } from "../utils/git-default-branch.js";
 import { loadProject, saveProject } from "../state/state.js";
 import { fetchPrDetail, fetchIssueDetail, listOpenPullRequests, listOpenIssues } from "../utils/github.js";
 
@@ -333,6 +334,29 @@ describe("POST /api/projects/:id/workspaces with source kind 'issue'", () => {
     );
   });
 
+  it("force-refreshes the default branch when the shared refresh cache is warm", async () => {
+    const bare = join(dataDir, projectId, "repo.git");
+    await refreshDefaultBranchFromOrigin(bare, "main");
+    const remoteHead = await createCommit("merged after refresh", fixtureRepoUrl);
+    await git(["update-ref", "refs/heads/main", remoteHead], fixtureRepoUrl);
+    await setProjectGitHubUrl();
+    vi.mocked(fetchIssueDetail).mockResolvedValue({
+      number: 46,
+      title: "Use latest main",
+      body: "",
+      url: "https://github.com/acme/demo/issues/46",
+    });
+
+    const res = await createFromSource({ kind: "issue", number: 46 });
+    expect(res.statusCode).toBe(201);
+    const wsPath = join(dataDir, projectId, "workspaces", res.json().name);
+    const { stdout: workspaceHead } = await git(["rev-parse", "HEAD"], wsPath);
+    expect(workspaceHead).toBe(remoteHead);
+
+    const { stdout: hiveRefs } = await git(["for-each-ref", "refs/hive"], bare);
+    expect(hiveRefs).toBe("");
+  });
+
   it("honors a customized issue-draft.md template", async () => {
     await setProjectGitHubUrl();
     const promptsDir = join(dataDir, "prompts");
@@ -360,6 +384,17 @@ describe("POST /api/projects/:id/workspaces body validation", () => {
     expect(res.statusCode).toBe(201);
     expect(res.json().branch).toMatch(/^workspace\//);
     expect(res.json().source).toBeUndefined();
+  });
+
+  it("fails clearly when the latest default branch cannot be fetched", async () => {
+    await rm(fixtureRepoUrl, { recursive: true, force: true });
+
+    const res = await app.inject({
+      method: "POST",
+      url: `/api/projects/${projectId}/workspaces`,
+    });
+    expect(res.statusCode).toBe(500);
+    expect(res.json().error).toBe('Could not fetch the latest "main" from origin');
   });
 
   it("rejects an invalid source kind", async () => {

--- a/backend/src/api/workspace-create-from.test.ts
+++ b/backend/src/api/workspace-create-from.test.ts
@@ -394,7 +394,7 @@ describe("POST /api/projects/:id/workspaces body validation", () => {
       url: `/api/projects/${projectId}/workspaces`,
     });
     expect(res.statusCode).toBe(500);
-    expect(res.json().error).toBe('Could not fetch the latest "main" from origin');
+    expect(res.json().error).toBe('Could not refresh default branch "main" from origin');
   });
 
   it("rejects an invalid source kind", async () => {

--- a/backend/src/utils/git-default-branch.test.ts
+++ b/backend/src/utils/git-default-branch.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./git.js", () => ({ git: vi.fn() }));
+
+import { git } from "./git.js";
+import {
+  _resetDefaultBranchRefreshCache,
+  refreshDefaultBranchFromOriginStrict,
+} from "./git-default-branch.js";
+
+const mockGit = vi.mocked(git);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  _resetDefaultBranchRefreshCache();
+});
+
+describe("refreshDefaultBranchFromOriginStrict", () => {
+  it("accepts a concurrent ref update that already contains the fetched tip", async () => {
+    const localRef = "refs/heads/main";
+    const oldTip = "a".repeat(40);
+    const incomingTip = "b".repeat(40);
+    const currentTip = "c".repeat(40);
+    let incomingRef = "";
+    let localRefReads = 0;
+
+    mockGit.mockImplementation(async (args) => {
+      if (args[0] === "fetch") {
+        incomingRef = args.at(-1)!.split(":")[1]!;
+      } else if (args[0] === "rev-parse" && args[1] === localRef) {
+        localRefReads += 1;
+        return { stdout: localRefReads === 1 ? oldTip : currentTip, stderr: "" };
+      } else if (args[0] === "rev-parse") {
+        return { stdout: incomingTip, stderr: "" };
+      } else if (args[0] === "update-ref" && args[1] === localRef) {
+        throw new Error("reference changed concurrently");
+      }
+      return { stdout: "", stderr: "" };
+    });
+
+    await expect(refreshDefaultBranchFromOriginStrict("/repo.git", "main")).resolves.toBe(
+      currentTip,
+    );
+    expect(localRefReads).toBe(2);
+    expect(
+      mockGit.mock.calls.filter(
+        ([args]) => args[0] === "update-ref" && args[1] === localRef,
+      ),
+    ).toHaveLength(1);
+    expect(mockGit).toHaveBeenCalledWith(
+      ["merge-base", "--is-ancestor", incomingTip, currentTip],
+      "/repo.git",
+    );
+    expect(mockGit).toHaveBeenCalledWith(["update-ref", "-d", incomingRef], "/repo.git");
+  });
+});

--- a/backend/src/utils/git-default-branch.ts
+++ b/backend/src/utils/git-default-branch.ts
@@ -1,3 +1,4 @@
+import { nanoid } from "nanoid";
 import { git } from "./git.js";
 
 // The network fetch dominates workspace creation and diff endpoints (~1s+ per
@@ -7,6 +8,57 @@ import { git } from "./git.js";
 const REFRESH_TTL_MS = 30_000;
 const lastRefreshAt = new Map<string, number>();
 
+async function updateDefaultBranchFromOrigin(
+  bareRepo: string,
+  defaultBranch: string,
+): Promise<string> {
+  const localRef = `refs/heads/${defaultBranch}`;
+  const incomingRef = `refs/hive/incoming/${nanoid(8)}`;
+  try {
+    await git(
+      [
+        "fetch",
+        "--no-tags",
+        "--no-write-fetch-head",
+        "origin",
+        `+refs/heads/${defaultBranch}:${incomingRef}`,
+      ],
+      bareRepo,
+    );
+    const [{ stdout: localTip }, { stdout: incomingTip }] = await Promise.all([
+      git(["rev-parse", localRef], bareRepo),
+      git(["rev-parse", incomingRef], bareRepo),
+    ]);
+    try {
+      await git(["merge-base", "--is-ancestor", localTip, incomingTip], bareRepo);
+      if (localTip !== incomingTip) {
+        await git(["update-ref", localRef, incomingTip, localTip], bareRepo);
+      }
+      return incomingTip;
+    } catch {
+      // A local merge may leave the default branch ahead of origin while still
+      // containing every remote commit. Only fail when the histories diverge.
+      await git(["merge-base", "--is-ancestor", incomingTip, localTip], bareRepo);
+      return localTip;
+    }
+  } finally {
+    await git(["update-ref", "-d", incomingRef], bareRepo).catch(() => {});
+  }
+}
+
+export async function refreshDefaultBranchFromOriginStrict(
+  bareRepo: string,
+  defaultBranch: string,
+): Promise<string> {
+  try {
+    const startPoint = await updateDefaultBranchFromOrigin(bareRepo, defaultBranch);
+    lastRefreshAt.set(`${bareRepo}\0${defaultBranch}`, Date.now());
+    return startPoint;
+  } catch (err) {
+    throw new Error(`Could not fetch the latest "${defaultBranch}" from origin`, { cause: err });
+  }
+}
+
 export async function refreshDefaultBranchFromOrigin(
   bareRepo: string,
   defaultBranch: string,
@@ -15,12 +67,7 @@ export async function refreshDefaultBranchFromOrigin(
   const last = lastRefreshAt.get(key);
   if (last !== undefined && Date.now() - last < REFRESH_TTL_MS) return;
   try {
-    await git(["fetch", "origin", defaultBranch], bareRepo);
-    await git(
-      ["merge-base", "--is-ancestor", `refs/heads/${defaultBranch}`, "FETCH_HEAD"],
-      bareRepo,
-    );
-    await git(["update-ref", `refs/heads/${defaultBranch}`, "FETCH_HEAD"], bareRepo);
+    await updateDefaultBranchFromOrigin(bareRepo, defaultBranch);
     lastRefreshAt.set(key, Date.now());
   } catch {
     // Local-only repos, missing remotes, and diverged default branches keep

--- a/backend/src/utils/git-default-branch.ts
+++ b/backend/src/utils/git-default-branch.ts
@@ -31,16 +31,22 @@ async function updateDefaultBranchFromOrigin(
     ]);
     try {
       await git(["merge-base", "--is-ancestor", localTip, incomingTip], bareRepo);
-      if (localTip !== incomingTip) {
-        await git(["update-ref", localRef, incomingTip, localTip], bareRepo);
-      }
-      return incomingTip;
     } catch {
       // A local merge may leave the default branch ahead of origin while still
       // containing every remote commit. Only fail when the histories diverge.
       await git(["merge-base", "--is-ancestor", incomingTip, localTip], bareRepo);
       return localTip;
     }
+    if (localTip !== incomingTip) {
+      try {
+        await git(["update-ref", localRef, incomingTip, localTip], bareRepo);
+      } catch {
+        const { stdout: currentTip } = await git(["rev-parse", localRef], bareRepo);
+        await git(["merge-base", "--is-ancestor", incomingTip, currentTip], bareRepo);
+        return currentTip;
+      }
+    }
+    return incomingTip;
   } finally {
     await git(["update-ref", "-d", incomingRef], bareRepo).catch(() => {});
   }
@@ -55,7 +61,9 @@ export async function refreshDefaultBranchFromOriginStrict(
     lastRefreshAt.set(`${bareRepo}\0${defaultBranch}`, Date.now());
     return startPoint;
   } catch (err) {
-    throw new Error(`Could not fetch the latest "${defaultBranch}" from origin`, { cause: err });
+    throw new Error(`Could not refresh default branch "${defaultBranch}" from origin`, {
+      cause: err,
+    });
   }
 }
 

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -227,7 +227,7 @@ describe("createWorkspace", () => {
     );
 
     await expect(createWorkspace(projectId, dataDir)).rejects.toThrow(
-      'Could not fetch the latest "main" from origin',
+      'Could not refresh default branch "main" from origin',
     );
     const { stdout: hiveRefs } = await git(["for-each-ref", "refs/hive"], bare);
     expect(hiveRefs).toBe("");

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -17,7 +17,10 @@ import {
 } from "./workspace-manager.js";
 import { git } from "../utils/git.js";
 import { CITIES } from "../utils/city-names.js";
-import { _resetDefaultBranchRefreshCache } from "../utils/git-default-branch.js";
+import {
+  _resetDefaultBranchRefreshCache,
+  refreshDefaultBranchFromOrigin,
+} from "../utils/git-default-branch.js";
 import { loadProject, saveProject } from "../state/state.js";
 import * as stateStore from "../state/state.js";
 import { saveProjectEnv } from "../state/project-env.js";
@@ -32,6 +35,7 @@ async function pushRemoteMainFile(
   cloneName: string,
   fileName: string,
   content: string,
+  resetRefreshCache = true,
 ): Promise<void> {
   const pushClone = join(tempDir, cloneName);
   await git(["clone", fixtureRepoUrl, pushClone]);
@@ -41,8 +45,10 @@ async function pushRemoteMainFile(
   await git(["add", "."], pushClone);
   await git(["commit", "-m", `add ${fileName}`], pushClone);
   await git(["push", "origin", "main"], pushClone);
-  // The remote moved: drop the refresh TTL so the next refresh refetches.
-  _resetDefaultBranchRefreshCache();
+  if (resetRefreshCache) {
+    // The remote moved: drop the refresh TTL so the next refresh refetches.
+    _resetDefaultBranchRefreshCache();
+  }
 }
 
 beforeEach(async () => {
@@ -173,6 +179,58 @@ describe("createWorkspace", () => {
     expect(existsSync(join(wsPath, "new-remote-file.txt"))).toBe(true);
     const content = await readFile(join(wsPath, "new-remote-file.txt"), "utf-8");
     expect(content).toBe("from remote\n");
+  });
+
+  it("force-refreshes the default branch when the shared refresh cache is warm", async () => {
+    const bare = bareRepoPath(dataDir, projectId);
+    await refreshDefaultBranchFromOrigin(bare, "main");
+    await pushRemoteMainFile(
+      "push-clone-warm-cache",
+      "after-refresh.txt",
+      "latest remote state\n",
+      false,
+    );
+
+    const ws = await createWorkspace(projectId, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+    expect(await readFile(join(wsPath, "after-refresh.txt"), "utf-8")).toBe(
+      "latest remote state\n",
+    );
+
+    const { stdout: hiveRefs } = await git(["for-each-ref", "refs/hive"], bare);
+    expect(hiveRefs).toBe("");
+  });
+
+  it("fails and cleans up the fetched ref when local and remote main diverge", async () => {
+    const bare = bareRepoPath(dataDir, projectId);
+    const { stdout: localCommit } = await git(
+      [
+        "-c",
+        "user.email=test@hive.dev",
+        "-c",
+        "user.name=Hive Test",
+        "commit-tree",
+        "main^{tree}",
+        "-p",
+        "main",
+        "-m",
+        "local main commit",
+      ],
+      bare,
+    );
+    await git(["update-ref", "refs/heads/main", localCommit], bare);
+    await pushRemoteMainFile(
+      "push-clone-diverged-main",
+      "remote-only.txt",
+      "remote change\n",
+      false,
+    );
+
+    await expect(createWorkspace(projectId, dataDir)).rejects.toThrow(
+      'Could not fetch the latest "main" from origin',
+    );
+    const { stdout: hiveRefs } = await git(["for-each-ref", "refs/hive"], bare);
+    expect(hiveRefs).toBe("");
   });
 
   it("picks up modified files pushed to remote after project creation", async () => {

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -84,7 +84,10 @@ async function assertBranchNotCheckedOut(
  */
 async function fetchToTempRef(bare: string, remoteRef: string): Promise<string> {
   const tempRef = `refs/hive/incoming/${nanoid(8)}`;
-  await git(["fetch", "--no-tags", "origin", `+${remoteRef}:${tempRef}`], bare);
+  await git(
+    ["fetch", "--no-tags", "--no-write-fetch-head", "origin", `+${remoteRef}:${tempRef}`],
+    bare,
+  );
   return tempRef;
 }
 

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -17,7 +17,10 @@ import { buildFileTree } from "../utils/file-tree.js";
 import { MAX_TEXT_FILE_SIZE, resolveSafeRepoFilePath } from "../utils/repo-files.js";
 import { buildDiffResponse, getUntrackedDiff } from "../utils/git-diff.js";
 import { bareRepoPath, workspacesDir, resolveDefaultBranch } from "../utils/paths.js";
-import { refreshDefaultBranchFromOrigin } from "../utils/git-default-branch.js";
+import {
+  refreshDefaultBranchFromOrigin,
+  refreshDefaultBranchFromOriginStrict,
+} from "../utils/git-default-branch.js";
 import { pickCityName } from "../utils/city-names.js";
 import { loadProject, loadAllProjects, saveProject, getDataDir, withProjectStateLock } from "../state/state.js";
 import { isInitialized, lookupWorkspace } from "../state/workspace-index.js";
@@ -234,15 +237,19 @@ export async function createWorkspace(
 
       const defaultBranch = await resolveDefaultBranch(bare);
 
+      let defaultBranchStartPoint = defaultBranch;
+      if ((!source || source.kind === "issue") && state.url) {
+        defaultBranchStartPoint = await refreshDefaultBranchFromOriginStrict(bare, defaultBranch);
+      }
+
       let branch: string;
       let wsSource: WorkspaceSource | undefined;
       let draftPrompt: string | undefined;
 
       if (!source) {
-        // Default flow: new branch off the refreshed default branch.
+        // Default flow: new branch off the default branch.
         branch = `workspace/${cityName}`;
-        await refreshDefaultBranchFromOrigin(bare, defaultBranch);
-        await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranch);
+        await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranchStartPoint);
       } else if (source.kind === "branch") {
         branch = source.branch;
         await checkoutSourceBranch(state, bare, wsPath, branch, dataDir);
@@ -268,8 +275,7 @@ export async function createWorkspace(
         const issue = issueDetail!;
         // Issues have no code: branch off the default branch like the default flow.
         branch = `workspace/${cityName}`;
-        await refreshDefaultBranchFromOrigin(bare, defaultBranch);
-        await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranch);
+        await addWorktreeWithNewBranch(bare, wsPath, branch, defaultBranchStartPoint);
         wsSource = { kind: "issue", number: issue.number, title: issue.title, url: issue.url };
         const template = await loadIssueDraftPrompt(join(dataDir, "prompts"));
         const rendered = interpolateIssueDraftPrompt(template, {


### PR DESCRIPTION
## Summary

- force-refresh the remote default branch before standard and issue-sourced workspace creation, bypassing the shared refresh TTL
- fetch into isolated temporary Hive refs without writing FETCH_HEAD, then create the workspace from the resolved commit snapshot
- update the local default branch atomically and tolerate a concurrent winner only when it already contains the fetched remote tip
- fail clearly on remote errors or truly divergent histories while preserving local-ahead merges and local-only projects

## Tests

- npm --prefix backend run lint
- npm --prefix backend run typecheck
- npm --prefix backend test -- src/utils/git-default-branch.test.ts src/workspaces/workspace-manager.test.ts src/api/workspace-create-from.test.ts (93 tests)