### PR TITLE
fix(ios): harmonize composer options popover

### DIFF
--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -202,7 +202,7 @@ struct ChatInputBar: View {
                         lineWidth: 0.5
                     )
                 )
-                .frame(width: 44, height: 44)
+                .frame(width: 44, height: 44, alignment: .leading)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -202,10 +202,10 @@ struct ChatInputBar: View {
                         lineWidth: 0.5
                     )
                 )
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .frame(width: 44, height: 44)
-        .contentShape(Rectangle())
         .accessibilityLabel("More options")
         .accessibilityValue(isOptionsMenuActive ? "Active" : "Inactive")
         .popover(isPresented: $showOptionsMenu, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
@@ -439,20 +439,11 @@ private struct ModelMenu: View {
                     Button {
                         onSelect(model.id)
                     } label: {
-                        HStack(spacing: 8) {
-                            Image(systemName: "checkmark")
-                                .font(.footnote.weight(.semibold))
-                                .foregroundStyle(accent)
-                                .opacity(model.id == selectedModelId ? 1 : 0)
-                                .frame(width: 15)
-                            Text(model.label)
-                                .foregroundStyle(.primary)
-                            Spacer(minLength: 8)
-                        }
-                        .font(.subheadline)
-                        .padding(.horizontal, 14)
-                        .padding(.vertical, 9)
-                        .contentShape(Rectangle())
+                        PopoverCheckRow(
+                            label: model.label,
+                            isSelected: model.id == selectedModelId,
+                            accent: accent
+                        )
                     }
                     .buttonStyle(.plain)
                 }
@@ -486,20 +477,11 @@ private struct SelectionMenu<Option: Hashable>: View {
                 Button {
                     onSelect(option)
                 } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark")
-                            .font(.footnote.weight(.semibold))
-                            .foregroundStyle(accent)
-                            .opacity(option == selectedOption ? 1 : 0)
-                            .frame(width: 15)
-                        Text(option[keyPath: label])
-                            .foregroundStyle(.primary)
-                        Spacer(minLength: 8)
-                    }
-                    .font(.subheadline)
-                    .padding(.horizontal, 14)
-                    .padding(.vertical, 9)
-                    .contentShape(Rectangle())
+                    PopoverCheckRow(
+                        label: option[keyPath: label],
+                        isSelected: option == selectedOption,
+                        accent: accent
+                    )
                 }
                 .buttonStyle(.plain)
             }
@@ -689,29 +671,43 @@ private struct ComposerOptionsPopover: View {
                     outputStyle = style
                     onDismiss()
                 } label: {
-                    HStack(spacing: 8) {
-                        Image(systemName: "checkmark")
-                            .font(.footnote.weight(.semibold))
-                            .foregroundStyle(accent)
-                            .opacity(style == selectedOutputStyle ? 1 : 0)
-                            .frame(width: 15)
-
-                        Text(style.label)
-                            .foregroundStyle(WhisperColor.text)
-
-                        Spacer(minLength: 8)
-                    }
-                    .font(.subheadline)
-                    .padding(.horizontal, 14)
-                    .frame(minHeight: 44)
-                    .contentShape(Rectangle())
+                    PopoverCheckRow(
+                        label: style.label,
+                        isSelected: style == selectedOutputStyle,
+                        accent: accent
+                    )
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(style.label)
-                .accessibilityValue(style == selectedOutputStyle ? "Selected" : "")
             }
         }
         .padding(.bottom, 5)
