### PR TITLE
chore: prepare release 0.1.5

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -1574,7 +1574,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hive"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "dirs",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hive"
-version = "0.1.4"
+version = "0.1.5"
 description = "Hive"
 authors = ["419Labs"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- bump the Tauri package version to 0.1.5
- refresh the Cargo lockfile version

## Validation

- `npm run release:version:check -- 0.1.5`
- `npm run lint`
- `npm run typecheck`
- frontend tests: 1922 passed
- backend tests: 2051 passed; one timing-sensitive WebSocket test failed in the full run and passed when rerun in isolation