### PR TITLE
feat: restore archived workspaces

### DIFF
--- a/backend/src/api/projects.test.ts
+++ b/backend/src/api/projects.test.ts
@@ -56,6 +56,41 @@ async function createFixtureRepoWithFile(
   return bareDir;
 }
 
+describe("GET /api/projects/:id/archives", () => {
+  it("returns 404 for a non-existent project", async () => {
+    const res = await app.inject({ method: "GET", url: "/api/projects/nonexistent/archives" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("lists archived workspaces newest first with branchExists", async () => {
+    const projectRes = await app.inject({ method: "POST", url: "/api/projects", payload: { url: fixtureRepoUrl } });
+    const projectId = projectRes.json().id;
+    const empty = await app.inject({ method: "GET", url: `/api/projects/${projectId}/archives` });
+    expect(empty.json()).toEqual([]);
+
+    const older = (await app.inject({ method: "POST", url: `/api/projects/${projectId}/workspaces` })).json();
+    const newer = (await app.inject({ method: "POST", url: `/api/projects/${projectId}/workspaces` })).json();
+    await app.inject({ method: "POST", url: `/api/workspaces/${older.id}/archive` });
+    await app.inject({ method: "POST", url: `/api/workspaces/${newer.id}/archive` });
+    // Archive timestamps can land in the same millisecond; pin them apart.
+    const olderMeta = join(dataDir, projectId, "archive", older.id, "workspace.json");
+    const { readFile } = await import("node:fs/promises");
+    await writeFile(
+      olderMeta,
+      JSON.stringify({ ...JSON.parse(await readFile(olderMeta, "utf-8")), archivedAt: "2020-01-01T00:00:00.000Z" }),
+      "utf-8",
+    );
+    await git(["branch", "-D", older.branch], join(dataDir, projectId, "repo.git"));
+
+    const res = await app.inject({ method: "GET", url: `/api/projects/${projectId}/archives` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toEqual([
+      { id: newer.id, name: newer.name, branch: newer.branch, archivedAt: expect.any(String), branchExists: true, deletesBranch: true },
+      { id: older.id, name: older.name, branch: older.branch, archivedAt: "2020-01-01T00:00:00.000Z", branchExists: false, deletesBranch: false },
+    ]);
+  });
+});
+
 describe("POST /api/projects", () => {
   it("creates a project and returns 201", async () => {
     const res = await app.inject({

--- a/backend/src/api/projects.ts
+++ b/backend/src/api/projects.ts
@@ -9,6 +9,7 @@ import {
   deleteProject,
   fetchProject,
 } from "../projects/project-manager.js";
+import { listArchivedWorkspaceItems } from "../workspaces/workspace-manager.js";
 import { errorMessage, errorStatus } from "../utils/errors.js";
 import { bareRepoPath, workspacesDir } from "../utils/paths.js";
 import { getDataDir } from "../state/state.js";
@@ -159,6 +160,14 @@ export async function projectRoutes(app: FastifyInstance, dataDir?: string) {
       return reply
         .status(errorStatus(err))
         .send({ error: errorMessage(err, "Fetch failed") });
+    }
+  });
+
+  app.get<{ Params: { id: string } }>("/api/projects/:id/archives", async (req, reply) => {
+    try {
+      return reply.send(await listArchivedWorkspaceItems(req.params.id, dataDir));
+    } catch (err: unknown) {
+      return reply.status(errorStatus(err)).send({ error: errorMessage(err, "Failed") });
     }
   });
 

--- a/backend/src/api/workspaces.test.ts
+++ b/backend/src/api/workspaces.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Fastify, { type FastifyInstance } from "fastify";
+import { existsSync } from "node:fs";
 import { mkdir, rm, symlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
@@ -389,7 +390,6 @@ describe("POST /api/workspaces/:wsId/archive", () => {
   });
 
   it("preserves archive data on disk", async () => {
-    const { existsSync } = await import("node:fs");
     const createRes = await app.inject({
       method: "POST",
       url: `/api/projects/${projectId}/workspaces`,
@@ -401,6 +401,65 @@ describe("POST /api/workspaces/:wsId/archive", () => {
     const archiveDir = join(dataDir, projectId, "archive", ws.id);
     expect(existsSync(archiveDir)).toBe(true);
     expect(existsSync(join(archiveDir, "workspace.json"))).toBe(true);
+  });
+});
+
+describe("POST /api/workspaces/:wsId/restore", () => {
+  async function createAndArchive() {
+    const createRes = await app.inject({ method: "POST", url: `/api/projects/${projectId}/workspaces` });
+    const ws = createRes.json();
+    await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/archive` });
+    return ws;
+  }
+
+  it("restores the workspace and returns 200", async () => {
+    const ws = await createAndArchive();
+
+    const res = await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/restore` });
+    expect(res.statusCode).toBe(200);
+    expect(res.json()).toMatchObject({ id: ws.id, name: ws.name, branch: ws.branch, status: "idle" });
+
+    const getRes = await app.inject({ method: "GET", url: `/api/workspaces/${ws.id}` });
+    expect(getRes.statusCode).toBe(200);
+    const archivesRes = await app.inject({ method: "GET", url: `/api/projects/${projectId}/archives` });
+    expect(archivesRes.json()).toEqual([]);
+  });
+
+  it("returns 404 for an unknown archive", async () => {
+    const res = await app.inject({ method: "POST", url: "/api/workspaces/nonexistent/restore" });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("returns 409 when the branch no longer exists", async () => {
+    const ws = await createAndArchive();
+    await git(["branch", "-D", ws.branch], join(dataDir, projectId, "repo.git"));
+
+    const res = await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/restore` });
+    expect(res.statusCode).toBe(409);
+    expect(res.json().error).toContain("no longer exists");
+  });
+});
+
+describe("DELETE /api/workspaces/:wsId/archive", () => {
+  it("deletes the archive and its branch and returns 204", async () => {
+    const createRes = await app.inject({ method: "POST", url: `/api/projects/${projectId}/workspaces` });
+    const ws = createRes.json();
+    await app.inject({ method: "POST", url: `/api/workspaces/${ws.id}/archive` });
+
+    const res = await app.inject({ method: "DELETE", url: `/api/workspaces/${ws.id}/archive` });
+    expect(res.statusCode).toBe(204);
+
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id))).toBe(false);
+    const archivesRes = await app.inject({ method: "GET", url: `/api/projects/${projectId}/archives` });
+    expect(archivesRes.json()).toEqual([]);
+    await expect(
+      git(["show-ref", "--verify", `refs/heads/${ws.branch}`], join(dataDir, projectId, "repo.git")),
+    ).rejects.toThrow();
+  });
+
+  it("returns 404 for an unknown archive", async () => {
+    const res = await app.inject({ method: "DELETE", url: "/api/workspaces/nonexistent/archive" });
+    expect(res.statusCode).toBe(404);
   });
 });
 

--- a/backend/src/api/workspaces.ts
+++ b/backend/src/api/workspaces.ts
@@ -11,6 +11,8 @@ import {
   getWorkspaceFileEntry,
   mergeWorkspace,
   archiveWorkspace,
+  restoreWorkspace,
+  deleteArchivedWorkspace,
 } from "../workspaces/workspace-manager.js";
 import { git } from "../utils/git.js";
 import { endSession } from "../agents/agent-manager.js";
@@ -234,6 +236,28 @@ export async function workspaceRoutes(app: FastifyInstance, dataDir?: string) {
       return reply
         .status(errorStatus(err))
         .send({ error: errorMessage(err, "Archive failed") });
+    }
+  });
+
+  app.delete<{ Params: { wsId: string } }>("/api/workspaces/:wsId/archive", async (req, reply) => {
+    try {
+      await deleteArchivedWorkspace(req.params.wsId, dataDir);
+      return reply.status(204).send();
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Delete failed") });
+    }
+  });
+
+  app.post<{ Params: { wsId: string } }>("/api/workspaces/:wsId/restore", async (req, reply) => {
+    try {
+      const workspace = await restoreWorkspace(req.params.wsId, dataDir);
+      return reply.send(workspace);
+    } catch (err: unknown) {
+      return reply
+        .status(errorStatus(err))
+        .send({ error: errorMessage(err, "Restore failed") });
     }
   });
 }

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -21,6 +21,24 @@ export interface Workspace {
   draftPrompt?: string;
 }
 
+/** Metadata persisted in `<dataDir>/<projectId>/archive/<wsId>/workspace.json`. */
+export interface ArchivedWorkspace extends Workspace {
+  archivedAt: string;
+}
+
+/** Item of `GET /api/projects/:id/archives`. */
+export interface ArchivedWorkspaceItem {
+  id: string;
+  name: string;
+  branch: string;
+  source?: WorkspaceSource;
+  archivedAt: string;
+  /** False when the kept branch no longer exists in the bare repo; restore is refused. */
+  branchExists: boolean;
+  /** True when deleting the archive also deletes the branch (Hive-owned branch that still exists). */
+  deletesBranch: boolean;
+}
+
 export type WorkspaceSourceKind = "branch" | "pr" | "issue";
 
 export interface WorkspaceSource {

--- a/backend/src/utils/city-names.test.ts
+++ b/backend/src/utils/city-names.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { pickCityName, CITIES } from "./city-names.js";
 
 describe("pickCityName", () => {
@@ -15,8 +15,25 @@ describe("pickCityName", () => {
     }
   });
 
-  it("throws when all names are exhausted", () => {
-    expect(() => pickCityName([...CITIES])).toThrow("All city names exhausted");
+  it("suffixes -1 when every plain city is used", () => {
+    const name = pickCityName([...CITIES]);
+    expect(name).toMatch(/^[a-z]+-1$/);
+    expect(CITIES).toContain(name.slice(0, -2));
+  });
+
+  it("picks the smallest free suffix", () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const used = [...CITIES, `${CITIES[0]}-1`, `${CITIES[0]}-2`, `${CITIES[0]}-4`];
+      expect(pickCityName(used)).toBe(`${CITIES[0]}-3`);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("never suffixes while a plain city is free", () => {
+    const [free, ...rest] = CITIES;
+    expect(pickCityName([...rest, `${free}-1`])).toBe(free);
   });
 
   it("only exposes ASCII-safe filesystem slugs", () => {

--- a/backend/src/utils/city-names.ts
+++ b/backend/src/utils/city-names.ts
@@ -28,12 +28,19 @@ const CITIES = [
   "versailles", "wollongong", "xining", "yakutsk", "zermatt",
 ] as const;
 
+/**
+ * Pick a random city not in `usedNames`. Only when every plain city is taken
+ * does it fall back to `<city>-N`, with the smallest N >= 1 that is free.
+ */
 export function pickCityName(usedNames: string[]): string {
   const available = CITIES.filter((c) => !usedNames.includes(c));
-  if (available.length === 0) {
-    throw new Error("All city names exhausted");
+  if (available.length > 0) {
+    return available[Math.floor(Math.random() * available.length)];
   }
-  return available[Math.floor(Math.random() * available.length)];
+  const city = CITIES[Math.floor(Math.random() * CITIES.length)];
+  let n = 1;
+  while (usedNames.includes(`${city}-${n}`)) n++;
+  return `${city}-${n}`;
 }
 
 export { CITIES };

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { rm, writeFile, mkdir, readFile } from "node:fs/promises";
+import { rm, writeFile, mkdir, readFile, stat } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { createTempDir, createFixtureRepo } from "../utils/test-helpers.js";
@@ -11,6 +11,10 @@ import {
   getWorkspace,
   deleteWorkspace,
   archiveWorkspace,
+  listArchivedWorkspaces,
+  listArchivedWorkspaceItems,
+  restoreWorkspace,
+  deleteArchivedWorkspace,
   getWorkspaceDiff,
   getWorkspaceDiffStat,
   mergeWorkspace,
@@ -25,6 +29,7 @@ import { loadProject, saveProject } from "../state/state.js";
 import * as stateStore from "../state/state.js";
 import { saveProjectEnv } from "../state/project-env.js";
 import { initWorkspaceIndex, _clearForTests as clearWorkspaceIndexForTests } from "../state/workspace-index.js";
+import { listWorkspaceSessions } from "../agents/agent-manager.js";
 
 let tempDir: string;
 let dataDir: string;
@@ -358,6 +363,25 @@ describe("archiveWorkspace", () => {
     expect(meta.id).toBe(ws.id);
     expect(meta.name).toBe(ws.name);
     expect(meta.branch).toBe(ws.branch);
+    expect(meta.archivedAt).toBe(new Date(meta.archivedAt).toISOString());
+  });
+
+  it("reserves the city of an archived workspace created from a branch", async () => {
+    await git(["branch", "feature-x", "main"], fixtureRepoUrl);
+    // Pin the pick to the first available city so the archived one would be
+    // chosen again unless the archive metadata keeps it out. A branch-sourced
+    // workspace has no workspace/<city> branch, so only that metadata can.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const first = await createWorkspace(projectId, dataDir, { kind: "branch", branch: "feature-x" });
+      expect(first.name).toBe(CITIES[0]);
+      await archiveWorkspace(first.id, dataDir);
+
+      const second = await createWorkspace(projectId, dataDir);
+      expect(second.name).toBe(CITIES[1]);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 
   it("moves session directories belonging to the workspace", async () => {
@@ -448,6 +472,232 @@ describe("archiveWorkspace", () => {
     // ws2's worktree should still exist
     const ws2Path = join(dataDir, projectId, "workspaces", ws2.name);
     expect(existsSync(ws2Path)).toBe(true);
+  });
+});
+
+describe("listArchivedWorkspaces", () => {
+  it("returns an empty list without an archive directory", async () => {
+    expect(await listArchivedWorkspaces(projectId, dataDir)).toEqual([]);
+  });
+
+  it("returns archived metadata and skips invalid entries", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    const archiveRoot = join(dataDir, projectId, "archive");
+    await mkdir(join(archiveRoot, "empty"), { recursive: true });
+    await mkdir(join(archiveRoot, "broken"), { recursive: true });
+    await writeFile(join(archiveRoot, "broken", "workspace.json"), "{ not json", "utf-8");
+
+    const archived = await listArchivedWorkspaces(projectId, dataDir);
+    expect(archived).toHaveLength(1);
+    expect(archived[0].id).toBe(ws.id);
+    expect(archived[0].name).toBe(ws.name);
+    expect(archived[0].archivedAt).toBe(new Date(archived[0].archivedAt).toISOString());
+  });
+
+  it("falls back to the directory mtime for legacy entries without archivedAt", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const legacyDir = join(dataDir, projectId, "archive", ws.id);
+    await mkdir(legacyDir, { recursive: true });
+    await writeFile(join(legacyDir, "workspace.json"), JSON.stringify(ws), "utf-8");
+
+    const archived = await listArchivedWorkspaces(projectId, dataDir);
+    expect(archived).toHaveLength(1);
+    expect(archived[0].archivedAt).toBe((await stat(legacyDir)).mtime.toISOString());
+  });
+});
+
+describe("listArchivedWorkspaceItems", () => {
+  it("throws for a non-existent project", async () => {
+    await expect(listArchivedWorkspaceItems("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+
+  it("returns items newest first with branchExists", async () => {
+    const older = await createWorkspace(projectId, dataDir);
+    const newer = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(older.id, dataDir);
+    await archiveWorkspace(newer.id, dataDir);
+    // Archive timestamps can land in the same millisecond; pin them apart.
+    const olderMeta = join(dataDir, projectId, "archive", older.id, "workspace.json");
+    await writeFile(
+      olderMeta,
+      JSON.stringify({ ...JSON.parse(await readFile(olderMeta, "utf-8")), archivedAt: "2020-01-01T00:00:00.000Z" }),
+      "utf-8",
+    );
+    await git(["branch", "-D", older.branch], bareRepoPath(dataDir, projectId));
+
+    const items = await listArchivedWorkspaceItems(projectId, dataDir);
+    expect(items.map((item) => item.id)).toEqual([newer.id, older.id]);
+    expect(items[0]).toMatchObject({ name: newer.name, branch: newer.branch, branchExists: true });
+    expect(items[1].branchExists).toBe(false);
+    expect(items[0]).not.toHaveProperty("projectId");
+  });
+});
+
+describe("restoreWorkspace", () => {
+  async function writeSessionFixture(wsId: string, sessionId: string): Promise<void> {
+    const dir = join(dataDir, projectId, "sessions", sessionId);
+    await mkdir(dir, { recursive: true });
+    const now = new Date().toISOString();
+    await writeFile(
+      join(dir, "metadata.json"),
+      JSON.stringify({
+        sessionId,
+        workspaceId: wsId,
+        createdAt: now,
+        updatedAt: now,
+        assistantMessageCount: 1,
+        readAssistantMessageCount: 1,
+      }),
+      "utf-8",
+    );
+    await writeFile(join(dir, "messages.jsonl"), '{"role":"user"}\n', "utf-8");
+  }
+
+  it("recreates the worktree, moves sessions back, and re-adds the workspace", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    const sessionId = "restored-session";
+    await writeSessionFixture(ws.id, sessionId);
+    const state = await loadProject(projectId, dataDir);
+    state!.workspaces[0].activeSessionId = sessionId;
+    await saveProject(state!, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    const wsPath = join(dataDir, projectId, "workspaces", ws.name);
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+    expect(existsSync(wsPath)).toBe(false);
+
+    const restored = await restoreWorkspace(ws.id, dataDir);
+
+    expect(restored).toMatchObject({
+      id: ws.id,
+      name: ws.name,
+      projectId,
+      branch: ws.branch,
+      status: "idle",
+      createdAt: ws.createdAt,
+      activeSessionId: sessionId,
+    });
+    expect(restored).not.toHaveProperty("archivedAt");
+    const { stdout } = await git(["rev-parse", "--abbrev-ref", "HEAD"], wsPath);
+    expect(stdout.trim()).toBe(ws.branch);
+
+    const sessionDir = join(dataDir, projectId, "sessions", sessionId);
+    expect(existsSync(join(sessionDir, "metadata.json"))).toBe(true);
+    expect(existsSync(join(sessionDir, "messages.jsonl"))).toBe(true);
+    expect(existsSync(archiveDir)).toBe(false);
+
+    const found = await getWorkspace(ws.id, dataDir);
+    expect(found?.workspace).toEqual(restored);
+    const sessions = await listWorkspaceSessions(ws.id, dataDir);
+    expect(sessions.map((s) => s.sessionId)).toEqual([sessionId]);
+  });
+
+  it("resolves the restored id through the workspace index", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    await initWorkspaceIndex(dataDir);
+    expect(await getWorkspace(ws.id, dataDir)).toBeNull();
+
+    await restoreWorkspace(ws.id, dataDir);
+
+    expect((await getWorkspace(ws.id, dataDir))?.workspace.id).toBe(ws.id);
+  });
+
+  it("refuses when the branch was deleted and keeps the archive", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    await git(["branch", "-D", ws.branch], bareRepoPath(dataDir, projectId));
+
+    await expect(restoreWorkspace(ws.id, dataDir)).rejects.toThrow(
+      `Branch "${ws.branch}" no longer exists; the workspace cannot be restored`,
+    );
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id, "workspace.json"))).toBe(true);
+    expect(existsSync(join(dataDir, projectId, "workspaces", ws.name))).toBe(false);
+    expect(await listWorkspaces(projectId, dataDir)).toHaveLength(0);
+  });
+
+  it("refuses when the workspace path is occupied", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    await mkdir(join(dataDir, projectId, "workspaces", ws.name), { recursive: true });
+
+    await expect(restoreWorkspace(ws.id, dataDir)).rejects.toThrow(
+      `Workspace path "${ws.name}" is already in use`,
+    );
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id, "workspace.json"))).toBe(true);
+  });
+
+  it("refuses when the branch is checked out in another workspace", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    const other = await createWorkspace(projectId, dataDir, { kind: "branch", branch: ws.branch });
+
+    await expect(restoreWorkspace(ws.id, dataDir)).rejects.toThrow(
+      `Branch "${ws.branch}" is already checked out in workspace "${other.name}"`,
+    );
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id, "workspace.json"))).toBe(true);
+  });
+
+  it("throws NotFoundError for an unknown id", async () => {
+    await expect(restoreWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+});
+
+describe("deleteArchivedWorkspace", () => {
+  it("removes the archive directory and the workspace branch", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    const bare = bareRepoPath(dataDir, projectId);
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+
+    await deleteArchivedWorkspace(ws.id, dataDir);
+
+    expect(existsSync(archiveDir)).toBe(false);
+    expect(await listArchivedWorkspaces(projectId, dataDir)).toEqual([]);
+    await expect(git(["show-ref", "--verify", `refs/heads/${ws.branch}`], bare)).rejects.toThrow();
+  });
+
+  it("frees the city name for new workspaces", async () => {
+    // Pin the pick to the first available city: it is reused only once both
+    // the archive metadata and the workspace/<city> branch are gone.
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0);
+    try {
+      const first = await createWorkspace(projectId, dataDir);
+      expect(first.name).toBe(CITIES[0]);
+      await archiveWorkspace(first.id, dataDir);
+      await deleteArchivedWorkspace(first.id, dataDir);
+
+      const second = await createWorkspace(projectId, dataDir);
+      expect(second.name).toBe(first.name);
+    } finally {
+      randomSpy.mockRestore();
+    }
+  });
+
+  it("keeps the branch of a workspace created from an existing branch", async () => {
+    await git(["branch", "feature-x", "main"], fixtureRepoUrl);
+    const ws = await createWorkspace(projectId, dataDir, { kind: "branch", branch: "feature-x" });
+    await archiveWorkspace(ws.id, dataDir);
+    const bare = bareRepoPath(dataDir, projectId);
+
+    await deleteArchivedWorkspace(ws.id, dataDir);
+
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id))).toBe(false);
+    await expect(git(["show-ref", "--verify", "refs/heads/feature-x"], bare)).resolves.toBeDefined();
+  });
+
+  it("succeeds when the branch is already missing", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    await git(["branch", "-D", ws.branch], bareRepoPath(dataDir, projectId));
+
+    await deleteArchivedWorkspace(ws.id, dataDir);
+
+    expect(existsSync(join(dataDir, projectId, "archive", ws.id))).toBe(false);
+  });
+
+  it("throws NotFoundError for an unknown id", async () => {
+    await expect(deleteArchivedWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
   });
 });
 

--- a/backend/src/workspaces/workspace-manager.test.ts
+++ b/backend/src/workspaces/workspace-manager.test.ts
@@ -603,6 +603,32 @@ describe("restoreWorkspace", () => {
     expect((await getWorkspace(ws.id, dataDir))?.workspace.id).toBe(ws.id);
   });
 
+  it("allows retry after project persistence fails with all sessions already moved", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await writeSessionFixture(ws.id, "session-a");
+    await archiveWorkspace(ws.id, dataDir);
+    const save = vi.spyOn(stateStore, "saveProject").mockRejectedValueOnce(new Error("save failed"));
+    await expect(restoreWorkspace(ws.id, dataDir)).rejects.toThrow("save failed");
+    save.mockRestore();
+
+    await restoreWorkspace(ws.id, dataDir);
+    expect((await listWorkspaceSessions(ws.id, dataDir)).map((s) => s.sessionId)).toEqual(["session-a"]);
+    expect(await listWorkspaces(projectId, dataDir)).toHaveLength(1);
+  });
+
+  it("hides and protects a residual archive of an active workspace", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    // Leftover archive metadata for a live workspace (archive cleanup that
+    // never completed) must neither be listed nor deletable.
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+    await mkdir(archiveDir, { recursive: true });
+    await writeFile(join(archiveDir, "workspace.json"), JSON.stringify(ws), "utf-8");
+
+    expect(await listArchivedWorkspaceItems(projectId, dataDir)).toEqual([]);
+    await expect(deleteArchivedWorkspace(ws.id, dataDir)).rejects.toThrow("active workspace");
+    expect(existsSync(archiveDir)).toBe(true);
+  });
+
   it("refuses when the branch was deleted and keeps the archive", async () => {
     const ws = await createWorkspace(projectId, dataDir);
     await archiveWorkspace(ws.id, dataDir);
@@ -698,6 +724,20 @@ describe("deleteArchivedWorkspace", () => {
 
   it("throws NotFoundError for an unknown id", async () => {
     await expect(deleteArchivedWorkspace("nonexistent", dataDir)).rejects.toThrow("not found");
+  });
+
+  it("only resolves listed archive ids, never a path built from the request", async () => {
+    const ws = await createWorkspace(projectId, dataDir);
+    await archiveWorkspace(ws.id, dataDir);
+    const archiveDir = join(dataDir, projectId, "archive", ws.id);
+
+    // Both ids name existing directories once joined under archive/; the
+    // project dir must survive the delete attempt.
+    await expect(deleteArchivedWorkspace("..", dataDir)).rejects.toThrow("not found");
+    await expect(deleteArchivedWorkspace(`../archive/${ws.id}`, dataDir)).rejects.toThrow("not found");
+    await expect(restoreWorkspace(`../archive/${ws.id}`, dataDir)).rejects.toThrow("not found");
+    expect(existsSync(archiveDir)).toBe(true);
+    expect(existsSync(join(dataDir, projectId, "state.json"))).toBe(true);
   });
 });
 

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -1,5 +1,5 @@
-import type { Stats } from "node:fs";
-import { readdir, readFile, stat, mkdir, writeFile, rename } from "node:fs/promises";
+import type { Dirent, Stats } from "node:fs";
+import { readdir, readFile, stat, mkdir, writeFile, rename, rm } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { nanoid } from "nanoid";
 import { git } from "../utils/git.js";
@@ -28,7 +28,73 @@ import { copyProjectEnvToWorkspace } from "../state/project-env.js";
 import { BadRequestError, ConflictError, NotFoundError } from "../utils/errors.js";
 import { stopAllForWorkspace } from "../services/script-runner.js";
 import { stopAllTerminalsForWorkspace } from "../services/terminal-runner.js";
-import type { Workspace, WorkspaceSource, CreateWorkspaceSourceInput, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffScope, DiffResponse, DiffStatResponse } from "../types.js";
+import type { Workspace, ArchivedWorkspace, ArchivedWorkspaceItem, WorkspaceSource, CreateWorkspaceSourceInput, ProjectState, WorkspaceFileTreeNode, DiffFileStat, DiffFileStatus, DiffScope, DiffResponse, DiffStatResponse } from "../types.js";
+
+/**
+ * Read the archived workspace metadata of a project. Entries written before
+ * `archivedAt` existed get the archive directory's mtime instead.
+ */
+export async function listArchivedWorkspaces(
+  projectId: string,
+  dataDir = getDataDir(),
+): Promise<ArchivedWorkspace[]> {
+  const archiveRoot = join(dataDir, projectId, "archive");
+  let entries: string[];
+  try {
+    entries = await readdir(archiveRoot);
+  } catch {
+    return [];
+  }
+  const archived: ArchivedWorkspace[] = [];
+  for (const entry of entries) {
+    const dir = join(archiveRoot, entry);
+    try {
+      const raw = await readFile(join(dir, "workspace.json"), "utf-8");
+      const meta = JSON.parse(raw) as Workspace & { archivedAt?: string };
+      if (typeof meta.id !== "string" || typeof meta.name !== "string") continue;
+      const archivedAt = meta.archivedAt ?? (await stat(dir)).mtime.toISOString();
+      archived.push({ ...meta, archivedAt });
+    } catch {
+      // Skip entries without readable metadata
+    }
+  }
+  return archived;
+}
+
+async function localBranchExists(bare: string, branch: string): Promise<boolean> {
+  return git(["show-ref", "--verify", "--quiet", `refs/heads/${branch}`], bare)
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Archived workspaces of a project as the API exposes them, newest first,
+ * flagged with whether their kept branch still exists in the bare repo.
+ */
+export async function listArchivedWorkspaceItems(
+  projectId: string,
+  dataDir = getDataDir(),
+): Promise<ArchivedWorkspaceItem[]> {
+  const state = await loadProject(projectId, dataDir);
+  if (!state) throw new NotFoundError(`Project ${projectId} not found`);
+  const bare = bareRepoPath(dataDir, projectId);
+  const archived = await listArchivedWorkspaces(projectId, dataDir);
+  const items = await Promise.all(
+    archived.map(async (ws) => {
+      const branchExists = await localBranchExists(bare, ws.branch);
+      return {
+        id: ws.id,
+        name: ws.name,
+        branch: ws.branch,
+        source: ws.source,
+        archivedAt: ws.archivedAt,
+        branchExists,
+        deletesBranch: branchExists && !keepsBranchOnDelete(ws),
+      };
+    }),
+  );
+  return items.sort((a, b) => b.archivedAt.localeCompare(a.archivedAt));
+}
 
 function findWorkspace(state: ProjectState, wsId: string): Workspace | undefined {
   return state.workspaces.find((ws) => ws.id === wsId);
@@ -106,10 +172,7 @@ async function addWorktreeOnBranch(
   branch: string,
   fetchedRef: string | null,
 ): Promise<void> {
-  const hasLocal = await git(["show-ref", "--verify", `refs/heads/${branch}`], bare)
-    .then(() => true)
-    .catch(() => false);
-  if (hasLocal) {
+  if (await localBranchExists(bare, branch)) {
     if (fetchedRef) {
       // Fast-forward to the remote tip when possible; keep a diverged local ref.
       try {
@@ -173,10 +236,7 @@ async function checkoutPullRequestHead(
     // A stale pr/<n> branch (e.g. from an archived workspace) may only be
     // reset when the PR head already contains its commits; otherwise deleting
     // it would destroy unpushed local work.
-    const hasStale = await git(["show-ref", "--verify", `refs/heads/${branch}`], bare)
-      .then(() => true)
-      .catch(() => false);
-    if (hasStale) {
+    if (await localBranchExists(bare, branch)) {
       try {
         await git(["merge-base", "--is-ancestor", `refs/heads/${branch}`, fetchedRef], bare);
       } catch {
@@ -222,8 +282,10 @@ export async function createWorkspace(
 
       const bare = bareRepoPath(dataDir, projectId);
 
-      // Archived workspaces keep their workspace/<city> branch for restore;
-      // exclude those cities too or `worktree add -b` collides. Full refnames
+      // Archived workspaces reserve their city so a restore lands on the
+      // original path, whatever branch they were on. The workspace/<city>
+      // ref scan additionally covers branches that outlived their archive,
+      // where `worktree add -b` would collide. Full refnames
       // (%(refname:short) is ambiguous next to a same-named tag), first path
       // segment only (a nested workspace/<city>/x ref blocks workspace/<city>).
       const { stdout: branchRefs } = await git(
@@ -234,7 +296,8 @@ export async function createWorkspace(
         .split("\n")
         .filter(Boolean)
         .map((ref) => ref.slice("refs/heads/workspace/".length).split("/")[0]);
-      const usedNames = [...state.workspaces.map((ws) => ws.name), ...branchCities];
+      const archivedNames = (await listArchivedWorkspaces(projectId, dataDir)).map((ws) => ws.name);
+      const usedNames = [...state.workspaces.map((ws) => ws.name), ...branchCities, ...archivedNames];
       const cityName = pickCityName(usedNames);
       const wsPath = join(workspacesDir(dataDir, projectId), cityName);
 
@@ -339,6 +402,25 @@ export async function getWorkspace(
   return { projectState: found.state, workspace: found.workspace };
 }
 
+/**
+ * Branches that pre-existed the workspace (created from an existing branch or
+ * a same-repo PR head) outlive it. Cross-repo PR checkouts live on the
+ * Hive-owned `pr/<n>` branch and are deleted with the workspace.
+ */
+function keepsBranchOnDelete(workspace: Pick<Workspace, "branch" | "source">): boolean {
+  const src = workspace.source;
+  return src?.kind === "branch" || (src?.kind === "pr" && workspace.branch !== prBranchName(src.number!));
+}
+
+async function deleteOwnedBranch(bare: string, workspace: Pick<Workspace, "branch" | "source">): Promise<void> {
+  if (keepsBranchOnDelete(workspace)) return;
+  try {
+    await git(["branch", "-D", workspace.branch], bare);
+  } catch {
+    // Branch may not exist
+  }
+}
+
 export async function deleteWorkspace(
   wsId: string,
   dataDir = getDataDir()
@@ -364,21 +446,7 @@ export async function deleteWorkspace(
       // Remove the worktree
       await removeWorktreeOrDeleteDirectory(bare, wsPath);
 
-      // Remove the branch — but keep branches that pre-existed the workspace
-      // (created from an existing branch or a same-repo PR head). Cross-repo PR
-      // checkouts live on the Hive-owned `pr/<n>` branch and are deleted with
-      // the workspace.
-      const src = workspace.source;
-      const keepBranch =
-        src?.kind === "branch" ||
-        (src?.kind === "pr" && workspace.branch !== prBranchName(src.number!));
-      if (!keepBranch) {
-        try {
-          await git(["branch", "-D", workspace.branch], bare);
-        } catch {
-          // Branch may not exist
-        }
-      }
+      await deleteOwnedBranch(bare, workspace);
 
       // Update state
       latest.workspaces = latest.workspaces.filter((ws) => ws.id !== wsId);
@@ -415,9 +483,10 @@ export async function archiveWorkspace(
       await mkdir(archiveDir, { recursive: true });
 
       // Save workspace metadata
+      const archived: ArchivedWorkspace = { ...workspace, archivedAt: new Date().toISOString() };
       await writeFile(
         join(archiveDir, "workspace.json"),
-        JSON.stringify(workspace, null, 2),
+        JSON.stringify(archived, null, 2),
         "utf-8",
       );
 
@@ -452,6 +521,119 @@ export async function archiveWorkspace(
       // Update state — remove workspace from project
       latest.workspaces = latest.workspaces.filter((ws) => ws.id !== wsId);
       await saveProject(latest, dataDir);
+    },
+    dataDir,
+  );
+}
+
+/** Archives are keyed by workspace id under each project; find the owning project. */
+async function findArchiveProjectId(wsId: string, dataDir: string): Promise<string | undefined> {
+  for (const project of await loadAllProjects(dataDir)) {
+    const entry = await stat(join(dataDir, project.id, "archive", wsId)).catch(() => null);
+    if (entry?.isDirectory()) return project.id;
+  }
+  return undefined;
+}
+
+async function readArchivedWorkspace(archiveDir: string, wsId: string): Promise<ArchivedWorkspace> {
+  try {
+    return JSON.parse(await readFile(join(archiveDir, "workspace.json"), "utf-8"));
+  } catch {
+    throw new NotFoundError(`Archived workspace ${wsId} not found`);
+  }
+}
+
+/**
+ * Permanently drop an archived workspace: its metadata, its archived
+ * sessions, and the kept branch unless it pre-existed the workspace. Frees
+ * the city name for new workspaces.
+ */
+export async function deleteArchivedWorkspace(
+  wsId: string,
+  dataDir = getDataDir(),
+): Promise<void> {
+  const projectId = await findArchiveProjectId(wsId, dataDir);
+  if (!projectId) throw new NotFoundError(`Archived workspace ${wsId} not found`);
+
+  await withProjectStateLock(
+    projectId,
+    async () => {
+      const archiveDir = join(dataDir, projectId, "archive", wsId);
+      const archived = await readArchivedWorkspace(archiveDir, wsId);
+      await deleteOwnedBranch(bareRepoPath(dataDir, projectId), archived);
+      await rm(archiveDir, { recursive: true, force: true });
+    },
+    dataDir,
+  );
+}
+
+/**
+ * Bring an archived workspace back under its original id, name, and branch:
+ * recreate the worktree, move its sessions back, re-add it to the project
+ * state, and drop the archive directory.
+ */
+export async function restoreWorkspace(
+  wsId: string,
+  dataDir = getDataDir(),
+): Promise<Workspace> {
+  const projectId = await findArchiveProjectId(wsId, dataDir);
+  if (!projectId) throw new NotFoundError(`Archived workspace ${wsId} not found`);
+
+  return withProjectStateLock(
+    projectId,
+    async () => {
+      const latest = await loadProject(projectId, dataDir);
+      if (!latest) throw new NotFoundError(`Project ${projectId} not found`);
+
+      const archiveDir = join(dataDir, projectId, "archive", wsId);
+      const archived = await readArchivedWorkspace(archiveDir, wsId);
+
+      const bare = bareRepoPath(dataDir, projectId);
+      const wsPath = join(workspacesDir(dataDir, projectId), archived.name);
+
+      // All guards run before anything is mutated.
+      if (!(await localBranchExists(bare, archived.branch))) {
+        throw new ConflictError(
+          `Branch "${archived.branch}" no longer exists; the workspace cannot be restored`,
+        );
+      }
+      if (await stat(wsPath).catch(() => null)) {
+        throw new ConflictError(`Workspace path "${archived.name}" is already in use`);
+      }
+      await assertBranchNotCheckedOut(latest, bare, archived.branch, dataDir);
+
+      await addWorktreeFromBranch(bare, wsPath, archived.branch);
+
+      const { archivedAt: _archivedAt, ...kept } = archived;
+      const workspace: Workspace = { ...kept, projectId, status: "idle" };
+      try {
+        await copyProjectEnvToWorkspace(projectId, wsPath, dataDir);
+
+        // Move session directories back next to the project's live sessions
+        const archivedSessionsDir = join(archiveDir, "sessions");
+        const sessionsRoot = join(dataDir, projectId, "sessions");
+        let entries: Dirent[] = [];
+        try {
+          entries = await readdir(archivedSessionsDir, { withFileTypes: true });
+        } catch {
+          // No archived sessions
+        }
+        if (entries.length > 0) await mkdir(sessionsRoot, { recursive: true });
+        for (const entry of entries) {
+          if (!entry.isDirectory()) continue;
+          await rename(join(archivedSessionsDir, entry.name), join(sessionsRoot, entry.name));
+        }
+
+        latest.workspaces.push(workspace);
+        await saveProject(latest, dataDir);
+      } catch (err) {
+        // Keep the archive intact when a post-worktree step fails
+        await removeWorktreeOrDeleteDirectory(bare, wsPath);
+        throw err;
+      }
+
+      await rm(archiveDir, { recursive: true, force: true });
+      return workspace;
     },
     dataDir,
   );

--- a/backend/src/workspaces/workspace-manager.ts
+++ b/backend/src/workspaces/workspace-manager.ts
@@ -80,7 +80,7 @@ export async function listArchivedWorkspaceItems(
   const bare = bareRepoPath(dataDir, projectId);
   const archived = await listArchivedWorkspaces(projectId, dataDir);
   const items = await Promise.all(
-    archived.map(async (ws) => {
+    archived.filter((ws) => !findWorkspace(state, ws.id)).map(async (ws) => {
       const branchExists = await localBranchExists(bare, ws.branch);
       return {
         id: ws.id,
@@ -526,11 +526,14 @@ export async function archiveWorkspace(
   );
 }
 
-/** Archives are keyed by workspace id under each project; find the owning project. */
+/**
+ * Find the project owning an archive. Matching against the listed archive ids
+ * keeps a request-supplied id from naming any path outside the archive root.
+ */
 async function findArchiveProjectId(wsId: string, dataDir: string): Promise<string | undefined> {
   for (const project of await loadAllProjects(dataDir)) {
-    const entry = await stat(join(dataDir, project.id, "archive", wsId)).catch(() => null);
-    if (entry?.isDirectory()) return project.id;
+    const archived = await listArchivedWorkspaces(project.id, dataDir);
+    if (archived.some((ws) => ws.id === wsId)) return project.id;
   }
   return undefined;
 }
@@ -559,6 +562,11 @@ export async function deleteArchivedWorkspace(
     projectId,
     async () => {
       const archiveDir = join(dataDir, projectId, "archive", wsId);
+      const state = await loadProject(projectId, dataDir);
+      if (!state) throw new NotFoundError(`Project ${projectId} not found`);
+      if (findWorkspace(state, wsId)) {
+        throw new ConflictError("Cannot delete the archive of an active workspace");
+      }
       const archived = await readArchivedWorkspace(archiveDir, wsId);
       await deleteOwnedBranch(bareRepoPath(dataDir, projectId), archived);
       await rm(archiveDir, { recursive: true, force: true });
@@ -615,8 +623,8 @@ export async function restoreWorkspace(
         let entries: Dirent[] = [];
         try {
           entries = await readdir(archivedSessionsDir, { withFileTypes: true });
-        } catch {
-          // No archived sessions
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
         }
         if (entries.length > 0) await mkdir(sessionsRoot, { recursive: true });
         for (const entry of entries) {
@@ -627,7 +635,8 @@ export async function restoreWorkspace(
         latest.workspaces.push(workspace);
         await saveProject(latest, dataDir);
       } catch (err) {
-        // Keep the archive intact when a post-worktree step fails
+        // Keep the archive metadata when a post-worktree step fails. Sessions
+        // already moved stay in place; the next restore attempt completes them.
         await removeWorktreeOrDeleteDirectory(bare, wsPath);
         throw err;
       }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -54,6 +54,9 @@ $DATA_DIR/
     |       |-- messages.jsonl
     |       `-- attachments/
     |-- archive/
+    |   `-- <workspace-id>/
+    |       |-- workspace.json
+    |       `-- sessions/
     `-- logs/
 ```
 
@@ -64,8 +67,8 @@ Public backend surface exposed by route modules under `backend/src/api/`.
 | Area | Endpoints |
 |---|---|
 | Health | `GET /health` |
-| Projects | `GET/POST /api/projects`, `GET/DELETE /api/projects/:id`, `POST /api/projects/:id/fetch`, `GET /api/projects/:id/favicon`, `GET/PUT /api/projects/:id/env` |
-| Workspaces | `GET/POST /api/projects/:id/workspaces` (POST accepts an optional `source`: branch, PR, or issue), `GET /api/projects/:id/branches`, `GET /api/projects/:id/pulls`, `GET /api/projects/:id/issues`, `GET/DELETE /api/workspaces/:wsId`, `GET /api/workspaces/:wsId/files`, `GET /api/workspaces/:wsId/file`, `GET /api/workspaces/:wsId/file/raw`, `GET /api/workspaces/:wsId/file-completions`, `GET /api/workspaces/:wsId/diff`, `GET /api/workspaces/:wsId/diff/stat`, `POST /api/workspaces/:wsId/merge`, `POST /api/workspaces/:wsId/archive` |
+| Projects | `GET/POST /api/projects`, `GET/DELETE /api/projects/:id`, `POST /api/projects/:id/fetch`, `GET /api/projects/:id/favicon`, `GET/PUT /api/projects/:id/env`, `GET /api/projects/:id/archives` |
+| Workspaces | `GET/POST /api/projects/:id/workspaces` (POST accepts an optional `source`: branch, PR, or issue), `GET /api/projects/:id/branches`, `GET /api/projects/:id/pulls`, `GET /api/projects/:id/issues`, `GET/DELETE /api/workspaces/:wsId`, `GET /api/workspaces/:wsId/files`, `GET /api/workspaces/:wsId/file`, `GET /api/workspaces/:wsId/file/raw`, `GET /api/workspaces/:wsId/file-completions`, `GET /api/workspaces/:wsId/diff`, `GET /api/workspaces/:wsId/diff/stat`, `POST /api/workspaces/:wsId/merge`, `POST/DELETE /api/workspaces/:wsId/archive`, `POST /api/workspaces/:wsId/restore` |
 | Sessions | `GET/POST/DELETE /api/workspaces/:wsId/session`, `GET /api/workspaces/:wsId/session/messages`, `GET/POST /api/workspaces/:wsId/sessions`, `POST /api/workspaces/:wsId/sessions/:sessionId/convert-to-terminal`, `DELETE /api/workspaces/:wsId/sessions/:sessionId`, `GET /api/workspaces/:wsId/sessions/:sessionId/messages`, `GET /api/workspaces/:wsId/sessions/:sessionId/attachments/:filename` |
 | Brain | `GET/POST/DELETE /api/brain`, `GET /api/brain/files`, `GET/PUT /api/brain/file`, `GET /api/brain/file/raw`, `GET /api/brain/status`, `GET /api/brain/diff`, `POST /api/brain/save` |
 | Models & usage | `GET /api/models`, `GET /api/provider-usage` |

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import AppLayout from "@/components/AppLayout";
 import AddProjectDialog from "@/components/AddProjectDialog";
 import WorkspaceLauncher from "@/components/WorkspaceLauncher";
+import RestoreWorkspaceDialog from "@/components/RestoreWorkspaceDialog";
 import HomeView from "@/pages/HomeView";
 import NotificationSettings from "@/pages/settings/NotificationSettings";
 import { useProjects } from "@/hooks/useProjects";
@@ -116,6 +117,7 @@ function ConfiguredApp({
   // "New workspace from…" picker — owned here so both the global shortcuts
   // (WorkspaceLauncher) and the sidebar "+" context menu can open it.
   const [workspaceFrom, setWorkspaceFrom] = useState<{ open: boolean; projectId?: string }>({ open: false });
+  const [restoreWorkspace, setRestoreWorkspace] = useState<{ open: boolean; projectId?: string }>({ open: false });
   const workspaceIds = useMemo(
     () =>
       Array.from(
@@ -157,6 +159,13 @@ function ConfiguredApp({
             setWorkspaceFrom((prev) => (open ? { ...prev, open: true } : { open: false }))
           }
         />
+        <RestoreWorkspaceDialog
+          open={restoreWorkspace.open}
+          projectId={restoreWorkspace.projectId}
+          onOpenChange={(open) =>
+            setRestoreWorkspace((prev) => (open ? { ...prev, open: true } : { open: false }))
+          }
+        />
         <NotificationToastsBridge projects={projects} />
         <ServerUpdatePrompt />
         <AddProjectDialog
@@ -185,6 +194,7 @@ function ConfiguredApp({
                   onAddProject={() => setShowAddProject(true)}
                   onAddAutomation={() => setShowAddAutomation(true)}
                   onNewWorkspaceFrom={(projectId) => setWorkspaceFrom({ open: true, projectId })}
+                  onRestoreWorkspace={(projectId) => setRestoreWorkspace({ open: true, projectId })}
                 />
               }
             >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,6 @@ import { useQueryClient } from "@tanstack/react-query";
 import AppLayout from "@/components/AppLayout";
 import AddProjectDialog from "@/components/AddProjectDialog";
 import WorkspaceLauncher from "@/components/WorkspaceLauncher";
-import RestoreWorkspaceDialog from "@/components/RestoreWorkspaceDialog";
 import HomeView from "@/pages/HomeView";
 import NotificationSettings from "@/pages/settings/NotificationSettings";
 import { useProjects } from "@/hooks/useProjects";
@@ -158,11 +157,9 @@ function ConfiguredApp({
           onPickerOpenChange={(open) =>
             setWorkspaceFrom((prev) => (open ? { ...prev, open: true } : { open: false }))
           }
-        />
-        <RestoreWorkspaceDialog
-          open={restoreWorkspace.open}
-          projectId={restoreWorkspace.projectId}
-          onOpenChange={(open) =>
+          restoreOpen={restoreWorkspace.open}
+          restoreProjectId={restoreWorkspace.projectId}
+          onRestoreOpenChange={(open) =>
             setRestoreWorkspace((prev) => (open ? { ...prev, open: true } : { open: false }))
           }
         />

--- a/frontend/src/components/AppLayout.tsx
+++ b/frontend/src/components/AppLayout.tsx
@@ -76,6 +76,7 @@ interface AppLayoutProps {
   isResyncing?: boolean;
   onAddProject: () => void;
   onNewWorkspaceFrom?: (projectId: string) => void;
+  onRestoreWorkspace?: (projectId: string) => void;
   onAddAutomation?: () => void;
 }
 
@@ -84,6 +85,7 @@ export default function AppLayout({
   onAddProject,
   onAddAutomation,
   onNewWorkspaceFrom,
+  onRestoreWorkspace,
 }: AppLayoutProps) {
   const { pathname } = useLocation();
   const isSettings = pathname.startsWith("/settings");
@@ -175,6 +177,7 @@ export default function AppLayout({
               onAddProject={onAddProject}
               onAddAutomation={onAddAutomation}
               onNewWorkspaceFrom={onNewWorkspaceFrom}
+              onRestoreWorkspace={onRestoreWorkspace}
             />
           )}
         </Panel>

--- a/frontend/src/components/RestoreWorkspaceDialog.tsx
+++ b/frontend/src/components/RestoreWorkspaceDialog.tsx
@@ -226,8 +226,9 @@ export default function RestoreWorkspaceDialog({
                     <Button
                       variant="ghost"
                       size="icon-xs"
+                      // Same affordance as the sidebar archive button: muted, red on hover.
                       className={cn(
-                        "shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/row:opacity-100",
+                        "shrink-0 text-muted-foreground opacity-0 transition-[opacity,color] hover:bg-transparent hover:text-destructive focus-visible:opacity-100 group-hover/row:opacity-100",
                         selected && "opacity-100",
                       )}
                       disabled={restoringId !== null || deleteArchive.isPending}

--- a/frontend/src/components/RestoreWorkspaceDialog.tsx
+++ b/frontend/src/components/RestoreWorkspaceDialog.tsx
@@ -1,7 +1,7 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
-import { CircleDot, GitPullRequest, Trash2 } from "lucide-react";
+import { ChevronDownIcon, CircleDot, GitBranch, GitPullRequest, SearchIcon, Trash2 } from "lucide-react";
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import {
   AlertDialog,
@@ -14,10 +14,17 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { SPOTLIGHT_DIALOG_CLASS, SPOTLIGHT_LIST_CLASS } from "@/components/ui/command";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from "@/components/ui/dropdown-menu";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { cn } from "@/lib/utils";
 import { formatRelativeTime } from "@/lib/time";
+import { useProjects } from "@/hooks/useProjects";
 import {
   useArchivedWorkspaces,
   useDeleteArchivedWorkspace,
@@ -28,33 +35,60 @@ import type { ArchivedWorkspaceItem } from "@/types";
 interface RestoreWorkspaceDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  projectId?: string;
+  defaultProjectId?: string;
 }
 
-function SourceBadge({ source }: { source: ArchivedWorkspaceItem["source"] }) {
-  if (!source?.number || (source.kind !== "pr" && source.kind !== "issue")) return null;
-  const Icon = source.kind === "pr" ? GitPullRequest : CircleDot;
-  return (
-    <>
-        <Icon className="size-3.5 shrink-0 text-pr-open" />
-        <span className="shrink-0 tabular-nums">#{source.number}</span>
-    </>
-  );
+function RowIcon({ source }: { source: ArchivedWorkspaceItem["source"] }) {
+  if (source?.kind === "pr") return <GitPullRequest className="size-4 shrink-0 text-pr-open" />;
+  if (source?.kind === "issue") return <CircleDot className="size-4 shrink-0 text-pr-open" />;
+  return <GitBranch className="size-4 shrink-0 text-muted-foreground" />;
 }
 
-/** Lists a project's archived workspaces; each can be restored from its kept branch or permanently deleted. */
-export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }: RestoreWorkspaceDialogProps) {
+/** Spotlight picker: restore an archived workspace from its kept branch, or delete it for good. */
+export default function RestoreWorkspaceDialog({
+  open,
+  onOpenChange,
+  defaultProjectId,
+}: RestoreWorkspaceDialogProps) {
   const navigate = useNavigate();
-  const archives = useArchivedWorkspaces(projectId, open);
-  const restore = useRestoreWorkspace(projectId);
-  const deleteArchive = useDeleteArchivedWorkspace(projectId);
+  const { projects } = useProjects();
+  const [projectId, setProjectId] = useState<string | undefined>(undefined);
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
   const [deleteTarget, setDeleteTarget] = useState<ArchivedWorkspaceItem | null>(null);
-  const items = archives.data ?? [];
+  const inputRef = useRef<HTMLInputElement>(null);
 
-  async function handleRestore(wsId: string) {
-    if (restore.isPending) return;
+  const activeProjectId = projectId ?? defaultProjectId ?? projects[0]?.id;
+  const activeProject = projects.find((p) => p.id === activeProjectId);
+  const archives = useArchivedWorkspaces(activeProjectId, open);
+  const restore = useRestoreWorkspace(activeProjectId);
+  const deleteArchive = useDeleteArchivedWorkspace(activeProjectId);
+  const restoringId = restore.isPending ? restore.variables : null;
+
+  useEffect(() => {
+    if (!open) return;
+    setProjectId(undefined);
+    setQuery("");
+    setSelectedIndex(0);
+  }, [open]);
+
+  const normalizedQuery = query.trim().replace(/^#/, "").toLowerCase();
+  const rows = useMemo(
+    () =>
+      (archives.data ?? []).filter(
+        (item) =>
+          !normalizedQuery ||
+          [item.name, item.branch, item.source?.number]
+            .some((f) => f !== undefined && String(f).toLowerCase().includes(normalizedQuery)),
+      ),
+    [archives.data, normalizedQuery],
+  );
+  const clampedIndex = Math.min(selectedIndex, Math.max(rows.length - 1, 0));
+
+  async function restoreRow(item: ArchivedWorkspaceItem) {
+    if (!item.branchExists || restoringId) return;
     try {
-      const workspace = await restore.mutateAsync(wsId);
+      const workspace = await restore.mutateAsync(item.id);
       onOpenChange(false);
       navigate(`/workspaces/${workspace.id}`);
     } catch (err) {
@@ -62,7 +96,7 @@ export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }
     }
   }
 
-  async function handleDelete(item: ArchivedWorkspaceItem) {
+  async function deleteRow(item: ArchivedWorkspaceItem) {
     setDeleteTarget(null);
     try {
       await deleteArchive.mutateAsync(item.id);
@@ -71,7 +105,19 @@ export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }
     }
   }
 
-  // Branches that pre-existed the workspace are kept; only mention removal when it will happen.
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setSelectedIndex((prev) => Math.min(prev + 1, rows.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setSelectedIndex((prev) => Math.max(prev - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      const row = rows[clampedIndex];
+      if (row) void restoreRow(row);
+    }
+  }
 
   return (
     <>
@@ -80,9 +126,59 @@ export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }
           className={cn(SPOTLIGHT_DIALOG_CLASS, "gap-0 bg-popover p-0 text-popover-foreground")}
           showCloseButton={false}
           aria-describedby={undefined}
+          onOpenAutoFocus={(e) => {
+            e.preventDefault();
+            inputRef.current?.focus();
+          }}
         >
-          <DialogTitle className="border-b px-3 py-3 text-sm font-medium">Restore workspace</DialogTitle>
-          <div className={cn(SPOTLIGHT_LIST_CLASS, "overflow-y-auto p-1")} role="list" aria-label="Archived workspaces">
+          <DialogTitle className="sr-only">Restore workspace</DialogTitle>
+          <div className="flex items-center gap-2 border-b px-3">
+            <SearchIcon className="size-4 shrink-0 opacity-50" />
+            <input
+              ref={inputRef}
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelectedIndex(0);
+              }}
+              onKeyDown={handleKeyDown}
+              placeholder="Search archived workspaces"
+              className="h-12 w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+              disabled={restoringId !== null}
+            />
+          </div>
+          <div
+            className={cn(
+              "flex items-center justify-between border-b px-3 py-2",
+              restoringId && "pointer-events-none opacity-50",
+            )}
+          >
+            <span className="px-1 text-xs font-medium text-muted-foreground">Archived workspaces</span>
+            {projects.length > 1 && (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="xs" className="text-muted-foreground hover:text-foreground">
+                    {activeProject?.name ?? "Select project"}
+                    <ChevronDownIcon className="ml-0.5 size-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[160px]">
+                  {projects.map((p) => (
+                    <DropdownMenuItem
+                      key={p.id}
+                      onSelect={() => {
+                        setProjectId(p.id);
+                        setSelectedIndex(0);
+                      }}
+                    >
+                      {p.name}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            )}
+          </div>
+          <div className={cn(SPOTLIGHT_LIST_CLASS, "overflow-y-auto p-1")} role="listbox" aria-label="Archived workspaces">
             {archives.isLoading ? (
               <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
                 <Spinner className="size-4" />
@@ -90,46 +186,55 @@ export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }
               </div>
             ) : archives.isError ? (
               <div className="py-8 text-center text-sm text-muted-foreground">Failed to load archived workspaces</div>
-            ) : items.length === 0 ? (
-              <div className="py-8 text-center text-sm text-muted-foreground">No archived workspaces</div>
+            ) : rows.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">
+                {normalizedQuery ? "No results found." : "No archived workspaces"}
+              </div>
             ) : (
-              items.map((item) => {
-                const isRestoring = restore.isPending && restore.variables === item.id;
+              rows.map((item, index) => {
+                const selected = index === clampedIndex;
+                const isRestoring = item.id === restoringId;
                 return (
+                  // The row hosts a nested delete button, so it cannot be a button itself.
                   <div
                     key={item.id}
-                    role="listitem"
+                    role="option"
+                    aria-selected={selected}
+                    aria-disabled={!item.branchExists || undefined}
                     className={cn(
-                      "flex w-full items-center gap-2 rounded-sm px-2 py-2 text-sm",
-                      !item.branchExists && "text-muted-foreground opacity-60",
+                      "group/row flex w-full cursor-pointer items-center gap-2 rounded-sm px-2 py-2 text-sm",
+                      selected && "bg-accent text-accent-foreground",
+                      !item.branchExists && "cursor-default text-muted-foreground",
+                      restoringId && !isRestoring && "opacity-50",
                     )}
+                    onMouseMove={() => setSelectedIndex(index)}
+                    onClick={() => void restoreRow(item)}
                   >
-                    <span className="min-w-0 truncate">{item.name}</span>
-                    <span className="flex min-w-0 items-center gap-1 truncate text-xs text-muted-foreground">
-                      <SourceBadge source={item.source} />
-                      <span className="truncate">{item.branch}</span>
-                      {!item.branchExists && <span className="shrink-0">· Branch missing</span>}
-                    </span>
+                    {isRestoring ? <Spinner className="size-4 shrink-0" /> : <RowIcon source={item.source} />}
+                    {item.source?.number && (
+                      <span className="shrink-0 tabular-nums text-muted-foreground">#{item.source.number}</span>
+                    )}
+                    <span className="min-w-0 shrink-0 truncate">{item.name}</span>
+                    <span className="min-w-0 truncate text-xs text-muted-foreground">{item.branch}</span>
                     <span className="ml-auto shrink-0 text-xs text-muted-foreground">
-                      {formatRelativeTime(item.archivedAt)}
+                      {isRestoring
+                        ? "Restoring…"
+                        : item.branchExists
+                          ? formatRelativeTime(item.archivedAt)
+                          : "Branch missing"}
                     </span>
-                    <Button
-                      variant="outline"
-                      size="xs"
-                      className="shrink-0"
-                      disabled={!item.branchExists || restore.isPending}
-                      onClick={() => void handleRestore(item.id)}
-                      aria-label={`Restore ${item.name}`}
-                    >
-                      {isRestoring && <Spinner className="size-3" />}
-                      Restore
-                    </Button>
                     <Button
                       variant="ghost"
                       size="icon-xs"
-                      className="shrink-0"
-                      disabled={deleteArchive.isPending}
-                      onClick={() => setDeleteTarget(item)}
+                      className={cn(
+                        "shrink-0 opacity-0 transition-opacity focus-visible:opacity-100 group-hover/row:opacity-100",
+                        selected && "opacity-100",
+                      )}
+                      disabled={restoringId !== null || deleteArchive.isPending}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteTarget(item);
+                      }}
                       aria-label={`Delete ${item.name}`}
                     >
                       <Trash2 />
@@ -156,7 +261,7 @@ export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }
             <AlertDialogAction
               variant="destructive"
               onClick={() => {
-                if (deleteTarget) void handleDelete(deleteTarget);
+                if (deleteTarget) void deleteRow(deleteTarget);
               }}
             >
               Delete

--- a/frontend/src/components/RestoreWorkspaceDialog.tsx
+++ b/frontend/src/components/RestoreWorkspaceDialog.tsx
@@ -1,0 +1,169 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
+import { CircleDot, GitPullRequest, Trash2 } from "lucide-react";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { SPOTLIGHT_DIALOG_CLASS, SPOTLIGHT_LIST_CLASS } from "@/components/ui/command";
+import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
+import { cn } from "@/lib/utils";
+import { formatRelativeTime } from "@/lib/time";
+import {
+  useArchivedWorkspaces,
+  useDeleteArchivedWorkspace,
+  useRestoreWorkspace,
+} from "@/hooks/useArchivedWorkspaces";
+import type { ArchivedWorkspaceItem } from "@/types";
+
+interface RestoreWorkspaceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  projectId?: string;
+}
+
+function SourceBadge({ source }: { source: ArchivedWorkspaceItem["source"] }) {
+  if (!source?.number || (source.kind !== "pr" && source.kind !== "issue")) return null;
+  const Icon = source.kind === "pr" ? GitPullRequest : CircleDot;
+  return (
+    <>
+        <Icon className="size-3.5 shrink-0 text-pr-open" />
+        <span className="shrink-0 tabular-nums">#{source.number}</span>
+    </>
+  );
+}
+
+/** Lists a project's archived workspaces; each can be restored from its kept branch or permanently deleted. */
+export default function RestoreWorkspaceDialog({ open, onOpenChange, projectId }: RestoreWorkspaceDialogProps) {
+  const navigate = useNavigate();
+  const archives = useArchivedWorkspaces(projectId, open);
+  const restore = useRestoreWorkspace(projectId);
+  const deleteArchive = useDeleteArchivedWorkspace(projectId);
+  const [deleteTarget, setDeleteTarget] = useState<ArchivedWorkspaceItem | null>(null);
+  const items = archives.data ?? [];
+
+  async function handleRestore(wsId: string) {
+    if (restore.isPending) return;
+    try {
+      const workspace = await restore.mutateAsync(wsId);
+      onOpenChange(false);
+      navigate(`/workspaces/${workspace.id}`);
+    } catch (err) {
+      toast.error(err instanceof Error && err.message ? err.message : "Failed to restore workspace");
+    }
+  }
+
+  async function handleDelete(item: ArchivedWorkspaceItem) {
+    setDeleteTarget(null);
+    try {
+      await deleteArchive.mutateAsync(item.id);
+    } catch (err) {
+      toast.error(err instanceof Error && err.message ? err.message : "Failed to delete archived workspace");
+    }
+  }
+
+  // Branches that pre-existed the workspace are kept; only mention removal when it will happen.
+
+  return (
+    <>
+      <Dialog open={open} onOpenChange={onOpenChange}>
+        <DialogContent
+          className={cn(SPOTLIGHT_DIALOG_CLASS, "gap-0 bg-popover p-0 text-popover-foreground")}
+          showCloseButton={false}
+          aria-describedby={undefined}
+        >
+          <DialogTitle className="border-b px-3 py-3 text-sm font-medium">Restore workspace</DialogTitle>
+          <div className={cn(SPOTLIGHT_LIST_CLASS, "overflow-y-auto p-1")} role="list" aria-label="Archived workspaces">
+            {archives.isLoading ? (
+              <div className="flex items-center justify-center gap-2 py-8 text-sm text-muted-foreground">
+                <Spinner className="size-4" />
+                Loading…
+              </div>
+            ) : archives.isError ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">Failed to load archived workspaces</div>
+            ) : items.length === 0 ? (
+              <div className="py-8 text-center text-sm text-muted-foreground">No archived workspaces</div>
+            ) : (
+              items.map((item) => {
+                const isRestoring = restore.isPending && restore.variables === item.id;
+                return (
+                  <div
+                    key={item.id}
+                    role="listitem"
+                    className={cn(
+                      "flex w-full items-center gap-2 rounded-sm px-2 py-2 text-sm",
+                      !item.branchExists && "text-muted-foreground opacity-60",
+                    )}
+                  >
+                    <span className="min-w-0 truncate">{item.name}</span>
+                    <span className="flex min-w-0 items-center gap-1 truncate text-xs text-muted-foreground">
+                      <SourceBadge source={item.source} />
+                      <span className="truncate">{item.branch}</span>
+                      {!item.branchExists && <span className="shrink-0">· Branch missing</span>}
+                    </span>
+                    <span className="ml-auto shrink-0 text-xs text-muted-foreground">
+                      {formatRelativeTime(item.archivedAt)}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="xs"
+                      className="shrink-0"
+                      disabled={!item.branchExists || restore.isPending}
+                      onClick={() => void handleRestore(item.id)}
+                      aria-label={`Restore ${item.name}`}
+                    >
+                      {isRestoring && <Spinner className="size-3" />}
+                      Restore
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon-xs"
+                      className="shrink-0"
+                      disabled={deleteArchive.isPending}
+                      onClick={() => setDeleteTarget(item)}
+                      aria-label={`Delete ${item.name}`}
+                    >
+                      <Trash2 />
+                    </Button>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={deleteTarget !== null} onOpenChange={(isOpen) => !isOpen && setDeleteTarget(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Delete archived workspace</AlertDialogTitle>
+            <AlertDialogDescription>
+              &quot;{deleteTarget?.name}&quot; and its conversations will be permanently deleted.
+              {deleteTarget?.deletesBranch && <> The branch &quot;{deleteTarget?.branch}&quot; will be removed too.</>}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              onClick={() => {
+                if (deleteTarget) void handleDelete(deleteTarget);
+              }}
+            >
+              Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -67,6 +67,7 @@ interface SidebarProps {
   onAddProject: () => void;
   onAddAutomation?: () => void;
   onNewWorkspaceFrom?: (projectId: string) => void;
+  onRestoreWorkspace?: (projectId: string) => void;
 }
 
 type SidebarDropTarget = { type: "folder"; folderId: string };
@@ -170,6 +171,7 @@ export default function Sidebar({
   onAddProject,
   onAddAutomation,
   onNewWorkspaceFrom,
+  onRestoreWorkspace,
 }: SidebarProps) {
   const {
     projects,
@@ -523,6 +525,7 @@ export default function Sidebar({
         projectInsertIndicator={projectInsertIndicator}
         onAddWorkspace={(projectId) => { void handleAddWorkspace(projectId); }}
         onAddWorkspaceFrom={onNewWorkspaceFrom}
+        onRestoreWorkspace={onRestoreWorkspace}
         onArchiveWorkspace={(wsId) => { void handleArchiveClick(wsId); }}
         onProjectDragStart={handleProjectDragStart}
         onProjectDragEnd={handleProjectDragEnd}

--- a/frontend/src/components/WorkspaceCommandPalette.tsx
+++ b/frontend/src/components/WorkspaceCommandPalette.tsx
@@ -1,4 +1,5 @@
 import {
+  ArchiveRestore,
   ArrowLeft,
   ArrowRight,
   ChevronLeft,
@@ -38,6 +39,7 @@ interface WorkspaceCommandPaletteProps {
 export type CommandPaletteAction =
   | "new-workspace"
   | "new-workspace-from"
+  | "restore-workspace"
   | "settings"
   | "zoom-in"
   | "zoom-out"
@@ -91,6 +93,11 @@ export function WorkspaceCommandPalette({
             <GitBranch />
             New workspace from…
             <CommandShortcut>{shortcutLabel("N", { shift: true })}</CommandShortcut>
+          </CommandItem>
+          <CommandItem onSelect={() => run("restore-workspace")}>
+            <ArchiveRestore />
+            Restore workspace…
+            <CommandShortcut>{shortcutLabel("T", { shift: true })}</CommandShortcut>
           </CommandItem>
         </CommandGroup>
         <CommandGroup heading="Conversation actions">

--- a/frontend/src/components/WorkspaceLauncher.tsx
+++ b/frontend/src/components/WorkspaceLauncher.tsx
@@ -5,6 +5,7 @@ import { WorkspaceCommandPalette } from "@/components/WorkspaceCommandPalette";
 import type { CommandPaletteAction } from "@/components/WorkspaceCommandPalette";
 import { ProjectPickerDialog } from "@/components/ProjectPickerDialog";
 import NewWorkspaceFromDialog from "@/components/NewWorkspaceFromDialog";
+import RestoreWorkspaceDialog from "@/components/RestoreWorkspaceDialog";
 import { useProjects } from "@/hooks/useProjects";
 import { useAppZoom } from "@/hooks/useAppZoom";
 import { dispatchAppCommand, subscribeAppCommand } from "@/lib/app-commands";
@@ -14,6 +15,10 @@ interface WorkspaceLauncherProps {
   pickerOpen: boolean;
   pickerProjectId?: string;
   onPickerOpenChange: (open: boolean) => void;
+  /** "Restore workspace…" picker state, owned by App for the same reason. */
+  restoreOpen: boolean;
+  restoreProjectId?: string;
+  onRestoreOpenChange: (open: boolean) => void;
 }
 
 /**
@@ -25,6 +30,9 @@ export default function WorkspaceLauncher({
   pickerOpen,
   pickerProjectId,
   onPickerOpenChange,
+  restoreOpen,
+  restoreProjectId,
+  onRestoreOpenChange,
 }: WorkspaceLauncherProps) {
   const [spotlightOpen, setSpotlightOpen] = useState(false);
   const [projectPickerOpen, setProjectPickerOpen] = useState(false);
@@ -71,9 +79,10 @@ export default function WorkspaceLauncher({
   const toggleSpotlight = useCallback(() => {
     dispatchAppCommand("dismiss-view-dialogs");
     onPickerOpenChange(false);
+    onRestoreOpenChange(false);
     setProjectPickerOpen(false);
     setSpotlightOpen((prev) => !prev);
-  }, [onPickerOpenChange]);
+  }, [onPickerOpenChange, onRestoreOpenChange]);
 
   // Lets the sidebar's search button open the palette without owning its state.
   useEffect(() => subscribeAppCommand("open-spotlight", toggleSpotlight), [toggleSpotlight]);
@@ -86,6 +95,9 @@ export default function WorkspaceLauncher({
         return;
       case "new-workspace-from":
         onPickerOpenChange(true);
+        return;
+      case "restore-workspace":
+        onRestoreOpenChange(true);
         return;
       case "toggle-sidebar":
         dispatchAppCommand("toggle-sidebar");
@@ -113,7 +125,7 @@ export default function WorkspaceLauncher({
       default:
         if (workspaceCommandsEnabled) dispatchAppCommand(command);
     }
-  }, [instantCreate, location.pathname, navigate, onPickerOpenChange, resetZoom, workspaceCommandsEnabled, zoomIn, zoomOut]);
+  }, [instantCreate, location.pathname, navigate, onPickerOpenChange, onRestoreOpenChange, resetZoom, workspaceCommandsEnabled, zoomIn, zoomOut]);
 
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
@@ -162,10 +174,11 @@ export default function WorkspaceLauncher({
         if (!workspaceCommandsEnabled) return;
         e.preventDefault();
         executeCommand("quick-open-file");
-      } else if (key === "t" && !e.shiftKey) {
-        if (!workspaceCommandsEnabled) return;
+      } else if (key === "t") {
+        // Shift+T restores an archived workspace, the app-level "reopen closed tab".
+        if (!e.shiftKey && !workspaceCommandsEnabled) return;
         e.preventDefault();
-        executeCommand("new-chat");
+        executeCommand(e.shiftKey ? "restore-workspace" : "new-chat");
       } else if (key === "g") {
         if (!workspaceCommandsEnabled) return;
         e.preventDefault();
@@ -193,6 +206,11 @@ export default function WorkspaceLauncher({
         open={pickerOpen}
         onOpenChange={onPickerOpenChange}
         defaultProjectId={pickerProjectId ?? contextProject?.id}
+      />
+      <RestoreWorkspaceDialog
+        open={restoreOpen}
+        onOpenChange={onRestoreOpenChange}
+        defaultProjectId={restoreProjectId ?? contextProject?.id}
       />
     </>
   );

--- a/frontend/src/components/sidebar/SidebarProjectItem.tsx
+++ b/frontend/src/components/sidebar/SidebarProjectItem.tsx
@@ -1,4 +1,4 @@
-import { GitBranch, Plus } from "lucide-react";
+import { ArchiveRestore, GitBranch, Plus } from "lucide-react";
 import { Collapsible, CollapsibleContent } from "@/components/ui/collapsible";
 import { ContextMenuItem } from "@/components/ui/context-menu";
 import { SidebarGroupHeader } from "@/components/sidebar/SidebarHeaders";
@@ -31,6 +31,7 @@ interface SidebarProjectItemProps {
   projectInsertIndicator: ProjectInsertIndicator;
   onAddWorkspace: (projectId: string) => void;
   onAddWorkspaceFrom?: (projectId: string) => void;
+  onRestoreWorkspace?: (projectId: string) => void;
   onArchiveWorkspace: (wsId: string) => void;
   onProjectDragStart: (event: React.DragEvent<HTMLButtonElement>, projectId: string) => void;
   onProjectDragEnd: () => void;
@@ -64,6 +65,7 @@ export function SidebarProjectItem({
   projectInsertIndicator,
   onAddWorkspace,
   onAddWorkspaceFrom,
+  onRestoreWorkspace,
   onArchiveWorkspace,
   onProjectDragStart,
   onProjectDragEnd,
@@ -120,6 +122,12 @@ export function SidebarProjectItem({
                   <GitBranch />
                   New workspace from…
                 </ContextMenuItem>
+                {onRestoreWorkspace && (
+                  <ContextMenuItem onSelect={() => onRestoreWorkspace(project.id)}>
+                    <ArchiveRestore />
+                    Restore workspace…
+                  </ContextMenuItem>
+                )}
               </>
             ) : undefined
           }

--- a/frontend/src/hooks/useArchivedWorkspaces.ts
+++ b/frontend/src/hooks/useArchivedWorkspaces.ts
@@ -17,9 +17,20 @@ export function useArchivedWorkspaces(projectId: string | undefined, enabled: bo
 export function useRestoreWorkspace(projectId: string | undefined) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: (wsId: string) => api.post<Workspace>(`/api/workspaces/${wsId}/restore`),
+    mutationFn: async (wsId: string) => {
+      const workspace = await api.post<Workspace>(`/api/workspaces/${wsId}/restore`);
+      // The picker keeps its row spinner until this settles, so land the
+      // sidebar row and warm the workspace view before the dialog closes.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: ["projects"] }),
+        queryClient.prefetchQuery({
+          queryKey: ["workspace", workspace.id],
+          queryFn: () => api.get<Workspace>(`/api/workspaces/${workspace.id}`),
+        }),
+      ]);
+      return workspace;
+    },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["projects"] });
       void queryClient.invalidateQueries({ queryKey: ["project-archives", projectId] });
       invalidateWorkspaceSources(queryClient, projectId);
     },

--- a/frontend/src/hooks/useArchivedWorkspaces.ts
+++ b/frontend/src/hooks/useArchivedWorkspaces.ts
@@ -1,0 +1,38 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "./useApi";
+import { invalidateWorkspaceSources } from "./useProjects";
+import type { ArchivedWorkspaceItem, Workspace } from "@/types";
+
+/** Archived workspaces of a project for the "Restore workspace…" dialog; fetched only while it is open. */
+export function useArchivedWorkspaces(projectId: string | undefined, enabled: boolean) {
+  return useQuery({
+    queryKey: ["project-archives", projectId],
+    queryFn: () => api.get<ArchivedWorkspaceItem[]>(`/api/projects/${projectId}/archives`),
+    enabled: enabled && !!projectId,
+    // No WS event announces archives made by other clients, so refetch on every open.
+    staleTime: 0,
+  });
+}
+
+export function useRestoreWorkspace(projectId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (wsId: string) => api.post<Workspace>(`/api/workspaces/${wsId}/restore`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["projects"] });
+      void queryClient.invalidateQueries({ queryKey: ["project-archives", projectId] });
+      invalidateWorkspaceSources(queryClient, projectId);
+    },
+  });
+}
+
+export function useDeleteArchivedWorkspace(projectId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (wsId: string) => api.delete<void>(`/api/workspaces/${wsId}/archive`),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ["project-archives", projectId] });
+      invalidateWorkspaceSources(queryClient, projectId);
+    },
+  });
+}

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import { useQuery, useMutation, useMutationState, useQueryClient } from "@tanstack/react-query";
+import { useQuery, useMutation, useMutationState, useQueryClient, type QueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { api } from "./useApi";
 import type { CreateWorkspaceSource, Project, Workspace } from "@/types";
@@ -83,15 +83,15 @@ function formatProjectsError(error: unknown): string {
   return "Unable to load repositories.";
 }
 
+/** Drop cached picker lists whose workspace annotations just changed. */
+export function invalidateWorkspaceSources(queryClient: QueryClient, projectId?: string) {
+  for (const key of ["project-branches", "project-pulls"]) {
+    void queryClient.invalidateQueries({ queryKey: projectId ? [key, projectId] : [key] });
+  }
+}
+
 export function useProjects() {
   const queryClient = useQueryClient();
-
-  /** Drop cached picker lists whose workspace annotations just changed. */
-  function invalidateWorkspaceSources(projectId?: string) {
-    for (const key of ["project-branches", "project-pulls"]) {
-      void queryClient.invalidateQueries({ queryKey: projectId ? [key, projectId] : [key] });
-    }
-  }
 
   const query = useQuery({
     queryKey: ["projects"],
@@ -166,7 +166,7 @@ export function useProjects() {
             : { ...p, workspaces: [...p.workspaces, workspace] },
         ) ?? [],
       );
-      invalidateWorkspaceSources(projectId);
+      invalidateWorkspaceSources(queryClient, projectId);
     },
   });
 
@@ -220,7 +220,8 @@ export function useProjects() {
           workspaces: p.workspaces.filter((ws) => ws.id !== wsId),
         })) ?? [],
       );
-      invalidateWorkspaceSources();
+      invalidateWorkspaceSources(queryClient);
+      void queryClient.invalidateQueries({ queryKey: ["project-archives"] });
     },
     onError: (err, _wsId, removed) => {
       toast.error(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -112,6 +112,19 @@ export interface WorkspaceSource {
   url?: string;
 }
 
+/** Row of `GET /api/projects/:id/archives`, sorted by `archivedAt` descending. */
+export interface ArchivedWorkspaceItem {
+  id: string;
+  name: string;
+  branch: string;
+  source?: WorkspaceSource;
+  archivedAt: string;
+  /** False when the kept branch no longer exists; restore is refused. */
+  branchExists: boolean;
+  /** True when deleting the archive also deletes the branch. */
+  deletesBranch: boolean;
+}
+
 /** Body of `POST /api/projects/:id/workspaces`. */
 export type CreateWorkspaceSource =
   | { kind: "branch"; branch: string }

--- a/frontend/tests/components/RestoreWorkspaceDialog.test.tsx
+++ b/frontend/tests/components/RestoreWorkspaceDialog.test.tsx
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import userEvent from "@testing-library/user-event";
+import RestoreWorkspaceDialog from "@/components/RestoreWorkspaceDialog";
+import type { ArchivedWorkspaceItem } from "@/types";
+
+const { apiGet, apiPost, apiDelete, toastError } = vi.hoisted(() => ({
+  apiGet: vi.fn(),
+  apiPost: vi.fn(),
+  apiDelete: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@/hooks/useApi", () => ({
+  api: { get: apiGet, post: apiPost, put: vi.fn(), patch: vi.fn(), delete: apiDelete },
+  ApiError: class ApiError extends Error {},
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: toastError, success: vi.fn() },
+}));
+
+const archives: ArchivedWorkspaceItem[] = [
+  {
+    id: "ws-new",
+    name: "lyon",
+    branch: "workspace/lyon",
+    source: { kind: "pr", number: 12 },
+    archivedAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    branchExists: true,
+    deletesBranch: true,
+  },
+  {
+    id: "ws-old",
+    name: "tokyo",
+    branch: "workspace/tokyo",
+    archivedAt: new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(),
+    branchExists: false,
+    deletesBranch: false,
+  },
+];
+
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-path">{location.pathname}</div>;
+}
+
+function renderDialog(onOpenChange = vi.fn()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/home"]}>
+        <Routes>
+          <Route
+            path="*"
+            element={
+              <>
+                <RestoreWorkspaceDialog open onOpenChange={onOpenChange} projectId="p1" />
+                <LocationProbe />
+              </>
+            }
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  return { onOpenChange, queryClient };
+}
+
+describe("RestoreWorkspaceDialog", () => {
+  beforeEach(() => {
+    apiGet.mockReset();
+    apiPost.mockReset();
+    apiDelete.mockReset();
+    toastError.mockReset();
+    apiGet.mockResolvedValue(archives);
+  });
+
+  it("lists archived workspaces in server order with branch details and archive time", async () => {
+    renderDialog();
+
+    await screen.findByText("lyon");
+    expect(apiGet).toHaveBeenCalledWith("/api/projects/p1/archives");
+
+    const rows = screen.getAllByRole("listitem");
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent("lyon");
+    expect(rows[0]).toHaveTextContent("#12");
+    expect(rows[0]).toHaveTextContent("workspace/lyon");
+    expect(rows[0]).toHaveTextContent("2h ago");
+    expect(rows[1]).toHaveTextContent("tokyo");
+    expect(rows[1]).toHaveTextContent("3d ago");
+  });
+
+  it("greys out a workspace whose branch is missing and disables its restore button", async () => {
+    renderDialog();
+
+    await screen.findByText("tokyo");
+    const rows = screen.getAllByRole("listitem");
+    expect(rows[1]).toHaveClass("opacity-60");
+    expect(rows[1]).toHaveTextContent("Branch missing");
+    expect(screen.getByRole("button", { name: "Restore tokyo" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Restore lyon" })).toBeEnabled();
+  });
+
+  it("shows an empty state when nothing is archived", async () => {
+    apiGet.mockResolvedValue([]);
+    renderDialog();
+
+    expect(await screen.findByText("No archived workspaces")).toBeInTheDocument();
+  });
+
+  it("shows an error when the list fails to load", async () => {
+    apiGet.mockRejectedValue(new Error("boom"));
+    renderDialog();
+
+    expect(await screen.findByText("Failed to load archived workspaces")).toBeInTheDocument();
+  });
+
+  it("restores a workspace, closes the dialog, and navigates to it", async () => {
+    apiPost.mockResolvedValue({ id: "ws-new", name: "lyon", branch: "workspace/lyon", status: "idle" });
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Restore lyon" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("location-path")).toHaveTextContent("/workspaces/ws-new");
+    });
+    expect(apiPost).toHaveBeenCalledWith("/api/workspaces/ws-new/restore");
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server error and keeps the dialog open when restore is refused", async () => {
+    apiPost.mockRejectedValue(new Error("Branch workspace/lyon is checked out elsewhere"));
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Restore lyon" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Branch workspace/lyon is checked out elsewhere");
+    });
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(screen.getByTestId("location-path")).toHaveTextContent("/home");
+    expect(screen.getByRole("button", { name: "Restore lyon" })).toBeEnabled();
+  });
+
+  it("asks for confirmation before deleting, naming the workspace and its branch", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Delete lyon" }));
+
+    const confirm = await screen.findByRole("alertdialog");
+    expect(confirm).toHaveTextContent("Delete archived workspace");
+    expect(confirm).toHaveTextContent('"lyon" and its conversations will be permanently deleted.');
+    expect(confirm).toHaveTextContent('The branch "workspace/lyon" will be removed too.');
+    expect(apiDelete).not.toHaveBeenCalled();
+  });
+
+  it("omits the branch sentence when the branch is already missing", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Delete tokyo" }));
+
+    const confirm = await screen.findByRole("alertdialog");
+    expect(confirm).toHaveTextContent('"tokyo" and its conversations will be permanently deleted.');
+    expect(confirm).not.toHaveTextContent("will be removed too");
+  });
+
+  it("deletes the archive on confirm and drops the row after refetch", async () => {
+    apiDelete.mockResolvedValue(undefined);
+    apiGet.mockResolvedValueOnce(archives).mockResolvedValue([archives[1]]);
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Delete lyon" }));
+    await user.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(screen.queryByText("lyon")).not.toBeInTheDocument();
+    });
+    expect(apiDelete).toHaveBeenCalledWith("/api/workspaces/ws-new/archive");
+    expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    expect(screen.getByText("tokyo")).toBeInTheDocument();
+    expect(onOpenChange).not.toHaveBeenCalled();
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it("sends nothing when the confirmation is cancelled", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Delete lyon" }));
+    await user.click(await screen.findByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("alertdialog")).not.toBeInTheDocument();
+    });
+    expect(apiDelete).not.toHaveBeenCalled();
+    expect(screen.getByText("lyon")).toBeInTheDocument();
+  });
+
+  it("surfaces the server error when deletion fails", async () => {
+    apiDelete.mockRejectedValue(new Error("Delete failed"));
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(await screen.findByRole("button", { name: "Delete lyon" }));
+    await user.click(await screen.findByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(toastError).toHaveBeenCalledWith("Delete failed");
+    });
+    expect(screen.getByText("lyon")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/RestoreWorkspaceDialog.test.tsx
+++ b/frontend/tests/components/RestoreWorkspaceDialog.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
 import RestoreWorkspaceDialog from "@/components/RestoreWorkspaceDialog";
-import type { ArchivedWorkspaceItem } from "@/types";
+import type { ArchivedWorkspaceItem, Project } from "@/types";
 
 const { apiGet, apiPost, apiDelete, toastError } = vi.hoisted(() => ({
   apiGet: vi.fn(),
@@ -42,6 +42,21 @@ const archives: ArchivedWorkspaceItem[] = [
   },
 ];
 
+const projects: Project[] = [
+  { id: "p1", name: "hive", createdAt: "2026-01-01T00:00:00.000Z", workspaces: [] },
+  { id: "p2", name: "blog", createdAt: "2026-01-01T00:00:00.000Z", workspaces: [] },
+];
+
+/** Routes the shared GET mock: the projects list stays stable, archives vary per test. */
+function mockArchives(...responses: Array<ArchivedWorkspaceItem[] | Error>) {
+  let call = 0;
+  apiGet.mockImplementation((url: string) => {
+    if (url === "/api/projects") return Promise.resolve(projects);
+    const response = responses[Math.min(call++, responses.length - 1)];
+    return response instanceof Error ? Promise.reject(response) : Promise.resolve(response);
+  });
+}
+
 function LocationProbe() {
   const location = useLocation();
   return <div data-testid="location-path">{location.pathname}</div>;
@@ -51,6 +66,7 @@ function renderDialog(onOpenChange = vi.fn()) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
+  queryClient.setQueryData(["projects"], projects);
   render(
     <QueryClientProvider client={queryClient}>
       <MemoryRouter initialEntries={["/home"]}>
@@ -59,7 +75,7 @@ function renderDialog(onOpenChange = vi.fn()) {
             path="*"
             element={
               <>
-                <RestoreWorkspaceDialog open onOpenChange={onOpenChange} projectId="p1" />
+                <RestoreWorkspaceDialog open onOpenChange={onOpenChange} defaultProjectId="p1" />
                 <LocationProbe />
               </>
             }
@@ -77,7 +93,7 @@ describe("RestoreWorkspaceDialog", () => {
     apiPost.mockReset();
     apiDelete.mockReset();
     toastError.mockReset();
-    apiGet.mockResolvedValue(archives);
+    mockArchives(archives);
   });
 
   it("lists archived workspaces in server order with branch details and archive time", async () => {
@@ -86,36 +102,69 @@ describe("RestoreWorkspaceDialog", () => {
     await screen.findByText("lyon");
     expect(apiGet).toHaveBeenCalledWith("/api/projects/p1/archives");
 
-    const rows = screen.getAllByRole("listitem");
+    const rows = screen.getAllByRole("option");
     expect(rows).toHaveLength(2);
     expect(rows[0]).toHaveTextContent("lyon");
     expect(rows[0]).toHaveTextContent("#12");
     expect(rows[0]).toHaveTextContent("workspace/lyon");
     expect(rows[0]).toHaveTextContent("2h ago");
     expect(rows[1]).toHaveTextContent("tokyo");
-    expect(rows[1]).toHaveTextContent("3d ago");
   });
 
-  it("greys out a workspace whose branch is missing and disables its restore button", async () => {
+  it("marks a workspace whose branch is missing and refuses to restore it", async () => {
+    const user = userEvent.setup();
     renderDialog();
 
     await screen.findByText("tokyo");
-    const rows = screen.getAllByRole("listitem");
-    expect(rows[1]).toHaveClass("opacity-60");
+    const rows = screen.getAllByRole("option");
+    expect(rows[1]).toHaveAttribute("aria-disabled", "true");
     expect(rows[1]).toHaveTextContent("Branch missing");
-    expect(screen.getByRole("button", { name: "Restore tokyo" })).toBeDisabled();
-    expect(screen.getByRole("button", { name: "Restore lyon" })).toBeEnabled();
+    expect(rows[1]).not.toHaveTextContent("3d ago");
+    expect(rows[0]).not.toHaveAttribute("aria-disabled");
+
+    await user.click(rows[1]);
+    expect(apiPost).not.toHaveBeenCalled();
+  });
+
+  it("filters rows by name, branch, or source number", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("lyon");
+    await user.type(screen.getByPlaceholderText("Search archived workspaces"), "tok");
+    expect(screen.getAllByRole("option")).toHaveLength(1);
+    expect(screen.getByRole("option")).toHaveTextContent("tokyo");
+
+    await user.clear(screen.getByPlaceholderText("Search archived workspaces"));
+    await user.type(screen.getByPlaceholderText("Search archived workspaces"), "#12");
+    expect(screen.getByRole("option")).toHaveTextContent("lyon");
+
+    await user.type(screen.getByPlaceholderText("Search archived workspaces"), "zzz");
+    expect(screen.getByText("No results found.")).toBeInTheDocument();
+  });
+
+  it("switches project from the header dropdown", async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await screen.findByText("lyon");
+    await user.click(screen.getByRole("button", { name: /hive/ }));
+    await user.click(await screen.findByRole("menuitem", { name: "blog" }));
+
+    await waitFor(() => {
+      expect(apiGet).toHaveBeenCalledWith("/api/projects/p2/archives");
+    });
   });
 
   it("shows an empty state when nothing is archived", async () => {
-    apiGet.mockResolvedValue([]);
+    mockArchives([]);
     renderDialog();
 
     expect(await screen.findByText("No archived workspaces")).toBeInTheDocument();
   });
 
   it("shows an error when the list fails to load", async () => {
-    apiGet.mockRejectedValue(new Error("boom"));
+    mockArchives(new Error("boom"));
     renderDialog();
 
     expect(await screen.findByText("Failed to load archived workspaces")).toBeInTheDocument();
@@ -126,7 +175,8 @@ describe("RestoreWorkspaceDialog", () => {
     const user = userEvent.setup();
     const { onOpenChange } = renderDialog();
 
-    await user.click(await screen.findByRole("button", { name: "Restore lyon" }));
+    await screen.findByText("lyon");
+    await user.keyboard("{Enter}");
 
     await waitFor(() => {
       expect(screen.getByTestId("location-path")).toHaveTextContent("/workspaces/ws-new");
@@ -141,14 +191,14 @@ describe("RestoreWorkspaceDialog", () => {
     const user = userEvent.setup();
     const { onOpenChange } = renderDialog();
 
-    await user.click(await screen.findByRole("button", { name: "Restore lyon" }));
+    await user.click(await screen.findByText("lyon"));
 
     await waitFor(() => {
       expect(toastError).toHaveBeenCalledWith("Branch workspace/lyon is checked out elsewhere");
     });
     expect(onOpenChange).not.toHaveBeenCalled();
     expect(screen.getByTestId("location-path")).toHaveTextContent("/home");
-    expect(screen.getByRole("button", { name: "Restore lyon" })).toBeEnabled();
+    expect(screen.getByPlaceholderText("Search archived workspaces")).toBeEnabled();
   });
 
   it("asks for confirmation before deleting, naming the workspace and its branch", async () => {
@@ -177,7 +227,7 @@ describe("RestoreWorkspaceDialog", () => {
 
   it("deletes the archive on confirm and drops the row after refetch", async () => {
     apiDelete.mockResolvedValue(undefined);
-    apiGet.mockResolvedValueOnce(archives).mockResolvedValue([archives[1]]);
+    mockArchives(archives, [archives[1]]);
     const user = userEvent.setup();
     const { onOpenChange } = renderDialog();
 

--- a/frontend/tests/components/Sidebar.test.tsx
+++ b/frontend/tests/components/Sidebar.test.tsx
@@ -131,6 +131,7 @@ function SettingsStateProbe() {
 }
 
 const onNewWorkspaceFromMock = vi.fn();
+const onRestoreWorkspaceMock = vi.fn();
 
 function SidebarRoute({ isResyncing = false }: { isResyncing?: boolean }) {
   const location = useLocation();
@@ -140,6 +141,7 @@ function SidebarRoute({ isResyncing = false }: { isResyncing?: boolean }) {
         isResyncing={isResyncing}
         onAddProject={vi.fn()}
         onNewWorkspaceFrom={onNewWorkspaceFromMock}
+        onRestoreWorkspace={onRestoreWorkspaceMock}
       />
       <div data-testid="location-path">{location.pathname}</div>
     </>
@@ -1289,6 +1291,19 @@ describe("Sidebar", () => {
 
     expect(onNewWorkspaceFromMock).toHaveBeenCalledWith("p1");
     expect(api.post).not.toHaveBeenCalledWith("/api/projects/p1/workspaces");
+  });
+
+  it("offers 'Restore workspace…' in the add button context menu", async () => {
+    onRestoreWorkspaceMock.mockClear();
+    const user = userEvent.setup();
+    renderSidebar("/projects", projects);
+    await screen.findByText(withTextContent("acme/alpha"));
+
+    fireEvent.contextMenu(screen.getByRole("button", { name: "Add workspace to acme/alpha" }));
+    await user.click(await screen.findByText("Restore workspace…"));
+
+    expect(onRestoreWorkspaceMock).toHaveBeenCalledWith("p1");
+    expect(api.post).not.toHaveBeenCalled();
   });
 
   it("shows the streaming indicator on a streaming workspace and hides it when idle", async () => {

--- a/frontend/tests/components/WorkspaceLauncher.test.tsx
+++ b/frontend/tests/components/WorkspaceLauncher.test.tsx
@@ -23,6 +23,7 @@ const singleProject: Project[] = [
 
 function LauncherHarness() {
   const [picker, setPicker] = useState<{ open: boolean; projectId?: string }>({ open: false });
+  const [restore, setRestore] = useState<{ open: boolean; projectId?: string }>({ open: false });
   return (
     <>
       <WorkspaceLauncher
@@ -30,6 +31,11 @@ function LauncherHarness() {
         pickerProjectId={picker.projectId}
         onPickerOpenChange={(open) =>
           setPicker((prev) => (open ? { ...prev, open: true } : { open: false }))
+        }
+        restoreOpen={restore.open}
+        restoreProjectId={restore.projectId}
+        onRestoreOpenChange={(open) =>
+          setRestore((prev) => (open ? { ...prev, open: true } : { open: false }))
         }
       />
       <LocationProbe />
@@ -76,6 +82,7 @@ describe("WorkspaceLauncher", () => {
     expect(await screen.findByText("Workspace actions")).toBeInTheDocument();
     expect(screen.getByText("New workspace")).toBeInTheDocument();
     expect(screen.getByText("New workspace from…")).toBeInTheDocument();
+    expect(screen.getByText("Restore workspace…")).toBeInTheDocument();
     expect(screen.getByText("Conversation actions")).toBeInTheDocument();
     expect(screen.getByText("Quick open file")).toBeInTheDocument();
     expect(screen.getByText("Previous tab")).toBeInTheDocument();
@@ -83,6 +90,19 @@ describe("WorkspaceLauncher", () => {
     expect(screen.getByText("Navigation")).toBeInTheDocument();
     expect(screen.getByText("Application")).toBeInTheDocument();
     expect(screen.getByText("Settings")).toBeInTheDocument();
+  });
+
+  it("opens the restore picker from the spotlight", async () => {
+    apiGet.mockImplementation((url: string) =>
+      Promise.resolve(url === "/api/projects" ? singleProject : []),
+    );
+    renderLauncher(singleProject);
+    pressShortcut("k");
+
+    fireEvent.click(await screen.findByText("Restore workspace…"));
+
+    expect(await screen.findByPlaceholderText("Search archived workspaces")).toBeInTheDocument();
+    expect(apiGet).toHaveBeenCalledWith("/api/projects/p1/archives");
   });
 
   it("runs global navigation actions from the spotlight", async () => {
@@ -165,6 +185,17 @@ describe("WorkspaceLauncher", () => {
     await waitFor(() => {
       expect(apiPost).toHaveBeenCalledWith("/api/projects/p1/workspaces");
     });
+  });
+
+  it("opens the restore picker on Cmd+Shift+T, even outside a workspace", async () => {
+    apiGet.mockImplementation((url: string) =>
+      Promise.resolve(url === "/api/projects" ? singleProject : []),
+    );
+    renderLauncher(singleProject, ["/home"]);
+    pressShortcut("t", true);
+
+    expect(await screen.findByPlaceholderText("Search archived workspaces")).toBeInTheDocument();
+    expect(apiGet).toHaveBeenCalledWith("/api/projects/p1/archives");
   });
 
   it("opens the picker on Cmd+Shift+N", async () => {

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -40,10 +40,11 @@ final class ProjectStore {
     private let archiveWorkspaceClosure: @MainActor (String) async throws -> Void
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
-    /// Session-lifetime tombstones for successfully archived workspaces. There
-    /// is no restore path and ids are never reused, so an archived id can never
-    /// legitimately reappear; stripping these from refresh results guards
-    /// against a stale snapshot fetched before the archive completed.
+    /// Tombstones for archived workspaces, kept only until a refresh confirms
+    /// the server no longer returns them. They guard against a stale snapshot
+    /// fetched before the archive completed. Once a refresh payload omits an
+    /// id, the tombstone is dropped, so a later refresh that contains the id
+    /// again (the workspace was restored elsewhere) shows the workspace.
     private var archivedIds: Set<String> = []
 
     init(
@@ -274,9 +275,13 @@ final class ProjectStore {
             }
             // A refresh must not resurrect an archived workspace: neither one
             // whose archive is still in flight, nor one from a stale snapshot
-            // fetched before an archive completed.
+            // fetched before an archive completed. Once the payload omits an
+            // archived id, the server has confirmed the removal and the
+            // tombstone is dropped so a restore elsewhere can show it again.
             let hiddenIds = pendingArchiveIds.union(archivedIds)
             if !hiddenIds.isEmpty {
+                let fetchedIds = Set(fresh.flatMap(\.workspaces).map(\.id))
+                archivedIds = archivedIds.intersection(fetchedIds)
                 for i in fresh.indices {
                     fresh[i].workspaces.removeAll { hiddenIds.contains($0.id) }
                 }

--- a/ios/HiveMobile/Stores/ProjectStore.swift
+++ b/ios/HiveMobile/Stores/ProjectStore.swift
@@ -40,12 +40,14 @@ final class ProjectStore {
     private let archiveWorkspaceClosure: @MainActor (String) async throws -> Void
     private var hasFetchedOnce = false
     private var lastRefreshedAt = Date.distantPast
-    /// Tombstones for archived workspaces, kept only until a refresh confirms
-    /// the server no longer returns them. They guard against a stale snapshot
-    /// fetched before the archive completed. Once a refresh payload omits an
-    /// id, the tombstone is dropped, so a later refresh that contains the id
-    /// again (the workspace was restored elsewhere) shows the workspace.
-    private var archivedIds: Set<String> = []
+    /// Tombstones for archived workspaces, keyed by the refresh generation
+    /// that was current when the archive completed. Only a fetch that started
+    /// before the archive completed can carry a stale copy of the workspace, so
+    /// a tombstone is dropped as soon as a later refresh returns, whatever its
+    /// payload says. A workspace restored elsewhere with the same id therefore
+    /// shows up on the next refresh.
+    private var archivedIds: [String: Int] = [:]
+    private var refreshGeneration = 0
 
     init(
         storeCache: ConversationStoreCache,
@@ -204,7 +206,7 @@ final class ProjectStore {
         do {
             try await archiveWorkspaceClosure(id)
             pendingArchiveIds.remove(id)
-            archivedIds.insert(id)
+            archivedIds[id] = refreshGeneration
             syncMonitoredWorkspaces()
         } catch {
             pendingArchiveIds.remove(id)
@@ -259,12 +261,19 @@ final class ProjectStore {
         isLoading = true
         errorMessage = nil
         refreshFailedWithCachedData = false
+        refreshGeneration += 1
+        let generation = refreshGeneration
+        defer {
+            if generation == refreshGeneration { isLoading = false }
+        }
         do {
             async let projectsTask = fetchProjectsClosure()
             async let preferencesTask = fetchPreferencesClosure()
 
             var fresh = try await projectsTask
             let preferences = (try? await preferencesTask) ?? .empty
+            // A newer request owns the snapshot and its loading/error state.
+            guard generation == refreshGeneration else { return }
 
             // Enrich workspaces with parent project metadata for downstream views.
             for i in fresh.indices {
@@ -275,13 +284,12 @@ final class ProjectStore {
             }
             // A refresh must not resurrect an archived workspace: neither one
             // whose archive is still in flight, nor one from a stale snapshot
-            // fetched before an archive completed. Once the payload omits an
-            // archived id, the server has confirmed the removal and the
-            // tombstone is dropped so a restore elsewhere can show it again.
-            let hiddenIds = pendingArchiveIds.union(archivedIds)
+            // fetched before an archive completed. Tombstones from earlier
+            // generations predate this fetch, so this payload is authoritative
+            // for them and they are dropped.
+            archivedIds = archivedIds.filter { $0.value >= generation }
+            let hiddenIds = pendingArchiveIds.union(archivedIds.keys)
             if !hiddenIds.isEmpty {
-                let fetchedIds = Set(fresh.flatMap(\.workspaces).map(\.id))
-                archivedIds = archivedIds.intersection(fetchedIds)
                 for i in fresh.indices {
                     fresh[i].workspaces.removeAll { hiddenIds.contains($0.id) }
                 }
@@ -296,12 +304,12 @@ final class ProjectStore {
         } catch is CancellationError {
             // View disappeared — ignore
         } catch {
+            guard generation == refreshGeneration else { return }
             fetchFailure = Self.classify(error)
             if !projects.isEmpty, userInitiated {
                 refreshFailedWithCachedData = true
             }
         }
-        isLoading = false
     }
 
     /// Dismiss the transient pull-to-refresh failure notice.

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
@@ -77,18 +77,25 @@ struct ProjectStoreArchiveTests {
         )
     }
 
-    private func sampleProject() -> Project {
+    private func sampleProject(workspaceIds: [String] = ["w1", "w2", "w3"]) -> Project {
         Project(
             id: "p1",
             name: "Project p1",
             url: nil,
             createdAt: "2026-01-01T00:00:00.000Z",
-            workspaces: [
-                sampleWorkspace(id: "w1"),
-                sampleWorkspace(id: "w2"),
-                sampleWorkspace(id: "w3")
-            ]
+            workspaces: workspaceIds.map { sampleWorkspace(id: $0) }
         )
+    }
+
+    /// Builds a fetch closure that returns `payloads` in order, repeating the
+    /// last one once the sequence is exhausted.
+    private func sequencedFetch(_ payloads: [[Project]]) -> @MainActor () async throws -> [Project] {
+        let fetchCount = Counter()
+        return {
+            let index = min(fetchCount.value, payloads.count - 1)
+            fetchCount.value += 1
+            return payloads[index]
+        }
     }
 
     private func makeStore(
@@ -224,6 +231,49 @@ struct ProjectStoreArchiveTests {
         // survive subsequent refreshes, not be treated as archived.
         await store.refresh(force: true)
         #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+    }
+
+    @Test
+    func tombstoneDropsOnceServerConfirmsRemovalSoRestoreShowsWorkspace() async {
+        let (store, _) = makeStore(
+            archiveWorkspace: { _ in },
+            fetchProjects: sequencedFetch([
+                [sampleProject()],
+                [sampleProject(workspaceIds: ["w1", "w3"])],
+                [sampleProject()]
+            ])
+        )
+        await store.refresh()
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+
+        await store.archiveWorkspace(id: "w2")
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        // The server no longer returns w2: the archive is confirmed and the
+        // tombstone is dropped.
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        // w2 was restored on another client with the same id; it must show.
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
+    }
+
+    @Test
+    func staleRefreshStillContainingArchivedIdKeepsItHidden() async {
+        let (store, _) = makeStore(archiveWorkspace: { _ in })
+        await store.refresh()
+
+        await store.archiveWorkspace(id: "w2")
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        // Every refresh still returns w2 (stale snapshots): the tombstone
+        // stays in place until the server stops returning the id.
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w3"])
+
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w3"])
     }
 
     @Test

--- a/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ProjectStoreArchiveTests.swift
@@ -233,6 +233,70 @@ struct ProjectStoreArchiveTests {
         #expect(workspaceIds(store) == ["w1", "w2", "w3"])
     }
 
+    @Test(arguments: [false, true])
+    func olderRefreshCannotOverwriteNewerSnapshotOrErrorState(fails: Bool) async {
+        let fetchGate = ArchiveGate()
+        let fetchCount = Counter()
+        let original = [sampleProject()]
+        let archived = [sampleProject(workspaceIds: ["w1", "w3"])]
+        let (store, _) = makeStore(
+            archiveWorkspace: { _ in },
+            fetchProjects: {
+                fetchCount.value += 1
+                if fetchCount.value == 2 {
+                    try await fetchGate.wait()
+                    return original
+                }
+                return fetchCount.value == 1 ? original : archived
+            }
+        )
+        await store.refresh()
+        let oldRefresh = Task { await store.refresh(force: true, userInitiated: true) }
+        await fetchGate.entered()
+        await store.archiveWorkspace(id: "w2")
+
+        // This authoritative response drops the tombstone before the old fetch returns.
+        await store.refresh(force: true)
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        fetchGate.resume(fails ? .failure(ArchiveError()) : .success(()))
+        await oldRefresh.value
+
+        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(store.fetchFailure == nil)
+        #expect(store.refreshFailedWithCachedData == false)
+        #expect(store.isLoading == false)
+    }
+
+    @Test
+    func olderRefreshDoesNotClearLoadingWhileNewerFetchIsPending() async {
+        let oldGate = ArchiveGate()
+        let newGate = ArchiveGate()
+        let fetchCount = Counter()
+        let snapshot = [sampleProject()]
+        let (store, _) = makeStore(
+            archiveWorkspace: { _ in },
+            fetchProjects: {
+                fetchCount.value += 1
+                let call = fetchCount.value
+                if call == 2 { try await oldGate.wait() }
+                if call == 3 { try await newGate.wait() }
+                return snapshot
+            }
+        )
+        await store.refresh()
+        let oldRefresh = Task { await store.refresh(force: true) }
+        await oldGate.entered()
+        let newRefresh = Task { await store.refresh(force: true) }
+        await newGate.entered()
+
+        oldGate.resume()
+        await oldRefresh.value
+        #expect(store.isLoading)
+        newGate.resume()
+        await newRefresh.value
+        #expect(store.isLoading == false)
+    }
+
     @Test
     func tombstoneDropsOnceServerConfirmsRemovalSoRestoreShowsWorkspace() async {
         let (store, _) = makeStore(
@@ -260,20 +324,18 @@ struct ProjectStoreArchiveTests {
     }
 
     @Test
-    func staleRefreshStillContainingArchivedIdKeepsItHidden() async {
+    func refreshStartedAfterArchiveShowsWorkspaceRestoredElsewhere() async {
         let (store, _) = makeStore(archiveWorkspace: { _ in })
         await store.refresh()
 
         await store.archiveWorkspace(id: "w2")
         #expect(workspaceIds(store) == ["w1", "w3"])
 
-        // Every refresh still returns w2 (stale snapshots): the tombstone
-        // stays in place until the server stops returning the id.
+        // No refresh observed the archived state before w2 was restored on
+        // another client. A fetch started after the archive completed is
+        // authoritative, so the returned w2 must show.
         await store.refresh(force: true)
-        #expect(workspaceIds(store) == ["w1", "w3"])
-
-        await store.refresh(force: true)
-        #expect(workspaceIds(store) == ["w1", "w3"])
+        #expect(workspaceIds(store) == ["w1", "w2", "w3"])
     }
 
     @Test


### PR DESCRIPTION
## Summary

Archived workspaces can be restored from the sidebar with their conversations, or permanently deleted. Implements #506, #507, #509 and #510; supersedes the branch-cleanup options in #462. iOS restore UI is tracked separately in #508.

- **Archive metadata and city reservation (#506)**: archiving writes `archivedAt`; the city picker also reserves the cities of archived workspaces (legacy archives use the directory mtime), and returns `<city>-N` when the pool is exhausted instead of throwing.
- **Restore (#507)**: `GET /api/projects/:id/archives` (newest first, with `branchExists` and `deletesBranch`) and `POST /api/workspaces/:wsId/restore`. Restore recreates the worktree at its original path from the kept branch, copies the project env, moves the session directories back, and re-adds the workspace under the same id. It refuses with 409 when the branch is gone, the path is taken, or the branch is checked out in another workspace, and leaves the archive intact. Web: "Restore workspace…" in the project context menu opens a per-project dialog; restoring navigates to the workspace. No toast, no badge.
- **Permanent delete (#509)**: `DELETE /api/workspaces/:wsId/archive` removes the archive and the branch under the same keep rule as hard delete (rule extracted and shared). Trash button plus confirmation in the dialog; the copy only mentions the branch when the backend reports it will be deleted.
- **iOS (#510)**: `ProjectStore.archivedIds` tombstones are dropped once a refresh omits the id, so a workspace restored on another client reappears on the next refresh.

Design decisions locked during grilling: restore never renames or relocates (Claude `--resume` keys its transcript on the worktree path), never re-fetches a PR or recreates a branch, no automatic retention, no lifecycle WS event (clients refetch projects as archive does today).

## Verification

- Root `npm run lint`, `npm run typecheck`, `npm run test` green (backend 2002, frontend 1874).
- Live in an isolated dev instance: sent a codeword to a Haiku session, archived from the sidebar, restored from the dialog, asked for the codeword: answered correctly, so `--resume` survives the cycle. Also checked 404/409 refusals, missing-branch rows greyed, and permanent delete.
- Swift not compiled here (no toolchain); `cd ios && swift test` should run before merge.
- Note: the pre-existing city reservation tests from #461 spawn ~200 git processes and can hit the 5s timeout when the machine is loaded; they pass alone and on main under the same conditions.

Closes #506, closes #507, closes #509, closes #510.