### PR TITLE
feat: add a designed iOS code block and enable copying completed streaming code

### DIFF
--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -33,6 +33,7 @@ import { Streamdown } from "streamdown";
 import type { LinkSafetyModalProps } from "streamdown";
 import { ExternalLinkDialog } from "@/components/ExternalLinkDialog";
 import { openExternal } from "@/lib/open-external";
+import { StreamingCodeBlock } from "@/components/chat/StreamingCodeBlock";
 
 export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   from: UIMessage["role"];
@@ -326,6 +327,7 @@ export const MessageBranchPage = ({
 export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
+const streamdownComponents = { pre: StreamingCodeBlock };
 
 const renderLinkModal = (props: LinkSafetyModalProps) => (
   <ExternalLinkDialog
@@ -349,6 +351,7 @@ export const MessageResponse = memo(
         className
       )}
       plugins={streamdownPlugins}
+      components={streamdownComponents}
       linkSafety={streamdownLinkSafety}
       {...props}
     />

--- a/frontend/src/components/ai-elements/message.tsx
+++ b/frontend/src/components/ai-elements/message.tsx
@@ -352,8 +352,7 @@ export const MessageResponse = memo(
       linkSafety={streamdownLinkSafety}
       {...props}
     />
-  ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  )
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/frontend/src/components/chat/StreamingCodeBlock.tsx
+++ b/frontend/src/components/chat/StreamingCodeBlock.tsx
@@ -1,0 +1,21 @@
+import { cloneElement, isValidElement, useContext, useMemo, type ComponentProps, type ReactElement } from "react";
+import { StreamdownContext, useIsCodeFenceIncomplete } from "streamdown";
+
+/** Keep Streamdown's code renderer, but scope its controls to the current fence. */
+export function StreamingCodeBlock({ children }: ComponentProps<"pre">) {
+  const context = useContext(StreamdownContext);
+  const incomplete = useIsCodeFenceIncomplete();
+  const value = useMemo(
+    () => ({ ...context, isAnimating: context.isAnimating && incomplete }),
+    [context, incomplete],
+  );
+
+  return (
+    <StreamdownContext.Provider value={value}>
+      {isValidElement(children)
+        // Streamdown's default pre renderer marks its code child as a block.
+        ? cloneElement(children as ReactElement<{ "data-block"?: string }>, { "data-block": "true" })
+        : children}
+    </StreamdownContext.Provider>
+  );
+}

--- a/frontend/tests/components/MessageResponse.streaming.test.tsx
+++ b/frontend/tests/components/MessageResponse.streaming.test.tsx
@@ -7,7 +7,7 @@ describe("MessageResponse streaming controls", () => {
   it("enables copying when streaming ends without changing the code", async () => {
     const user = userEvent.setup();
     const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
-    const markdown = "```bash\nnpm run dev\n```";
+    const markdown = "```bash\nnpm run dev\n";
     const { rerender } = render(
       <MessageResponse isAnimating>{markdown}</MessageResponse>,
     );
@@ -21,6 +21,25 @@ describe("MessageResponse streaming controls", () => {
     expect(screen.getByRole("button", { name: /download file/i })).toBeEnabled();
     await user.click(screen.getByRole("button", { name: /copy code/i }));
     expect(writeText).toHaveBeenCalledWith("npm run dev\n");
+  });
+
+  it("enables a closed block while the response continues and keeps an open block disabled", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    const first = "```bash\nnpm run dev\n";
+    const { rerender } = render(<MessageResponse isAnimating>{first}</MessageResponse>);
+    expect(await screen.findByRole("button", { name: /copy code/i })).toBeDisabled();
+
+    rerender(<MessageResponse isAnimating>{first + "```"}</MessageResponse>);
+    await waitFor(() => expect(screen.getByRole("button", { name: /copy code/i })).toBeEnabled());
+    expect(screen.getByRole("button", { name: /download file/i })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /copy code/i }));
+    expect(writeText).toHaveBeenCalledWith("npm run dev\n");
+
+    rerender(<MessageResponse isAnimating>{first + "```\n\nNext command:\n\n```bash\nnpm test"}</MessageResponse>);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: /copy code/i })).toHaveLength(2));
+    expect(screen.getAllByRole("button", { name: /copy code/i })[0]).toBeEnabled();
+    expect(screen.getAllByRole("button", { name: /copy code/i })[1]).toBeDisabled();
   });
 
   it("updates table controls across streaming state changes with unchanged Markdown", async () => {

--- a/frontend/tests/components/MessageResponse.streaming.test.tsx
+++ b/frontend/tests/components/MessageResponse.streaming.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { MessageResponse } from "@/components/ai-elements/message";
+
+describe("MessageResponse streaming controls", () => {
+  it("enables copying when streaming ends without changing the code", async () => {
+    const user = userEvent.setup();
+    const writeText = vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue();
+    const markdown = "```bash\nnpm run dev\n```";
+    const { rerender } = render(
+      <MessageResponse isAnimating>{markdown}</MessageResponse>,
+    );
+
+    expect(await screen.findByRole("button", { name: /copy code/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /download file/i })).toBeDisabled();
+
+    rerender(<MessageResponse isAnimating={false}>{markdown}</MessageResponse>);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /copy code/i })).toBeEnabled());
+    expect(screen.getByRole("button", { name: /download file/i })).toBeEnabled();
+    await user.click(screen.getByRole("button", { name: /copy code/i }));
+    expect(writeText).toHaveBeenCalledWith("npm run dev\n");
+  });
+
+  it("updates table controls across streaming state changes with unchanged Markdown", async () => {
+    const markdown = "| Command | Status |\n| --- | --- |\n| Tests | Passed |";
+    const { rerender } = render(
+      <MessageResponse isAnimating>{markdown}</MessageResponse>,
+    );
+    const controls = [
+      await screen.findByRole("button", { name: /copy table/i }),
+      screen.getByRole("button", { name: /download table/i }),
+      screen.getByRole("button", { name: /view fullscreen/i }),
+    ];
+    for (const control of controls) expect(control).toBeDisabled();
+
+    rerender(<MessageResponse isAnimating={false}>{markdown}</MessageResponse>);
+
+    await waitFor(() => {
+      for (const control of controls) expect(control).toBeEnabled();
+    });
+
+    rerender(<MessageResponse isAnimating>{markdown}</MessageResponse>);
+
+    await waitFor(() => {
+      for (const control of controls) expect(control).toBeDisabled();
+    });
+  });
+});

