### PR TITLE
chore: prepare release 0.1.4

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1573,7 +1573,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "dirs",
  "log",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.3"
+version = "0.1.4"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the canonical Hive version from 0.1.3 to 0.1.4
- keep Cargo.toml and Cargo.lock aligned for the release workflow

## Validation

- npm run release:version:check
- npm run lint
- npm run typecheck
- npm test
- npm run test:release
- npm run test:provision