### PR TITLE
fix(ios): make wide markdown tables readable in chat

### DIFF
--- a/ios/HiveMobile.xcodeproj/project.pbxproj
+++ b/ios/HiveMobile.xcodeproj/project.pbxproj
@@ -334,8 +334,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.4.0;
+				kind = exactVersion;
+				version = 2.4.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -1156,6 +1156,36 @@ extension Theme {
             .background(WhisperColor.codeBlockBg, in: RoundedRectangle(cornerRadius: 8))
             .markdownMargin(top: .em(0.4), bottom: .em(0.4))
         }
+        // ── Tables ──
+        // The stock table style squeezes columns into the bubble width, which
+        // collapses wide tables to one character per line. Let the grid take
+        // its natural width inside a horizontal scroll instead.
+        .table { configuration in
+            ScrollView(.horizontal) {
+                configuration.label
+                    .fixedSize(horizontal: true, vertical: true)
+                    .markdownTableBorderStyle(.init(color: WhisperColor.border))
+                    .markdownTableBackgroundStyle(
+                        .alternatingRows(Color.clear, WhisperColor.codeBlockBg)
+                    )
+            }
+            .markdownMargin(top: .em(0.4), bottom: .em(0.4))
+        }
+        .tableCell { configuration in
+            configuration.label
+                .markdownTextStyle {
+                    if configuration.row == 0 {
+                        FontWeight(.semibold)
+                    }
+                    BackgroundColor(nil)
+                    FontSize(.em(12.0 / 14))
+                }
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 260, alignment: .leading)
+                .padding(.vertical, 6)
+                .padding(.horizontal, 10)
+                .relativeLineSpacing(.em(0.25))
+        }
         // ── Blockquotes ──
         .blockquote { configuration in
             HStack(spacing: 0) {
@@ -1230,6 +1260,19 @@ extension Theme {
             ))
             MessageBubble(message: ChatMessage(
                 id: "3", sessionId: "s1", role: .assistant,
+                content: """
+                Findings summary:
+
+                | # | Finding | Category | Tag | Impact | Effort | Risk | Evidence |
+                | --- | --- | --- | --- | --- | --- | --- | --- |
+                | 1 | `tickets.md` sits untracked at repo root and leaks planning context into every session | housekeeping | intro | Low | Low | None | `tickets.md` at repo root |
+                | 2 | Retained error ref in session store keys on workspace+session so a blocking error can bleed | correctness | store | High | Medium | Low | `useSessionStore.ts` |
+                """,
+                images: nil, toolCalls: nil,
+                timestamp: "2026-02-17T12:00:30.000Z", cancelled: nil, durationMs: nil
+            ))
+            MessageBubble(message: ChatMessage(
+                id: "4", sessionId: "s1", role: .assistant,
                 content: "This was cancelled midway.",
                 images: nil, toolCalls: nil,
                 timestamp: "2026-02-17T12:01:00.000Z", cancelled: true, durationMs: 1500

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -1058,6 +1058,28 @@ private struct AskUserQuestionContent: View {
 
 // MARK: - Whisper Chat Markdown Theme
 
+/// Caps a table cell's width so prose cells wrap at a readable measure.
+/// `frame(maxWidth:)` cannot do this here: it only clamps the size it reports
+/// and never proposes the cap to its child, so the table grid measures row
+/// heights as if every cell were a single line and wrapped cells overlap the
+/// rows below. A Layout proposes the cap during measurement, so the reported
+/// height is the wrapped height.
+private struct TableCellWidthCap: Layout {
+    let maxWidth: CGFloat
+
+    private func childProposal(_ proposal: ProposedViewSize) -> ProposedViewSize {
+        ProposedViewSize(width: min(proposal.width ?? maxWidth, maxWidth), height: proposal.height)
+    }
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        subviews[0].sizeThatFits(childProposal(proposal))
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        subviews[0].place(at: bounds.origin, anchor: .topLeading, proposal: childProposal(proposal))
+    }
+}
+
 private let whisperLinkColor = Color.accentColor
 
 extension Theme {
@@ -1172,19 +1194,20 @@ extension Theme {
             .markdownMargin(top: .em(0.4), bottom: .em(0.4))
         }
         .tableCell { configuration in
-            configuration.label
-                .markdownTextStyle {
-                    if configuration.row == 0 {
-                        FontWeight(.semibold)
+            TableCellWidthCap(maxWidth: 260) {
+                configuration.label
+                    .markdownTextStyle {
+                        if configuration.row == 0 {
+                            FontWeight(.semibold)
+                        }
+                        BackgroundColor(nil)
+                        FontSize(.em(12.0 / 14))
                     }
-                    BackgroundColor(nil)
-                    FontSize(.em(12.0 / 14))
-                }
-                .fixedSize(horizontal: false, vertical: true)
-                .frame(maxWidth: 260, alignment: .leading)
-                .padding(.vertical, 6)
-                .padding(.horizontal, 10)
-                .relativeLineSpacing(.em(0.25))
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 6)
+            .padding(.horizontal, 10)
+            .relativeLineSpacing(.em(0.25))
         }
         // ── Blockquotes ──
         .blockquote { configuration in


### PR DESCRIPTION
## Problem

Wide GFM tables in agent responses render unreadably on iOS: MarkdownUI's stock `gitHub` table style applies `.fixedSize(horizontal: false, vertical: true)` to the table grid, forcing it into the bubble width and collapsing columns down to one character per line.

## Fix

Two theme overrides in `.whisperChat` (verified against swift-markdown-ui 2.4.1 source):

- **`.table`**: wrap the grid in a horizontal `ScrollView` with `.fixedSize(horizontal: true, vertical: true)` so columns take their natural width, the same idiom the theme already uses for code blocks. Border and alternating-row colors are re-supplied from `WhisperColor` tokens since the override replaces the gitHub block style.
- **`.tableCell`**: gitHub cell style (semibold header row, padding, line spacing) plus `FontSize(.em(12/14))` to match inline code, and a small custom `Layout` (`TableCellWidthCap`) that caps cell width at 260pt so prose cells wrap at a readable measure while short columns (`#`, `Risk`, ...) stay compact. A `Layout` rather than `frame(maxWidth:)` because a flexible frame only clamps the size it reports and never proposes the cap to its child, so the grid measured row heights as if every cell were a single line and wrapped cells overlapped the rows below (caught during on-device testing). The Layout proposes the cap during measurement, so a cell's reported height is its wrapped height. Cells also keep their natural width inside the column, so GFM `:--:` / `--:` column alignments keep working.

Matches web behavior (streamdown's `table-wrapper` already horizontal-scrolls with natural widths) and the standard pattern in ChatGPT iOS / GitHub mobile.

Also adds a wide Findings-style table message to the `#Preview` for quick visual verification.

## Testing

- `swift test` not run: no Swift toolchain on the Linux dev host, and the SPM target excludes `Views/` anyway; this file only compiles under Xcode.
- First commit verified on device: natural column widths and horizontal scroll work; it exposed the row-height overlap fixed by the second commit, whose device re-test is pending.
