### PR TITLE
feat(frontend): replace conversation error banner

### DIFF
--- a/frontend/src/components/ChatConversation.tsx
+++ b/frontend/src/components/ChatConversation.tsx
@@ -16,7 +16,7 @@ import { AgentActivityList, getInlineAgentActivities } from "@/components/chat/A
 import { WorkspaceWelcome } from "@/components/WorkspaceWelcome";
 import { formatElapsed } from "@/lib/time";
 import { getFallbackInteractiveAssistantIndex, hasExitPlanModeTool } from "@/lib/plan-state";
-import { Trash2Icon } from "lucide-react";
+import { CircleAlertIcon, RefreshCwIcon, Trash2Icon } from "lucide-react";
 import type { AgentActivity, ChatMessage as ChatMessageType, QueuedMessage, ReasoningSegment, ToolCall, QuestionAnswer } from "@/types";
 import type { PendingToolInput } from "@/hooks/useConversation";
 import type { PlanStatus } from "@/components/chat/PlanProposal";
@@ -30,7 +30,9 @@ interface ChatConversationProps {
    * the empty state before the fetched messages arrive.
    */
   isHistoryLoading?: boolean;
-  isHistoryError?: boolean;
+  historyError?: string;
+  isHistoryRetrying?: boolean;
+  onRetryHistory?: () => void;
   isStreaming: boolean;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
@@ -51,7 +53,6 @@ interface ChatConversationProps {
   defaultBranch?: string;
   fileCount?: number;
   switchCounter: number;
-  error?: string;
   agentPlanMode?: boolean;
   queuedMessage?: QueuedMessage | null;
   onClearQueue?: () => void;
@@ -64,10 +65,60 @@ interface ChatConversationProps {
   emptyState?: ReactNode;
 }
 
+function ConversationHistoryError({
+  error,
+  isRetrying,
+  onRetry,
+}: {
+  error: string;
+  isRetrying: boolean;
+  onRetry?: () => void;
+}) {
+  return (
+    <div role="alert" className="flex w-full max-w-lg flex-col gap-6">
+      <div className="w-full rounded-xl border border-border/50 bg-sidebar px-5 py-4">
+        <p className="text-center text-sm text-foreground">
+          We couldn&apos;t load this conversation
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-4 text-sm text-muted-foreground">
+        <div className="flex items-start gap-3">
+          <CircleAlertIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0 text-destructive" />
+          <span className="min-w-0 break-words">{error}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <RefreshCwIcon
+            aria-hidden="true"
+            className={`size-4 shrink-0${isRetrying ? " animate-spin motion-reduce:animate-none" : ""}`}
+          />
+          {isRetrying ? (
+            <span>Retrying…</span>
+          ) : (
+            <span>
+              You can{" "}
+              <button
+                type="button"
+                onClick={onRetry}
+                disabled={!onRetry}
+                className="cursor-pointer font-medium text-foreground underline decoration-border underline-offset-4 transition-colors hover:decoration-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                retry loading the conversation
+              </button>
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function ChatConversation({
   messages,
   isHistoryLoading = false,
-  isHistoryError = false,
+  historyError,
+  isHistoryRetrying = false,
+  onRetryHistory,
   isStreaming,
   streamingStartedAt,
   currentStreamingText,
@@ -87,7 +138,6 @@ export default function ChatConversation({
   fileCount,
   switchCounter,
   agentPlanMode,
-  error,
   queuedMessage,
   onClearQueue,
   scrollToBottomTrigger = 0,
@@ -221,16 +271,17 @@ export default function ChatConversation({
       className={`flex-1${isHydrating ? " invisible" : ""}`}
       resize={settled ? "smooth" : "instant"}
     >
-      {error && (
-        <div className="border-b bg-destructive/10 px-4 py-2 text-sm text-destructive">
-          {error}
-        </div>
-      )}
       <ConversationContent className="gap-4 px-8 py-4">
-        {!hasContent &&
-          !isHistoryLoading &&
-          !isHistoryError &&
-          (workspaceName && projectName && branch && defaultBranch ? (
+        {!hasContent && historyError ? (
+          <ConversationEmptyState className="py-20">
+            <ConversationHistoryError
+              error={historyError}
+              isRetrying={isHistoryRetrying}
+              onRetry={onRetryHistory}
+            />
+          </ConversationEmptyState>
+        ) : !hasContent && !isHistoryLoading ? (
+          workspaceName && projectName && branch && defaultBranch ? (
             <ConversationEmptyState className="py-20">
               <WorkspaceWelcome
                 projectName={projectName}
@@ -251,7 +302,8 @@ export default function ChatConversation({
               title="Send a message to start a conversation."
               description=""
             />
-          ))}
+          )
+        ) : null}
         {messages.map((msg, i) => {
           // Hide "Question dismissed." user bubbles — the CANCELLED badge already conveys this
           if (msg.role === "user" && msg.content === "Question dismissed.") return null;

--- a/frontend/src/components/chat/ConversationErrorChip.tsx
+++ b/frontend/src/components/chat/ConversationErrorChip.tsx
@@ -139,10 +139,17 @@ export function ConversationErrorChip({ message, onDismiss }: ConversationErrorC
         onPointerUpCapture={() => {
           isPointerFocusRef.current = false;
         }}
+        onPointerCancelCapture={() => {
+          isPointerFocusRef.current = false;
+        }}
         // Mouse clicks focus buttons (on mousedown) and would pause the
-        // auto-dismiss forever; only keyboard-driven focus should pause.
+        // auto-dismiss forever; only keyboard-driven focus should pause. The
+        // flag only needs to live from pointerdown to the focus it causes, so
+        // it is consumed here; a gesture released outside the chip (no
+        // pointerup on it) then cannot leave the flag stuck.
         onFocusCapture={() => {
           if (!isPointerFocusRef.current) setHasFocus(true);
+          isPointerFocusRef.current = false;
         }}
         onBlurCapture={handleBlur}
         className={cn(

--- a/frontend/src/components/chat/ConversationErrorChip.tsx
+++ b/frontend/src/components/chat/ConversationErrorChip.tsx
@@ -1,15 +1,17 @@
-import { useCallback, useEffect, useRef, useState, type FocusEvent } from "react";
-import { CircleAlertIcon, XIcon } from "lucide-react";
-import { cn } from "@/lib/utils";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type FocusEvent,
+} from "react";
+import { flushSync } from "react-dom";
+import { XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 const DISPLAY_DURATION_MS = 5_000;
-const EXIT_DURATION_MS = 180;
+const EXIT_DURATION_MS = 200;
 
 interface ConversationErrorChipProps {
   message?: string;
@@ -19,12 +21,17 @@ interface ConversationErrorChipProps {
 export function ConversationErrorChip({ message, onDismiss }: ConversationErrorChipProps) {
   const [displayedMessage, setDisplayedMessage] = useState(message);
   const [isVisible, setIsVisible] = useState(!!message);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isTruncated, setIsTruncated] = useState(false);
   const [isPointerOver, setIsPointerOver] = useState(false);
   const [hasFocus, setHasFocus] = useState(false);
   const [isWindowInactive, setIsWindowInactive] = useState(
     () => typeof document !== "undefined" && document.visibilityState === "hidden",
   );
   const remainingMsRef = useRef(DISPLAY_DURATION_MS);
+  const messageRef = useRef<HTMLSpanElement>(null);
+  const chipRef = useRef<HTMLDivElement>(null);
+  const isPointerFocusRef = useRef(false);
 
   useEffect(() => {
     if (message) {
@@ -40,7 +47,14 @@ export function ConversationErrorChip({ message, onDismiss }: ConversationErrorC
 
   useEffect(() => {
     remainingMsRef.current = DISPLAY_DURATION_MS;
+    setIsExpanded(false);
   }, [message]);
+
+  useLayoutEffect(() => {
+    if (isExpanded) return;
+    const element = messageRef.current;
+    setIsTruncated(!!element && element.scrollWidth > element.clientWidth);
+  }, [displayedMessage, isExpanded]);
 
   useEffect(() => {
     const updateVisibility = () => setIsWindowInactive(document.visibilityState === "hidden");
@@ -56,7 +70,7 @@ export function ConversationErrorChip({ message, onDismiss }: ConversationErrorC
     };
   }, []);
 
-  const isPaused = isPointerOver || hasFocus || isWindowInactive;
+  const isPaused = isPointerOver || hasFocus || isWindowInactive || isExpanded;
   useEffect(() => {
     if (!message || isPaused) return;
 
@@ -75,50 +89,102 @@ export function ConversationErrorChip({ message, onDismiss }: ConversationErrorC
     if (!event.currentTarget.contains(event.relatedTarget)) setHasFocus(false);
   }, []);
 
+  // FLIP: measure the height around the synchronous re-render, then morph
+  // height and border-radius together so the pill-to-card change is one motion.
+  // The pill radius is height/2 because rounded-full computes to an
+  // un-animatable near-infinite value; the card radius is read from the theme.
+  const toggleExpanded = useCallback(() => {
+    const chip = chipRef.current;
+    const nextExpanded = !isExpanded;
+    const fromHeight = chip?.offsetHeight;
+    const preRadius = chip ? getComputedStyle(chip).borderRadius : "";
+    flushSync(() => setIsExpanded(nextExpanded));
+    if (!chip || !fromHeight || typeof chip.animate !== "function") return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const toHeight = chip.offsetHeight;
+    if (toHeight === fromHeight) return;
+    const [fromRadius, toRadius] = nextExpanded
+      ? [`${fromHeight / 2}px`, getComputedStyle(chip).borderRadius]
+      : [preRadius, `${toHeight / 2}px`];
+    chip.animate(
+      [
+        { height: `${fromHeight}px`, borderRadius: fromRadius },
+        { height: `${toHeight}px`, borderRadius: toRadius },
+      ],
+      { duration: 200, easing: "ease-out" },
+    );
+  }, [isExpanded]);
+
   if (!displayedMessage) return null;
+
+  const messageText = (
+    <span
+      ref={messageRef}
+      className={cn("block text-sm leading-5", isExpanded ? "break-words" : "truncate")}
+    >
+      {displayedMessage}
+    </span>
+  );
 
   return (
     <div className="pointer-events-none absolute inset-x-0 top-12 z-40 flex justify-center px-4">
-      <TooltipProvider delayDuration={300}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <div
-              role="alert"
-              tabIndex={0}
-              onPointerEnter={() => setIsPointerOver(true)}
-              onPointerLeave={() => setIsPointerOver(false)}
-              onFocusCapture={() => setHasFocus(true)}
-              onBlurCapture={handleBlur}
-              className={cn(
-                "pointer-events-auto flex max-w-xl min-w-0 items-start gap-2 rounded-lg bg-destructive px-3 py-2 text-destructive-foreground shadow-lg",
-                "transition-[opacity,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-destructive/30",
-                "motion-reduce:transform-none motion-reduce:transition-none",
-                isVisible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0",
-              )}
-            >
-              <CircleAlertIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
-              <span className="line-clamp-2 min-w-0 flex-1 break-words text-sm leading-5">
-                {displayedMessage}
-              </span>
-              <button
-                type="button"
-                aria-label="Dismiss error"
-                onClick={() => onDismiss(displayedMessage)}
-                className="-m-1 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded text-destructive-foreground/70 transition-colors hover:bg-destructive-foreground/10 hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-destructive-foreground/40"
-              >
-                <XIcon className="size-3.5" />
-              </button>
-            </div>
-          </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            sideOffset={6}
-            className="max-w-[min(36rem,calc(100vw-2rem))] break-words text-left"
+      <div
+        ref={chipRef}
+        role="alert"
+        onPointerEnter={() => setIsPointerOver(true)}
+        onPointerLeave={() => setIsPointerOver(false)}
+        onPointerDownCapture={() => {
+          isPointerFocusRef.current = true;
+        }}
+        onPointerUpCapture={() => {
+          isPointerFocusRef.current = false;
+        }}
+        // Mouse clicks focus buttons (on mousedown) and would pause the
+        // auto-dismiss forever; only keyboard-driven focus should pause.
+        onFocusCapture={() => {
+          if (!isPointerFocusRef.current) setHasFocus(true);
+        }}
+        onBlurCapture={handleBlur}
+        className={cn(
+          "pointer-events-auto flex max-w-xl min-w-0 items-start gap-2.5 overflow-hidden border border-background/15 bg-foreground py-2 pr-1.5 pl-3.5 text-background shadow-xl",
+          isExpanded ? "rounded-2xl" : "rounded-full",
+          // animation-duration (not duration-*) so transition-duration stays 0
+          // and no stray "transition: all" fights the expand/collapse morph.
+          isVisible
+            ? "animate-in fade-in slide-in-from-top-2 [animation-duration:300ms]"
+            : "animate-out fade-out slide-out-to-top-2 fill-mode-forwards [animation-duration:200ms]",
+          "motion-reduce:animate-none",
+        )}
+      >
+        <span
+          aria-hidden="true"
+          className="mt-1.5 size-2 shrink-0 rounded-full"
+          style={{
+            background: "var(--toast-error)",
+            boxShadow: "0 0 0 3px color-mix(in oklch, var(--toast-error) 18%, transparent)",
+          }}
+        />
+        {isTruncated || isExpanded ? (
+          <button
+            type="button"
+            aria-expanded={isExpanded}
+            onClick={toggleExpanded}
+            className="min-w-0 flex-1 cursor-pointer rounded-sm text-left focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-background/40"
           >
-            {displayedMessage}
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+            {messageText}
+          </button>
+        ) : (
+          <span className="min-w-0 flex-1">{messageText}</span>
+        )}
+        <button
+          type="button"
+          aria-label="Dismiss error"
+          onClick={() => onDismiss(displayedMessage)}
+          className="-my-1 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded-full text-background opacity-60 transition-[background-color,opacity] hover:bg-background/10 hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-background/40"
+        >
+          <XIcon className="size-3.5" />
+        </button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/chat/ConversationErrorChip.tsx
+++ b/frontend/src/components/chat/ConversationErrorChip.tsx
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState, type FocusEvent } from "react";
+import { CircleAlertIcon, XIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const DISPLAY_DURATION_MS = 5_000;
+const EXIT_DURATION_MS = 180;
+
+interface ConversationErrorChipProps {
+  message?: string;
+  onDismiss: (message: string) => void;
+}
+
+export function ConversationErrorChip({ message, onDismiss }: ConversationErrorChipProps) {
+  const [displayedMessage, setDisplayedMessage] = useState(message);
+  const [isVisible, setIsVisible] = useState(!!message);
+  const [isPointerOver, setIsPointerOver] = useState(false);
+  const [hasFocus, setHasFocus] = useState(false);
+  const [isWindowInactive, setIsWindowInactive] = useState(
+    () => typeof document !== "undefined" && document.visibilityState === "hidden",
+  );
+  const remainingMsRef = useRef(DISPLAY_DURATION_MS);
+
+  useEffect(() => {
+    if (message) {
+      setDisplayedMessage(message);
+      setIsVisible(true);
+      return;
+    }
+
+    setIsVisible(false);
+    const timeout = window.setTimeout(() => setDisplayedMessage(undefined), EXIT_DURATION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [message]);
+
+  useEffect(() => {
+    remainingMsRef.current = DISPLAY_DURATION_MS;
+  }, [message]);
+
+  useEffect(() => {
+    const updateVisibility = () => setIsWindowInactive(document.visibilityState === "hidden");
+    const handleBlur = () => setIsWindowInactive(true);
+
+    document.addEventListener("visibilitychange", updateVisibility);
+    window.addEventListener("blur", handleBlur);
+    window.addEventListener("focus", updateVisibility);
+    return () => {
+      document.removeEventListener("visibilitychange", updateVisibility);
+      window.removeEventListener("blur", handleBlur);
+      window.removeEventListener("focus", updateVisibility);
+    };
+  }, []);
+
+  const isPaused = isPointerOver || hasFocus || isWindowInactive;
+  useEffect(() => {
+    if (!message || isPaused) return;
+
+    const startedAt = performance.now();
+    const timeout = window.setTimeout(() => onDismiss(message), remainingMsRef.current);
+    return () => {
+      window.clearTimeout(timeout);
+      remainingMsRef.current = Math.max(
+        0,
+        remainingMsRef.current - (performance.now() - startedAt),
+      );
+    };
+  }, [isPaused, message, onDismiss]);
+
+  const handleBlur = useCallback((event: FocusEvent<HTMLDivElement>) => {
+    if (!event.currentTarget.contains(event.relatedTarget)) setHasFocus(false);
+  }, []);
+
+  if (!displayedMessage) return null;
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 top-12 z-40 flex justify-center px-4">
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <div
+              role="alert"
+              tabIndex={0}
+              onPointerEnter={() => setIsPointerOver(true)}
+              onPointerLeave={() => setIsPointerOver(false)}
+              onFocusCapture={() => setHasFocus(true)}
+              onBlurCapture={handleBlur}
+              className={cn(
+                "pointer-events-auto flex max-w-xl min-w-0 items-start gap-2 rounded-lg bg-destructive px-3 py-2 text-destructive-foreground shadow-lg",
+                "transition-[opacity,transform] duration-200 ease-out focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-destructive/30",
+                "motion-reduce:transform-none motion-reduce:transition-none",
+                isVisible ? "translate-y-0 opacity-100" : "-translate-y-2 opacity-0",
+              )}
+            >
+              <CircleAlertIcon aria-hidden="true" className="mt-0.5 size-4 shrink-0" />
+              <span className="line-clamp-2 min-w-0 flex-1 break-words text-sm leading-5">
+                {displayedMessage}
+              </span>
+              <button
+                type="button"
+                aria-label="Dismiss error"
+                onClick={() => onDismiss(displayedMessage)}
+                className="-m-1 flex size-7 shrink-0 cursor-pointer items-center justify-center rounded text-destructive-foreground/70 transition-colors hover:bg-destructive-foreground/10 hover:text-destructive-foreground focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-destructive-foreground/40"
+              >
+                <XIcon className="size-3.5" />
+              </button>
+            </div>
+          </TooltipTrigger>
+          <TooltipContent
+            side="bottom"
+            sideOffset={6}
+            className="max-w-[min(36rem,calc(100vw-2rem))] break-words text-left"
+          >
+            {displayedMessage}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ConversationPane.tsx
+++ b/frontend/src/components/chat/ConversationPane.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import ChatConversation from "@/components/ChatConversation";
 import QuestionPanel from "@/components/chat/QuestionPanel";
+import { ConversationErrorChip } from "@/components/chat/ConversationErrorChip";
 import { ConversationTabs } from "@/components/ConversationTabs";
 import TaskTracker from "@/components/TaskTracker";
 import type { GoalState } from "@/hooks/useGoalState";
@@ -57,8 +58,10 @@ export interface ConversationPaneProps {
   messages: ChatMessage[];
   /** True only on a cache-miss first history load; suppresses the empty state. */
   isHistoryLoading?: boolean;
-  /** True when the active REST history query failed; suppresses the empty state. */
-  isHistoryError?: boolean;
+  /** Initial REST history failure, shown as a recoverable conversation state. */
+  historyError?: string;
+  isHistoryRetrying?: boolean;
+  onRetryHistory?: () => void;
   streamingStartedAt?: number | null;
   currentStreamingText: string;
   currentReasoningSegments: ReasoningSegment[];
@@ -73,6 +76,7 @@ export interface ConversationPaneProps {
   switchCounter: number;
   agentPlanMode?: boolean;
   error?: string;
+  onDismissError: (message: string) => void;
   queuedMessage?: QueuedMessage | null;
   onClearQueue?: () => void;
   scrollToBottomTrigger: number;
@@ -128,7 +132,9 @@ export function ConversationPane({
   activeProvider,
   messages,
   isHistoryLoading,
-  isHistoryError,
+  historyError,
+  isHistoryRetrying,
+  onRetryHistory,
   streamingStartedAt,
   currentStreamingText,
   currentReasoningSegments,
@@ -142,6 +148,7 @@ export function ConversationPane({
   switchCounter,
   agentPlanMode,
   error,
+  onDismissError,
   queuedMessage,
   onClearQueue,
   scrollToBottomTrigger,
@@ -188,6 +195,10 @@ export function ConversationPane({
         onConversationActivate={onConversationActivate}
         activeProvider={activeProvider}
       />
+      <ConversationErrorChip
+        message={error}
+        onDismiss={onDismissError}
+      />
       <div className={!isFileTabActive ? "flex min-h-0 flex-1 flex-col" : "hidden"}>
         {activeIsTerminal ? (
           terminalView
@@ -196,7 +207,9 @@ export function ConversationPane({
             <ChatConversation
               messages={messages}
               isHistoryLoading={isHistoryLoading}
-              isHistoryError={isHistoryError}
+              historyError={historyError}
+              isHistoryRetrying={isHistoryRetrying}
+              onRetryHistory={onRetryHistory}
               isStreaming={isStreaming}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}
@@ -217,7 +230,6 @@ export function ConversationPane({
               emptyState={emptyState}
               switchCounter={switchCounter}
               agentPlanMode={agentPlanMode}
-              error={error}
               queuedMessage={queuedMessage}
               onClearQueue={onClearQueue}
               scrollToBottomTrigger={scrollToBottomTrigger}

--- a/frontend/src/hooks/useConversation.ts
+++ b/frontend/src/hooks/useConversation.ts
@@ -52,7 +52,10 @@ const emptyStreamState: SessionStreamState = {
 interface ConversationState {
   sessionStreams: Record<string, SessionStreamState>;
   workspaceStatus?: "idle" | "busy";
-  error?: string;
+  error?: {
+    message: string;
+    source: "runtime" | "history";
+  };
   sessionId?: string;
   lockedProvider?: string;
   switchCounter: number;
@@ -64,6 +67,9 @@ const TERMINAL_STATUS_RESYNC_DELAY_MS = 300;
 type LocalAction =
   | { type: "reset" }
   | { type: "clear_chat" }
+  | { type: "show_history_error"; message: string }
+  | { type: "clear_history_error" }
+  | { type: "clear_error"; message: string }
   | { type: "prepare_session_switch"; sessionId: string; preserveComposer?: boolean }
   | { type: "prepare_workspace_switch" }
   | { type: "clear_pending_tool_inputs" }
@@ -80,6 +86,15 @@ const initialState: ConversationState = {
   sessionId: undefined,
   switchCounter: 0,
 };
+
+function showError(
+  state: ConversationState,
+  message: string,
+  source: "runtime" | "history",
+): ConversationState {
+  if (state.error?.message === message && state.error.source === source) return state;
+  return { ...state, error: { message, source } };
+}
 
 // Replace the contiguous run of segments belonging to a reasoning block
 // (segment ids are `${blockId}:${index}`), or append when the block is new.
@@ -337,8 +352,10 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       const sid = action.sessionId;
       const existing = state.sessionStreams[sid] ?? { ...emptyStreamState };
       const backendStartedAt = normalizeStreamingStartedAt(action.streamingStartedAt);
+      const isActive = !state.sessionId || sid === state.sessionId;
       return {
         ...state,
+        error: isActive ? undefined : state.error,
         sessionId: state.sessionId ?? sid,
         sessionStreams: {
           ...state.sessionStreams,
@@ -382,7 +399,16 @@ function reducer(state: ConversationState, action: Action): ConversationState {
       if (action.sessionId && state.sessionId && action.sessionId !== state.sessionId) {
         return state;
       }
-      return { ...state, error: action.message };
+      return showError(state, action.message, "runtime");
+
+    case "show_history_error":
+      return showError(state, action.message, "history");
+
+    case "clear_history_error":
+      return state.error?.source === "history" ? { ...state, error: undefined } : state;
+
+    case "clear_error":
+      return state.error?.message === action.message ? { ...state, error: undefined } : state;
 
     case "status": {
       const sid = action.sessionId ?? state.sessionId;
@@ -427,6 +453,7 @@ function reducer(state: ConversationState, action: Action): ConversationState {
 
       return {
         ...state,
+        error: newIsStreaming && sid === newSessionId ? undefined : state.error,
         workspaceStatus: action.status,
         sessionId: newSessionId,
         sessionStreams: newStreams,
@@ -573,8 +600,13 @@ export function useConversation(workspaceId: string | undefined) {
   const {
     messages,
     isLoading: isHistoryLoading,
+    isFetching: isHistoryFetching,
+    hasData: hasHistoryData,
     error: historyError,
+    errorUpdatedAt: historyErrorUpdatedAt,
+    retry: retryHistory,
   } = useSessionMessages(workspaceId, state.sessionId);
+  const historyRefreshErrorRef = useRef<string | undefined>(undefined);
 
   // Track latest state so the WS handler (set up once per workspace) can read the
   // current stream content and session id without re-subscribing.
@@ -707,6 +739,19 @@ export function useConversation(workspaceId: string | undefined) {
     dispatch({ type: "reconcile_history", sessionId: state.sessionId, messages });
   }, [messages, state.sessionId]);
 
+  useEffect(() => {
+    if (historyError && hasHistoryData) {
+      const message = `Failed to refresh conversation history: ${historyError}`;
+      historyRefreshErrorRef.current = message;
+      dispatch({ type: "show_history_error", message });
+      return;
+    }
+    if (historyRefreshErrorRef.current) {
+      historyRefreshErrorRef.current = undefined;
+      dispatch({ type: "clear_history_error" });
+    }
+  }, [hasHistoryData, historyError, historyErrorUpdatedAt]);
+
   const sendMessage = useCallback((
     content: string,
     images?: ImageAttachment[],
@@ -817,10 +862,7 @@ export function useConversation(workspaceId: string | undefined) {
 
   // Derive active session's stream state for the public API
   const activeStream = state.sessionId ? state.sessionStreams[state.sessionId] : undefined;
-  const historyErrorMessage = historyError
-    ? `Failed to load conversation history: ${historyError}`
-    : undefined;
-  const isHistoryError = !!historyError;
+  const blockingHistoryError = historyError && !hasHistoryData ? historyError : undefined;
 
   const answerQuestion = useCallback((toolCallId: string, answers: QuestionAnswer[]) => {
     if (!workspaceId) return;
@@ -901,10 +943,16 @@ export function useConversation(workspaceId: string | undefined) {
     }
   }, [workspaceId, activeStream?.pendingToolInputs, state.sessionId]);
 
+  const dismissError = useCallback((message: string) => {
+    dispatch({ type: "clear_error", message });
+  }, []);
+
   return {
     messages,
     isHistoryLoading,
-    isHistoryError,
+    historyError: blockingHistoryError,
+    isHistoryRetrying: !!blockingHistoryError && isHistoryFetching,
+    retryHistory,
     isStreaming: activeStream?.isStreaming ?? false,
     streamingStartedAt: activeStream?.streamingStartedAt ?? null,
     workspaceStatus: state.workspaceStatus,
@@ -914,7 +962,7 @@ export function useConversation(workspaceId: string | undefined) {
     activeAgentActivities: activeStream?.activeAgentActivities ?? [],
     pendingToolInputs: activeStream?.pendingToolInputs ?? [],
     connectionStatus,
-    error: state.error ?? historyErrorMessage,
+    error: state.error?.message,
     sessionId: state.sessionId,
     agentPlanMode: activeStream?.agentPlanMode,
     lockedProvider: state.lockedProvider,
@@ -930,5 +978,6 @@ export function useConversation(workspaceId: string | undefined) {
     approvePlan,
     rejectToolInput,
     dismissPlan,
+    dismissError,
   };
 }

--- a/frontend/src/hooks/useSessionMessages.ts
+++ b/frontend/src/hooks/useSessionMessages.ts
@@ -1,3 +1,4 @@
+import { useCallback, useRef } from "react";
 import { useQuery, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { api } from "@/hooks/useApi";
 import {
@@ -94,7 +95,15 @@ export function fetchAndMergeSessionMessages(
 export function useSessionMessages(
   workspaceId: string | undefined,
   sessionId: string | undefined,
-): { messages: ChatMessage[]; isLoading: boolean; error: string | undefined } {
+): {
+  messages: ChatMessage[];
+  isLoading: boolean;
+  isFetching: boolean;
+  hasData: boolean;
+  error: string | undefined;
+  errorUpdatedAt: number;
+  retry: () => void;
+} {
   const queryClient = useQueryClient();
   const key = sessionMessagesKey(workspaceId, sessionId);
   const query = useQuery({
@@ -106,10 +115,44 @@ export function useSessionMessages(
     // policy in query-client.ts. So inherit the global staleTime default instead
     // of forcing a full-transcript refetch on every workspace switch-back.
   });
+  // A manual refetch clears Query's error while it is in flight when no data
+  // exists. Retain that last error so the recoverable empty state can show
+  // "Retrying…" instead of briefly turning blank.
+  const retainedErrorRef = useRef<{
+    workspaceId: string | undefined;
+    sessionId: string | undefined;
+    message: string;
+  } | undefined>(undefined);
+  const queryError = historyErrorMessage(query.error);
+  if (query.data !== undefined) {
+    retainedErrorRef.current = undefined;
+  } else if (queryError) {
+    retainedErrorRef.current = { workspaceId, sessionId, message: queryError };
+  } else if (
+    retainedErrorRef.current &&
+    (retainedErrorRef.current.workspaceId !== workspaceId ||
+      retainedErrorRef.current.sessionId !== sessionId)
+  ) {
+    retainedErrorRef.current = undefined;
+  }
+  const retainedErrorEntry = retainedErrorRef.current;
+  const retainedError = retainedErrorEntry && retainedErrorEntry.workspaceId === workspaceId &&
+    retainedErrorEntry.sessionId === sessionId
+    ? retainedErrorEntry.message
+    : undefined;
+  const { refetch } = query;
+  const retry = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
   return {
     messages: query.data ?? EMPTY_MESSAGES,
     isLoading: query.isLoading,
-    error: historyErrorMessage(query.error),
+    isFetching: query.isFetching,
+    hasData: query.data !== undefined,
+    error: queryError ?? retainedError,
+    errorUpdatedAt: query.errorUpdatedAt,
+    retry,
   };
 }
 

--- a/frontend/src/pages/BrainView.tsx
+++ b/frontend/src/pages/BrainView.tsx
@@ -113,7 +113,9 @@ export default function BrainView() {
   const {
     messages,
     isHistoryLoading,
-    isHistoryError,
+    historyError,
+    isHistoryRetrying,
+    retryHistory,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -123,6 +125,7 @@ export default function BrainView() {
     pendingToolInputs,
     connectionStatus,
     error,
+    dismissError,
     sessionId,
     sendStates,
     sendMessage,
@@ -375,7 +378,9 @@ export default function BrainView() {
               onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
               messages={messages}
               isHistoryLoading={isHistoryLoading}
-              isHistoryError={isHistoryError}
+              historyError={historyError}
+              isHistoryRetrying={isHistoryRetrying}
+              onRetryHistory={retryHistory}
               streamingStartedAt={streamingStartedAt}
               currentStreamingText={currentStreamingText}
               currentReasoningSegments={currentReasoningSegments}
@@ -392,6 +397,7 @@ export default function BrainView() {
               switchCounter={switchCounter}
               agentPlanMode={agentPlanMode}
               error={error}
+              onDismissError={dismissError}
               queuedMessage={queuedMessage}
               onClearQueue={() => setQueuedMessage(null)}
               scrollToBottomTrigger={scrollToBottomTrigger}

--- a/frontend/src/pages/WorkspaceView.tsx
+++ b/frontend/src/pages/WorkspaceView.tsx
@@ -154,7 +154,9 @@ export default function WorkspaceView() {
   const {
     messages,
     isHistoryLoading,
-    isHistoryError,
+    historyError,
+    isHistoryRetrying,
+    retryHistory,
     isStreaming,
     streamingStartedAt,
     currentStreamingText,
@@ -164,6 +166,7 @@ export default function WorkspaceView() {
     pendingToolInputs,
     connectionStatus,
     error,
+    dismissError,
     sessionId,
     sendStates,
     sendMessage,
@@ -494,7 +497,9 @@ export default function WorkspaceView() {
             onConversationActivate={() => sessionId && activateTab(`session:${sessionId}`)}
             messages={messages}
             isHistoryLoading={isHistoryLoading}
-            isHistoryError={isHistoryError}
+            historyError={historyError}
+            isHistoryRetrying={isHistoryRetrying}
+            onRetryHistory={retryHistory}
             streamingStartedAt={streamingStartedAt}
             currentStreamingText={currentStreamingText}
             currentReasoningSegments={currentReasoningSegments}
@@ -514,6 +519,7 @@ export default function WorkspaceView() {
             switchCounter={switchCounter}
             agentPlanMode={agentPlanMode}
             error={error}
+            onDismissError={dismissError}
             queuedMessage={queuedMessage}
             onClearQueue={() => setQueuedMessage(null)}
             scrollToBottomTrigger={scrollToBottomTrigger}

--- a/frontend/tests/components/ChatConversation.test.tsx
+++ b/frontend/tests/components/ChatConversation.test.tsx
@@ -151,10 +151,11 @@ describe("ChatConversation empty states", () => {
     expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
   });
 
-  it("suppresses empty states when history failed to load", () => {
+  it("renders a harmonized recoverable state when history failed to load", () => {
+    const onRetryHistory = vi.fn();
     renderConversation({
-      isHistoryError: true,
-      error: "Failed to load conversation history: network down",
+      historyError: "network down",
+      onRetryHistory,
       messages: [],
       isStreaming: false,
       workspaceName: "san-antonio",
@@ -163,9 +164,24 @@ describe("ChatConversation empty states", () => {
       defaultBranch: "main",
     });
 
-    expect(screen.getByText("Failed to load conversation history: network down")).toBeInTheDocument();
+    expect(screen.getByText("We couldn't load this conversation")).toBeInTheDocument();
+    expect(screen.getByText("network down")).toBeInTheDocument();
     expect(screen.queryByText(/You're in a new copy of/i)).not.toBeInTheDocument();
     expect(screen.queryByText("Send a message to start a conversation.")).not.toBeInTheDocument();
+
+    screen.getByRole("button", { name: "retry loading the conversation" }).click();
+    expect(onRetryHistory).toHaveBeenCalledOnce();
+  });
+
+  it("shows retry progress without hiding the history error state", () => {
+    renderConversation({
+      historyError: "network down",
+      isHistoryRetrying: true,
+    });
+
+    expect(screen.getByText("We couldn't load this conversation")).toBeInTheDocument();
+    expect(screen.getByText("Retrying…")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /retry loading/i })).not.toBeInTheDocument();
   });
 
   it("defaults fileCount to 0 when not provided", () => {
@@ -304,38 +320,6 @@ describe("ChatConversation streaming timer", () => {
     });
     expect(screen.getByText("0.0s")).toBeInTheDocument();
     vi.useRealTimers();
-  });
-});
-
-describe("ChatConversation error banner", () => {
-  it("renders error banner when error prop is provided", () => {
-    renderConversation({ error: "Something went wrong" });
-
-    const banner = screen.getByText("Something went wrong");
-    expect(banner).toBeInTheDocument();
-    expect(banner.closest("div")).toHaveClass("text-destructive");
-  });
-
-  it("does not render error banner when error is undefined", () => {
-    renderConversation({ error: undefined });
-
-    expect(screen.queryByText(/went wrong/i)).not.toBeInTheDocument();
-  });
-
-  it("renders both error banner and messages together", () => {
-    renderConversation({
-      error: "Connection lost",
-      messages: [{
-        id: "u1",
-        sessionId: "sess-1",
-        role: "user",
-        content: "hello",
-        timestamp: "2026-02-12T00:00:00.000Z",
-      }],
-    });
-
-    expect(screen.getByText("Connection lost")).toBeInTheDocument();
-    expect(screen.getByTestId("msg-u1")).toHaveTextContent("hello");
   });
 });
 

--- a/frontend/tests/components/ConversationErrorChip.test.tsx
+++ b/frontend/tests/components/ConversationErrorChip.test.tsx
@@ -5,6 +5,7 @@ import { ConversationErrorChip } from "@/components/chat/ConversationErrorChip";
 describe("ConversationErrorChip", () => {
   afterEach(() => {
     vi.useRealTimers();
+    vi.restoreAllMocks();
   });
 
   it("renders an accessible themed error and dismisses after five active seconds", () => {
@@ -14,7 +15,7 @@ describe("ConversationErrorChip", () => {
 
     const alert = screen.getByRole("alert");
     expect(alert).toHaveTextContent("Connection lost");
-    expect(alert).toHaveClass("bg-destructive", "text-destructive-foreground");
+    expect(alert).toHaveClass("bg-foreground", "text-background", "rounded-full");
 
     act(() => vi.advanceTimersByTime(4_999));
     expect(onDismiss).not.toHaveBeenCalled();
@@ -107,11 +108,54 @@ describe("ConversationErrorChip", () => {
     );
 
     rerender(<ConversationErrorChip message={undefined} onDismiss={vi.fn()} />);
-    expect(screen.getByRole("alert")).toHaveClass("opacity-0");
+    expect(screen.getByRole("alert")).toHaveClass("animate-out", "fill-mode-forwards");
 
-    act(() => vi.advanceTimersByTime(179));
+    act(() => vi.advanceTimersByTime(199));
     expect(screen.getByRole("alert")).toBeInTheDocument();
     act(() => vi.advanceTimersByTime(1));
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("expands a truncated message on click and pauses auto-dismiss while expanded", () => {
+    vi.useFakeTimers();
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(600);
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(300);
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="A very long error message" onDismiss={onDismiss} />);
+
+    const expand = screen.getByRole("button", { name: "A very long error message" });
+    expect(expand).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(expand);
+    expect(expand).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("alert")).toHaveClass("rounded-2xl");
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.click(expand);
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(onDismiss).toHaveBeenCalledWith("A very long error message");
+  });
+
+  it("resumes auto-dismiss after a mouse click leaves focus on the chip", () => {
+    vi.useFakeTimers();
+    vi.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(600);
+    vi.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(300);
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="A very long error message" onDismiss={onDismiss} />);
+
+    const alert = screen.getByRole("alert");
+    const expand = screen.getByRole("button", { name: "A very long error message" });
+
+    // A mouse click focuses the button on pointerdown; that focus must not
+    // pause the timer the way keyboard focus does.
+    fireEvent.pointerDown(alert);
+    fireEvent.focus(expand);
+    fireEvent.pointerUp(alert);
+    fireEvent.click(expand);
+    fireEvent.click(expand);
+
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(onDismiss).toHaveBeenCalledWith("A very long error message");
   });
 });

--- a/frontend/tests/components/ConversationErrorChip.test.tsx
+++ b/frontend/tests/components/ConversationErrorChip.test.tsx
@@ -158,4 +158,24 @@ describe("ConversationErrorChip", () => {
     act(() => vi.advanceTimersByTime(5_000));
     expect(onDismiss).toHaveBeenCalledWith("A very long error message");
   });
+
+  it("still pauses on keyboard focus after an interrupted pointer gesture", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+    const alert = screen.getByRole("alert");
+    const dismiss = screen.getByRole("button", { name: "Dismiss error" });
+
+    // A cancelled gesture never delivers pointerup to the chip.
+    fireEvent.pointerDown(alert);
+    fireEvent.pointerCancel(alert);
+
+    fireEvent.focus(dismiss);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.blur(dismiss, { relatedTarget: null });
+    act(() => vi.advanceTimersByTime(5_000));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
 });

--- a/frontend/tests/components/ConversationErrorChip.test.tsx
+++ b/frontend/tests/components/ConversationErrorChip.test.tsx
@@ -1,0 +1,117 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ConversationErrorChip } from "@/components/chat/ConversationErrorChip";
+
+describe("ConversationErrorChip", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders an accessible themed error and dismisses after five active seconds", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Connection lost");
+    expect(alert).toHaveClass("bg-destructive", "text-destructive-foreground");
+
+    act(() => vi.advanceTimersByTime(4_999));
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onDismiss).toHaveBeenCalledWith("Connection lost");
+  });
+
+  it("can be dismissed immediately", () => {
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss error" }));
+
+    expect(onDismiss).toHaveBeenCalledWith("Connection lost");
+  });
+
+  it("pauses while hovered and resumes with the remaining time", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+    const alert = screen.getByRole("alert");
+
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.pointerEnter(alert);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.pointerLeave(alert);
+    act(() => vi.advanceTimersByTime(2_999));
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("pauses while focused", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+    const alert = screen.getByRole("alert");
+
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.focus(alert);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.blur(alert, { relatedTarget: null });
+    act(() => vi.advanceTimersByTime(3_000));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("does not extend an identical error but resets for a different one", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    const { rerender } = render(
+      <ConversationErrorChip message="First error" onDismiss={onDismiss} />,
+    );
+
+    act(() => vi.advanceTimersByTime(3_000));
+    rerender(<ConversationErrorChip message="First error" onDismiss={onDismiss} />);
+    act(() => vi.advanceTimersByTime(2_000));
+    expect(onDismiss).toHaveBeenLastCalledWith("First error");
+
+    onDismiss.mockClear();
+    rerender(<ConversationErrorChip message="Second error" onDismiss={onDismiss} />);
+    act(() => vi.advanceTimersByTime(4_999));
+    expect(onDismiss).not.toHaveBeenCalled();
+    act(() => vi.advanceTimersByTime(1));
+    expect(onDismiss).toHaveBeenCalledWith("Second error");
+  });
+
+  it("pauses while the window is inactive", () => {
+    vi.useFakeTimers();
+    const onDismiss = vi.fn();
+    render(<ConversationErrorChip message="Connection lost" onDismiss={onDismiss} />);
+
+    act(() => vi.advanceTimersByTime(2_000));
+    fireEvent.blur(window);
+    act(() => vi.advanceTimersByTime(10_000));
+    expect(onDismiss).not.toHaveBeenCalled();
+
+    fireEvent.focus(window);
+    act(() => vi.advanceTimersByTime(3_000));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it("keeps the chip mounted for its short exit transition", () => {
+    vi.useFakeTimers();
+    const { rerender } = render(
+      <ConversationErrorChip message="Connection lost" onDismiss={vi.fn()} />,
+    );
+
+    rerender(<ConversationErrorChip message={undefined} onDismiss={vi.fn()} />);
+    expect(screen.getByRole("alert")).toHaveClass("opacity-0");
+
+    act(() => vi.advanceTimersByTime(179));
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    act(() => vi.advanceTimersByTime(1));
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/ConversationPane.test.tsx
+++ b/frontend/tests/components/ConversationPane.test.tsx
@@ -10,6 +10,10 @@ vi.mock("@/components/ChatConversation", () => ({
 vi.mock("@/components/ConversationTabs", () => ({
   ConversationTabs: () => <div data-testid="tabs">tabs</div>,
 }));
+vi.mock("@/components/chat/ConversationErrorChip", () => ({
+  ConversationErrorChip: ({ message }: { message?: string }) =>
+    message ? <div data-testid="conversation-error-chip">{message}</div> : null,
+}));
 vi.mock("@/components/TaskTracker", () => ({
   default: () => <div data-testid="task-tracker">tasks</div>,
 }));
@@ -32,6 +36,7 @@ function baseProps(overrides: Partial<ConversationPaneProps> = {}): Conversation
     activeAgentActivities: [],
     pendingToolInputs: [],
     switchCounter: 0,
+    onDismissError: vi.fn(),
     scrollToBottomTrigger: 0,
     tasks: [],
     currentTask: undefined,
@@ -63,6 +68,14 @@ describe("ConversationPane", () => {
     const chat = screen.getByTestId("chat-conversation");
     // Body is still mounted but inside a `.hidden` container.
     expect(chat.closest(".hidden")).not.toBeNull();
+  });
+
+  it("keeps the error chip outside the hidden chat body when a file tab is active", () => {
+    render(<ConversationPane {...baseProps({ isFileTabActive: true, error: "Connection lost" })} />);
+
+    const chip = screen.getByTestId("conversation-error-chip");
+    expect(chip).toHaveTextContent("Connection lost");
+    expect(chip.closest(".hidden")).toBeNull();
   });
 
   it("renders the chat input footer when there is no pending question", () => {
@@ -110,6 +123,32 @@ describe("ConversationPane", () => {
     expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
     expect(screen.queryByTestId("chat-conversation")).not.toBeInTheDocument();
     expect(screen.queryByTestId("chat-input")).not.toBeInTheDocument();
+  });
+
+  it("keeps the error chip visible over a terminal session", () => {
+    render(
+      <ConversationPane
+        {...baseProps({
+          activeSessionId: "term-1",
+          error: "Terminal session failed",
+          sessions: [
+            {
+              sessionId: "term-1",
+              workspaceId: "ws-1",
+              kind: "terminal",
+              createdAt: "2026-02-12T00:00:00.000Z",
+              updatedAt: "2026-02-12T00:00:00.000Z",
+              assistantMessageCount: 0,
+              readAssistantMessageCount: 0,
+            },
+          ],
+          terminalView: <div data-testid="terminal-view">terminal</div>,
+        })}
+      />,
+    );
+
+    expect(screen.getByTestId("conversation-error-chip")).toBeInTheDocument();
+    expect(screen.getByTestId("terminal-view")).toBeInTheDocument();
   });
 
   it("renders the chat (not the terminalView) when the active session is a regular chat", () => {

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -793,14 +793,16 @@ describe("useConversation", () => {
       __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1", streaming: false });
     });
 
+    // The stale stream slot is cleared by the reconcile_history effect that
+    // runs after the messages render, so wait for it alongside the messages.
     await waitFor(() => {
       expect(result.current.messages).toEqual([
         expect.objectContaining({ id: "u1" }),
         expect.objectContaining({ id: "a1", content: "final answer from persistence" }),
       ]);
+      expect(result.current.activeToolCalls).toEqual([]);
+      expect(result.current.isStreaming).toBe(false);
     });
-    expect(result.current.activeToolCalls).toEqual([]);
-    expect(result.current.isStreaming).toBe(false);
     expect(__apiMock.getMock).toHaveBeenCalledTimes(2);
   });
 

--- a/frontend/tests/hooks/useConversation.test.tsx
+++ b/frontend/tests/hooks/useConversation.test.tsx
@@ -1872,7 +1872,7 @@ describe("useConversation", () => {
     expect(result.current.isStreaming).toBe(false);
   });
 
-  it("surfaces REST history errors for the active session", async () => {
+  it("separates an initial REST history failure from transient errors", async () => {
     const { __apiMock } = await getApiMock();
     __apiMock.getMock.mockRejectedValue(new Error("network down"));
 
@@ -1883,10 +1883,53 @@ describe("useConversation", () => {
     });
 
     await waitFor(() => {
-      expect(result.current.error).toBe("Failed to load conversation history: network down");
+      expect(result.current.historyError).toBe("network down");
     });
-    expect(result.current.isHistoryError).toBe(true);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isHistoryRetrying).toBe(false);
     expect(result.current.messages).toEqual([]);
+  });
+
+  it("surfaces a cached history refresh failure as transient and clears it on recovery", async () => {
+    const { __apiMock } = await getApiMock();
+    const { result, queryClient } = renderConversation("ws-1");
+    const key = sessionMessagesKey("ws-1", "sess-1");
+    queryClient.setQueryData(key, [
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "cached",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+    ]);
+    await activateSession("ws-1", "sess-1");
+    __apiMock.getMock.mockRejectedValueOnce(new Error("network down"));
+
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: key });
+    });
+
+    await waitFor(() => {
+      expect(result.current.error).toBe("Failed to refresh conversation history: network down");
+    });
+    expect(result.current.historyError).toBeUndefined();
+    expect(result.current.messages).toHaveLength(1);
+
+    __apiMock.getMock.mockResolvedValueOnce([
+      {
+        id: "a1",
+        sessionId: "sess-1",
+        role: "assistant",
+        content: "recovered",
+        timestamp: "2026-02-12T00:00:00.000Z",
+      },
+    ]);
+    await act(async () => {
+      await queryClient.invalidateQueries({ queryKey: key });
+    });
+
+    await waitFor(() => expect(result.current.error).toBeUndefined());
   });
 
   it("restores cached messages synchronously when switching to a previously-viewed session", async () => {
@@ -2972,6 +3015,41 @@ describe("useConversation", () => {
     expect(result.current.error).toBe("Connection lost");
     expect(result.current.isStreaming).toBe(false);
     expect(result.current.streamingStartedAt).toBeNull();
+  });
+
+  it("dismisses an error and allows the same message to appear again later", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderConversation("ws-1");
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "error", message: "Connection lost" });
+    });
+    act(() => result.current.dismissError("Connection lost"));
+    expect(result.current.error).toBeUndefined();
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "error", message: "Connection lost" });
+    });
+    expect(result.current.error).toBe("Connection lost");
+  });
+
+  it("clears the active error when the session resumes streaming", async () => {
+    const { __wsMock } = await getWsMock();
+    const { result } = renderConversation("ws-1");
+
+    act(() => {
+      __wsMock.emit("ws-1", { type: "status", status: "idle", sessionId: "sess-1" });
+      __wsMock.emit("ws-1", { type: "error", sessionId: "sess-1", message: "Connection lost" });
+      __wsMock.emit("ws-1", {
+        type: "status",
+        status: "busy",
+        sessionId: "sess-1",
+        streaming: true,
+      });
+    });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isStreaming).toBe(true);
   });
 
   // ── Stale error filtering on buffer replay ─────────────────────────

--- a/frontend/tests/hooks/useSessionMessages.test.tsx
+++ b/frontend/tests/hooks/useSessionMessages.test.tsx
@@ -121,6 +121,43 @@ describe("useSessionMessages", () => {
       expect(result.current.error).toBe("network down");
     });
     expect(result.current.messages).toEqual([]);
+    expect(result.current.hasData).toBe(false);
+    expect(result.current.errorUpdatedAt).toBeGreaterThan(0);
+  });
+
+  it("retries an initial history failure and replaces it with loaded messages", async () => {
+    const { __apiMock } = await getApiMock();
+    __apiMock.getMock
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce([message("a1", "recovered")]);
+
+    const queryClient = newClient();
+    const { result } = renderHook(() => useSessionMessages("ws-1", "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+    await waitFor(() => expect(result.current.error).toBe("network down"));
+
+    act(() => result.current.retry());
+
+    await waitFor(() => expect(result.current.messages).toEqual([message("a1", "recovered")]));
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.hasData).toBe(true);
+  });
+
+  it("treats a failed refresh of cached empty history as non-blocking", async () => {
+    const { __apiMock } = await getApiMock();
+    const queryClient = newClient();
+    const key = sessionMessagesKey("ws-1", "sess-1");
+    queryClient.setQueryData<ChatMessage[]>(key, []);
+    __apiMock.getMock.mockRejectedValue(new Error("refresh failed"));
+
+    const { result } = renderHook(() => useSessionMessages("ws-1", "sess-1"), {
+      wrapper: wrapperFor(queryClient),
+    });
+
+    await waitFor(() => expect(result.current.error).toBe("refresh failed"));
+    expect(result.current.messages).toEqual([]);
+    expect(result.current.hasData).toBe(true);
   });
 
   it("does not fetch when there is no workspaceId", async () => {


### PR DESCRIPTION
## Summary

- replace the persistent full-width conversation error banner with a workspace-scoped transient chip
- style the chip in the HiveToast inverted-surface language: a rounded pill with a toast-error status dot, readable in both themes
- truncated messages expand on click (replacing the old tooltip); height and border-radius morph together via a FLIP animation
- pause dismissal while the chip is hovered, expanded, or keyboard-focused; mouse-click focus does not pin it open, and the pointer-origin flag cannot stay stuck after an interrupted gesture (resets on pointercancel, consumed on focus)
- coalesce duplicate errors and keep background-session errors out of the active workspace UI
- present initial history failures as a recoverable empty state with an inline retry
- stabilize the idle-status resync test by waiting for the reconcile_history effect

## Audit disposition

An audit of the branch surfaced four findings: the pointer-focus edge case and the flaky resync test are fixed here. Two were declined by design: the chip is a transient 5s toast, so a single latest-wins error slot is intended (history refresh errors re-surface on the next failed refetch, and initial-load failures already have their own persistent empty state), and resize-driven truncation remeasurement is not worth a ResizeObserver for a surface that lives at most 5 seconds.

## Validation

- `npm run lint --workspace frontend`
- `npm run typecheck --workspace frontend`
- full frontend suite: 1862 passed
- manually verified light and dark themes, expand/collapse morph, auto-dismiss after mouse interaction, keyboard focus, hover behavior, and a 768px viewport