--- a/ios/HiveMobile/Stores/MarkdownStructure.swift
+++ b/ios/HiveMobile/Stores/MarkdownStructure.swift
@@ -146,6 +146,46 @@ func markdownNeedsRichRenderer(_ markdown: String) -> Bool {
     return false
 }
 
+func markdownContainsCodeBlock(_ markdown: String) -> Bool {
+    markdownRenderSegments(markdown)?.contains { $0.block.isCodeBlock } == true
+}
+
+/// Only closed fences enable actions during streaming. Markdown parsing and code
+/// extraction remain Foundation-owned; this scan only finds a safe source prefix.
+func completedMarkdownCodeBlocks(_ markdown: String) -> Set<String> {
+    var fence: (marker: Character, count: Int)?
+    var completedEnd = markdown.startIndex
+    var lineStart = markdown.startIndex
+    while lineStart < markdown.endIndex {
+        let lineEnd = markdown[lineStart...].firstIndex(of: "\n") ?? markdown.endIndex
+        let rawLine = markdown[lineStart..<lineEnd]
+        let indentation = rawLine.prefix(while: { $0 == " " }).count
+        let line = rawLine.dropFirst(indentation)
+        let nextLine = lineEnd < markdown.endIndex ? markdown.index(after: lineEnd) : lineEnd
+        if indentation <= 3, let marker = line.first, marker == "`" || marker == "~" {
+            let count = line.prefix(while: { $0 == marker }).count
+            let suffix = line.dropFirst(count)
+            if let current = fence {
+                if marker == current.marker, count >= current.count,
+                   suffix.allSatisfy({ $0.isWhitespace }) {
+                    fence = nil
+                    completedEnd = nextLine
+                }
+            } else if count >= 3, marker != "`" || !suffix.contains("`") {
+                fence = (marker, count)
+            }
+        }
+        lineStart = nextLine
+    }
+
+    let segments = markdownRenderSegments(String(markdown[..<completedEnd])) ?? []
+    var blocks: [[Int]: String] = [:]
+    for segment in segments where segment.block.isCodeBlock && segment.kind == .content {
+        blocks[segment.block.identity, default: ""] += segment.text
+    }
+    return Set(blocks.values.map { $0.trimmingCharacters(in: .newlines) })
+}
+
 /// Boundary = blank line outside any ``` / ~~~ fenced block, so the stable
 /// prefix never ends inside an open code block.
 func splitStableMarkdownPrefix(_ text: String) -> (stable: String, tail: String) {

--- a/ios/HiveMobile/Views/Chat/CodeBlockView.swift
+++ b/ios/HiveMobile/Views/Chat/CodeBlockView.swift
@@ -75,20 +75,25 @@ struct CodeBlockView: View {
         }
         .buttonStyle(.plain)
         .disabled(!actionsEnabled)
+        // Each icon carries 6pt of its own slack, so this lands the trailing
+        // one on the same 12pt inset as the language label.
+        .padding(.trailing, 6)
         .background(WhisperColor.codeBg)
     }
 