+    }
+}
+
+private struct PopoverCheckRow: View {
+    let label: String
+    let isSelected: Bool
+    let accent: Color
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark")
+                .font(.footnote.weight(.semibold))
+                .foregroundStyle(accent)
+                .opacity(isSelected ? 1 : 0)
+                .frame(width: 15)
+
+            Text(label)
+                .foregroundStyle(WhisperColor.text)
+
+            Spacer(minLength: 8)
+        }
+        .font(.subheadline)
+        .padding(.horizontal, 14)
+        .frame(minHeight: 44)
+        .contentShape(Rectangle())
+        .accessibilityLabel(label)
+        .accessibilityValue(isSelected ? "Selected" : "")
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -29,6 +29,7 @@ struct ChatInputBar: View {
     @State private var showAttachmentError = false
     @State private var showModelMenu = false
     @State private var showEffortMenu = false
+    @State private var showOptionsMenu = false
 
     private var hiveAccent: Color {
         AccentOption(rawValue: accentId)?.color ?? AccentOption.violet.color
@@ -182,52 +183,46 @@ struct ChatInputBar: View {
         .padding(.horizontal, 16)
     }
 
-    /// Overflow menu grouping the output style picker and the fast mode toggle.
+    /// Compact popover grouping the output style picker and the fast mode toggle.
     private var optionsMenu: some View {
-        Menu {
-            if let effectiveOutputStyle {
-                Menu {
-                    ForEach(outputStyles, id: \.self) { style in
-                        Button {
-                            Haptics.selection()
-                            outputStyle = style
-                        } label: {
-                            if style == effectiveOutputStyle {
-                                Label(style.label, systemImage: "checkmark")
-                            } else {
-                                Text(style.label)
-                            }
-                        }
-                    }
-                } label: {
-                    Text("Output")
-                    Text(effectiveOutputStyle.label)
-                }
-                .disabled(isOutputStyleLocked)
-            }
-            if providerHasFastMode {
-                Button {
-                    Haptics.selection()
-                    fastModeEnabled.toggle()
-                } label: {
-                    if supportsFastMode && fastModeEnabled {
-                        Label("Fast mode", systemImage: "checkmark")
-                    } else if supportsFastMode {
-                        Text("Fast mode")
-                    } else {
-                        Text("Fast mode")
-                        Text("Opus only")
-                    }
-                }
-                .disabled(!supportsFastMode)
-            }
+        Button {
+            Haptics.selection()
+            showOptionsMenu = true
         } label: {
             Image(systemName: "slider.horizontal.3")
                 .font(.caption)
                 .foregroundStyle(isOptionsMenuActive ? hiveAccent : WhisperColor.textSecondary)
+                .frame(width: 28, height: 28)
+                .background(
+                    Capsule().fill(isOptionsMenuActive ? hiveAccent.opacity(0.15) : .clear)
+                )
+                .overlay(
+                    Capsule().stroke(
+                        isOptionsMenuActive ? hiveAccent.opacity(0.3) : .clear,
+                        lineWidth: 0.5
+                    )
+                )
         }
-        .frame(minHeight: 44)
+        .buttonStyle(.plain)
+        .frame(width: 44, height: 44)
+        .contentShape(Rectangle())
         .accessibilityLabel("More options")
+        .accessibilityValue(isOptionsMenuActive ? "Active" : "Inactive")
+        .popover(isPresented: $showOptionsMenu, attachmentAnchor: .rect(.bounds), arrowEdge: .bottom) {
+            ComposerOptionsPopover(
+                outputStyles: outputStyles,
+                outputStyle: $outputStyle,
+                selectedOutputStyle: effectiveOutputStyle,
+                isOutputStyleLocked: isOutputStyleLocked,
+                showsFastMode: providerHasFastMode,
+                supportsFastMode: supportsFastMode,
+                fastModeEnabled: $fastModeEnabled,
+                accent: hiveAccent
+            ) {
+                showOptionsMenu = false
+            }
+            .presentationCompactAdaptation(.popover)
+        }
     }
 
     // MARK: - Attachment Chip Tray
@@ -512,6 +507,211 @@ private struct SelectionMenu<Option: Hashable>: View {
         .padding(.vertical, 5)
         .frame(width: 180)
         .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+private struct ComposerOptionsPopover: View {
+    private enum Page: Equatable {
+        case options
+        case outputStyles
+    }
+
+    let outputStyles: [OutputStyle]
+    @Binding var outputStyle: OutputStyle
+    let selectedOutputStyle: OutputStyle?
+    let isOutputStyleLocked: Bool
+    let showsFastMode: Bool
+    let supportsFastMode: Bool
+    @Binding var fastModeEnabled: Bool
+    let accent: Color
+    let onDismiss: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var page = Page.options
+
+    var body: some View {
+        ZStack(alignment: .topLeading) {
+            switch page {
+            case .options:
+                optionsPage
+                    .transition(
+                        .asymmetric(
+                            insertion: .move(edge: .leading).combined(with: .opacity),
+                            removal: .move(edge: .leading).combined(with: .opacity)
+                        )
+                    )
+            case .outputStyles:
+                outputStylesPage
+                    .transition(
+                        .asymmetric(
+                            insertion: .move(edge: .trailing).combined(with: .opacity),
+                            removal: .move(edge: .trailing).combined(with: .opacity)
+                        )
+                    )
+            }
+        }
+        .animation(reduceMotion ? nil : .easeInOut(duration: 0.18), value: page)
+        .frame(width: 234)
+        .fixedSize(horizontal: false, vertical: true)
+        .clipped()
+        .onDisappear {
+            page = .options
+        }
+    }
+
+    private var optionsPage: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text("Options")
+                .font(.caption2)
+                .foregroundStyle(WhisperColor.textMuted)
+                .padding(.horizontal, 14)
+                .padding(.top, 12)
+                .padding(.bottom, 3)
+
+            if let selectedOutputStyle {
+                Button {
+                    page = .outputStyles
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "bubble.left")
+                            .foregroundStyle(WhisperColor.textSecondary)
+                            .frame(width: 15)
+
+                        Text("Output")
+                            .foregroundStyle(WhisperColor.text)
+
+                        Spacer(minLength: 8)
+
+                        Text(selectedOutputStyle.label)
+                            .foregroundStyle(WhisperColor.textMuted)
+                            .lineLimit(1)
+
+                        Image(systemName: isOutputStyleLocked ? "lock.fill" : "chevron.right")
+                            .font(.caption2.weight(.semibold))
+                            .foregroundStyle(WhisperColor.textMuted)
+                            .frame(width: 12)
+                    }
+                    .font(.subheadline)
+                    .padding(.horizontal, 14)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(isOutputStyleLocked)
+                .opacity(isOutputStyleLocked ? 0.55 : 1)
+                .accessibilityLabel(
+                    isOutputStyleLocked
+                        ? "Output, \(selectedOutputStyle.label), locked"
+                        : "Output, \(selectedOutputStyle.label)"
+                )
+                .accessibilityHint(
+                    isOutputStyleLocked
+                        ? "Output style is fixed after the first message."
+                        : "Shows output styles."
+                )
+            }
+
+            if selectedOutputStyle != nil && showsFastMode {
+                Divider()
+                    .overlay(WhisperColor.hubSeparator)
+                    .padding(.leading, 37)
+            }
+
+            if showsFastMode {
+                Button {
+                    Haptics.selection()
+                    fastModeEnabled.toggle()
+                    onDismiss()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "bolt.fill")
+                            .foregroundStyle(WhisperColor.textSecondary)
+                            .frame(width: 15)
+
+                        Text("Fast mode")
+                            .foregroundStyle(WhisperColor.text)
+
+                        Spacer(minLength: 8)
+
+                        if supportsFastMode {
+                            Image(systemName: "checkmark")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(accent)
+                                .opacity(fastModeEnabled ? 1 : 0)
+                                .frame(width: 15)
+                        } else {
+                            Text("Opus only")
+                                .font(.caption)
+                                .foregroundStyle(WhisperColor.textMuted)
+                        }
+                    }
+                    .font(.subheadline)
+                    .padding(.horizontal, 14)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(!supportsFastMode)
+                .opacity(supportsFastMode ? 1 : 0.55)
+                .accessibilityLabel("Fast mode")
+                .accessibilityValue(supportsFastMode ? (fastModeEnabled ? "On" : "Off") : "Unavailable")
+                .accessibilityHint(supportsFastMode ? "Toggles Fast mode." : "Available for Opus only.")
+            }
+        }
+        .padding(.bottom, 5)
+    }
+
+    private var outputStylesPage: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Button {
+                page = .options
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "chevron.left")
+                        .font(.caption2.weight(.semibold))
+                    Text("Options")
+                }
+                .font(.caption)
+                .foregroundStyle(WhisperColor.textSecondary)
+                .padding(.horizontal, 14)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Back to options")
+
+            Divider()
+                .overlay(WhisperColor.hubSeparator)
+
+            ForEach(outputStyles, id: \.self) { style in
+                Button {
+                    Haptics.selection()
+                    outputStyle = style
+                    onDismiss()
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark")
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(accent)
+                            .opacity(style == selectedOutputStyle ? 1 : 0)
+                            .frame(width: 15)
+
+                        Text(style.label)
+                            .foregroundStyle(WhisperColor.text)
+
+                        Spacer(minLength: 8)
+                    }
+                    .font(.subheadline)
+                    .padding(.horizontal, 14)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(style.label)
+                .accessibilityValue(style == selectedOutputStyle ? "Selected" : "")
+            }
+        }
+        .padding(.bottom, 5)
     }
 }
 

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -727,17 +727,11 @@ private struct ReasoningThoughtRow: View {
     let thought: ReasoningSegment
 
     private var line: Text {
-        var result = Text("")
-        if let headline = thought.headline {
-            result = result + Text(headline).foregroundColor(WhisperColor.text)
-        }
-        if thought.headline != nil, thought.body != nil {
-            result = result + Text(" — ").foregroundColor(WhisperColor.textMuted)
-        }
-        if let body = thought.body {
-            result = result + Text(body).foregroundColor(WhisperColor.textSecondary)
-        }
-        return result
+        let headline = Text(thought.headline ?? "").foregroundColor(WhisperColor.text)
+        let separator = Text(thought.headline != nil && thought.body != nil ? " — " : "")
+            .foregroundColor(WhisperColor.textMuted)
+        let body = Text(thought.body ?? "").foregroundColor(WhisperColor.textSecondary)
+        return Text("\(headline)\(separator)\(body)")
     }
 
     var body: some View {

--- a/ios/HiveMobile/Views/Chat/ScriptLogView.swift
+++ b/ios/HiveMobile/Views/Chat/ScriptLogView.swift
@@ -238,9 +238,10 @@ struct ScriptLogView: View {
 
     private func lineText(_ line: AnsiLine) -> some View {
         let text = line.spans.reduce(Text("")) { partial, span in
-            partial + Text(span.text)
+            let styledSpan = Text(span.text)
                 .foregroundColor(color(for: span.color))
                 .fontWeight(span.bold ? .bold : .regular)
+            return Text("\(partial)\(styledSpan)")
         }
         return text
             .font(WhisperFont.mono(12))


### PR DESCRIPTION
## Summary

- replace the nested native composer menu with a Hive-styled popover
- add an in-popover output-style drill-down and compact Fast mode state
- improve active, locked, unsupported, VoiceOver, touch-target, and Reduce Motion handling
- replace deprecated iOS 26 `Text` concatenation in reasoning rows and script logs

## Testing

- `git diff --check`
- not run: `cd ios && swift test` (Swift/Xcode toolchain unavailable in this workspace)