### PR TITLE
fix(backend): prevent redundant Claude session naming

### DIFF
--- a/backend/src/agents/providers/claude.test.ts
+++ b/backend/src/agents/providers/claude.test.ts
@@ -98,6 +98,7 @@ describe("ClaudeProvider", () => {
     const args = provider.buildArgs("Hello", {}, baseSession({ isFirstMessage: true }));
     expect(args).toContain("--session-id");
     expect(args).toContain("test-session-id");
+    expect(args[args.indexOf("--name") + 1]).toBe("hive-test-session-id");
     expect(args).not.toContain("--resume");
   });
 
@@ -106,6 +107,7 @@ describe("ClaudeProvider", () => {
     expect(args).toContain("--resume");
     expect(args).toContain("test-session-id");
     expect(args).not.toContain("--session-id");
+    expect(args).not.toContain("--name");
   });
 
   it("adds --model with cli value when model is specified", () => {

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -83,6 +83,9 @@ export class ClaudeProvider implements AgentProvider {
       ...(session.isFirstMessage && session.systemPrompt
         ? ["--append-system-prompt", session.systemPrompt]
         : []),
+      // Hive owns the user-facing title. Naming the underlying Claude session
+      // prevents Claude Code from launching its redundant title-generation request.
+      ...(session.isFirstMessage ? ["--name", `hive-${session.sessionId}`] : []),
       ...(session.isFirstMessage
         ? ["--session-id", session.sessionId]
         : ["--resume", session.sessionId]),

--- a/backend/src/agents/providers/kimi.test.ts
+++ b/backend/src/agents/providers/kimi.test.ts
@@ -85,6 +85,7 @@ describe("KimiProvider", () => {
     expect(args).toContain("--print");
     expect(args).toContain("--output-format");
     expect(args).toContain("stream-json");
+    expect(args[args.indexOf("--name") + 1]).toBe("hive-test-session-id");
     const idx = args.indexOf("--model");
     expect(args[idx + 1]).toBe("k3");
     expect(args).not.toContain("--effort");


### PR DESCRIPTION
## Summary

- assign a unique technical name to new Claude-backed sessions
- prevent Claude Code from launching its redundant session-title request
- avoid the benign Kimi k3 unrecognized-model diagnostic reaching the conversation UI
- cover first-turn, resume, and Kimi argument behavior

## Validation

- npm test -- --run src/agents/providers/claude.test.ts src/agents/providers/kimi.test.ts
- npm run lint
- npm run typecheck