### PR TITLE
feat(backend): update Claude model catalog to Fable 5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Hive runs on your own server, keeping your projects, workspaces, and agent sessi
 
 | Provider | Runtime | Models |
 |---|---|---|
-| Anthropic | Claude Code | Fable 5, Opus 5, Sonnet 5, Haiku 4.5 |
+| Anthropic | Claude Code | Fable 5.1, Opus 5, Sonnet 5, Haiku 4.5 |
 | OpenAI | Codex | GPT-5.6 Sol, GPT-5.6 Terra, GPT-5.6 Luna, GPT-5.5 |
 | Moonshot | Claude Code | K3, K3 1M, K2.7 Coding, K2.7 Coding Highspeed |
 

--- a/backend/src/agents/providers/claude.test.ts
+++ b/backend/src/agents/providers/claude.test.ts
@@ -38,18 +38,19 @@ describe("ClaudeProvider", () => {
 
   it("includes fable, opus, sonnet, and haiku", () => {
     const ids = provider.models.map((m) => m.id);
-    expect(ids).toContain("fable-5");
+    expect(ids).toContain("fable-5-1");
     expect(ids).toContain("opus-5");
     expect(ids).toContain("sonnet-5");
     expect(ids).toContain("haiku-4-5");
   });
 
-  it("exposes Fable 5 as a 1M-context model without fast mode and not default", () => {
-    const fable = provider.models.find((m) => m.id === "fable-5");
-    expect(fable?.cliValue).toBe("claude-fable-5");
+  it("exposes Fable 5.1 as a 1M-context model without fast mode and not default", () => {
+    const fable = provider.models.find((m) => m.id === "fable-5-1");
+    expect(fable?.cliValue).toBe("claude-fable-5-1");
     expect(fable?.contextWindow).toBe(1_000_000);
     expect(fable?.isDefault).toBeFalsy();
     expect(fable?.supportsFastMode).toBeFalsy();
+    expect(fable?.aliases).toContain("fable-5");
   });
 
   it("maps each model to a cli value", () => {
@@ -288,7 +289,7 @@ describe("ClaudeProvider", () => {
   });
 
   it("marks Opus as supporting fast mode and the others as not", () => {
-    const fable = provider.models.find((m) => m.id === "fable-5");
+    const fable = provider.models.find((m) => m.id === "fable-5-1");
     const opus = provider.models.find((m) => m.id === "opus-5");
     const sonnet = provider.models.find((m) => m.id === "sonnet-5");
     const haiku = provider.models.find((m) => m.id === "haiku-4-5");

--- a/backend/src/agents/providers/claude.ts
+++ b/backend/src/agents/providers/claude.ts
@@ -10,11 +10,12 @@ import {
 } from "./types.js";
 
 const CLAUDE_MODELS: ModelDefinition[] = [
-  // Fable 5 and Sonnet 5 ship with a 1M context window by default, so their
-  // cliValues need no explicit `[1m]` opt-in (unlike Opus 5). Fable 5's
-  // adaptive thinking is always on and depth is controlled via --effort; it
-  // has no fast mode.
-  { id: "fable-5", label: "Fable 5", cliValue: "claude-fable-5", contextWindow: 1_000_000 },
+  // Fable 5.1 and Sonnet 5 ship with a 1M context window by default, so their
+  // cliValues need no explicit `[1m]` opt-in (unlike Opus 5). Fable's adaptive
+  // thinking is always on and depth is controlled via --effort; it has no fast
+  // mode on the first-party API. The API rejects claude-fable-5-1 from Claude
+  // Code CLIs older than 2.1.251 with a 400.
+  { id: "fable-5-1", label: "Fable 5.1", cliValue: "claude-fable-5-1", aliases: ["fable-5"], contextWindow: 1_000_000 },
   { id: "opus-5", label: "Opus 5", cliValue: "claude-opus-5[1m]", aliases: ["opus-4-8", "opus-4-7"], isDefault: true, contextWindow: 1_000_000, supportsFastMode: true },
   { id: "sonnet-5", label: "Sonnet 5", cliValue: "claude-sonnet-5", aliases: ["sonnet-4-6"], contextWindow: 1_000_000 },
   { id: "haiku-4-5", label: "Haiku 4.5", cliValue: "claude-haiku-4-5", contextWindow: 200_000 },

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -466,7 +466,7 @@ describe("contextWindow in catalog", () => {
     const catalog = getModelCatalog();
     const claudeModels = catalog.models.filter((m) => m.provider === "claude");
 
-    const fable = claudeModels.find((m) => m.id === "claude:fable-5");
+    const fable = claudeModels.find((m) => m.id === "claude:fable-5-1");
     expect(fable?.contextWindow).toBe(1_000_000);
     const opus = claudeModels.find((m) => m.id === "claude:opus-5");
     expect(opus?.contextWindow).toBe(1_000_000);


### PR DESCRIPTION
## Summary

Anthropic released **Claude Fable 5.1** (`claude-fable-5-1`) on 2026-09-01, superseding Fable 5 as the default Fable model in Claude Code. This updates our Claude model catalog accordingly.

- Replace the `fable-5` entry with `fable-5-1` (label **Fable 5.1**, cliValue `claude-fable-5-1`)
- Keep `fable-5` as a retired-ID alias so stored sessions and Team agent definitions resolve to the new entry (same pattern as `opus-4-8`/`opus-4-7` -> `opus-5`)
- Unchanged characteristics verified against the official docs: 1M native context (no `[1m]` opt-in needed), always-on adaptive thinking driven by `--effort`, no fast mode on the first-party API, not the default model
- Opus 5, Sonnet 5, and Haiku 4.5 are still the current lineup for their tiers; no other catalog changes needed
- README supported-models table updated

## Compatibility note

The API rejects `claude-fable-5-1` from Claude Code CLIs older than **2.1.251** with a 400 ("version 2.1.251 or newer is required") - reproduced locally on 2.1.241. Servers should update the Claude CLI to pick up the model; provisioning already installs latest.

## Testing

- `backend` lint + typecheck clean
- `vitest run src/agents/providers/claude.test.ts src/agents/providers/registry.test.ts`: 108 tests pass