### PR TITLE
fix(provision): isolate agent-browser socket directory

### DIFF
--- a/scripts/provision/steps.sh
+++ b/scripts/provision/steps.sh
@@ -153,9 +153,11 @@ assert_safe_archive() {
 }
 
 as_hive() {
-  # Run a command as the service account with Hive's own PATH and HOME. stdin
-  # is /dev/null so a child can never consume a `curl | bash` script body.
-  runuser -u "$HIVE_USER" -- env HOME="$HIVE_HOME" PATH="$HIVE_SERVICE_PATH" "$@" </dev/null
+  # Run a command as the service account with Hive's own PATH, HOME, and browser
+  # socket directory. stdin is /dev/null so a child can never consume a
+  # `curl | bash` script body.
+  runuser -u "$HIVE_USER" -- env HOME="$HIVE_HOME" PATH="$HIVE_SERVICE_PATH" \
+    AGENT_BROWSER_SOCKET_DIR="$HIVE_HOME/.agent-browser" "$@" </dev/null
 }
 
 # --- Read-only inspection ---------------------------------------------------
@@ -977,12 +979,13 @@ step_generate_token() {
 title_write_secrets() { echo "Write the service configuration"; }
 
 hive_env_base() {
-  # AGENT_BROWSER_ARGS: Chromium's sandbox cannot work under the hive unit —
-  # NoNewPrivileges blocks the setuid helper and Ubuntu 24.04 restricts
-  # unprivileged user namespaces — so the browser the agents drive through
-  # `agent-browser` must run without it. Deliberately not HIVE_-prefixed: the
-  # backend strips HIVE_* from agent environments (backend/src/utils/env.ts)
-  # and this variable must reach them.
+  # Chromium's sandbox cannot work under the hive unit — NoNewPrivileges blocks
+  # the setuid helper and Ubuntu 24.04 restricts unprivileged user namespaces —
+  # so the browser the agents drive through `agent-browser` must run without it.
+  # The socket directory must also be independent of any ambient
+  # XDG_RUNTIME_DIR. Deliberately not HIVE_-prefixed: the backend strips HIVE_*
+  # from agent environments (backend/src/utils/env.ts), and both variables must
+  # reach them.
   cat <<EOF
 NODE_ENV=production
 HOST=0.0.0.0
@@ -994,6 +997,7 @@ HIVE_UPDATE_METHOD=provisioner
 HOME=$HIVE_HOME
 PATH=$HIVE_SERVICE_PATH
 AGENT_BROWSER_ARGS=--no-sandbox
+AGENT_BROWSER_SOCKET_DIR=$HIVE_HOME/.agent-browser
 EOF
   [ -z "${OPT_ALLOWED_HOST:-}" ] || echo "HIVE_ALLOWED_HOSTS=$OPT_ALLOWED_HOST"
   # A prerelease install is a developer's test server. The webview of a debug

--- a/test/provision/contract.sh
+++ b/test/provision/contract.sh
@@ -327,11 +327,17 @@ paths_out="$(bash -c '
 managed_env_keys="$(sed -n '/^--env--$/,/^--uninstall--$/p' <<<"$paths_out" \
   | sed '1d;$d' | sed -n 's/^\([A-Z][A-Z0-9_]*\)=.*/\1/p' | sort)"
 expected_managed_env_keys="$(printf '%s\n' \
-  AGENT_BROWSER_ARGS DATA_DIR HIVE_ALLOWED_HOSTS HIVE_ALLOWED_ORIGINS \
+  AGENT_BROWSER_ARGS AGENT_BROWSER_SOCKET_DIR DATA_DIR HIVE_ALLOWED_HOSTS HIVE_ALLOWED_ORIGINS \
   HIVE_AUTH_TOKEN_SHA256 HIVE_AUTOMATION_TIMEOUT_SEC HIVE_UPDATE_METHOD \
   HOME HOST NODE_ENV PATH PORT)"
 expect "managed hive.env key changes require an explicit update decision" \
   test "$managed_env_keys" = "$expected_managed_env_keys"
+expect "the service uses a browser socket directory owned by the hive account" \
+  grep -q '^AGENT_BROWSER_SOCKET_DIR=/home/hive/.agent-browser$' <<<"$paths_out"
+expect "service-account commands override an inherited browser socket directory" \
+  bash -c 'sed -n "/^as_hive()/,/^}/p" "$1" |
+             grep -q "AGENT_BROWSER_SOCKET_DIR=\"\\\$HIVE_HOME/.agent-browser\""' \
+    _ "$PROV/steps.sh"
 
 # A step that creates the install directory without stamping the marker first
 # makes the install unresumable: the next run sees a directory it did not

--- a/test/provision/e2e-docker.sh
+++ b/test/provision/e2e-docker.sh
@@ -161,11 +161,15 @@ peer_can_reach() { from_peer "$@" >/dev/null 2>&1; }
 # Run the generated provision.sh over stdin, exactly as `curl | bash` would.
 # shellcheck disable=SC2120  # most callers deliberately pass no options
 run_provision() {
+  local runtime_env=()
+  [ -z "${PROVISION_XDG_RUNTIME_DIR:-}" ] || \
+    runtime_env=(-e "XDG_RUNTIME_DIR=$PROVISION_XDG_RUNTIME_DIR")
   docker exec -i \
     -e "HIVE_RELEASE_BASE_URL=http://$RELEASE_HOST" \
     -e "HIVE_TEST_DIE_AFTER=${DIE_AFTER:-}" \
     -e "HIVE_TEST_DIE_DURING=${DIE_DURING:-}" \
     -e "HIVE_HEALTH_ATTEMPTS=${HEALTH_ATTEMPTS:-}" \
+    "${runtime_env[@]}" \
     "$CID" bash -s -- "$@" <"$PROV/dist/provision.sh"
 }
 
@@ -237,6 +241,8 @@ assert_provisioned() {
     || die "the browser state directory is not owned by the service account"
   sh_server 'grep -q "^AGENT_BROWSER_ARGS=--no-sandbox$" /etc/hive/hive.env' \
     || die "the service environment does not disable the Chrome sandbox"
+  sh_server 'grep -q "^AGENT_BROWSER_SOCKET_DIR=/home/hive/.agent-browser$" /etc/hive/hive.env' \
+    || die "the service environment does not use the hive-owned browser socket directory"
   echo "OK: agent-browser and its Chrome live under /home/hive, sandbox flag configured"
   fi
 
@@ -290,8 +296,9 @@ assert_provisioned() {
 mode_install() {
   build_release; build_provision; start_stack
 
-  log "Fresh install succeeds and writes both durable markers"
-  run_provision --port "$PORT" --ssh-public-key "$TEST_SSH_KEY" >"$WORK/fresh.ndjson" \
+  log "Fresh install succeeds with an inaccessible operator runtime directory"
+  PROVISION_XDG_RUNTIME_DIR=/root/hive-operator-runtime \
+    run_provision --port "$PORT" --ssh-public-key "$TEST_SSH_KEY" >"$WORK/fresh.ndjson" \
     || { tail -30 "$WORK/fresh.ndjson" >&2; die "fresh provisioning failed"; }
   assert_run_ok "$WORK/fresh.ndjson"
   assert_provisioned "$WORK/fresh.ndjson"


### PR DESCRIPTION
## Summary

- force agent-browser sockets into the hive-owned state directory during provisioning
- persist the same socket directory in the Hive service environment
- cover inaccessible inherited XDG runtime directories in contract and Docker installation tests

## Root cause

The provisioner switched to the `hive` account while preserving an ambient `XDG_RUNTIME_DIR`. agent-browser prefers that location for daemon sockets, so an operator-owned runtime directory caused the final browser smoke test to fail with `Permission denied` even though Chrome downloaded successfully.

## Tests

- `npm run test:provision`
- `npm run lint`
- `npm run typecheck`
- `npm run test:provision:e2e -- install`