### PR TITLE
feat(backend): update Codex model catalog

### DIFF
--- a/backend/src/agents/providers/codex.test.ts
+++ b/backend/src/agents/providers/codex.test.ts
@@ -17,9 +17,10 @@ describe("CodexProvider", () => {
 
   // ── Models ─────────────────────────────────────────────────────────
 
-  it("exposes the GPT-5.6 tiers and gpt-5.5", () => {
+  it("exposes the Codex 0.153 model catalog", () => {
     expect(provider.models.map((m) => m.id)).toEqual([
-      "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5",
+      "gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+      "gpt-5.3-codex-spark", "gpt-5.5",
     ]);
   });
 
@@ -28,15 +29,18 @@ describe("CodexProvider", () => {
     expect(defaults.map((m) => m.id)).toEqual(["gpt-5.6-sol"]);
   });
 
-  it("tracks the catalog context windows (372K for 5.6 tiers, 272K for 5.5)", () => {
-    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
-      expect(provider.models.find((m) => m.id === id)?.contextWindow).toBe(372_000);
+  it("tracks the catalog context windows", () => {
+    for (const id of ["gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5"]) {
+      expect(provider.models.find((m) => m.id === id)?.contextWindow).toBe(272_000);
     }
-    expect(provider.models.find((m) => m.id === "gpt-5.5")?.contextWindow).toBe(272_000);
+    expect(provider.models.find((m) => m.id === "gpt-5.3-codex-spark")?.contextWindow)
+      .toBe(128_000);
   });
 
-  it("aliases retired gpt-5.3-codex to gpt-5.6-sol", () => {
+  it("aliases retired models to their catalog replacements", () => {
     expect(findModel(provider.models, "gpt-5.3-codex")?.id).toBe("gpt-5.6-sol");
+    expect(findModel(provider.models, "gpt-5.4")?.id).toBe("gpt-5.6-terra");
+    expect(findModel(provider.models, "gpt-5.4-mini")?.id).toBe("gpt-5.6-luna");
   });
 
   // ── Capabilities ───────────────────────────────────────────────────
@@ -47,19 +51,23 @@ describe("CodexProvider", () => {
     ]);
   });
 
-  it("exposes per-model effort ceilings for the GPT-5.6 tiers", () => {
+  it("exposes per-model effort ceilings for Astra and the GPT-5.6 tiers", () => {
     const levels = (id: string) => provider.models.find((m) => m.id === id)?.thinkingLevels;
+    expect(levels("gpt-6-astra")).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
     expect(levels("gpt-5.6-sol")).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
     expect(levels("gpt-5.6-terra")).toEqual(["low", "medium", "high", "xhigh", "max", "ultra"]);
     expect(levels("gpt-5.6-luna")).toEqual(["low", "medium", "high", "xhigh", "max"]);
-    // gpt-5.5 inherits the provider baseline.
+    // Codex Spark and GPT-5.5 inherit the provider baseline.
+    expect(levels("gpt-5.3-codex-spark")).toBeUndefined();
     expect(levels("gpt-5.5")).toBeUndefined();
   });
 
   it("exposes native personalities only for gpt-5.5", () => {
     expect(provider.models.find((model) => model.id === "gpt-5.5")?.outputStyles)
       .toEqual(["default", "friendly", "pragmatic", "none"]);
-    for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    for (const id of [
+      "gpt-6-astra", "gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.3-codex-spark",
+    ]) {
       expect(provider.models.find((model) => model.id === id)?.outputStyles).toBeUndefined();
     }
   });

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -20,32 +20,46 @@ export function codexPersonalityFromOutputStyle(
   }
 }
 
-// Mirrors the Codex CLI built-in catalog (models.json, requires CLI >= 0.144).
-// GPT-5.6 tiers each cap reasoning effort differently, so levels are per model;
-// gpt-5.3-codex was retired from the catalog and aliases to the flagship.
+// Mirrors the Codex CLI 0.153 model lineup. Astra requires CLI >= 0.153;
+// GPT-5.6 tiers require CLI >= 0.144 and cap reasoning effort per model.
 const CODEX_MODELS: ModelDefinition[] = [
+  {
+    id: "gpt-6-astra",
+    label: "GPT-6 Astra",
+    cliValue: "gpt-6-astra",
+    contextWindow: 272_000,
+    thinkingLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  },
   {
     id: "gpt-5.6-sol",
     label: "GPT-5.6 Sol",
     cliValue: "gpt-5.6-sol",
     aliases: ["gpt-5.3-codex"],
     isDefault: true,
-    contextWindow: 372_000,
+    contextWindow: 272_000,
     thinkingLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
   },
   {
     id: "gpt-5.6-terra",
     label: "GPT-5.6 Terra",
     cliValue: "gpt-5.6-terra",
-    contextWindow: 372_000,
+    aliases: ["gpt-5.4"],
+    contextWindow: 272_000,
     thinkingLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
   },
   {
     id: "gpt-5.6-luna",
     label: "GPT-5.6 Luna",
     cliValue: "gpt-5.6-luna",
-    contextWindow: 372_000,
+    aliases: ["gpt-5.4-mini"],
+    contextWindow: 272_000,
     thinkingLevels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    id: "gpt-5.3-codex-spark",
+    label: "GPT-5.3-Codex-Spark",
+    cliValue: "gpt-5.3-codex-spark",
+    contextWindow: 128_000,
   },
   {
     id: "gpt-5.5",
@@ -57,7 +71,7 @@ const CODEX_MODELS: ModelDefinition[] = [
 ];
 
 const CODEX_CAPABILITIES: ProviderCapabilities = {
-  // Baseline for models without per-model levels (gpt-5.5).
+  // Baseline for models without per-model levels (Codex Spark and GPT-5.5).
   thinkingLevels: ["low", "medium", "high", "xhigh"],
   planMode: false,
   blockingTools: false,

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -204,7 +204,7 @@ describe("getModelCatalog", () => {
 
     expect(codexModels.find((model) => model.id === "codex:gpt-5.5")?.capabilities.outputStyles)
       .toEqual(["default", "friendly", "pragmatic", "none"]);
-    for (const model of codexModels.filter((model) => model.id.startsWith("codex:gpt-5.6-"))) {
+    for (const model of codexModels.filter((model) => model.id !== "codex:gpt-5.5")) {
       expect(model.capabilities.outputStyles).toEqual([]);
     }
   });
@@ -273,7 +273,8 @@ describe("getModelCatalog", () => {
 
     const codexIds = catalog.models.filter((m) => m.provider === "codex").map((m) => m.id);
     expect(codexIds).toEqual([
-      "codex:gpt-5.6-sol", "codex:gpt-5.6-terra", "codex:gpt-5.6-luna", "codex:gpt-5.5",
+      "codex:gpt-6-astra", "codex:gpt-5.6-sol", "codex:gpt-5.6-terra",
+      "codex:gpt-5.6-luna", "codex:gpt-5.3-codex-spark", "codex:gpt-5.5",
     ]);
   });
 
@@ -282,9 +283,13 @@ describe("getModelCatalog", () => {
     const catalog = getModelCatalog();
 
     const byId = new Map(catalog.models.map((m) => [m.id, m]));
+    expect(byId.get("codex:gpt-6-astra")?.capabilities.thinkingLevels).toContain("ultra");
     expect(byId.get("codex:gpt-5.6-sol")?.capabilities.thinkingLevels).toContain("ultra");
     expect(byId.get("codex:gpt-5.6-luna")?.capabilities.thinkingLevels).not.toContain("ultra");
     expect(byId.get("codex:gpt-5.5")?.capabilities.thinkingLevels).toEqual([
+      "low", "medium", "high", "xhigh",
+    ]);
+    expect(byId.get("codex:gpt-5.3-codex-spark")?.capabilities.thinkingLevels).toEqual([
       "low", "medium", "high", "xhigh",
     ]);
   });


### PR DESCRIPTION
## Summary

- add GPT-6 Astra and GPT-5.3-Codex-Spark to Hive's Codex model catalog
- preserve GPT-5.6 Sol as the default and route retired GPT-5.4 IDs to Terra/Luna
- align the GPT-5.6 default context windows with Codex CLI 0.153 metadata

GPT-6 Astra requires Codex CLI 0.153 or newer. GPT-5.3-Codex-Spark remains a ChatGPT Pro research preview, so availability still depends on the signed-in account.

## Validation

- `npm run lint` (backend)
- `npm run typecheck` (backend)
- `npm test` (backend: 114 files, 1,976 tests)