-    /// Matches the message footer's hit area (44 x 38) so the header stays
-    /// compact while every action clears the touch-target minimum.
+    /// 40 x 36 tap target over 28pt of layout. The negative padding keeps the
+    /// icons 12pt apart instead of 28pt; the reclaimed 6pt per side is exactly
+    /// half the gap, so the two targets tile without overlapping.
     private func actionIcon(_ systemName: String, tint: Color) -> some View {
         Image(systemName: systemName)
             .font(.system(size: 12, weight: .medium))
             .foregroundStyle(tint)
             .contentTransition(.symbolEffect(.replace))
             .frame(width: 16, height: 16)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 11)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
             .contentShape(Rectangle())
+            .padding(.horizontal, -6)
             .opacity(actionsEnabled ? 1 : 0.4)
             .animation(.easeOut(duration: 0.2), value: actionsEnabled)
     }

--- a/ios/HiveMobile/Views/Chat/CodeBlockView.swift
+++ b/ios/HiveMobile/Views/Chat/CodeBlockView.swift
@@ -2,6 +2,9 @@ import SwiftUI
 import UIKit
 
 /// Presentation only: MarkdownUI supplies the code; the caller owns stream completion.
+///
+/// Chrome mirrors the web renderer: a tinted header carrying the lowercase
+/// language and the block actions, a hairline, then the code on the card fill.
 struct CodeBlockView: View {
     let code: String
     let language: String?
@@ -10,47 +13,100 @@ struct CodeBlockView: View {
     @ScaledMetric(relativeTo: .body) private var fontSize: CGFloat = 12
     @State private var copied = false
 
+    private static let cornerRadius: CGFloat = 10
+
+    /// Actions stay mounted while a fence is open so the header never reflows.
+    private var actionsEnabled: Bool { isComplete && !code.isEmpty }
+
+    private var languageLabel: String {
+        guard let language, !language.trimmingCharacters(in: .whitespaces).isEmpty else { return "code" }
+        return language.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            HStack {
-                Text(language ?? "Code")
-                    .font(.caption.monospaced())
-                    .lineLimit(1)
-                Spacer(minLength: 8)
-                Button {
-                    UIPasteboard.general.string = code
-                    copied = true
-                } label: {
-                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
-                        .frame(width: 44, height: 44)
-                }
-                .accessibilityLabel(copied ? "Copied" : "Copy code")
-                ShareLink(item: code) {
-                    Image(systemName: "square.and.arrow.up")
-                        .frame(width: 44, height: 44)
-                }
-                .accessibilityLabel("Share code")
-            }
-            .buttonStyle(.plain)
-            .disabled(!isComplete || code.isEmpty)
-            .foregroundStyle(WhisperColor.textSecondary)
-
-            ScrollView(.horizontal) {
-                SelectableCodeText(code: code, fontSize: fontSize)
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            .padding(.bottom, 12)
+            header
+            Divider().overlay(WhisperColor.separator)
+            codeBody
         }
-        .padding(.horizontal, 12)
-        .background(WhisperColor.codeBlockBg, in: RoundedRectangle(cornerRadius: 8))
+        .background(WhisperColor.codeBlockBg)
+        .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: Self.cornerRadius, style: .continuous)
+                .strokeBorder(WhisperColor.border, lineWidth: 1)
+        )
         .task(id: copied) {
             guard copied else { return }
             do {
                 try await Task.sleep(for: .seconds(2))
-                copied = false
+                withAnimation(.snappy(duration: 0.2)) { copied = false }
             } catch {}
         }
         .onChange(of: code) { copied = false }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 0) {
+            Text(languageLabel)
+                .font(WhisperFont.mono(10))
+                .foregroundStyle(WhisperColor.textMuted)
+                .lineLimit(1)
+                .padding(.leading, 12)
+
+            Spacer(minLength: 8)
+
+            Button {
+                UIPasteboard.general.string = code
+                withAnimation(.snappy(duration: 0.2)) { copied = true }
+            } label: {
+                actionIcon(
+                    copied ? "checkmark" : "doc.on.doc",
+                    tint: copied ? WhisperColor.success : WhisperColor.textSecondary
+                )
+            }
+            .accessibilityLabel(copied ? "Copied" : "Copy code")
+
+            ShareLink(item: code) {
+                actionIcon("square.and.arrow.up", tint: WhisperColor.textSecondary)
+            }
+            .accessibilityLabel("Share code")
+        }
+        .buttonStyle(.plain)
+        .disabled(!actionsEnabled)
+        .background(WhisperColor.codeBg)
+    }
+
+    /// Matches the message footer's hit area (44 x 38) so the header stays
+    /// compact while every action clears the touch-target minimum.
+    private func actionIcon(_ systemName: String, tint: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(tint)
+            .contentTransition(.symbolEffect(.replace))
+            .frame(width: 16, height: 16)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 11)
+            .contentShape(Rectangle())
+            .opacity(actionsEnabled ? 1 : 0.4)
+            .animation(.easeOut(duration: 0.2), value: actionsEnabled)
+    }
+
+    // MARK: - Code
+
+    private var codeBody: some View {
+        ScrollView(.horizontal) {
+            SelectableCodeText(code: code, fontSize: fontSize)
+                .fixedSize(horizontal: true, vertical: false)
+        }
+        .scrollIndicators(.hidden)
+        .scrollBounceBehavior(.basedOnSize)
+        // Full-bleed scrolling: the code slides to the card edge instead of
+        // vanishing into a padded gutter, but rests inset like the header.
+        .contentMargins(.horizontal, 12, for: .scrollContent)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
 
@@ -117,4 +173,26 @@ struct MarkdownCodeBlock: View {
             isComplete: completed.map { $0.contains(code.trimmingCharacters(in: .newlines)) } ?? true
         )
     }
