### PR TITLE
chore: prepare release 0.1.2

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.1"
+version = "0.1.2"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the canonical Cargo release version from 0.1.1 to 0.1.2
- keep Cargo.toml and Cargo.lock aligned

## Validation

- `npm run release:version:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test:release`
- `npm run test:provision`
- backend test suite: 1,974 passed
- targeted rerun of the only timed-out frontend test: passed