### PR TITLE
fix: make foreground resync tolerate stale workspaces

### DIFF
--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -7,7 +7,7 @@ import { chmod, rm, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
 import { createProject } from "../projects/project-manager.js";
-import { createWorkspace } from "../workspaces/workspace-manager.js";
+import { archiveWorkspace, createWorkspace } from "../workspaces/workspace-manager.js";
 import {
   getSession,
   getOrCreateSession,
@@ -1619,6 +1619,64 @@ describe("WS /ws/hub", () => {
 
     ws.close();
     await local.app.close();
+  });
+
+  it("completes a correlated initial sync containing an archived workspace", async () => {
+    const archivedWorkspace = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(archivedWorkspace.id, dataDir);
+    const hubMessages: HubOutgoing[] = [];
+    const ws = await app.injectWS(
+      "/ws/hub",
+      {},
+      {
+        onInit: (socket) => {
+          socket.on("message", (data: Buffer) => {
+            hubMessages.push(JSON.parse(data.toString()) as HubOutgoing);
+          });
+          socket.on("open", () => {
+            syncWorkspaces(
+              socket,
+              [archivedWorkspace.id, wsId],
+              [archivedWorkspace.id, wsId],
+              [archivedWorkspace.id, wsId],
+              true,
+              "refresh-after-archive",
+            );
+          });
+        },
+      },
+    ) as WebSocket;
+
+    await waitForCondition(() => hubMessages.some((message) =>
+      "type" in message &&
+      message.type === "sync_complete" &&
+      message.requestId === "refresh-after-archive"
+    ));
+
+    const validBootstrapIndex = hubMessages.findIndex((message) =>
+      "workspaceId" in message &&
+      message.workspaceId === wsId &&
+      message.event.type === "status"
+    );
+    const ackIndex = hubMessages.findIndex((message) =>
+      "type" in message &&
+      message.type === "sync_complete" &&
+      message.requestId === "refresh-after-archive"
+    );
+    expect(validBootstrapIndex).toBeGreaterThanOrEqual(0);
+    expect(ackIndex).toBeGreaterThan(validBootstrapIndex);
+
+    const hub = [..._getHubSocketsForTests()].find((candidate) =>
+      candidate.subscribedWorkspaces.has(wsId)
+    );
+    expect(hub?.subscribedWorkspaces.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.requestedWorkspaces?.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.focusWorkspaces?.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.prWorkspaces.has(archivedWorkspace.id)).toBe(false);
+    expect(_getChannelsForTests().has(archivedWorkspace.id)).toBe(false);
+    expect(_getChannelsForTests().get(wsId)?.hubSockets.has(hub!)).toBe(true);
+
+    ws.close();
   });
 
   it("acknowledges a correlated bootstrap without waiting for its requested PR refresh", async () => {

--- a/backend/src/ws/stream.test.ts
+++ b/backend/src/ws/stream.test.ts
@@ -1679,6 +1679,72 @@ describe("WS /ws/hub", () => {
     ws.close();
   });
 
+  it("drops a workspace archived after subscription on a forced re-bootstrap", async () => {
+    const archivedWorkspace = await createWorkspace(projectId, dataDir);
+    const { wsReady, allEnvelopes, hubMessages } = connectHub(
+      [archivedWorkspace.id, wsId],
+      {
+        collectAll: true,
+        focusWorkspaces: [archivedWorkspace.id, wsId],
+        prWorkspaces: [archivedWorkspace.id, wsId],
+      },
+    );
+    const ws = await wsReady;
+
+    await waitForCondition(() =>
+      allEnvelopes.some((message) =>
+        message.workspaceId === archivedWorkspace.id && message.event.type === "status"
+      ) &&
+      allEnvelopes.some((message) =>
+        message.workspaceId === wsId && message.event.type === "status"
+      ) &&
+      _getChannelsForTests().get(archivedWorkspace.id)?.hubSockets.size === 1,
+    );
+
+    await archiveWorkspace(archivedWorkspace.id, dataDir);
+    const messageCountBeforeRefresh = hubMessages.length;
+    syncWorkspaces(
+      ws,
+      [archivedWorkspace.id, wsId],
+      [archivedWorkspace.id, wsId],
+      [archivedWorkspace.id, wsId],
+      true,
+      "refresh-after-subscription-archive",
+    );
+
+    await waitForCondition(() => hubMessages.some((message) =>
+      "type" in message &&
+      message.type === "sync_complete" &&
+      message.requestId === "refresh-after-subscription-archive"
+    ));
+
+    const validBootstrapIndex = hubMessages.findIndex((message, index) =>
+      index >= messageCountBeforeRefresh &&
+      "workspaceId" in message &&
+      message.workspaceId === wsId &&
+      message.event.type === "status"
+    );
+    const ackIndex = hubMessages.findIndex((message) =>
+      "type" in message &&
+      message.type === "sync_complete" &&
+      message.requestId === "refresh-after-subscription-archive"
+    );
+    expect(validBootstrapIndex).toBeGreaterThanOrEqual(messageCountBeforeRefresh);
+    expect(ackIndex).toBeGreaterThan(validBootstrapIndex);
+
+    const hub = [..._getHubSocketsForTests()].find((candidate) =>
+      candidate.subscribedWorkspaces.has(wsId)
+    );
+    expect(hub?.subscribedWorkspaces.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.requestedWorkspaces?.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.focusWorkspaces?.has(archivedWorkspace.id)).toBe(false);
+    expect(hub?.prWorkspaces.has(archivedWorkspace.id)).toBe(false);
+    expect(_getChannelsForTests().has(archivedWorkspace.id)).toBe(false);
+    expect(_getChannelsForTests().get(wsId)?.hubSockets.has(hub!)).toBe(true);
+
+    ws.close();
+  });
+
   it("acknowledges a correlated bootstrap without waiting for its requested PR refresh", async () => {
     let resolveRefresh!: (value: { pr: null }) => void;
     const deferredRefresh = new Promise<{ pr: null }>((resolve) => {

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -316,6 +316,18 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     channel.pendingToolRequests.clear();
   };
 
+  const removeHubFromChannel = (
+    wsId: string,
+    channel: WorkspaceChannel,
+    hub: HubSocket,
+  ): void => {
+    channel.hubSockets.delete(hub);
+    if (channel.hubSockets.size === 0) {
+      detachAllSessionListeners(channel);
+      channels.delete(wsId);
+    }
+  };
+
   const attachSessionListeners = (
     workspaceId: string,
     channel: WorkspaceChannel,
@@ -545,11 +557,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       hub.requestedWorkspaces?.delete(wsId);
       hub.focusWorkspaces?.delete(wsId);
       hub.prWorkspaces.delete(wsId);
-      channel.hubSockets.delete(hub);
-      if (channel.hubSockets.size === 0) {
-        detachAllSessionListeners(channel);
-        channels.delete(wsId);
-      }
+      removeHubFromChannel(wsId, channel, hub);
       app.log.info(
         { err, workspaceId: wsId },
         "Ignoring unavailable workspace during sync",
@@ -575,11 +583,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       if (!desired.has(wsId)) {
         const channel = channels.get(wsId);
         if (channel) {
-          channel.hubSockets.delete(hub);
-          if (channel.hubSockets.size === 0) {
-            detachAllSessionListeners(channel);
-            channels.delete(wsId);
-          }
+          removeHubFromChannel(wsId, channel, hub);
         }
       }
     }
@@ -612,7 +616,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
           channel.hubSockets.add(hub);
           // Join before reading unread state so any concurrent completion also
           // reaches this socket through the same serialized snapshot queue.
-          await queueUnreadStateBroadcast(wsId);
+          await broadcastUnreadState(wsId, dataDir);
         }
       } catch (err: unknown) {
         if (!(err instanceof NotFoundError)) throw err;
@@ -631,7 +635,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         if (channel) {
           try {
             await sendWorkspaceBootstrap(hub, wsId, channel);
-            await queueUnreadStateBroadcast(wsId);
+            await broadcastUnreadState(wsId, dataDir);
           } catch (err: unknown) {
             if (!(err instanceof NotFoundError)) throw err;
             dropUnavailableWorkspace(wsId, channel, err);
@@ -909,11 +913,7 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         ])) {
           const channel = channels.get(wsId);
           if (channel) {
-            channel.hubSockets.delete(hub);
-            if (channel.hubSockets.size === 0) {
-              detachAllSessionListeners(channel);
-              channels.delete(wsId);
-            }
+            removeHubFromChannel(wsId, channel, hub);
           }
         }
         hubSockets.delete(hub);

--- a/backend/src/ws/stream.ts
+++ b/backend/src/ws/stream.ts
@@ -13,7 +13,7 @@ import {
   stopStreaming,
 } from "../agents/session-dispatch.js";
 import type { SessionOptions } from "../agents/agent-manager.js";
-import { errorMessage } from "../utils/errors.js";
+import { errorMessage, NotFoundError } from "../utils/errors.js";
 import { isAuthorized, type AuthExpectation } from "../utils/auth.js";
 import type { WsIncoming, WsOutgoing, HubIncoming, HubOutgoing } from "../types.js";
 import { getScriptStatus } from "../services/script-runner.js";
@@ -437,7 +437,10 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
       ? isLoadedDefaultSessionCandidate(wsId, session)
       : false;
     const defaultSessionId = !session || !sessionIsDefaultCandidate
-      ? await getDefaultSessionId(wsId, dataDir).catch(() => undefined)
+      ? await getDefaultSessionId(wsId, dataDir).catch((err: unknown) => {
+          if (err instanceof NotFoundError) throw err;
+          return undefined;
+        })
       : undefined;
 
     if (session && (sessionIsDefaultCandidate || !defaultSessionId)) {
@@ -533,6 +536,26 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     hub.focusWorkspaces = focusWorkspaces ? new Set(focusWorkspaces) : undefined;
     hub.prWorkspaces = new Set(prWorkspaces ?? []);
 
+    const dropUnavailableWorkspace = (
+      wsId: string,
+      channel: WorkspaceChannel,
+      err: NotFoundError,
+    ): void => {
+      desired.delete(wsId);
+      hub.requestedWorkspaces?.delete(wsId);
+      hub.focusWorkspaces?.delete(wsId);
+      hub.prWorkspaces.delete(wsId);
+      channel.hubSockets.delete(hub);
+      if (channel.hubSockets.size === 0) {
+        detachAllSessionListeners(channel);
+        channels.delete(wsId);
+      }
+      app.log.info(
+        { err, workspaceId: wsId },
+        "Ignoring unavailable workspace during sync",
+      );
+    };
+
     // A forced refresh resends full bootstrap below, which already covers the
     // streaming snapshot replay -- skip the focus-only replay here to avoid
     // sending the snapshot twice.
@@ -581,14 +604,19 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
     hub.subscribedWorkspaces = desired;
 
     for (const [wsId, channel] of newlySubscribed) {
-      await sendWorkspaceBootstrap(hub, wsId, channel);
-      // The socket may close while a bootstrap awaits; adding it then would
-      // resurrect membership the close handler already cleaned up.
-      if (hub.ws.readyState === hub.ws.OPEN) {
-        channel.hubSockets.add(hub);
-        // Join before reading unread state so any concurrent completion also
-        // reaches this socket through the same serialized snapshot queue.
-        await queueUnreadStateBroadcast(wsId);
+      try {
+        await sendWorkspaceBootstrap(hub, wsId, channel);
+        // The socket may close while a bootstrap awaits; adding it then would
+        // resurrect membership the close handler already cleaned up.
+        if (hub.ws.readyState === hub.ws.OPEN) {
+          channel.hubSockets.add(hub);
+          // Join before reading unread state so any concurrent completion also
+          // reaches this socket through the same serialized snapshot queue.
+          await queueUnreadStateBroadcast(wsId);
+        }
+      } catch (err: unknown) {
+        if (!(err instanceof NotFoundError)) throw err;
+        dropUnavailableWorkspace(wsId, channel, err);
       }
     }
 
@@ -601,8 +629,13 @@ export async function streamRoutes(app: FastifyInstance, opts: StreamRoutesOptio
         if (!previouslySubscribed.has(wsId)) continue;
         const channel = channels.get(wsId);
         if (channel) {
-          await sendWorkspaceBootstrap(hub, wsId, channel);
-          await queueUnreadStateBroadcast(wsId);
+          try {
+            await sendWorkspaceBootstrap(hub, wsId, channel);
+            await queueUnreadStateBroadcast(wsId);
+          } catch (err: unknown) {
+            if (!(err instanceof NotFoundError)) throw err;
+            dropUnavailableWorkspace(wsId, channel, err);
+          }
         }
       }
     }

--- a/frontend/src/hooks/useAppResync.tsx
+++ b/frontend/src/hooks/useAppResync.tsx
@@ -57,26 +57,45 @@ export function useAppResync(): boolean {
       );
     });
 
-    const syncPromise = Promise.all([
-      queryClient.refetchQueries({ type: "active" }, { throwOnError: true }),
-      wsTransport.requestFullResync(abortController.signal),
-      import("@/components/BrowserPanel"),
-    ]).then(async ([, , { reconnectActiveBrowserStreams }]) => {
-      reconnectActivePtyTerminals();
-      reconnectActiveBrowserStreams();
-      // Inactive queries are cleared below, so warm the app-level catalog
-      // again after the rest of the resync has completed.
-      await prefetchModelCatalog(queryClient);
-    });
+    void queryClient
+      .refetchQueries({ type: "active" }, { throwOnError: true })
+      .catch((error) => {
+        console.warn("[app-resync] Failed to refresh active queries:", error);
+      });
 
     queryClient.removeQueries({ type: "inactive" });
 
-    const operation = Promise.race([syncPromise, abortPromise])
-      .then(() => undefined)
-      .catch(async () => {
-        await queryClient.cancelQueries();
-        if (mountedRef.current) showSyncFailureToast();
-      })
+    const operation = Promise.race([
+      wsTransport.requestFullResync(abortController.signal),
+      abortPromise,
+    ]).then(
+      () => {
+        void Promise.resolve()
+          .then(() => reconnectActivePtyTerminals())
+          .catch((error) => {
+            console.warn("[app-resync] Failed to reconnect PTY terminals:", error);
+          });
+        void import("@/components/BrowserPanel")
+          .then(({ reconnectActiveBrowserStreams }) => {
+            reconnectActiveBrowserStreams();
+          })
+          .catch((error) => {
+            console.warn("[app-resync] Failed to reconnect browser streams:", error);
+          });
+        // Inactive queries were cleared above, so warm the app-level catalog
+        // again without holding the hub resync open.
+        void Promise.resolve()
+          .then(() => prefetchModelCatalog(queryClient))
+          .catch((error) => {
+            console.warn("[app-resync] Failed to prefetch the model catalog:", error);
+          });
+      },
+      (error) => {
+        if (!mountedRef.current) return;
+        console.warn("[app-resync] Hub resync failed:", error);
+        showSyncFailureToast();
+      },
+    )
       .finally(() => {
         window.clearTimeout(timeoutId);
         if (abortRef.current === abortController) abortRef.current = null;

--- a/frontend/tests/hooks/useAppResync.test.tsx
+++ b/frontend/tests/hooks/useAppResync.test.tsx
@@ -37,10 +37,12 @@ vi.mock("sonner", () => ({ toast: { custom: mocks.toastCustom, dismiss: vi.fn() 
 
 function deferred() {
   let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<void>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, reject, resolve };
 }
 
 describe("useAppResync", () => {
@@ -59,6 +61,7 @@ describe("useAppResync", () => {
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -152,6 +155,7 @@ describe("useAppResync", () => {
     const { queryClient, wrapper } = createWrapper();
     vi.spyOn(queryClient, "refetchQueries").mockResolvedValue();
     const cancel = vi.spyOn(queryClient, "cancelQueries").mockResolvedValue();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     const { result } = renderHook(() => useAppResync(), { wrapper });
 
     act(() => window.dispatchEvent(new Event("blur")));
@@ -162,16 +166,48 @@ describe("useAppResync", () => {
     await act(async () => vi.advanceTimersByTime(RESYNC_TIMEOUT_MS));
 
     expect(resyncSignal?.aborted).toBe(true);
-    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(cancel).not.toHaveBeenCalled();
     expect(result.current).toBe(false);
     expect(mocks.reconnectActivePtyTerminals).not.toHaveBeenCalled();
     expect(mocks.reconnectActiveBrowserStreams).not.toHaveBeenCalled();
     expect(mocks.toastCustom).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps auxiliary transports intact when the core resync fails", async () => {
+  it("completes the hub resync when an active REST query fails", async () => {
+    const restRequest = deferred();
+    const restError = new Error("REST unavailable");
     const { queryClient, wrapper } = createWrapper();
-    vi.spyOn(queryClient, "refetchQueries").mockRejectedValue(new Error("REST unavailable"));
+    vi.spyOn(queryClient, "refetchQueries").mockReturnValue(restRequest.promise);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { result } = renderHook(() => useAppResync(), { wrapper });
+
+    act(() => window.dispatchEvent(new Event("blur")));
+    act(() => vi.advanceTimersByTime(FULL_RESYNC_AFTER_MS));
+    await act(async () => window.dispatchEvent(new Event("focus")));
+
+    expect(result.current).toBe(false);
+    expect(mocks.reconnectActivePtyTerminals).toHaveBeenCalledTimes(1);
+    expect(mocks.reconnectActiveBrowserStreams).toHaveBeenCalledTimes(1);
+    expect(mocks.toastCustom).not.toHaveBeenCalled();
+
+    await act(async () => {
+      restRequest.reject(restError);
+      await Promise.resolve();
+    });
+
+    expect(warn).toHaveBeenCalledWith(
+      "[app-resync] Failed to refresh active queries:",
+      restError,
+    );
+    expect(mocks.toastCustom).not.toHaveBeenCalled();
+  });
+
+  it("offers manual reload when the hub resync is rejected", async () => {
+    const hubError = new Error("Hub unavailable");
+    mocks.requestFullResync.mockRejectedValue(hubError);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { queryClient, wrapper } = createWrapper();
+    vi.spyOn(queryClient, "refetchQueries").mockResolvedValue();
     const { result } = renderHook(() => useAppResync(), { wrapper });
 
     act(() => window.dispatchEvent(new Event("blur")));
@@ -182,6 +218,7 @@ describe("useAppResync", () => {
     expect(mocks.reconnectActivePtyTerminals).not.toHaveBeenCalled();
     expect(mocks.reconnectActiveBrowserStreams).not.toHaveBeenCalled();
     expect(mocks.toastCustom).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith("[app-resync] Hub resync failed:", hubError);
   });
 
   it("removes recovery listeners on unmount", () => {


### PR DESCRIPTION
## Summary

- tolerate workspaces archived by another client during both fresh-socket and same-socket forced hub resyncs
- remove stale subscription, requested, focus, PR-interest, and channel state before acknowledging valid workspace bootstraps
- reserve the global reload warning for core hub failures while REST queries and auxiliary transports recover independently
- avoid duplicate error-level logging for unread-state failures already handled by the resync path

## Design decisions

Workspace membership remains REST-owned. We intentionally do not add dropped workspace IDs to `sync_complete`: that would introduce a second membership signal and require a backend, web, and iOS protocol change for a low-probability case where the hub succeeds while the projects REST refresh exhausts its retries. If that edge becomes observable, the preferred follow-up is a targeted, bounded retry of the projects query.

The foreground resync timeout remains ten seconds, archived workspaces disappear silently, and the reload toast remains reserved for genuine hub recovery failures.

## Testing

- backend WebSocket suite: 68 tests
- full backend suite: 1,955 tests
- full frontend suite: 1,841 tests
- backend and frontend lint/typecheck
- `git diff --check`