+}
+
+// MARK: - Preview
+
+private let previewCode = """
+func login(using credentials: Credentials) async throws -> Session {
+    let token = try await tokenStore.token(for: credentials)
+    return try await validate(token)
+}
+"""
+
+#Preview("Code block") {
+    ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+            CodeBlockView(code: previewCode, language: "Swift")
+            CodeBlockView(code: "npm run test -- --watch", language: "bash")
+            CodeBlockView(code: previewCode, language: nil)
+            CodeBlockView(code: "let partial = ", language: "swift", isComplete: false)
+        }
+        .padding()
+    }
+    .background(WhisperColor.appBackground)
 }

--- a/ios/HiveMobile/Views/Chat/CodeBlockView.swift
+++ b/ios/HiveMobile/Views/Chat/CodeBlockView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+import UIKit
+
+/// Presentation only: MarkdownUI supplies the code; the caller owns stream completion.
+struct CodeBlockView: View {
+    let code: String
+    let language: String?
+    var isComplete = true
+
+    @ScaledMetric(relativeTo: .body) private var fontSize: CGFloat = 12
+    @State private var copied = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Text(language ?? "Code")
+                    .font(.caption.monospaced())
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Button {
+                    UIPasteboard.general.string = code
+                    copied = true
+                } label: {
+                    Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel(copied ? "Copied" : "Copy code")
+                ShareLink(item: code) {
+                    Image(systemName: "square.and.arrow.up")
+                        .frame(width: 44, height: 44)
+                }
+                .accessibilityLabel("Share code")
+            }
+            .buttonStyle(.plain)
+            .disabled(!isComplete || code.isEmpty)
+            .foregroundStyle(WhisperColor.textSecondary)
+
+            ScrollView(.horizontal) {
+                SelectableCodeText(code: code, fontSize: fontSize)
+                    .fixedSize(horizontal: true, vertical: false)
+            }
+            .padding(.bottom, 12)
+        }
+        .padding(.horizontal, 12)
+        .background(WhisperColor.codeBlockBg, in: RoundedRectangle(cornerRadius: 8))
+        .task(id: copied) {
+            guard copied else { return }
+            do {
+                try await Task.sleep(for: .seconds(2))
+                copied = false
+            } catch {}
+        }
+        .onChange(of: code) { copied = false }
+    }
+}
+
+/// A read-only native text view keeps partial selection and copies whitespace verbatim.
+private struct SelectableCodeText: UIViewRepresentable {
+    let code: String
+    let fontSize: CGFloat
+
+    func makeUIView(context: Context) -> UITextView {
+        let view = UITextView()
+        view.isEditable = false
+        view.isSelectable = true
+        view.isScrollEnabled = false
+        view.backgroundColor = .clear
+        view.textContainerInset = .zero
+        view.textContainer.lineFragmentPadding = 0
+        return view
+    }
+
+    func updateUIView(_ view: UITextView, context: Context) {
+        if view.text != code {
+            let selection = view.selectedRange
+            view.text = code
+            if NSMaxRange(selection) <= (code as NSString).length {
+                view.selectedRange = selection
+            }
+        }
+        view.font = .monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        view.textColor = UIColor(WhisperColor.codeText)
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: UITextView, context: Context) -> CGSize? {
+        let font = UIFont.monospacedSystemFont(ofSize: fontSize, weight: .regular)
+        let longestLine = code.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { (String($0) as NSString).size(withAttributes: [.font: font]).width }
+            .max() ?? 0
+        let width = max(1, ceil(longestLine) + 1)
+        let size = uiView.sizeThatFits(CGSize(width: width, height: CGFloat.greatestFiniteMagnitude))
+        return CGSize(width: width, height: ceil(size.height))
+    }
+}
+
+private struct CompletedCodeBlocksKey: EnvironmentKey {
+    /// Nil means a finished response; an empty set means no streamed block has closed yet.
+    static let defaultValue: Set<String>? = nil
+}
+
+extension EnvironmentValues {
+    var completedCodeBlocks: Set<String>? {
+        get { self[CompletedCodeBlocksKey.self] }
+        set { self[CompletedCodeBlocksKey.self] = newValue }
+    }
+}
+
+struct MarkdownCodeBlock: View {
+    let code: String
+    let language: String?
+    @Environment(\.completedCodeBlocks) private var completed
+
+    var body: some View {
+        CodeBlockView(
+            code: code,
+            language: language,
+            isComplete: completed.map { $0.contains(code.trimmingCharacters(in: .newlines)) } ?? true
+        )
+    }
+}

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -285,6 +285,11 @@ struct MessageBubble: View, Equatable {
                             .padding(.horizontal, 15)
                             .padding(.vertical, 12)
                             .contentShape(Rectangle())
+                            // The padding above buys a 44 x 38 tap target; taking
+                            // it back out of the layout keeps the icon on the same
+                            // rhythm as the metadata instead of inflating the row.
+                            .padding(.horizontal, -15)
+                            .padding(.vertical, -9)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(copied ? "Copied" : "Copy message")

--- a/ios/HiveMobile/Views/Chat/MessageBubble.swift
+++ b/ios/HiveMobile/Views/Chat/MessageBubble.swift
@@ -81,17 +81,17 @@ struct MessageBubble: View, Equatable {
     @ViewBuilder
     private func textRow(id: String, text: String) -> some View {
         let highlight = textHighlight(rowId: id)
-        if isStreaming {
-            StreamingMarkdownView(text: text, baseSize: markdownBaseSize)
-        } else if highlight == nil, markdownNeedsRichRenderer(text) {
-            // MarkdownUI cannot paint arbitrary ranges; while this text has
-            // find matches it falls back to the selectable renderer so
-            // highlights stay visible.
+        if highlight == nil, markdownContainsCodeBlock(text) || (!isStreaming && markdownNeedsRichRenderer(text)) {
+            // Keep the same renderer mounted when a code-bearing response finishes.
             Markdown(text)
                 .markdownTextStyle { FontSize(markdownBaseSize) }
                 .markdownTheme(.whisperChat)
                 .textSelection(.enabled)
+                .environment(\.completedCodeBlocks, isStreaming ? completedMarkdownCodeBlocks(text) : nil)
+        } else if isStreaming {
+            StreamingMarkdownView(text: text, baseSize: markdownBaseSize)
         } else {
+            // Preserve native find-range highlighting, including matches inside code.
             SelectableMarkdownText(markdown: text, findHighlight: highlight)
         }
     }
@@ -583,19 +583,8 @@ extension Theme {
         }
         // ── Code blocks ──
         .codeBlock { configuration in
-            ScrollView(.horizontal) {
-                configuration.label
-                    .fixedSize(horizontal: true, vertical: false)
-            }
-            .scrollIndicators(.hidden)
-            .markdownTextStyle {
-                FontFamilyVariant(.monospaced)
-                FontSize(.em(12.0 / 14))
-                ForegroundColor(WhisperColor.codeText)
-            }
-            .padding(12)
-            .background(WhisperColor.codeBlockBg, in: RoundedRectangle(cornerRadius: 8))
-            .markdownMargin(top: .em(0.4), bottom: .em(0.4))
+            MarkdownCodeBlock(code: configuration.content, language: configuration.language)
+                .markdownMargin(top: .em(0.4), bottom: .em(0.4))
         }
         // ── Tables ──
         // The stock table style squeezes columns into the bubble width, which

--- a/ios/HiveMobile/Views/Chat/StreamingMarkdownView.swift
+++ b/ios/HiveMobile/Views/Chat/StreamingMarkdownView.swift
@@ -18,6 +18,7 @@ struct StreamingMarkdownView: View {
                     .markdownTheme(.whisperChat)
             }
         }
+        .environment(\.completedCodeBlocks, completedMarkdownCodeBlocks(text))
     }
 }
 

