### PR TITLE
fix: gate outdated Codex and modernize App Server handling

### DIFF
--- a/backend/src/agents/conversation-session.test.ts
+++ b/backend/src/agents/conversation-session.test.ts
@@ -280,7 +280,7 @@ describe("ConversationSession", () => {
   beforeEach(() => {
     mockProc = createMockProcess();
     mockSpawn.mockReturnValue(mockProc);
-    providerRegistry.markProviderAvailable("codex");
+    providerRegistry.markProviderAvailable("codex", "0.153.4");
   });
 
   function createSession(opts?: { sessionId?: string; command?: string; skipPermissions?: boolean; sessionKind?: "chat" | "automation" | "brain"; draftPrompt?: string }) {
@@ -295,6 +295,54 @@ describe("ConversationSession", () => {
       draftPrompt: opts?.draftPrompt,
     });
   }
+
+  it.each(["chat", "brain", "automation"] as const)("rejects an outdated harness before persisting a %s message", async (sessionKind) => {
+    const session = createSession({ sessionKind, draftPrompt: "Keep this draft" });
+    const messages: WsOutgoing[] = [];
+    session.on("message", (message) => messages.push(message));
+    providerRegistry.recordProviderDetection("codex", true, "0.153.3");
+
+    expect(() => session.sendMessage("Run this", { model: "codex:gpt-5.5" }))
+      .toThrow("Update Codex in settings");
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+    expect(messages).toEqual([]);
+    expect(await session.getMessages()).toEqual([]);
+    expect(session.metadata.draftPrompt).toBe("Keep this draft");
+    expect(session.metadata.lockedProvider).toBeUndefined();
+    expect(session.metadata.lastRunOptions).toBeUndefined();
+    expect(session.status).toBe("idle");
+  });
+
+  it("blocks goals on an outdated harness and permits retry after an update", async () => {
+    const session = createSession();
+    providerRegistry.recordProviderDetection("codex", true, null);
+    expect(() => session.sendMessage("/goal Ship this", { model: "codex:gpt-5.5" }))
+      .toThrow("Update Codex in settings");
+    expect(await session.getMessages()).toEqual([]);
+    providerRegistry.recordProviderDetection("codex", true, "0.153.4");
+    session.sendMessage("Run this", { model: "codex:gpt-5.5" });
+    await completeAppServerTurn(mockProc, "updated-thread", "updated-turn");
+    await session.drain();
+    expect((await session.getMessages()).filter((message) => message.role === "user"))
+      .toMatchObject([{ content: "Run this" }]);
+  });
+
+  it("rechecks the harness on an existing conversation without changing its selected model", async () => {
+    const session = createSession();
+    session.sendMessage("First turn", { model: "codex:gpt-5.5" });
+    await completeAppServerTurn(mockProc, "existing-thread", "first-turn");
+    await session.drain();
+    const history = await session.getMessages();
+    const runOptions = session.metadata.lastRunOptions;
+
+    providerRegistry.recordProviderDetection("codex", true, "0.153.3");
+    expect(() => session.sendMessage("Next turn", { model: "codex:gpt-5.6-sol" }))
+      .toThrow("Update Codex in settings");
+    expect(session.metadata.lastRunOptions).toEqual(runOptions);
+    expect(await session.getMessages()).toEqual(history);
+    expect(countStdinMethod(mockProc, "turn/start")).toBe(1);
+  });
 
   it("persists a draft prompt until the first user message", async () => {
     const session = createSession({

--- a/backend/src/agents/conversation-session.ts
+++ b/backend/src/agents/conversation-session.ts
@@ -11,7 +11,7 @@ import { parseReasoningThoughts } from "./reasoning-thoughts.js";
 import { appendBoundedAgentOutput, boundAgentOutput } from "./bounded-output.js";
 import type { CodexGoalResult, CodexGoalSetParams, CodexGoalStatus } from "./providers/codex-app-server.js";
 import { codexPersonalityFromOutputStyle, type CodexPersonality } from "./providers/codex.js";
-import { resolveProvider } from "./providers/registry.js";
+import { getProviderUnavailableReason, resolveProvider } from "./providers/registry.js";
 import { findModel, type AgentProvider } from "./providers/types.js";
 import { createAgentRunner, type AgentRunnerFactory } from "./runners/factory.js";
 import type { AgentRunner, AgentRunnerTurnStartedEvent, StopReason } from "./runners/types.js";
@@ -499,6 +499,8 @@ export class ConversationSession extends EventEmitter<ConversationSessionEvent> 
     let effectiveMsgOptions = msgOptions;
     if (!this.testCommand) {
       resolved = resolveProvider(msgOptions?.model);
+      const unavailableReason = getProviderUnavailableReason(resolved.provider.id);
+      if (unavailableReason) throw new Error(unavailableReason);
 
       if (this._metadata.lockedProvider && this._metadata.lockedProvider !== resolved.provider.id) {
         throw new Error(`Provider mismatch: session locked to "${this._metadata.lockedProvider}"`);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -1020,6 +1020,7 @@ describe("CodexAppServerSession normalized events", () => {
   it.each([
     ["interacted", "item/completed"],
     ["interrupted", "item/completed"],
+    ["completed", "item/completed"],
   ] as const)("emits %s sub-agent activity without a diagnostic", async (activityKind, method) => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -138,6 +138,30 @@ async function initializeSession(session: CodexAppServerSession, proc: ReturnTyp
   await started;
 }
 
+function completeCollabWait(proc: ReturnType<typeof createMockProcess>, threadIds = ["thread-child"]): void {
+  proc._stdout.push(JSON.stringify({
+    method: "item/completed",
+    params: {
+      threadId: "thread-1",
+      item: {
+        type: "collabAgentToolCall", id: "collab-wait", tool: "wait",
+        status: "completed", receiverThreadIds: threadIds,
+      },
+    },
+  }) + "\n");
+}
+
+function completedChildCommand(id: string) {
+  return { type: "commandExecution", id, command: "npm test", status: "completed", exitCode: 0 };
+}
+
+function completeMainTurn(proc: ReturnType<typeof createMockProcess>): void {
+  proc._stdout.push(JSON.stringify({
+    method: "turn/completed",
+    params: { threadId: "thread-1", turn: { id: "turn-1", status: "completed" } },
+  }) + "\n");
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -220,7 +244,7 @@ describe("CodexAppServerSession request handling", () => {
     }));
     const threadResume = await waitForMethod(proc, "thread/resume");
     expect(parseWrites(proc).find((write) => write.method === "thread/resume")?.params)
-      .toMatchObject({ threadId: "thread-existing", personality: "pragmatic" });
+      .toMatchObject({ threadId: "thread-existing", personality: "pragmatic", excludeTurns: true });
     proc._stdout.push(appServerResponse(threadResume.id, { thread: { id: "thread-existing" } }));
     const turnStart = await waitForMethod(proc, "turn/start");
     proc._stdout.push(appServerResponse(turnStart.id, { turn: { id: "turn-pragmatic" } }));
@@ -1209,26 +1233,24 @@ describe("CodexAppServerSession normalized events", () => {
       },
     }) + "\n");
 
-    const read = await waitForMethod(proc, "thread/read");
+    const read = await waitForMethod(proc, "thread/turns/list");
     expect(parseWrites(proc).find((write) => write.id === read.id)).toEqual(
       expect.objectContaining({ params: expect.objectContaining({ threadId: "thread-child" }) }),
     );
     proc._stdout.push(appServerResponse(read.id, {
-      thread: {
-        id: "thread-child",
-        turns: [{
-          id: "turn-child",
-          items: [{
-            type: "commandExecution",
-            id: "child-cmd-1",
-            command: "npm test",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "ok",
-            exitCode: 0,
-          }],
+      data: [{
+        id: "turn-child",
+        items: [{
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
         }],
-      },
+      }],
+      nextCursor: null,
     }));
 
     await waitForCondition(() =>
@@ -2248,31 +2270,29 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
-    const read = await waitForMethod(proc, "thread/read");
+    const read = await waitForMethod(proc, "thread/turns/list");
     proc._stdout.push(appServerResponse(read.id, {
-      thread: {
-        id: "thread-child",
-        turns: [{
-          id: "turn-child",
-          items: [{
-            type: "commandExecution",
-            id: "child-cmd-1",
-            command: "npm test",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "ok",
-            exitCode: 0,
-          }, {
-            type: "commandExecution",
-            id: "child-cmd-2",
-            command: "npm run lint",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "clean",
-            exitCode: 0,
-          }],
+      data: [{
+        id: "turn-child",
+        items: [{
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        }, {
+          type: "commandExecution",
+          id: "child-cmd-2",
+          command: "npm run lint",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "clean",
+          exitCode: 0,
         }],
-      },
+      }],
+      nextCursor: null,
     }));
 
     // The never-seen item is caught up, nested under the ORIGINAL Agent card.
@@ -2357,31 +2377,29 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
-    const read = await waitForMethod(proc, "thread/read");
+    const read = await waitForMethod(proc, "thread/turns/list");
     proc._stdout.push(appServerResponse(read.id, {
-      thread: {
-        id: "thread-child",
-        turns: [{
-          id: "turn-child",
-          items: [{
-            type: "commandExecution",
-            id: "child-cmd-1",
-            command: "npm test",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "ok",
-            exitCode: 0,
-          }, {
-            type: "commandExecution",
-            id: "child-cmd-2",
-            command: "npm run lint",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "clean",
-            exitCode: 0,
-          }],
+      data: [{
+        id: "turn-child",
+        items: [{
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
+        }, {
+          type: "commandExecution",
+          id: "child-cmd-2",
+          command: "npm run lint",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "clean",
+          exitCode: 0,
         }],
-      },
+      }],
+      nextCursor: null,
     }));
 
     await waitForCondition(() =>
@@ -2430,8 +2448,8 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
-    const read = await waitForMethod(proc, "thread/read");
-    proc._stdout.push(appServerResponse(read.id, { thread: { id: "thread-child", turns: [] } }));
+    const read = await waitForMethod(proc, "thread/turns/list");
+    proc._stdout.push(appServerResponse(read.id, { data: [], nextCursor: null }));
 
     proc._stdout.push(JSON.stringify({
       method: "item/started",
@@ -2477,8 +2495,8 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
-    const read = await waitForMethod(proc, "thread/read");
-    proc._stdout.push(appServerResponse(read.id, { thread: { id: "thread-child", turns: [] } }));
+    const read = await waitForMethod(proc, "thread/turns/list");
+    proc._stdout.push(appServerResponse(read.id, { data: [], nextCursor: null }));
 
     proc._stdout.push(JSON.stringify({
       method: "item/started",
@@ -2785,30 +2803,28 @@ describe("CodexAppServerSession normalized events", () => {
       },
     }) + "\n");
 
-    const read = await waitForMethod(proc, "thread/read");
+    const read = await waitForMethod(proc, "thread/turns/list");
     proc._stdout.push(appServerResponse(read.id, {
-      thread: {
-        id: "thread-child",
-        turns: [{
-          id: "turn-child",
-          items: [{
-            type: "collabAgentToolCall",
-            id: "collab-self",
-            tool: "spawnAgent",
-            status: "completed",
-            receiverThreadIds: ["thread-child"],
-            prompt: "Inspect auth",
-          }, {
-            type: "commandExecution",
-            id: "child-cmd-1",
-            command: "npm test",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "ok",
-            exitCode: 0,
-          }],
+      data: [{
+        id: "turn-child",
+        items: [{
+          type: "collabAgentToolCall",
+          id: "collab-self",
+          tool: "spawnAgent",
+          status: "completed",
+          receiverThreadIds: ["thread-child"],
+          prompt: "Inspect auth",
+        }, {
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
         }],
-      },
+      }],
+      nextCursor: null,
     }));
     proc._stdout.push(JSON.stringify({
       method: "turn/completed",
@@ -2893,27 +2909,25 @@ describe("CodexAppServerSession normalized events", () => {
       },
     }) + "\n");
 
-    const read = await waitForMethod(proc, "thread/read");
+    const read = await waitForMethod(proc, "thread/turns/list");
     expect(parseWrites(proc).find((write) => write.id === read.id)).toMatchObject({
-      method: "thread/read",
-      params: { threadId: "thread-child", includeTurns: true },
+      method: "thread/turns/list",
+      params: { threadId: "thread-child", sortDirection: "asc", itemsView: "full", limit: 50 },
     });
     proc._stdout.push(appServerResponse(read.id, {
-      thread: {
-        id: "thread-child",
-        turns: [{
-          id: "turn-child",
-          items: [{
-            type: "commandExecution",
-            id: "child-cmd-1",
-            command: "npm test",
-            cwd: "/tmp/project",
-            status: "completed",
-            aggregatedOutput: "ok",
-            exitCode: 0,
-          }],
+      data: [{
+        id: "turn-child",
+        items: [{
+          type: "commandExecution",
+          id: "child-cmd-1",
+          command: "npm test",
+          cwd: "/tmp/project",
+          status: "completed",
+          aggregatedOutput: "ok",
+          exitCode: 0,
         }],
-      },
+      }],
+      nextCursor: null,
     }));
 
     await waitForCondition(() =>
@@ -2935,6 +2949,210 @@ describe("CodexAppServerSession normalized events", () => {
       }),
     ]));
     expect(diagnostics).not.toContainEqual(expect.objectContaining({ method: "item/collabToolCall" }));
+  });
+
+  it("pages full child history in order and deduplicates live items before finalizing", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const emitted: string[] = [];
+    session.on("assistant", (event) => {
+      for (const block of event.message.content) {
+        if (block.type === "tool_use") emitted.push(block.id);
+      }
+    });
+    session.on("result", () => emitted.push("result"));
+    await initializeSession(session, proc);
+    completeCollabWait(proc);
+    const first = await waitForMethod(proc, "thread/turns/list");
+    completeMainTurn(proc);
+    proc._stdout.push(appServerResponse(first.id, {
+      data: [{ id: "child-turn-1", itemsView: "full", items: [completedChildCommand("first")] }],
+      nextCursor: "next-child-turn",
+    }));
+    const second = await waitForNthMethod(proc, "thread/turns/list", 2);
+    expect(parseWrites(proc).find((write) => write.id === second.id)?.params).toEqual({
+      threadId: "thread-child", limit: 50, sortDirection: "asc", itemsView: "full", cursor: "next-child-turn",
+    });
+    expect(emitted).toEqual(["collab-wait", "first"]);
+    proc._stdout.push(JSON.stringify({
+      method: "item/completed",
+      params: { threadId: "thread-child", item: completedChildCommand("live") },
+    }) + "\n");
+    proc._stdout.push(appServerResponse(second.id, {
+      data: [{ id: "child-turn-2", itemsView: "full", items: [
+        completedChildCommand("live"), completedChildCommand("last"),
+      ] }],
+      nextCursor: null,
+    }));
+    await waitForCondition(() => emitted.includes("result"));
+    expect(emitted).toEqual(["collab-wait", "first", "live", "last", "result"]);
+    expect(parseWrites(proc).some((write) => write.method === "thread/read")).toBe(false);
+  });
+
+  it("keeps responsive multi-page replay pending beyond the old finalization deadline", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const results: unknown[] = [];
+    session.on("result", (event) => results.push(event));
+    await initializeSession(session, proc);
+    vi.useFakeTimers();
+    try {
+      completeCollabWait(proc);
+      const first = parseWrites(proc).find((write) => write.method === "thread/turns/list")!;
+      completeMainTurn(proc);
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(results).toEqual([]);
+      proc._stdout.push(appServerResponse(first.id as number, { data: [], nextCursor: "next" }));
+      await vi.advanceTimersByTimeAsync(0);
+      const second = parseWrites(proc).filter((write) => write.method === "thread/turns/list")[1];
+      await vi.advanceTimersByTimeAsync(2000);
+      expect(results).toEqual([]);
+      proc._stdout.push(appServerResponse(second.id as number, { data: [], nextCursor: null }));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(results).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("stops a stalled history page and ignores its late response after finalization", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const diagnostics: unknown[] = [];
+    const assistantEvents: unknown[] = [];
+    const results: unknown[] = [];
+    session.on("agent_event", (event) => diagnostics.push(event));
+    session.on("assistant", (event) => assistantEvents.push(event));
+    session.on("result", (event) => results.push(event));
+    await initializeSession(session, proc);
+    vi.useFakeTimers();
+    try {
+      completeCollabWait(proc);
+      const read = parseWrites(proc).find((write) => write.method === "thread/turns/list")!;
+      completeMainTurn(proc);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(results).toHaveLength(1);
+      expect(diagnostics).toContainEqual(expect.objectContaining({
+        title: "Codex sub-agent replay failed", method: "thread/turns/list",
+      }));
+      const count = assistantEvents.length;
+      proc._stdout.push(appServerResponse(read.id as number, {
+        data: [{ items: [completedChildCommand("late")] }], nextCursor: "unused",
+      }));
+      await vi.advanceTimersByTimeAsync(0);
+      expect(assistantEvents).toHaveLength(count);
+      expect(parseWrites(proc).filter((write) => write.method === "thread/turns/list")).toHaveLength(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("waits for other children when one history page fails", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const results: unknown[] = [];
+    const diagnostics: unknown[] = [];
+    session.on("result", (event) => results.push(event));
+    session.on("agent_event", (event) => diagnostics.push(event));
+    await initializeSession(session, proc);
+    completeCollabWait(proc, ["thread-child", "thread-other"]);
+    const first = await waitForMethod(proc, "thread/turns/list");
+    const other = await waitForNthMethod(proc, "thread/turns/list", 2);
+    completeMainTurn(proc);
+    proc._stdout.push(appServerResponse(first.id, { data: [], nextCursor: "next" }));
+    const next = await waitForNthMethod(proc, "thread/turns/list", 3);
+    proc._stdout.push(appServerError(next.id, "Unable to load history page"));
+    await waitForCondition(() => diagnostics.length > 0);
+    expect(results).toEqual([]);
+    proc._stdout.push(appServerResponse(other.id, { data: [], nextCursor: null }));
+    await waitForCondition(() => results.length === 1);
+    expect(diagnostics).toContainEqual(expect.objectContaining({
+      message: "Unable to load history page", method: "thread/turns/list",
+    }));
+  });
+
+  it("drains grandchild replay discovered in a child page before finalizing", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const results: unknown[] = [];
+    const assistantEvents: unknown[] = [];
+    session.on("result", (event) => results.push(event));
+    session.on("assistant", (event) => assistantEvents.push(event));
+    await initializeSession(session, proc);
+    completeCollabWait(proc);
+    const child = await waitForMethod(proc, "thread/turns/list");
+    completeMainTurn(proc);
+    proc._stdout.push(appServerResponse(child.id, {
+      data: [{ items: [{
+        type: "collabAgentToolCall", id: "child-wait", tool: "wait",
+        status: "completed", receiverThreadIds: ["thread-grandchild"],
+      }] }],
+      nextCursor: null,
+    }));
+    const grandchild = await waitForNthMethod(proc, "thread/turns/list", 2);
+    expect(parseWrites(proc).find((write) => write.id === grandchild.id)?.params)
+      .toMatchObject({ threadId: "thread-grandchild" });
+    expect(results).toEqual([]);
+    proc._stdout.push(appServerResponse(grandchild.id, {
+      data: [{ items: [completedChildCommand("grandchild-command")] }], nextCursor: null,
+    }));
+    await waitForCondition(() => results.length === 1);
+    expect(assistantEvents).toContainEqual(expect.objectContaining({
+      message: expect.objectContaining({ content: [expect.objectContaining({
+        id: "grandchild-command", parentToolUseId: "child-wait",
+      })] }),
+    }));
+  });
+
+  it("does not recursively replay the same v2 child wait without receiver ids", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const results: unknown[] = [];
+    session.on("result", (event) => results.push(event));
+    await initializeSession(session, proc);
+    completeCollabWait(proc);
+    const first = await waitForMethod(proc, "thread/turns/list");
+    completeMainTurn(proc);
+    const history = {
+      data: [{ items: [{
+        type: "collabAgentToolCall", id: "child-wait", tool: "wait",
+        status: "completed", receiverThreadIds: [],
+      }] }],
+      nextCursor: null,
+    };
+    proc._stdout.push(appServerResponse(first.id, history));
+    const second = await waitForNthMethod(proc, "thread/turns/list", 2);
+    expect(results).toEqual([]);
+    proc._stdout.push(appServerResponse(second.id, history));
+    await waitForCondition(() => results.length === 1);
+    expect(parseWrites(proc).filter((write) => write.method === "thread/turns/list")).toHaveLength(2);
+  });
+
+  it("discards an old replay page after a new provider turn starts", async () => {
+    const proc = createMockProcess();
+    mockSpawn.mockReturnValue(proc);
+    const session = new CodexAppServerSession();
+    const assistantEvents: unknown[] = [];
+    session.on("assistant", (event) => assistantEvents.push(event));
+    await initializeSession(session, proc);
+    completeCollabWait(proc);
+    const read = await waitForMethod(proc, "thread/turns/list");
+    proc._stdout.push(JSON.stringify({
+      method: "turn/started", params: { threadId: "thread-1", turn: { id: "turn-2" } },
+    }) + "\n");
+    const count = assistantEvents.length;
+    proc._stdout.push(appServerResponse(read.id, {
+      data: [{ items: [completedChildCommand("old")] }], nextCursor: "unused",
+    }));
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(assistantEvents).toHaveLength(count);
+    expect(parseWrites(proc).filter((write) => write.method === "thread/turns/list")).toHaveLength(1);
   });
 
   it("does not replay receiver threads when spawnAgent completes", async () => {
@@ -2967,7 +3185,7 @@ describe("CodexAppServerSession normalized events", () => {
     }) + "\n");
 
     await waitForCondition(() => resultEvents.length === 1);
-    expect(parseWrites(proc).filter((write) => write.method === "thread/read")).toHaveLength(0);
+    expect(parseWrites(proc).filter((write) => write.method === "thread/turns/list")).toHaveLength(0);
   });
 
   it("emits context-window usage from token usage updates", async () => {
@@ -3089,7 +3307,7 @@ describe("CodexAppServerSession normalized events", () => {
     });
   });
 
-  it("does not surface benign too-young-thread replay errors", async () => {
+  it("handles empty child history and a transient empty rollout without warnings", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const session = new CodexAppServerSession();
@@ -3112,11 +3330,8 @@ describe("CodexAppServerSession normalized events", () => {
         },
       },
     }) + "\n");
-    const firstRead = await waitForMethod(proc, "thread/read");
-    proc._stdout.push(appServerError(
-      firstRead.id,
-      "thread thread-child is not materialized yet; includeTurns is unavailable before first user message",
-    ));
+    const firstRead = await waitForMethod(proc, "thread/turns/list");
+    proc._stdout.push(appServerResponse(firstRead.id, { data: [], nextCursor: null }));
 
     proc._stdout.push(JSON.stringify({
       method: "item/completed",
@@ -3132,9 +3347,9 @@ describe("CodexAppServerSession normalized events", () => {
       },
     }) + "\n");
     await waitForCondition(() =>
-      parseWrites(proc).filter((write) => write.method === "thread/read").length === 2,
+      parseWrites(proc).filter((write) => write.method === "thread/turns/list").length === 2,
     );
-    const secondRead = parseWrites(proc).filter((write) => write.method === "thread/read")[1] as { id: number };
+    const secondRead = parseWrites(proc).filter((write) => write.method === "thread/turns/list")[1] as { id: number };
     proc._stdout.push(appServerError(
       secondRead.id,
       "failed to read thread: thread-store internal error: failed to read thread /tmp/rollout-x.jsonl: rollout at /tmp/rollout-x.jsonl is empty",

--- a/backend/src/agents/providers/codex-app-server.test.ts
+++ b/backend/src/agents/providers/codex-app-server.test.ts
@@ -790,7 +790,7 @@ describe("CodexAppServerSession normalized events", () => {
     ]);
   });
 
-  it("absorbs empty terminal interaction polls but keeps non-empty interactions diagnostic-only", async () => {
+  it("absorbs terminal interaction notifications without surfacing stdin", async () => {
     const proc = createMockProcess();
     mockSpawn.mockReturnValue(proc);
     const session = new CodexAppServerSession();
@@ -798,41 +798,20 @@ describe("CodexAppServerSession normalized events", () => {
     session.on("agent_event", (event) => events.push(event));
     await initializeSession(session, proc);
 
-    proc._stdout.push(JSON.stringify({
-      method: "item/commandExecution/terminalInteraction",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "cmd-1",
-        processId: "123",
-        stdin: "",
-      },
-    }) + "\n");
+    for (const stdin of ["", "q\n", "\u0003", "sensitive-input\n"]) {
+      proc._stdout.push(JSON.stringify({
+        method: "item/commandExecution/terminalInteraction",
+        params: {
+          threadId: "thread-1",
+          turnId: "turn-1",
+          itemId: "cmd-1",
+          processId: "123",
+          stdin,
+        },
+      }) + "\n");
+    }
 
     expect(events).toEqual([]);
-
-    proc._stdout.push(JSON.stringify({
-      method: "item/commandExecution/terminalInteraction",
-      params: {
-        threadId: "thread-1",
-        turnId: "turn-1",
-        itemId: "cmd-1",
-        processId: "123",
-        stdin: "q\n",
-      },
-    }) + "\n");
-
-    expect(events).toEqual([
-      expect.objectContaining({
-        type: "diagnostic",
-        severity: "info",
-        title: "Unsupported App Server event",
-        message: "Hive does not render \"item/commandExecution/terminalInteraction\" yet.",
-        source: "codex_app_server",
-        method: "item/commandExecution/terminalInteraction",
-        details: expect.stringContaining("\"stdin\": \"q\\n\""),
-      }),
-    ]);
   });
 
   it.each([
@@ -903,6 +882,24 @@ describe("CodexAppServerSession normalized events", () => {
     proc._stdout.push(JSON.stringify({
       method: "thread/compacted",
       params: { threadId: "thread-1" },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/plan/delta",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "plan-1",
+        delta: "Draft the implementation",
+      },
+    }) + "\n");
+    proc._stdout.push(JSON.stringify({
+      method: "item/mcpToolCall/progress",
+      params: {
+        threadId: "thread-1",
+        turnId: "turn-1",
+        itemId: "mcp-1",
+        message: "Loading resources",
+      },
     }) + "\n");
 
     expect(events).toEqual([]);

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -1169,7 +1169,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     do {
       // Full items are explicit: the API defaults to summaries. Ascending pages
       // preserve provider order while avoiding full-thread history hydration.
-      const response: ThreadTurnsListResponse = await withTimeout(this.request<ThreadTurnsListResponse>("thread/turns/list", {
+      const response: ThreadTurnsListResponse = await withHistoryPageTimeout(this.request<ThreadTurnsListResponse>("thread/turns/list", {
         threadId,
         limit: COLLAB_HISTORY_PAGE_SIZE,
         sortDirection: "asc",
@@ -1658,7 +1658,7 @@ function formatCollabAgentTool(tool: string | undefined): string {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+function withHistoryPageTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise((resolve, reject) => {
     const timeout = setTimeout(() => reject(new Error("Codex sub-agent history page timed out")), timeoutMs);
     promise.then(

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -666,6 +666,11 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       case "item/reasoning/summaryPartAdded":
         break;
+      case "item/plan/delta":
+      case "item/mcpToolCall/progress":
+        // Authoritative plan and MCP tool state arrives through the structured
+        // plan update and item lifecycle notifications.
+        break;
       case "item/reasoning/textDelta":
       case "item/reasoning/summaryTextDelta":
         if (this.isForeignThread(asString(data?.threadId))) break;
@@ -699,8 +704,8 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         break;
       }
       case "item/commandExecution/terminalInteraction":
-        if (asString(data?.stdin) === "") break;
-        this.emitUnsupportedNotification(method, params);
+        // Command lifecycle items already own the UI. Never persist raw stdin,
+        // which may contain sensitive input.
         break;
       case "item/fileChange/patchUpdated": {
         const itemId = asString(data?.itemId);

--- a/backend/src/agents/providers/codex-app-server.ts
+++ b/backend/src/agents/providers/codex-app-server.ts
@@ -43,6 +43,11 @@ type ThreadResumeResponse = {
   thread: { id: string };
 };
 
+type ThreadTurnsListResponse = {
+  data: Array<{ items: ThreadItem[] }>;
+  nextCursor: string | null;
+};
+
 type TurnStartResponse = {
   turn: { id: string };
 };
@@ -217,7 +222,8 @@ const CLIENT_INFO = {
 const MAX_DIAGNOSTIC_DETAILS_LENGTH = 4000;
 /** Keep persisted chat payloads bounded when an image generation result is inline base64. */
 const MAX_IMAGE_GENERATION_RESULT_LENGTH = 262_144;
-const COLLAB_THREAD_REPLAY_TIMEOUT_MS = 1500;
+const COLLAB_HISTORY_PAGE_TIMEOUT_MS = 5000;
+const COLLAB_HISTORY_PAGE_SIZE = 50;
 
 /**
  * Canonical `codex app-server` CLI args. Single source of truth so the real spawn
@@ -264,6 +270,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
    *  previous turn's child tools from re-emitting as duplicates. */
   private completedCollabItemIds = new Set<string>();
   private pendingCollabReplays = new Set<Promise<void>>();
+  private collabReplayGeneration = 0;
   private lastUsage: TokenUsage | undefined;
   private lastProtocolError: string | undefined;
   private activeGoalRequestCount = 0;
@@ -451,6 +458,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     if (options.threadId) {
       const resumed = await this.request<ThreadResumeResponse>("thread/resume", {
         threadId: options.threadId,
+        excludeTurns: true,
         cwd: options.cwd,
         approvalPolicy: "never",
         sandbox,
@@ -506,6 +514,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private resetForThreadBoundary(): void {
+    this.collabReplayGeneration += 1;
     this.collabParentByThreadId.clear();
     this.toolParentByItemId.clear();
     this.completedCollabItemIds.clear();
@@ -521,6 +530,7 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
    * tool calls (they'd render top-level instead of nested under their Agent tool call).
    */
   private resetForNewTurn(): void {
+    this.collabReplayGeneration += 1;
     this.activeTurnId = undefined;
     this.emittedToolIds.clear();
     this.commandOutputs.clear();
@@ -941,12 +951,13 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
         }
         this.emitToolUse(collabItem.id, "Agent", JSON.stringify(collabAgentToolInput(collabItem)), parentToolUseId);
         if (phase === "completed") {
+          const alreadyCompleted = this.completedToolIds.has(collabItem.id);
           this.emitToolResult(collabItem.id, collabAgentToolResult(collabItem));
           // spawnAgent completes at thread creation: the child has no history
           // yet, and reading it races Codex's rollout flush ("rollout is
           // empty"). Catch-up replays only make sense once the child has run,
           // i.e. when a wait/closeAgent on it completes.
-          if (collabItem.tool !== "spawnAgent") {
+          if (collabItem.tool !== "spawnAgent" && !alreadyCompleted) {
             this.queueCollabAgentReplay(collabItem);
           }
         }
@@ -1124,37 +1135,55 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
     // Catch-up items nest under the spawning Agent card when known; the
     // triggering wait/closeAgent card is only a fallback for threads whose
     // spawn was never observed (e.g. resumed session).
-    const replay = Promise.all(threadIds.map((threadId) =>
-      this.replayCollabAgentThread(threadId, this.collabParentByThreadId.get(threadId) ?? item.id)))
-      .then(() => undefined)
-      .catch((err: unknown) => {
-        if (isUnmaterializedThreadReadError(err)) return;
+    const generation = this.collabReplayGeneration;
+    const replay = Promise.all(threadIds.map(async (threadId) => {
+      try {
+        await this.replayCollabAgentThread(
+          threadId,
+          this.collabParentByThreadId.get(threadId) ?? item.id,
+          generation,
+        );
+      } catch (err: unknown) {
+        if (generation !== this.collabReplayGeneration || isEmptyThreadHistoryError(err)) return;
         this.emitDiagnostic({
           id: diagnosticId("codex-collab-replay", item.id),
           severity: "warning",
           title: "Codex sub-agent replay failed",
           message: err instanceof Error ? err.message : "Unable to read Codex sub-agent thread.",
-          method: "thread/read",
+          method: "thread/turns/list",
           details: formatDiagnosticDetails({ receiverThreadIds: threadIds }),
           dedupeKey: `collab-replay:${item.id}`,
         });
-      });
+      }
+    })).then(() => undefined);
     this.pendingCollabReplays.add(replay);
     replay.finally(() => this.pendingCollabReplays.delete(replay));
   }
 
-  private async replayCollabAgentThread(threadId: string, parentToolUseId: string): Promise<void> {
-    const response = await this.request<{ thread?: { turns?: unknown[] } }>("thread/read", {
-      threadId,
-      includeTurns: true,
-    });
-    const turns = asArray(asRecord(response.thread)?.turns) ?? [];
-    for (const turn of turns) {
-      const items = asArray(asRecord(turn)?.items) ?? [];
-      for (const entry of items) {
-        this.handleItem(asRecord(entry) as ThreadItem | null, "completed", { threadId, parentToolUseId });
+  private async replayCollabAgentThread(
+    threadId: string,
+    parentToolUseId: string,
+    generation: number,
+  ): Promise<void> {
+    let cursor: string | null = null;
+    do {
+      // Full items are explicit: the API defaults to summaries. Ascending pages
+      // preserve provider order while avoiding full-thread history hydration.
+      const response: ThreadTurnsListResponse = await withTimeout(this.request<ThreadTurnsListResponse>("thread/turns/list", {
+        threadId,
+        limit: COLLAB_HISTORY_PAGE_SIZE,
+        sortDirection: "asc",
+        itemsView: "full",
+        ...(cursor ? { cursor } : {}),
+      }), COLLAB_HISTORY_PAGE_TIMEOUT_MS);
+      if (generation !== this.collabReplayGeneration) return;
+      for (const turn of response.data) {
+        for (const entry of turn.items) {
+          this.handleItem(entry, "completed", { threadId, parentToolUseId });
+        }
       }
-    }
+      cursor = response.nextCursor;
+    } while (cursor);
   }
 
   private handleTurnCompleted(data: JsonObject | null): void {
@@ -1219,19 +1248,12 @@ export class CodexAppServerSession extends EventEmitter<CodexAppServerEvent> {
   }
 
   private async waitForCollabReplays(): Promise<void> {
-    const pending = [...this.pendingCollabReplays];
-    if (pending.length === 0) return;
-    try {
-      await withTimeout(Promise.allSettled(pending), COLLAB_THREAD_REPLAY_TIMEOUT_MS);
-    } catch {
-      this.emitDiagnostic({
-        id: diagnosticId("codex-collab-replay", "timeout"),
-        severity: "warning",
-        title: "Codex sub-agent replay timed out",
-        message: "Hive finished the Codex turn before all sub-agent threads could be read.",
-        method: "thread/read",
-        dedupeKey: "collab-replay:timeout",
-      });
+    const generation = this.collabReplayGeneration;
+    // Each page has its own deadline; responsive multi-page histories must be
+    // emitted before the result. Replayed waits can discover more descendants,
+    // so drain those replays too before finalizing persistence for this turn.
+    while (generation === this.collabReplayGeneration && this.pendingCollabReplays.size > 0) {
+      await Promise.allSettled([...this.pendingCollabReplays]);
     }
   }
 
@@ -1638,7 +1660,7 @@ function formatCollabAgentTool(tool: string | undefined): string {
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   return new Promise((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error("Timed out")), timeoutMs);
+    const timeout = setTimeout(() => reject(new Error("Codex sub-agent history page timed out")), timeoutMs);
     promise.then(
       (value) => {
         clearTimeout(timeout);
@@ -1652,16 +1674,10 @@ function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
   });
 }
 
-/** Both variants mean the child thread is too young to be read: it was created
- *  but has not run (or Codex has not flushed its rollout to disk) yet. Nothing
- *  to catch up — not worth a user-facing warning. */
-function isUnmaterializedThreadReadError(err: unknown): boolean {
+/** A newly created child can race the first persisted rollout flush. */
+function isEmptyThreadHistoryError(err: unknown): boolean {
   const message = err instanceof Error ? err.message : String(err);
-  return (
-    (message.includes("not materialized yet") &&
-      message.includes("includeTurns is unavailable before first user message")) ||
-    (message.includes("rollout") && message.includes("is empty"))
-  );
+  return message.includes("rollout") && message.includes("is empty");
 }
 
 function diagnosticId(prefix: string, method: string): string {

--- a/backend/src/agents/providers/codex.ts
+++ b/backend/src/agents/providers/codex.ts
@@ -82,6 +82,7 @@ const CODEX_CAPABILITIES: ProviderCapabilities = {
 export class CodexProvider implements AgentProvider {
   readonly id = "codex";
   readonly command = "codex";
+  readonly minimumCliVersion = "0.153.4";
   readonly models = CODEX_MODELS;
   readonly capabilities = CODEX_CAPABILITIES;
 }

--- a/backend/src/agents/providers/registry.test.ts
+++ b/backend/src/agents/providers/registry.test.ts
@@ -20,6 +20,8 @@ import {
   markProviderAvailable,
   parseVersionFromOutput,
   getAllProviderInfo,
+  getProviderUnavailableReason,
+  recordProviderDetection,
   getDefaultThinkingLevelForModel,
   isKnownModelId,
   isThinkingLevelSupportedForModel,
@@ -361,6 +363,56 @@ describe("markProviderAvailable", () => {
     markProviderAvailable("codex");
 
     expect(getModelCatalog().models.some((m) => m.provider === "codex")).toBe(true);
+  });
+});
+
+describe("harness minimum version", () => {
+  it.each([
+    ["0.153.3", false],
+    ["0.153.4", true],
+    ["0.154.0", true],
+    ["1.0.0", true],
+    [null, false],
+    ["unknown", false],
+    ["0.154.0-alpha.1", false],
+  ])("checks detected version %s without hiding models", (version, compatible) => {
+    recordProviderDetection("codex", true, version);
+    const catalog = getModelCatalog();
+    expect(catalog.models.length).toBeGreaterThan(0);
+    expect(catalog.defaultModelId).toBe("codex:gpt-5.6-sol");
+    const reason = compatible ? undefined : "Update Codex in settings";
+    expect(getProviderUnavailableReason("codex")).toBe(reason);
+    expect(catalog.models.every((model) => model.unavailableReason === reason)).toBe(true);
+  });
+
+  it("does not impose a version requirement on other providers", () => {
+    markProviderAvailable("claude");
+    expect(getProviderUnavailableReason("claude")).toBeUndefined();
+    expect(getModelCatalog().models.every((model) => !model.unavailableReason)).toBe(true);
+  });
+
+  it("does not treat finding a binary as proof of compatibility", () => {
+    markProviderAvailable("codex");
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+    recordProviderDetection("codex", true, "0.153.3");
+    markProviderAvailable("codex");
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+  });
+
+  it("unblocks after re-detection and forgets a previously compatible version", async () => {
+    let stdout = "codex-cli 0.153.3";
+    mockExecFile.mockImplementation(
+      (_cmd: string, _args: string[], cb: (...a: unknown[]) => void) => cb(null, { stdout, stderr: "" }),
+    );
+    await detectAvailableProviders();
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+    stdout = "codex-cli 0.153.4";
+    await detectAvailableProviders();
+    expect(getProviderUnavailableReason("codex")).toBeUndefined();
+    stdout = "unknown";
+    await detectAvailableProviders();
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+    expect(getAllProviderInfo().find((provider) => provider.id === "codex")?.version).toBeNull();
   });
 });
 

--- a/backend/src/agents/providers/registry.ts
+++ b/backend/src/agents/providers/registry.ts
@@ -1,6 +1,7 @@
 import { execFile as execFileCb } from "node:child_process";
 import { promisify } from "node:util";
 import { getKimiApiKey } from "../../state/config.js";
+import { compareVersions } from "../../utils/version.js";
 import { ClaudeProvider } from "./claude.js";
 import { CodexProvider } from "./codex.js";
 import { KimiProvider } from "./kimi.js";
@@ -61,25 +62,37 @@ export function parseVersionFromOutput(stdout: string): string | null {
  * Callers must await completion before publishing state that triggers catalog or usage reads.
  */
 export async function detectAvailableProviders(): Promise<void> {
-  availableProviderIds.clear();
-  detectedVersions.clear();
   for (const provider of ALL_PROVIDERS) {
     try {
       const { stdout } = await execFile(provider.command, ["--version"]);
-      availableProviderIds.add(provider.id);
-      const version = parseVersionFromOutput(stdout);
-      if (version) {
-        detectedVersions.set(provider.id, version);
-      }
+      recordProviderDetection(provider.id, true, parseVersionFromOutput(stdout));
     } catch {
-      // CLI not found — provider won't appear in catalog
+      recordProviderDetection(provider.id, false, null);
     }
   }
 }
 
-/** Mark a provider as available (used by preflight or tests). */
-export function markProviderAvailable(providerId: string): void {
-  availableProviderIds.add(providerId);
+/** Keep startup and Settings detection on the same installed-version state. */
+export function recordProviderDetection(providerId: string, installed: boolean, version: string | null): void {
+  if (installed) availableProviderIds.add(providerId);
+  else availableProviderIds.delete(providerId);
+  if (installed && version) detectedVersions.set(providerId, version);
+  else detectedVersions.delete(providerId);
+}
+
+/** Mark a provider as installed in tests; installation alone does not prove compatibility. */
+export function markProviderAvailable(providerId: string, version?: string): void {
+  recordProviderDetection(providerId, true, version ?? detectedVersions.get(providerId) ?? null);
+}
+
+export function getProviderUnavailableReason(providerId: string): string | undefined {
+  const minimum = providerMap.get(providerId)?.minimumCliVersion;
+  if (!minimum) return undefined;
+  const version = detectedVersions.get(providerId);
+  if (version && /^\d+(?:\.\d+)+$/.test(version) && compareVersions(version, minimum) >= 0) {
+    return undefined;
+  }
+  return `Update ${PROVIDER_LABELS[providerId] ?? providerId} in settings`;
 }
 
 /**
@@ -172,6 +185,7 @@ export function getModelCatalog(options: ModelCatalogOptions = {}): ModelCatalog
     // resolveProvider is intentionally not gated — stored sessions must resolve.
     if (provider.id === "kimi" && !getKimiApiKey()) continue;
     const providerLabel = PROVIDER_LABELS[provider.id] ?? provider.id;
+    const unavailableReason = getProviderUnavailableReason(provider.id);
 
     for (const model of provider.models) {
       const compoundId = `${provider.id}:${model.id}`;
@@ -180,6 +194,7 @@ export function getModelCatalog(options: ModelCatalogOptions = {}): ModelCatalog
         label: model.label,
         provider: provider.id,
         providerLabel,
+        ...(unavailableReason ? { unavailableReason } : {}),
         isDefault: model.isDefault,
         capabilities: {
           ...provider.capabilities,

--- a/backend/src/agents/providers/types.ts
+++ b/backend/src/agents/providers/types.ts
@@ -95,6 +95,7 @@ export type StreamAdapter = EventEmitter<StreamParserEvent> & {
 export interface AgentProvider {
   readonly id: string;
   readonly command: string;
+  readonly minimumCliVersion?: string;
   readonly models: ModelDefinition[];
   readonly capabilities: ProviderCapabilities;
 
@@ -116,6 +117,8 @@ export interface ModelCatalogEntry {
   label: string;
   provider: string;
   providerLabel: string;
+  /** Installed harness cannot run this model until it is updated. */
+  unavailableReason?: string;
   isDefault?: boolean;
   capabilities: ProviderCapabilities;
   /** Maximum context window size in tokens. */

--- a/backend/src/api/models.test.ts
+++ b/backend/src/api/models.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { modelRoutes } from "./models.js";
-import { getModelCatalog, markProviderAvailable } from "../agents/providers/registry.js";
+import { getModelCatalog, markProviderAvailable, recordProviderDetection } from "../agents/providers/registry.js";
 import { loadConfig, saveConfig } from "../state/config.js";
 import type { ToolAuthenticationState } from "../services/setup/detect.js";
 import type { ProviderAuthenticationReader } from "../services/setup/provider-authentication.js";
@@ -64,6 +64,25 @@ describe("GET /api/models", () => {
 
     expect(res.statusCode).toBe(200);
     expect(res.json().defaultModelId).toMatch(/^claude:/);
+  });
+
+  it("preserves an outdated harness's saved default and clears its restriction after detection", async () => {
+    authenticationStates.codex = "authenticated";
+    const config = await loadConfig(tempDir);
+    await saveConfig({ ...config, defaultModelId: "codex:gpt-5.5" }, tempDir);
+    recordProviderDetection("codex", true, "0.153.3");
+
+    const blocked = (await app.inject({ method: "GET", url: "/api/models" })).json();
+    expect(blocked.defaultModelId).toBe("codex:gpt-5.5");
+    expect(blocked.models).toContainEqual(expect.objectContaining({
+      id: "codex:gpt-5.5", unavailableReason: "Update Codex in settings",
+    }));
+
+    recordProviderDetection("codex", true, "0.153.4");
+    const updated = (await app.inject({ method: "GET", url: "/api/models" })).json();
+    expect(updated.defaultModelId).toBe("codex:gpt-5.5");
+    expect(updated.models.find((model: { id: string }) => model.id === "codex:gpt-5.5"))
+      .not.toHaveProperty("unavailableReason");
   });
 
   it("ignores a saved default whose harness is not authenticated", async () => {

--- a/backend/src/services/setup/tools-service.test.ts
+++ b/backend/src/services/setup/tools-service.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest";
 import { findToolSpec, installCommand, toolsPrefix } from "./catalog.js";
 import type { CommandResult } from "./command.js";
 import { ToolOperationError } from "./operations.js";
+import { getModelCatalog, getProviderUnavailableReason } from "../../agents/providers/registry.js";
 import {
   getToolsStatus,
   makeToolOperationRunner,
@@ -62,6 +63,39 @@ const gh = findToolSpec("gh");
 const noop = { setPhase: () => {} };
 
 describe("getToolsStatus", () => {
+  it.each([
+    { version: "unknown", latest: "0.153.4" },
+    { version: "0.154.0-alpha.1", latest: "0.153.4" },
+    { version: "0.153.3", latest: null },
+    { version: "unknown", latest: null },
+  ])("offers recovery for blocked Codex $version even when latest is $latest", async ({ version, latest }) => {
+    const { deps } = makeDeps({
+      probes: { "codex --version": ok(`codex-cli ${version}`) },
+      latest: { "@openai/codex": latest },
+    });
+
+    const tools = await getToolsStatus(deps);
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+    expect(tools.find((tool) => tool.id === "codex")).toMatchObject({
+      installed: true,
+      updateAvailable: true,
+    });
+  });
+
+  it("refreshes model availability after an externally updated harness is detected", async () => {
+    const probes = { "codex --version": ok("codex-cli 0.153.3") };
+    const { deps } = makeDeps({ probes });
+    await getToolsStatus(deps);
+    expect(getProviderUnavailableReason("codex")).toBe("Update Codex in settings");
+    probes["codex --version"] = ok("codex-cli 0.153.4");
+    await getToolsStatus(deps);
+    expect(getProviderUnavailableReason("codex")).toBeUndefined();
+    expect(getModelCatalog().models.some((model) => model.provider === "codex")).toBe(true);
+    probes["codex --version"] = missing();
+    await getToolsStatus(deps);
+    expect(getModelCatalog().models.some((model) => model.provider === "codex")).toBe(false);
+  });
+
   it("reports installed state, version, sign-in and update availability", async () => {
     const { deps } = makeDeps({
       probes: {

--- a/backend/src/services/setup/tools-service.ts
+++ b/backend/src/services/setup/tools-service.ts
@@ -2,7 +2,7 @@ import type {
   ToolOperationKind,
   ToolStatus,
 } from "@hive/shared/setup-types";
-import { detectAvailableProviders } from "../../agents/providers/registry.js";
+import { detectAvailableProviders, getProviderUnavailableReason, recordProviderDetection } from "../../agents/providers/registry.js";
 import {
   installCommand,
   isManaged,
@@ -55,10 +55,17 @@ export async function getToolsStatus(deps: ToolsServiceDeps): Promise<ToolStatus
         detectTool(spec, deps.detect),
         isManaged(spec) ? deps.fetchLatestVersion(spec.npmPackage) : Promise.resolve(null),
       ]);
-      const updateAvailable =
-        detection.installed && detection.version != null && latestVersion != null
-          ? isNewerVersion(detection.version, latestVersion)
-          : false;
+      if (spec.authenticatedProviderId) {
+        recordProviderDetection(spec.authenticatedProviderId, detection.installed, detection.version);
+      }
+      const updateRequired = !!spec.authenticatedProviderId
+        && !!getProviderUnavailableReason(spec.authenticatedProviderId);
+      const updateAvailable = detection.installed && isManaged(spec) && (
+        updateRequired || (
+          detection.version != null && latestVersion != null
+          && isNewerVersion(detection.version, latestVersion)
+        )
+      );
 
       return {
         id: spec.id,

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -15,8 +15,8 @@ The backend runs a startup preflight and exits if a required dependency is missi
 - **Claude CLI** (`claude`), installed and authenticated
 - **GitHub CLI** (`gh`), installed and authenticated for GitHub-backed flows
 - **PM2** for the documented production process
-- **Codex CLI** (`codex`) 0.153.4 or newer, optional and required only for its provider features.
-  Older versions keep their models visible but cannot start runs. Update Codex in Settings to
+- **Codex CLI** (`codex`) stable version 0.153.4 or newer, optional and required only for its provider features.
+  Older versions and prereleases keep their models visible but cannot start runs. Update Codex in Settings to
   re-enable them without restarting Hive.
 - **agent-browser** (`agent-browser`), optional — powers the live browser panel and agent-driven UI
   checks; run `agent-browser install` once (`--with-deps` on Linux) to download its Chrome build

--- a/docs/manual-installation.md
+++ b/docs/manual-installation.md
@@ -15,7 +15,9 @@ The backend runs a startup preflight and exits if a required dependency is missi
 - **Claude CLI** (`claude`), installed and authenticated
 - **GitHub CLI** (`gh`), installed and authenticated for GitHub-backed flows
 - **PM2** for the documented production process
-- **Codex CLI** (`codex`), optional and required only for its provider features
+- **Codex CLI** (`codex`) 0.153.4 or newer, optional and required only for its provider features.
+  Older versions keep their models visible but cannot start runs. Update Codex in Settings to
+  re-enable them without restarting Hive.
 - **agent-browser** (`agent-browser`), optional — powers the live browser panel and agent-driven UI
   checks; run `agent-browser install` once (`--with-deps` on Linux) to download its Chrome build
 

--- a/frontend/src/components/ChatInput.tsx
+++ b/frontend/src/components/ChatInput.tsx
@@ -20,6 +20,7 @@ import { FileAutocompletePopup } from "@/components/chat/FileAutocompletePopup";
 import { MentionHighlightOverlay } from "@/components/chat/MentionHighlightOverlay";
 import { ContextRing } from "@/components/chat/ContextRing";
 import { ModelSelector } from "@/components/chat/ModelSelector";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { ThinkingSelector } from "@/components/chat/ThinkingSelector";
 import { ComposerOptionsMenu } from "@/components/chat/ComposerOptionsMenu";
 import { useCompletions } from "@/hooks/useCompletions";
@@ -154,9 +155,11 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
     isError: modelsError,
     retry: retryModels,
   } = useModels(lockedProvider, lastRunOptions?.model);
+  const unavailableReason = selectedModel?.unavailableReason;
   const canSubmit =
     !isInputDisabled &&
     selectedModel !== undefined &&
+    !unavailableReason &&
     (value.trim().length > 0 || fileCount > 0);
   const contextUsage = useContextUsage(messages, selectedModel);
   const completionProvider = lockedProvider ?? (selectedModelId ? selectedModelId.split(":")[0] : undefined);
@@ -351,6 +354,8 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
   );
 
   const handleSubmit = ({ text, files }: PromptInputMessage) => {
+    // PromptInput preserves attachments when submission is rejected.
+    if (unavailableReason) throw new Error(unavailableReason);
     const trimmed = text.trim();
     if (!trimmed && files.length === 0) return;
     if (disabled || isDisconnected || !selectedModel) return;
@@ -502,21 +507,30 @@ const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function ChatInput
                 <SquareIcon className="size-3 text-destructive" />
               </PromptInputButton>
             )}
-            <PromptInputSubmit
-              aria-label="Send"
-              status="ready"
-              variant="ghost"
-              disabled={!canSubmit}
-              size="icon-xs"
-              className={cn(
-                "size-5 border border-border/50",
-                canSubmit && "border-primary bg-primary text-primary-foreground hover:bg-primary/90",
-              )}
-            />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="inline-flex" tabIndex={unavailableReason ? 0 : undefined} aria-label={unavailableReason}>
+                    <PromptInputSubmit
+                      aria-label="Send"
+                      status="ready"
+                      variant="ghost"
+                      disabled={!canSubmit}
+                      size="icon-xs"
+                      className={cn(
+                        "size-5 border border-border/50",
+                        canSubmit && "border-primary bg-primary text-primary-foreground hover:bg-primary/90",
+                      )}
+                    />
+                  </span>
+                </TooltipTrigger>
+                {unavailableReason && <TooltipContent>{unavailableReason}</TooltipContent>}
+              </Tooltip>
+            </TooltipProvider>
           </PromptInputTools>
         </PromptInputFooter>
         </PromptInput>
-        {!value.trim() && !isInputDisabled && selectedModel && (
+        {!value.trim() && !isInputDisabled && selectedModel && !unavailableReason && (
           <div className="pointer-events-none absolute top-2 right-2 z-10 flex items-center gap-1.5">
             <button
               type="button"

--- a/frontend/src/components/chat/ModelSelector.tsx
+++ b/frontend/src/components/chat/ModelSelector.tsx
@@ -118,13 +118,21 @@ export function ModelSelector({
                   {group.models.map((model) => {
                     const isSelected = model.id === selectedModelId;
                     const isLocked = !!lockedProvider && model.provider !== lockedProvider;
+                    const disabledReason = model.unavailableReason ?? (isLocked ? "Cannot switch provider mid-session" : undefined);
 
-                    if (isLocked) {
+                    if (disabledReason) {
                       return (
                         <Tooltip key={model.id}>
                           <TooltipTrigger asChild>
-                            <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm opacity-30 cursor-not-allowed select-none">
+                            <div
+                              role="menuitem"
+                              aria-disabled="true"
+                              aria-label={`${model.label}: ${disabledReason}`}
+                              tabIndex={0}
+                              className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm opacity-30 cursor-not-allowed select-none"
+                            >
                               <span className="flex-1">{model.label}</span>
+                              {isSelected && <CheckIcon className="size-3.5 text-primary" />}
                             </div>
                           </TooltipTrigger>
                           <TooltipPrimitive.Portal>
@@ -133,7 +141,7 @@ export function ModelSelector({
                               sideOffset={4}
                               className="animate-in fade-in-0 zoom-in-95 z-50 rounded-md border border-border/30 bg-muted px-3 py-1.5 text-xs text-muted-foreground shadow-md"
                             >
-                              Cannot switch provider mid-session
+                              {disabledReason}
                             </TooltipPrimitive.Content>
                           </TooltipPrimitive.Portal>
                         </Tooltip>

--- a/frontend/src/lib/timeline-steps.ts
+++ b/frontend/src/lib/timeline-steps.ts
@@ -333,6 +333,7 @@ function activitySteps(activity: AgentActivity, streaming: boolean): TimelineSte
         started: ["Starting agent", "started"],
         interacted: ["Interacting", "interacted"],
         interrupted: ["Interrupting", "interrupted"],
+        completed: ["Completing agent", "completed"],
       } as const;
       const [liveVerb, verb] = verbs[activity.activityKind];
       return [activityStep(activity, "subagent_activity", "bot", liveVerb, verb, activity.agentPath, "completed")];

--- a/frontend/src/pages/settings/ModelsSettings.tsx
+++ b/frontend/src/pages/settings/ModelsSettings.tsx
@@ -7,6 +7,7 @@ import { SettingsPanel, SettingsSection } from "@/components/settings/SettingsSe
 import { ProviderIcon } from "@/components/chat/ProviderIcon";
 import { groupModelsByProvider } from "@/components/chat/ModelSelector";
 import { Input } from "@/components/ui/input";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { api } from "@/hooks/useApi";
 import { useModels, refreshModelCatalog, setCachedDefaultModelId } from "@/hooks/useModels";
 import { PROVIDER_USAGE_QUERY_KEY } from "@/hooks/useProviderUsage";
@@ -22,7 +23,7 @@ export default function ModelsSettings() {
   const grouped = useMemo(() => groupModelsByProvider(models), [models]);
 
   const selectDefault = async (modelId: string) => {
-    if (modelId === currentId) return;
+    if (modelId === currentId || models.find((model) => model.id === modelId)?.unavailableReason) return;
     const previous = currentId;
     setSavedId(modelId);
     setSaveFailed(false);
@@ -60,41 +61,49 @@ export default function ModelsSettings() {
               </p>
             )}
 
-            <div role="radiogroup" aria-label="Default model" className="mt-4 space-y-4">
-              {grouped.map((group) => (
-                <div key={group.provider}>
-                  <div className="mb-1.5 flex items-center gap-1.5">
-                    <ProviderIcon provider={group.provider} className="size-3 text-muted-foreground" />
-                    <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
-                      {group.providerLabel}
-                    </span>
+            <TooltipProvider>
+              <div role="radiogroup" aria-label="Default model" className="mt-4 space-y-4">
+                {grouped.map((group) => (
+                  <div key={group.provider}>
+                    <div className="mb-1.5 flex items-center gap-1.5">
+                      <ProviderIcon provider={group.provider} className="size-3 text-muted-foreground" />
+                      <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+                        {group.providerLabel}
+                      </span>
+                    </div>
+                    <div className="space-y-1">
+                      {group.models.map((model) => {
+                        const isActive = model.id === currentId;
+                        return (
+                          <Tooltip key={model.id}>
+                            <TooltipTrigger asChild>
+                              <button
+                                type="button"
+                                role="radio"
+                                aria-checked={isActive}
+                                aria-disabled={!!model.unavailableReason}
+                                onClick={() => void selectDefault(model.id)}
+                                className={cn(
+                                  "flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-all duration-200",
+                                  model.unavailableReason && "cursor-not-allowed opacity-40",
+                                  isActive
+                                    ? "border-primary/40 bg-primary/8 text-foreground"
+                                    : "border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
+                                )}
+                              >
+                                <span className="flex-1">{model.label}</span>
+                                {isActive && <Check className="h-4 w-4 text-primary" strokeWidth={2.5} />}
+                              </button>
+                            </TooltipTrigger>
+                            {model.unavailableReason && <TooltipContent>{model.unavailableReason}</TooltipContent>}
+                          </Tooltip>
+                        );
+                      })}
+                    </div>
                   </div>
-                  <div className="space-y-1">
-                    {group.models.map((model) => {
-                      const isActive = model.id === currentId;
-                      return (
-                        <button
-                          key={model.id}
-                          type="button"
-                          role="radio"
-                          aria-checked={isActive}
-                          onClick={() => void selectDefault(model.id)}
-                          className={cn(
-                            "flex w-full cursor-pointer items-center gap-2 rounded-lg border px-3 py-2 text-left text-sm transition-all duration-200",
-                            isActive
-                              ? "border-primary/40 bg-primary/8 text-foreground"
-                              : "border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/40 hover:text-foreground",
-                          )}
-                        >
-                          <span className="flex-1">{model.label}</span>
-                          {isActive && <Check className="h-4 w-4 text-primary" strokeWidth={2.5} />}
-                        </button>
-                      );
-                    })}
-                  </div>
-                </div>
-              ))}
-            </div>
+                ))}
+              </div>
+            </TooltipProvider>
 
             {saveFailed && (
               <p className="mt-3 text-xs text-destructive">

--- a/frontend/src/pages/settings/TeamSettings.tsx
+++ b/frontend/src/pages/settings/TeamSettings.tsx
@@ -555,8 +555,8 @@ function ModelSelect({
       className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       {models.map((m) => (
-        <option key={m.id} value={m.id}>
-          {m.label} ({m.providerLabel})
+        <option key={m.id} value={m.id} disabled={!!m.unavailableReason}>
+          {m.label} ({m.providerLabel}){m.unavailableReason ? ` — ${m.unavailableReason}` : ""}
         </option>
       ))}
     </select>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -471,6 +471,7 @@ export interface ModelCatalogEntry {
   label: string;
   provider: string;
   providerLabel: string;
+  unavailableReason?: string;
   isDefault?: boolean;
   capabilities: ProviderCapabilities;
   /** Maximum context window size in tokens. */

--- a/frontend/tests/components/ChatInput.persistence.test.tsx
+++ b/frontend/tests/components/ChatInput.persistence.test.tsx
@@ -1,4 +1,4 @@
-import { act, fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -406,5 +406,23 @@ describe("ChatInput draft persistence", () => {
 
     rerenderChatInput(rerender, { sessionId: sessionA });
     expect(screen.getByRole("img", { name: "avatar-a.png" })).toBeInTheDocument();
+  });
+
+  it("preserves attachments when an unavailable model rejects a submitted form", async () => {
+    const user = userEvent.setup();
+    const { a: sessionId } = makeSessionIds();
+    const onSend = vi.fn(() => true);
+    renderChatInput(sessionId, undefined, onSend);
+    await user.upload(getUploadInput(), new File(["image"], "draft.png", { type: "image/png" }));
+    await act(async () => {
+      queryClient.setQueryData(MODEL_CATALOG_QUERY_KEY, {
+        ...MODEL_CATALOG,
+        models: MODEL_CATALOG.models.map((model) => ({ ...model, unavailableReason: "Update Codex in settings" })),
+      });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "Send" })).toBeDisabled());
+    await act(async () => { fireEvent.submit(screen.getByRole("textbox").closest("form")!); });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.getByRole("img", { name: "draft.png" })).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/ChatInput.test.tsx
+++ b/frontend/tests/components/ChatInput.test.tsx
@@ -9,7 +9,7 @@ import type { OutputStyle } from "@/types";
 const modelMock = vi.hoisted(() => {
   const capabilities = { thinkingLevels: ["low", "medium", "high", "xhigh", "max"], planMode: true, blockingTools: true, completions: true, outputStyles: undefined as OutputStyle[] | undefined };
   const models = [
-    { id: "claude:opus-4-7", modelId: "opus-4-7", label: "Opus 4.7", provider: "claude", providerLabel: "Claude Code", supportsFastMode: true, capabilities: { ...capabilities } },
+    { id: "claude:opus-4-7", modelId: "opus-4-7", label: "Opus 4.7", provider: "claude", providerLabel: "Claude Code", supportsFastMode: true, unavailableReason: undefined as string | undefined, capabilities: { ...capabilities } },
     { id: "claude:sonnet-4-6", modelId: "sonnet-4-6", label: "Sonnet 4.6", provider: "claude", providerLabel: "Claude Code", capabilities: { ...capabilities } },
   ];
   return {
@@ -88,7 +88,10 @@ describe("ChatInput", () => {
     modelMock.isError = false;
     modelMock.setSelectedModelId.mockClear();
     modelMock.retry.mockClear();
-    for (const model of modelMock.models) model.capabilities.outputStyles = undefined;
+    for (const model of modelMock.models) {
+      model.capabilities.outputStyles = undefined;
+      model.unavailableReason = undefined;
+    }
   });
 
   it("does not render legacy status labels", () => {
@@ -96,6 +99,42 @@ describe("ChatInput", () => {
 
     expect(screen.queryByText("Working…")).not.toBeInTheDocument();
     expect(screen.queryByText("Awaiting response…")).not.toBeInTheDocument();
+  });
+
+  it("keeps an unavailable model and draft, blocks Enter and form submission, then unlocks after refresh", async () => {
+    modelMock.models[0].unavailableReason = "Update Codex in settings";
+    const user = userEvent.setup();
+    const { onSend, onQueue, rerender } = renderChatInput();
+    const input = screen.getByRole("textbox");
+
+    expect(screen.queryByRole("button", { name: "Commit & Push" })).not.toBeInTheDocument();
+    await user.type(input, "keep this draft{enter}");
+    await act(async () => { fireEvent.submit(input.closest("form")!); });
+    expect(onSend).not.toHaveBeenCalled();
+    expect(onQueue).not.toHaveBeenCalled();
+    expect(input).toHaveValue("keep this draft");
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Model: Opus 4.7" })).toBeInTheDocument();
+    await user.hover(screen.getByLabelText("Update Codex in settings"));
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Update Codex in settings");
+
+    modelMock.models[0].unavailableReason = undefined;
+    rerender();
+    expect(input).toHaveValue("keep this draft");
+    await user.click(screen.getByRole("button", { name: "Send" }));
+    expect(onSend).toHaveBeenCalledWith("keep this draft", undefined, expect.objectContaining({ model: "claude:opus-4-7" }), undefined);
+  });
+
+  it("keeps Stop available but prevents queued sends for an unavailable model", async () => {
+    modelMock.models[0].unavailableReason = "Update Codex in settings";
+    const user = userEvent.setup();
+    const { onStop, onSend, onQueue } = renderChatInput({ isStreaming: true });
+    await user.type(screen.getByRole("textbox"), "follow up{enter}");
+    expect(screen.getByRole("button", { name: "Send" })).toBeDisabled();
+    await user.click(screen.getByRole("button", { name: "Stop" }));
+    expect(onStop).toHaveBeenCalledOnce();
+    expect(onSend).not.toHaveBeenCalled();
+    expect(onQueue).not.toHaveBeenCalled();
   });
 
   it("keeps the submit button in send mode when idle", () => {

--- a/frontend/tests/components/ModelSelector.test.tsx
+++ b/frontend/tests/components/ModelSelector.test.tsx
@@ -36,6 +36,26 @@ const CODEX_MODELS: ModelCatalogEntry[] = [
 const ALL_MODELS = [...CLAUDE_MODELS, ...CODEX_MODELS];
 
 describe("ModelSelector", () => {
+  it("explains unavailable models and still allows other providers", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<ModelSelector
+      models={ALL_MODELS.map((model) => model.provider === "codex" ? { ...model, unavailableReason: "Update Codex in settings" } : model)}
+      selectedModelId="claude:opus-4-7"
+      onSelect={onSelect}
+    />);
+
+    await user.click(screen.getByRole("button", { name: "Model: Opus 4.7" }));
+    const unavailable = screen.getByRole("menuitem", { name: "GPT-5.5: Update Codex in settings" });
+    expect(unavailable).toHaveAttribute("aria-disabled", "true");
+    await user.hover(unavailable);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Update Codex in settings");
+    await user.click(unavailable);
+    expect(onSelect).not.toHaveBeenCalled();
+    await user.click(screen.getByRole("menuitem", { name: "Sonnet 4.6" }));
+    expect(onSelect).toHaveBeenCalledWith("claude:sonnet-4-6");
+  });
+
   it("renders a compact accessible loading state without a dropdown", async () => {
     const user = userEvent.setup();
     render(

--- a/frontend/tests/hooks/useModels.test.ts
+++ b/frontend/tests/hooks/useModels.test.ts
@@ -67,6 +67,22 @@ beforeEach(() => {
 });
 
 describe("useModels", () => {
+  it("preserves an unavailable default and unlocks it after a catalog refresh", async () => {
+    mockApi.get.mockResolvedValue({
+      ...MOCK_CATALOG,
+      models: MOCK_CATALOG.models.map((model) => model.provider === "codex" ? { ...model, unavailableReason: "Update Codex in settings" } : model),
+    });
+    const queryClient = createQueryClient();
+    const { result } = renderHook(() => useModels(), { wrapper: wrapperFor(queryClient) });
+    await waitFor(() => expect(result.current.selectedModel?.unavailableReason).toBe("Update Codex in settings"));
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+
+    mockApi.get.mockResolvedValue(MOCK_CATALOG);
+    await act(async () => { await refreshModelCatalog(queryClient); });
+    await waitFor(() => expect(result.current.selectedModel?.unavailableReason).toBeUndefined());
+    expect(result.current.selectedModelId).toBe("codex:gpt-5.5");
+  });
+
   it("loads the shared catalog and seeds the global default", async () => {
     mockApi.get.mockResolvedValue(MOCK_CATALOG);
     const queryClient = createQueryClient();

--- a/frontend/tests/lib/timeline-steps.test.ts
+++ b/frontend/tests/lib/timeline-steps.test.ts
@@ -330,6 +330,7 @@ describe("describeTool", () => {
       ["started", "Starting agent", "started"],
       ["interacted", "Interacting", "interacted"],
       ["interrupted", "Interrupting", "interrupted"],
+      ["completed", "Completing agent", "completed"],
     ] as const;
     for (const [activityKind, liveVerb, verb] of kinds) {
       const msg = message({

--- a/frontend/tests/pages/ModelsSettings.test.tsx
+++ b/frontend/tests/pages/ModelsSettings.test.tsx
@@ -55,6 +55,19 @@ beforeEach(() => {
 });
 
 describe("ModelsSettings", () => {
+  it("keeps an unavailable default selected and explains why it cannot be chosen", async () => {
+    mockApiGet({ ...MOCK_CATALOG, models: MOCK_CATALOG.models.map((model) => model.provider === "codex" ? { ...model, unavailableReason: "Update Codex in settings" } : model) });
+    const user = userEvent.setup();
+    renderModelsSettings();
+    const model = await screen.findByRole("radio", { name: "GPT-5.5" });
+    expect(model).toHaveAttribute("aria-checked", "true");
+    expect(model).toHaveAttribute("aria-disabled", "true");
+    await user.hover(model);
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("Update Codex in settings");
+    await user.click(model);
+    expect(mocks.put).not.toHaveBeenCalled();
+  });
+
   it("renders models grouped by provider with the current default checked", async () => {
     mockApiGet(MOCK_CATALOG);
     renderModelsSettings();

--- a/frontend/tests/pages/TeamSettings.test.tsx
+++ b/frontend/tests/pages/TeamSettings.test.tsx
@@ -185,6 +185,18 @@ describe("TeamSettings", () => {
     });
   });
 
+  it("disables unavailable models in the team model picker", async () => {
+    mocks.apiGet.mockResolvedValue({
+      ...catalog,
+      models: catalog.models.map((model) => model.provider === "codex" ? { ...model, unavailableReason: "Update Codex in settings" } : model),
+    });
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole("button", { name: "Add Agent" }));
+    expect(await screen.findByRole("option", { name: "GPT-5.5 (Codex) — Update Codex in settings" })).toBeDisabled();
+    expect(screen.getByRole("option", { name: "Sonnet 4.6 (Claude Code)" })).not.toBeDisabled();
+  });
+
   it("resets an incompatible thinking level when the model changes", async () => {
     const user = userEvent.setup();
     renderPage();

--- a/ios/HiveMobile/Models/AgentActivity.swift
+++ b/ios/HiveMobile/Models/AgentActivity.swift
@@ -32,6 +32,7 @@ enum AgentActivitySubagentActivityKind: String, Codable, Equatable, CaseIterable
     case started
     case interacted
     case interrupted
+    case completed
 }
 
 enum AgentActivity: Codable, Equatable, Identifiable {

--- a/ios/HiveMobile/Models/Models.swift
+++ b/ios/HiveMobile/Models/Models.swift
@@ -35,6 +35,7 @@ struct ModelCatalogEntry: Codable, Identifiable, Equatable {
     let label: String
     let provider: String
     let providerLabel: String
+    let unavailableReason: String?
     let isDefault: Bool?
     let capabilities: ProviderCapabilities
     let contextWindow: Int?

--- a/ios/HiveMobile/Models/TimelineSteps.swift
+++ b/ios/HiveMobile/Models/TimelineSteps.swift
@@ -372,6 +372,7 @@ private func activitySteps(_ activity: AgentActivity, streaming: Bool) -> [Timel
         case .started: verbs = ("Starting agent", "started")
         case .interacted: verbs = ("Interacting", "interacted")
         case .interrupted: verbs = ("Interrupting", "interrupted")
+        case .completed: verbs = ("Completing agent", "completed")
         }
         return [activityStep(activity, kind: .subagentActivity, icon: "arrow.triangle.branch",
                              liveVerb: verbs.live, verb: verbs.past, subject: subagent.agentPath, status: .completed)]

--- a/ios/HiveMobile/Views/Chat/ChatInputBar.swift
+++ b/ios/HiveMobile/Views/Chat/ChatInputBar.swift
@@ -54,6 +54,13 @@ struct ChatInputBar: View {
 
             // MARK: - Compose Area
             composeArea
+            if let unavailableReason {
+                Text(unavailableReason)
+                    .font(.caption2)
+                    .foregroundStyle(WhisperColor.textMuted)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
         }
         .glassCard(cornerRadius: 20)
         .overlay(planModeOverlay)
@@ -72,6 +79,10 @@ struct ChatInputBar: View {
 
     private var selectedModelLabel: String {
         models.first { $0.id == selectedModelId }?.label ?? "Model"
+    }
+
+    private var unavailableReason: String? {
+        models.first { $0.id == selectedModelId }?.unavailableReason
     }
 
 
@@ -302,6 +313,7 @@ struct ChatInputBar: View {
             }
             .disabled(!canSend)
             .accessibilityLabel("Send message")
+            .accessibilityHint(unavailableReason ?? "")
 
             if isBusy {
                 Button {
@@ -339,7 +351,7 @@ struct ChatInputBar: View {
     private var canSend: Bool {
         let hasPending = attachedImages.contains { $0.attachment == nil }
         let hasContent = !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || !attachedImages.isEmpty
-        return hasContent && !hasPending && !isBusy
+        return hasContent && !hasPending && !isBusy && unavailableReason == nil
     }
 
     private func animateAttachment(_ body: () -> Void) {
@@ -347,6 +359,7 @@ struct ChatInputBar: View {
     }
 
     private func handleSend() {
+        guard canSend else { return }
         Haptics.impact(.light)
         let imageAttachments = attachedImages.compactMap(\.attachment)
         attachedImages = []
@@ -446,6 +459,14 @@ private struct ModelMenu: View {
                         )
                     }
                     .buttonStyle(.plain)
+                    .disabled(model.unavailableReason != nil)
+                    .opacity(model.unavailableReason == nil ? 1 : 0.4)
+                    if let reason = model.unavailableReason {
+                        Text(reason)
+                            .font(.caption2)
+                            .foregroundStyle(WhisperColor.textMuted)
+                            .padding(.horizontal, 14)
+                    }
                 }
             }
             if let lockedProviderLabel {
@@ -846,10 +867,12 @@ private extension ImageAttachment {
 #Preview {
     let sampleModels: [ModelCatalogEntry] = [
         .init(id: "claude:opus-4-7", label: "Opus 4.7", provider: "claude", providerLabel: "Claude Code",
+              unavailableReason: nil,
               isDefault: true,
               capabilities: .init(thinkingLevels: [.low, .medium, .high, .xhigh, .max], outputStyles: [.default, .proactive, .concise, .explanatory, .learning], planMode: true, blockingTools: true, completions: true, goals: false),
               contextWindow: 1_000_000, supportsFastMode: true),
         .init(id: "claude:sonnet-4-6", label: "Sonnet 4.6", provider: "claude", providerLabel: "Claude Code",
+              unavailableReason: nil,
               isDefault: nil,
               capabilities: .init(thinkingLevels: [.low, .medium, .high, .xhigh, .max], outputStyles: [.default, .proactive, .concise, .explanatory, .learning], planMode: true, blockingTools: true, completions: true, goals: false),
               contextWindow: 1_000_000, supportsFastMode: nil),

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -729,7 +729,6 @@ struct ChatView: View {
     // MARK: - Send
 
     private func sendMessage(images: [ImageAttachment]) {
-        guard selectedModel?.unavailableReason == nil else { return }
         let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !content.isEmpty || !images.isEmpty else { return }
 

--- a/ios/HiveMobile/Views/Chat/ChatView.swift
+++ b/ios/HiveMobile/Views/Chat/ChatView.swift
@@ -729,6 +729,7 @@ struct ChatView: View {
     // MARK: - Send
 
     private func sendMessage(images: [ImageAttachment]) {
+        guard selectedModel?.unavailableReason == nil else { return }
         let content = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !content.isEmpty || !images.isEmpty else { return }
 

--- a/ios/Tests/ChatDraftStoreTests/ModelCatalogDecodingTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/ModelCatalogDecodingTests.swift
@@ -3,6 +3,32 @@ import Testing
 @testable import HiveMobileStoresCore
 
 struct ModelCatalogDecodingTests {
+    @Test(arguments: [nil, "Update Codex in settings"] as [String?])
+    func decodesModelAvailabilityWithoutChangingTheDefault(_ reason: String?) throws {
+        var model: [String: Any] = [
+            "id": "codex:gpt-5.5",
+            "label": "GPT-5.5",
+            "provider": "codex",
+            "providerLabel": "Codex",
+            "capabilities": [
+                "thinkingLevels": [],
+                "planMode": true,
+                "blockingTools": true,
+                "completions": true,
+            ] as [String: Any],
+        ]
+        model["unavailableReason"] = reason
+        let data = try JSONSerialization.data(withJSONObject: [
+            "models": [model],
+            "defaultModelId": "codex:gpt-5.5",
+        ])
+
+        let catalog = try JSONDecoder().decode(ModelCatalogResponse.self, from: data)
+        let entry = try #require(catalog.models.first)
+        #expect(entry.unavailableReason == reason)
+        #expect(catalog.defaultModelId == entry.id)
+    }
+
     @Test
     func decodesKimiLabelsAndModelSpecificThinkingLevels() throws {
         let data = Data(

--- a/ios/Tests/ChatDraftStoreTests/TimelineStepsTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/TimelineStepsTests.swift
@@ -358,7 +358,8 @@ struct TimelineStepsTests {
         let expected: [AgentActivitySubagentActivityKind: (liveVerb: String, verb: String)] = [
             .started: ("Starting agent", "started"),
             .interacted: ("Interacting", "interacted"),
-            .interrupted: ("Interrupting", "interrupted")
+            .interrupted: ("Interrupting", "interrupted"),
+            .completed: ("Completing agent", "completed")
         ]
         for kind in AgentActivitySubagentActivityKind.allCases {
             let msg = message(

--- a/shared/agent-activity.ts
+++ b/shared/agent-activity.ts
@@ -19,7 +19,7 @@ export interface AgentActivityToolCall {
   parentToolUseId?: string;
 }
 
-export const AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS = ["started", "interacted", "interrupted"] as const;
+export const AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS = ["started", "interacted", "interrupted", "completed"] as const;
 
 export type AgentActivitySubagentActivityKind = (typeof AGENT_ACTIVITY_SUBAGENT_ACTIVITY_KINDS)[number];
 


### PR DESCRIPTION
Codex reported deprecated full-history hydration when Hive resumed conversations or recovered sub-agent activity. Hive now requires Codex 0.153.4 or newer and uses one paginated history path while preserving existing conversations.

An optional minimum CLI version on each provider supplies a shared model unavailability reason. Existing model and send controls show `Update Codex in settings`, preserve selections and drafts, and unlock after a successful Settings update. Backend validation also rejects incompatible interactive, Brain, automation, and goal launches before persisting a message. Web and iOS clients consume the same availability field.

Resume requests use `excludeTurns: true`. Sub-agent catch-up follows ascending `thread/turns/list` pages with `itemsView: "full"`; no deprecated full-history read or legacy fallback remains. Finalization waits for child and grandchild recovery, and completed sub-agent activity is rendered without leaving the session streaming. Per-page deadlines and completion deduplication prevent stale or recursive replay.

Known informational App Server notifications are handled explicitly. Terminal interactions never surface or persist raw stdin, while plan deltas and MCP progress notifications defer to their authoritative structured lifecycle events. Unexpected and actionable protocol notifications remain visible as diagnostics.

## Validation

- Backend and frontend lint, typecheck, tests, and production builds pass.
- Real Codex 0.153.4 conversations preserve memory across consecutive messages and after backend restart/resume.
- Real multi-agent recovery completed with two sub-agents, paginated full-item history, and no deprecated hydration warning.
- Browser validation covered disabled model tooltips, rejected Enter submission, retained drafts/defaults, automatic unlock after refresh, successful send, and the Stop control.
- Targeted App Server tests cover terminal input suppression, including Ctrl+C and arbitrary stdin, plus redundant plan and MCP progress notifications.
- GitHub CI passes for backend/frontend, desktop, and iOS.

Closes #522
Closes #523