--- a/ios/Tests/ChatDraftStoreTests/MarkdownCodeBlockTests.swift
+++ b/ios/Tests/ChatDraftStoreTests/MarkdownCodeBlockTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import HiveMobileStoresCore
+
+@Suite("Markdown code block actions")
+struct MarkdownCodeBlockTests {
+    @Test("Code is detected without treating inline code as a block")
+    func codeDetection() {
+        #expect(markdownContainsCodeBlock("Use `npm test`.") == false)
+        #expect(markdownContainsCodeBlock("```bash\nnpm test\n```"))
+        #expect(markdownContainsCodeBlock("```unknown\npartial"))
+        #expect(markdownContainsCodeBlock("    indented code\n"))
+    }
+
+    @Test("Actions become available when a fence closes, before the response ends")
+    func closure() {
+        let source = "```bash\nnpm test\n"
+        #expect(completedMarkdownCodeBlocks(source).isEmpty)
+        #expect(completedMarkdownCodeBlocks(source + "```") == ["npm test"])
+        #expect(completedMarkdownCodeBlocks(source + "```\nStill working") == ["npm test"])
+    }
+
+    @Test("A later unfinished block does not disable an earlier complete block")
+    func multipleBlocks() {
+        let source = "```\nfirst\n```\n\n```swift\nsecond"
+        #expect(completedMarkdownCodeBlocks(source) == ["first"])
+    }
+
+    @Test("An indented fence inside code cannot enable actions early")
+    func indentedFenceContent() {
+        #expect(completedMarkdownCodeBlocks("```\ntext\n    ```\n").isEmpty)
+    }
+
+    @Test("Shorter or different fences cannot close a code block", arguments: ["```", "~~~~", "````suffix"])
+    func mismatchedFence(closing: String) {
+        #expect(completedMarkdownCodeBlocks("````swift\nlet x = 1\n" + closing).isEmpty)
+    }
+
+    @Test("Longer closing fences and tilde fences are supported")
+    func fenceVariants() {
+        #expect(completedMarkdownCodeBlocks("~~~\ntext\n~~~~  ") == ["text"])
+        #expect(completedMarkdownCodeBlocks("````\n```\n`````\n") == ["```"])
+    }
+
+    @Test("Code whitespace and Unicode are retained when matching completed blocks")
+    func whitespace() {
+        let code = "  echo '🐝'  \n\tprintf done"
+        #expect(completedMarkdownCodeBlocks("```sh\n" + code + "\n```") == [code])
+    }
+}


### PR DESCRIPTION
Code blocks should be usable as soon as they finish arriving, and on iOS they should look like a code surface rather than raw text. Previously, web controls could remain disabled after streaming ended until the conversation was reopened, and iOS had no per-block copy or share actions at all.

## Behaviour

- Web: respect streaming-state changes in the Markdown memoization and enable code copy/download as soon as the fence closes, while keeping incomplete code disabled. Keep the existing Streamdown renderer and styling.
- iOS: add a reusable code block with a language label, whole-block copy, native sharing, partial native selection and horizontal scrolling. Keep the code renderer mounted across streaming completion. Closed fences enable actions before the response ends; finished or interrupted responses release the remaining controls.
- Preserve the existing selectable search renderer while a message has highlighted matches. No new dependencies or syntax highlighting are added.

## Design

The iOS chrome now mirrors the web renderer, which is itself the convention used by ChatGPT, Claude and T3: a tinted header carrying the lowercase monospaced language and the block actions, a hairline, then the code on the card fill.

- Bordered, clipped card, so the block reads as a surface in light mode where `codeBlockBg` is nearly the app background.
- Header and body use the `codeBg` / `codeBlockBg` tonal split that `index.css` already forces on the web code block.
- Full-bleed horizontal scrolling with resting content margins, so long lines slide to the card edge instead of vanishing into a padded gutter.
- Actions dim while a fence is open, so the disabled state is visible instead of looking tappable and inert.
- Both this header and the existing message footer copy button reserved their whole tap target as layout, which spread the header icons 28pt apart and inflated the footer row. The padding is now reclaimed with negative padding after `contentShape`: the tap targets survive, and the icons sit on the surrounding rhythm (12pt between header icons and on the label's inset; the footer icon on the metadata's own 4pt spacing, with no dead row below it).

Presentation only. Copy, share and stream-completion behaviour are unchanged by the design commits.

## Validation

Frontend lint/typecheck and 49 targeted tests passed; browser verification confirmed a completed block is enabled while the following incomplete block remains disabled. The earlier full frontend suite (1,881 tests) and 334 targeted backend tests passed before the additional UI work.

Swift tests were added for the fence-completion scan, but `swift test` could not run because Swift/Xcode is unavailable in the workspace, and `Package.swift` excludes `Views/` from the SPM target regardless. The iOS views were verified on device instead: the header and footer spacing were tuned from device screenshots. On-device selection behaviour and Dynamic Type sizing are still worth a second look.